### PR TITLE
CMake refactoring for adding source and private includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,55 +72,7 @@ add_subdirectory(external)
 # ---------------------------------------------------------------------------
 # DLAF library
 # ---------------------------------------------------------------------------
-add_library(DLAF INTERFACE)
-target_include_directories(DLAF INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-  ${HPX_INCLUDE_DIRS}
-)
-target_link_libraries(DLAF INTERFACE ${HPX_LIBRARIES})
-
-# ----- DEPLOY
-include(GNUInstallDirs)
-
-install(TARGETS
-  DLAF
-  EXPORT DLAF-Targets
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-# install includes
-install(DIRECTORY include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-# install custom FindModules
-install(DIRECTORY cmake/
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
-  FILES_MATCHING PATTERN "Find*.cmake"
-)
-
-# ----- CMake INTEGRATION
-include(CMakePackageConfigHelpers)
-
-# install targets configuration
-install(EXPORT
-  DLAF-Targets
-  NAMESPACE DLAF::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
-)
-
-# Config-file preparation and install
-configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/template/DLAFConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
-)
-
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
-)
+add_subdirectory(src)
 
 # ---------------------------------------------------------------------------
 # Test

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,62 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2019, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(DLAF INTERFACE)
+
+target_include_directories(DLAF INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  $<INSTALL_INTERFACE:include>
+  ${HPX_INCLUDE_DIRS}
+)
+
+target_link_libraries(DLAF INTERFACE ${HPX_LIBRARIES})
+
+# ----- DEPLOY
+include(GNUInstallDirs)
+
+install(TARGETS
+  DLAF
+  EXPORT DLAF-Targets
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# install includes
+install(DIRECTORY ../include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# install custom FindModules
+install(DIRECTORY ../cmake/
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  FILES_MATCHING PATTERN "Find*.cmake"
+  PATTERN "template" EXCLUDE
+)
+
+# ----- CMake INTEGRATION
+include(CMakePackageConfigHelpers)
+
+# install targets configuration
+install(EXPORT
+  DLAF-Targets
+  NAMESPACE DLAF::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)
+
+# Config-file preparation and install
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/template/DLAFConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,10 +10,13 @@
 
 add_library(DLAF INTERFACE)
 
-target_include_directories(DLAF INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-  $<INSTALL_INTERFACE:include>
-  ${HPX_INCLUDE_DIRS}
+target_include_directories(DLAF
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+    ${HPX_INCLUDE_DIRS}
+  # PRIVATE
+  #   include/
 )
 
 target_link_libraries(DLAF INTERFACE ${HPX_LIBRARIES})


### PR DESCRIPTION
Close #45 

No source file or private header files has been added, but as soon as there will be, it is just a matter of:

- add sources to `src` and to `add_library` (removing the INTERFACE flag)
- in target_include_directories(DLAF) change from `INTERFACE` to `PUBLIC` 

In order to add private includes:
- create `src/include` folder, and add private includes in there
- uncomment `target_include_directories(DLAF)` private section


**minor-fix**: do not install `cmake/template` folder