### PR TITLE
Configuring deploy step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,18 +78,36 @@ target_include_directories(DLAF INTERFACE
   $<INSTALL_INTERFACE:include>
 )
 
+# ----- DEPLOY
+include(GNUInstallDirs)
+
 install(TARGETS
   DLAF
-  EXPORT DLAF-TARGETS
-  INCLUDES DESTINATION include
+  EXPORT DLAF-Targets
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(DIRECTORY include DESTINATION include)
+install(DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(EXPORT
-  DLAF-TARGETS
+  DLAF-Targets
   NAMESPACE DLAF::
-  DESTINATION share/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)
+
+# ----- CMake INTEGRATION
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/DLAFConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
 )
 
 # ---------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(MPI REQUIRED)
 # ----- LAPACK/SCALAPACK
 set(DLAF_WITH_MKL OFF CACHE BOOL "Enable MKL as provider for LAPACK")
 if (DLAF_WITH_MKL)
-  set(MKL_THREADING "Sequential" CACHE STRING "MKL Threading fixed to Sequential" FORCE)
+  set(MKL_CUSTOM_THREADING "Sequential")
   find_package(MKL REQUIRED COMPONENTS LAPACK)
   set(LAPACK_FOUND ${MKL_LAPACK_FOUND})
 
@@ -87,18 +87,28 @@ install(TARGETS
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+# install includes
 install(DIRECTORY include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
+# install custom FindModules
+install(DIRECTORY cmake/
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  FILES_MATCHING PATTERN "Find*.cmake"
+)
+
+# ----- CMake INTEGRATION
+include(CMakePackageConfigHelpers)
+
+# install targets configuration
 install(EXPORT
   DLAF-Targets
   NAMESPACE DLAF::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
 )
 
-# ----- CMake INTEGRATION
-include(CMakePackageConfigHelpers)
-
+# Config-file preparation and install
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/DLAFConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,24 @@ add_subdirectory(external)
 # DLAF library
 # ---------------------------------------------------------------------------
 add_library(DLAF INTERFACE)
-target_include_directories(DLAF INTERFACE include)
+target_include_directories(DLAF INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS
+  DLAF
+  EXPORT DLAF-TARGETS
+  INCLUDES DESTINATION include
+)
+
+install(DIRECTORY include DESTINATION include)
+
+install(EXPORT
+  DLAF-TARGETS
+  NAMESPACE DLAF::
+  DESTINATION share/cmake
+)
 
 # ---------------------------------------------------------------------------
 # Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ install(EXPORT
 include(CMakePackageConfigHelpers)
 
 configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/DLAFConfig.cmake.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/DLAFConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
 )

--- a/DLAFConfig.cmake.in
+++ b/DLAFConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+# TODO FindPackage management
+#include(CMakeFindDependencyMacro)
+
+include(${CMAKE_CURRENT_LIST_DIR}/NS3C-Targets.cmake)
+
+#check_required_components(NS3C)

--- a/DLAFConfig.cmake.in
+++ b/DLAFConfig.cmake.in
@@ -1,8 +1,0 @@
-@PACKAGE_INIT@
-
-# TODO FindPackage management
-#include(CMakeFindDependencyMacro)
-
-include(${CMAKE_CURRENT_LIST_DIR}/NS3C-Targets.cmake)
-
-#check_required_components(NS3C)

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -106,4 +106,16 @@ function(DLAF_addTest test_target_name)
       COMMAND ${test_target_name} ${DLAF_AT_ARGUMENTS}
     )
   endif()
+
+  ### DEPLOY
+  include(GNUInstallDirs)
+
+  set(DLAF_INSTALL_TESTS OFF CACHE BOOL "If tests are built, it controls if they will be installed")
+  if (DLAF_INSTALL_TESTS)
+    install(TARGETS
+      ${test_target_name}
+      # EXPORT DLAF-tests
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+  endif()
 endfunction()

--- a/cmake/FindLAPACK.cmake
+++ b/cmake/FindLAPACK.cmake
@@ -69,26 +69,40 @@ if(LAPACK_TYPE STREQUAL "Compiler")
     set(LAPACK_INCLUDE_DIR "" CACHE STRING "" FORCE)
     set(LAPACK_LIBRARY "" CACHE STRING "" FORCE)
   else()
-    message(FATAL_ERROR "With LAPACK_TYPE='${LAPACK_TYPE}',
+    message(FATAL_ERROR
+      "With LAPACK_TYPE='${LAPACK_TYPE}',
       LAPACK_CUSTOM_INCLUDE_DIR and LAPACK_CUSTOM_LIBRARY must be EMPTY.
       Instead they are set to
       LAPACK_CUSTOM_INCLUDE_DIR='${LAPACK_CUSTOM_INCLUDE_DIR}'
       LAPACK_CUSTOM_LIBRARY='${LAPACK_CUSTOM_LIBRARY}'")
   endif()
 elseif(LAPACK_TYPE STREQUAL "Custom")
-  # nothing to do
+  # allow to set LAPACK_INCLUDE_DIR from code
+  if (LAPACK_CUSTOM_INCLUDE_DIR)
+    set(LAPACK_INCLUDE_DIR "${LAPACK_CUSTOM_INCLUDE_DIR}" CACHE STRING
+      "BLAS and LAPACK include path for LAPACK_TYPE=Custom (from code)"
+      FORCE
+    )
+  else()
+    set(LAPACK_INCLUDE_DIR "" CACHE STRING
+      "BLAS and LAPACK include path for LAPACK_TYPE=Custom"
+    )
+  endif()
+
+  # allow to set LAPACK_LIBRARY from code
+  if (LAPACK_CUSTOM_LIBRARY)
+    set(LAPACK_LIBRARY "${LAPACK_CUSTOM_LIBRARY}" CACHE STRING
+      "BLAS and LAPACK link line for LAPACK_TYPE=Custom (from code)"
+      FORCE
+    )
+  else()
+    set(LAPACK_LIBRARY "" CACHE STRING
+      "BLAS and LAPACK link line for LAPACK_TYPE=Custom"
+    )
+  endif()
 else()
   message(FATAL_ERROR "Unknown LAPACK type: ${LAPACK_TYPE}")
 endif()
-
-set(LAPACK_INCLUDE_DIR
-  "${LAPACK_CUSTOM_INCLUDE_DIR}"
-  CACHE STRING
-  "BLAS and LAPACK include path for LAPACK_TYPE=Custom")
-set(LAPACK_LIBRARY
-  "${LAPACK_CUSTOM_LIBRARY}"
-  CACHE STRING
-  "BLAS and LAPACK link line for LAPACK_TYPE=Custom")
 
 mark_as_advanced(
   LAPACK_TYPE

--- a/cmake/FindLAPACK.cmake
+++ b/cmake/FindLAPACK.cmake
@@ -15,7 +15,7 @@
 # This module sets the following variables:
 #  LAPACK_FOUND - set to true if a library implementing the LAPACK interface is found
 #
-# Following options are allowed:
+# Following options are allowed (for setting options from code see next section):
 #   LAPACK_TYPE - it can be "Compiler" or "Custom"
 #     - Compiler (Default): The compiler add the scalapack flag automatically therefore no
 #                           extra link line has to be added.
@@ -25,32 +25,76 @@
 #   LAPACK_LIBRARY - used if SCALAPACK_TYPE=Custom
 #       ;-list of {lib name, lib filepath, -Llibrary_folder}
 #
+# If you want to set options from CMake script you cannot use previous variables, instead you should use:
+#   - LAPACK_CUSTOM_TYPE
+#   - LAPACK_CUSTOM_INCLUDE_DIR
+#   - LAPACK_CUSTOM_LIBRARY
+#
 # It creates target lapack::lapack
 
-### Options
-set(LAPACK_TYPE "Compiler" CACHE STRING "BLAS/LAPACK type setting")
-set_property(CACHE LAPACK_TYPE PROPERTY STRINGS "Compiler" "Custom")
+### helper function
+function(check_valid_option selected_option)
+  set(available_options ${ARGN})
+  list(LENGTH available_options _how_many_options)
 
-set(LAPACK_INCLUDE_DIR "" CACHE STRING "BLAS and LAPACK include path for DLA_LAPACK_TYPE = Custom")
-set(LAPACK_LIBRARY "" CACHE STRING "BLAS and LAPACK link line for DLA_LAPACK_TYPE = Custom")
+  if (NOT _how_many_options GREATER_EQUAL 1)
+    message(
+      FATAL_ERROR
+      "You are checking value of an option without giving the list of valid ones")
+  endif()
 
+  list(FIND available_options ${selected_option} selected_index)
+  if (${selected_index} EQUAL -1)
+    message(FATAL_ERROR
+      "You have selected '${selected_option}', but you have to choose among '${available_options}'")
+  endif()
+endfunction()
+
+### MAIN
+set(LAPACK_TYPE_OPTIONS "Compiler" "Custom")
+set(LAPACK_TYPE_DEFAULT "Compiler")
+
+# allow to set LAPACK_TYPE from code
+if (LAPACK_CUSTOM_TYPE)
+  set(LAPACK_TYPE ${LAPACK_CUSTOM_TYPE} CACHE STRING "BLAS/LAPACK type set from script" FORCE)
+else()
+  set(LAPACK_TYPE ${LAPACK_TYPE_DEFAULT} CACHE STRING "BLAS/LAPACK type setting")
+endif()
+set_property(CACHE LAPACK_TYPE PROPERTY STRINGS ${LAPACK_TYPE_OPTIONS})
+check_valid_option(${LAPACK_TYPE} ${LAPACK_TYPE_OPTIONS})
 
 if(LAPACK_TYPE STREQUAL "Compiler")
-  # reset variables
-  set(LAPACK_INCLUDE_DIR "" CACHE STRING "" FORCE)
-  set(LAPACK_LIBRARY "" CACHE STRING "" FORCE)
+  if (NOT LAPACK_CUSTOM_INCLUDE_DIR AND NOT LAPACK_CUSTOM_LIBRARY)
+    # reset variables
+    set(LAPACK_INCLUDE_DIR "" CACHE STRING "" FORCE)
+    set(LAPACK_LIBRARY "" CACHE STRING "" FORCE)
+  else()
+    message(FATAL_ERROR "With LAPACK_TYPE='${LAPACK_TYPE}',
+      LAPACK_CUSTOM_INCLUDE_DIR and LAPACK_CUSTOM_LIBRARY must be EMPTY.
+      Instead they are set to
+      LAPACK_CUSTOM_INCLUDE_DIR='${LAPACK_CUSTOM_INCLUDE_DIR}'
+      LAPACK_CUSTOM_LIBRARY='${LAPACK_CUSTOM_LIBRARY}'")
+  endif()
 elseif(LAPACK_TYPE STREQUAL "Custom")
   # nothing to do
 else()
   message(FATAL_ERROR "Unknown LAPACK type: ${LAPACK_TYPE}")
 endif()
 
+set(LAPACK_INCLUDE_DIR
+  "${LAPACK_CUSTOM_INCLUDE_DIR}"
+  CACHE STRING
+  "BLAS and LAPACK include path for LAPACK_TYPE=Custom")
+set(LAPACK_LIBRARY
+  "${LAPACK_CUSTOM_LIBRARY}"
+  CACHE STRING
+  "BLAS and LAPACK link line for LAPACK_TYPE=Custom")
+
 mark_as_advanced(
   LAPACK_TYPE
   LAPACK_INCLUDE_DIR
   LAPACK_LIBRARY
 )
-
 
 ### Checks
 include(CMakePushCheckState)

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -97,7 +97,7 @@ macro(_mkl_find_lapack)
       FORCE
     )
   else()
-  set(MKL_THREADING ${MKL_THREADING_DEFAULT} CACHE STRING "MKL Threading support")
+    set(MKL_THREADING ${MKL_THREADING_DEFAULT} CACHE STRING "MKL Threading support")
   endif()
   set_property(CACHE MKL_THREADING PROPERTY STRINGS ${MKL_THREADING_OPTIONS})
   check_valid_option(${MKL_THREADING} ${MKL_THREADING_OPTIONS})
@@ -266,13 +266,9 @@ endfunction()
 ### MAIN
 set(MKL_ROOT $ENV{MKLROOT} CACHE PATH "Intel MKL Path")
 
-if (NOT MKL_ROOT)
-  set(MKL_ROOT $ENV{MKLROOT})
-endif()
-
 find_path(MKL_INCLUDE_DIR
   mkl.h
-  PATHS ${MKL_ROOT} ENV MKLROOT
+  PATHS ${MKL_ROOT}/include
 )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -90,15 +90,17 @@ macro(_mkl_find_lapack)
 
   # allow to set option from script
   if (MKL_CUSTOM_THREADING)
-    set(_MKL_THREADING_SELECTED ${MKL_CUSTOM_THREADING})
-    set(MKL_THREADING_DEFAULT ${MKL_CUSTOM_THREADING})
+    set(MKL_THREADING
+      ${MKL_CUSTOM_THREADING}
+      CACHE STRING
+      "MKL Threading support (from code)"
+      FORCE
+    )
   else()
-    set(_MKL_THREADING_SELECTED ${MKL_THREADING})
-  endif()
-  check_valid_option(${_MKL_THREADING_SELECTED} ${MKL_THREADING_OPTIONS})
-
   set(MKL_THREADING ${MKL_THREADING_DEFAULT} CACHE STRING "MKL Threading support")
+  endif()
   set_property(CACHE MKL_THREADING PROPERTY STRINGS ${MKL_THREADING_OPTIONS})
+  check_valid_option(${MKL_THREADING} ${MKL_THREADING_OPTIONS})
 
   # ----- set MKL Threading
   if(MKL_THREADING MATCHES "Sequential")
@@ -122,6 +124,7 @@ macro(_mkl_find_lapack)
 
   # allow to set LAPACK_INCLUDE_DIR from script
   if (MKL_LAPACK_CUSTOM_INCLUDE_DIR)
+    unset(MKL_LAPACK_INCLUDE_DIR CACHE)
     find_path(MKL_LAPACK_INCLUDE_DIR
       mkl_lapack.h
       PATHS ${MKL_LAPACK_CUSTOM_INCLUDE_DIR}
@@ -134,14 +137,19 @@ macro(_mkl_find_lapack)
 
   # allow to set LAPACK_LIBRARY from script
   if (MKL_LAPACK_CUSTOM_LIBRARY)
-    set(_MKL_LAPACK_LIBRARY ${MKL_LAPACK_CUSTOM_LIBRARY})
+    set(MKL_LAPACK_LIBRARY
+      ${MKL_LAPACK_CUSTOM_LIBRARY}
+      CACHE STRING "LAPACK libraries (from code)"
+      FORCE
+    )
   else()
-    set(_MKL_LAPACK_LIBRARY
+    set(MKL_LAPACK_LIBRARY
       "${MKL_LIB_DIR} -lmkl_intel_lp64\
       ${MKL_THREAD_LIB} -lmkl_core\
-      -lpthread -lm -ldl")                        # TODO pthread, m, dl ???
+      -lpthread -lm -ldl"                            # TODO pthread, m, dl ???
+      CACHE STRING "LAPACK libraries"
+    )
   endif()
-  set(MKL_LAPACK_LIBRARY ${_MKL_LAPACK_LIBRARY} CACHE STRING "LAPACK libraries")
 
   mark_as_advanced(
     MKL_LAPACK_INCLUDE_DIR
@@ -162,14 +170,12 @@ macro(_mkl_find_scalapack)
 
     # allow to set MPI_MPI_TYPE from code
     if (MKL_CUSTOM_MPI_TYPE)
-      set(_MKL_MPI_TYPE_SELECTED ${MKL_CUSTOM_MPI_TYPE})
+      set(MKL_MPI_TYPE ${MKL_CUSTOM_MPI_TYPE} CACHE STRING "MKL MPI support (from code)" FORCE)
     else()
-      set(_MKL_MPI_TYPE_SELECTED ${MKL_MPI_TYPE_DEFAULT})
+      set(MKL_MPI_TYPE ${MKL_MPI_TYPE_DEFAULT} CACHE STRING "MKL MPI support")
     endif()
-    check_valid_option(${_MKL_MPI_TYPE_SELECTED} ${MKL_MPI_TYPE_OPTIONS})
-
-    set(MKL_MPI_TYPE ${_MKL_MPI_TYPE_SELECTED} CACHE STRING "MKL MPI support")
     set_property(CACHE MKL_MPI_TYPE PROPERTY STRINGS ${MKL_MPI_TYPE_OPTIONS})
+    check_valid_option(${MKL_MPI_TYPE} ${MKL_MPI_TYPE_OPTIONS})
   endif()
 
   # ----- set MPI support
@@ -189,11 +195,18 @@ macro(_mkl_find_scalapack)
 
   # allow to set LAPACK_LIBRARY from script
   if (MKL_SCALAPACK_CUSTOM_LIBRARY)
-    set(_MKL_SCALAPACK_LIBRARY ${MKL_SCALAPACK_CUSTOM_LIBRARY})
+    set(MKL_SCALAPACK_LIBRARY
+      ${MKL_SCALAPACK_CUSTOM_LIBRARY}
+      CACHE STRING
+      "Scalapack libraries (from code)"
+      FORCE
+    )
   else()
-    set(_MKL_SCALAPACK_LIBRARY "-lmkl_scalapack_lp64 ${MKL_BLACS_LIB}")
+    set(MKL_SCALAPACK_LIBRARY
+      "-lmkl_scalapack_lp64 ${MKL_BLACS_LIB}"
+      CACHE STRING "Scalapack libraries"
+    )
   endif()
-  set(MKL_SCALAPACK_LIBRARY ${_MKL_SCALAPACK_LIBRARY} CACHE STRING "Scalapack libraries")
 
   mark_as_advanced(MKL_SCALAPACK_LIBRARY)
 

--- a/cmake/template/DLAFConfig.cmake.in
+++ b/cmake/template/DLAFConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+# TODO FindPackage management
+#include(CMakeFindDependencyMacro)
+
+include(${CMAKE_CURRENT_LIST_DIR}/DLAF-Targets.cmake)
+
+#check_required_components(DLAF)

--- a/cmake/template/DLAFConfig.cmake.in
+++ b/cmake/template/DLAFConfig.cmake.in
@@ -26,11 +26,9 @@ if (DLAF_WITH_MKL)
 
   find_dependency(MKL REQUIRED COMPONENTS LAPACK)
 else()
-  # TODO manage LAPACK dependency (with custom include/libs)
-  message(FATAL_ERROR "not yet implemented")
-
-  set(LAPACK_INCLUDE_DIR "@LAPACK_INCLUDE_DIR@")
-  set(LAPACK_LIBRARY "@LAPACK_LIBRARY@")
+  set(LAPACK_CUSTOM_TYPE "@LAPACK_TYPE@")
+  set(LAPACK_CUSTOM_INCLUDE_DIR "@LAPACK_INCLUDE_DIR@")
+  set(LAPACK_CUSTOM_LIBRARY "@LAPACK_LIBRARY@")
 
   find_dependency(LAPACK REQUIRED)
 endif()

--- a/cmake/template/DLAFConfig.cmake.in
+++ b/cmake/template/DLAFConfig.cmake.in
@@ -1,8 +1,41 @@
 @PACKAGE_INIT@
 
-# TODO FindPackage management
-#include(CMakeFindDependencyMacro)
+if (NOT TARGET DLAF)
+  include(${CMAKE_CURRENT_LIST_DIR}/DLAF-Targets.cmake)
+endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/DLAF-Targets.cmake)
+# enable custom modules to be used
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
-#check_required_components(DLAF)
+# ===== VARIABLES
+set(DLAF_WITH_MKL @DLAF_WITH_MKL@)
+
+# ===== DEPENDENCIES
+include(CMakeFindDependencyMacro)
+
+# ----- MPI
+find_dependency(MPI REQUIRED)
+
+# ----- LAPACK
+if (DLAF_WITH_MKL)
+  set(MKL_ROOT "@MKL_ROOT@")
+  set(MKL_CUSTOM_THREADING "@MKL_THREADING@")
+
+  set(MKL_LAPACK_CUSTOM_INCLUDE_DIR "@MKL_LAPACK_INCLUDE_DIR@")
+  set(MKL_LAPACK_CUSTOM_LIBRARY "@MKL_LAPACK_LIBRARY@")
+
+  find_dependency(MKL REQUIRED COMPONENTS LAPACK)
+else()
+  # TODO manage LAPACK dependency (with custom include/libs)
+  message(FATAL_ERROR "not yet implemented")
+
+  set(LAPACK_INCLUDE_DIR "@LAPACK_INCLUDE_DIR@")
+  set(LAPACK_LIBRARY "@LAPACK_LIBRARY@")
+
+  find_dependency(LAPACK REQUIRED)
+endif()
+
+# ----- HPX
+find_dependency(HPX REQUIRED PATHS @HPX_DIR@)
+
+check_required_components(DLAF)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -35,3 +35,10 @@ add_custom_target(doc ALL
   COMMENT "Building Doxygen documentation"
   COMMAND Doxygen::doxygen
 )
+
+# INSTALL
+include(GNUInstallDirs)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1682,7 +1682,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
Close #24 

- configure CMake for library installation
- configure the project to introduce CMake interoperability and usage as a dependency from other projects
- add option `DLAF_INSTALL_TESTS` for installing tests along with the library

It required a workaround to MKL and LAPACK scripts to have the same build configuration at install time (e.g. link line).