### PR TITLE
bug: CI wasn't deleting build directory on success

### DIFF
--- a/ci/daint-mc_test.sbatch
+++ b/ci/daint-mc_test.sbatch
@@ -18,4 +18,5 @@ make test
 
 # only executed if tests passed
 echo "test successful"
+cd ..
 rm -rf $DIR

--- a/ci/make-doc.sbatch
+++ b/ci/make-doc.sbatch
@@ -31,3 +31,5 @@ make doc -j 50 VERBOSE=1
 
 # only executed if build passed
 echo "doc generated"
+cd ..
+rm -rf $DIR


### PR DESCRIPTION
Fixed CI script to delete the correct directory on success.