### PR TITLE
DLAF_AddTest improvement

### DIFF
--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -119,8 +119,8 @@ function(DLAF_addTest test_target_name)
     if (DLAF_AT_MPIRANKS GREATER MPIEXEC_MAX_NUMPROCS)
       message(WARNING "\
         YOU ARE ASKING FOR ${DLAF_AT_MPIRANKS} RANKS, BUT THERE ARE JUST ${MPIEXEC_MAX_NUMPROCS} CORES.
-        You can adjust MPIEXEC_MAX_NUMPROCS value to overcome this.
-        With OpenMPI it may be needed to set environment variable OMPI_MCA_rmaps_base_oversubscribe=1.")
+        You can adjust MPIEXEC_MAX_NUMPROCS value to suppress this warning.
+        Using OpenMPI may require to set the environment variable OMPI_MCA_rmaps_base_oversubscribe=1.")
     endif()
 
     target_compile_definitions(${test_target_name} PRIVATE NUM_MPI_RANKS=${DLAF_AT_MPIRANKS})

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -58,8 +58,14 @@ function(DLAF_addTest test_target_name)
   endif()
 
   set(_DLAF_MPI_MAINS "MPI;MPIHPX")
-  if (DLAF_AT_USE_MAIN IN_LIST _DLAF_MPI_MAINS AND NOT DLAF_AT_MPIRANKS)
-    message(FATAL_ERROR "You are asking for an MPI external main without specifying MPIRANKS")
+  if (DLAF_AT_USE_MAIN)
+    if (DLAF_AT_USE_MAIN IN_LIST _DLAF_MPI_MAINS AND NOT DLAF_AT_MPIRANKS)
+      message(FATAL_ERROR "You are asking for an MPI external main without specifying MPIRANKS")
+    endif()
+
+    if (DLAF_AT_MPIRANKS AND NOT DLAF_AT_USE_MAIN IN_LIST _DLAF_MPI_MAINS)
+      message(FATAL_ERROR "You specified MPIRANKS and asked for an external main without MPI")
+    endif()
   endif()
 
   ### Test executable target

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -14,6 +14,8 @@
 #   [INCLUDE_DIRS <arguments for target_include_directories>]
 #   [LIBRARIES <arguments for target_link_libraries>]
 #   [MPIRANKS <number of rank>]
+#   [MPI_OVERSUBSCRIBE]
+#   [USE_MAIN {PLAIN | HPX | MPI | MPIHPX}]
 # )
 #
 # At least one source file has to be specified, while other parameters are optional.
@@ -22,7 +24,17 @@
 # possible to specify PRIVATE/INTERFACE/PUBLIC modifiers.
 #
 # MPIRANKS specifies the number of ranks on which the test will be carried out and it implies a link with
-# MPI library.
+# MPI library. At build time the constant NUM_MPI_RANKS=MPIRANKS is set.
+#
+# MPI_OVERSUBSCRIBE flag allows to launch more ranks than number of cores available on the platform.
+# In case more ranks than cores are requested and this flag is not specified, it prints a warning message.
+#
+# USE_MAIN links to an external main function, in particular:
+#   - PLAIN: uses the classic gtest_main
+#   - HPX: uses a main that initializes HPX
+#   - MPI: uses a main that initializes MPI
+#   - MPIHPX: uses a main that initializes both HPX and MPI
+# If not specified, no external main is used and it should exist in the test source code.
 #
 # e.g.
 #
@@ -35,8 +47,8 @@
 # )
 
 function(DLAF_addTest test_target_name)
-  set(options "USE_GTEST_MAIN")
-  set(oneValueArgs MPIRANKS)
+  set(options MPI_OVERSUBSCRIBE)
+  set(oneValueArgs MPIRANKS USE_MAIN)
   set(multiValueArgs SOURCES COMPILE_DEFINITIONS INCLUDE_DIRS LIBRARIES ARGUMENTS)
   cmake_parse_arguments(DLAF_AT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -47,6 +59,15 @@ function(DLAF_addTest test_target_name)
 
   if (NOT DLAF_AT_SOURCES)
     message(FATAL_ERROR "No sources specified for this test")
+  endif()
+
+  if (NOT DLAF_AT_MPIRANKS AND DLAF_AT_MPI_OVERSUBSCRIBE)
+    message(FATAL_ERROR "You cannot specify MPI_OVERSUBSCRIBE without specifying MPIRANKS")
+  endif()
+
+  set(_DLAF_MPI_MAINS "MPI;MPIHPX")
+  if (DLAF_AT_USE_MAIN IN_LIST _DLAF_MPI_MAINS AND NOT DLAF_AT_MPIRANKS)
+    message(FATAL_ERROR "You are asking for an MPI external main without specifying MPIRANKS")
   endif()
 
   ### Test executable target
@@ -67,8 +88,19 @@ function(DLAF_addTest test_target_name)
 
   target_link_libraries(${test_target_name} PRIVATE DLAF)
   target_link_libraries(${test_target_name} PRIVATE DLAF_test)
-  if (DLAF_AT_USE_GTEST_MAIN)
-    target_link_libraries(${test_target_name} PRIVATE gtest_main)
+
+  if (DLAF_AT_USE_MAIN)
+    if (DLAF_AT_USE_MAIN STREQUAL PLAIN)
+      target_link_libraries(${test_target_name} PRIVATE gtest_main)
+    elseif (DLAF_AT_USE_MAIN STREQUAL HPX)
+      target_link_libraries(${test_target_name} PRIVATE DLAF_gtest_hpx_main)
+    elseif (DLAF_AT_USE_MAIN STREQUAL MPI)
+      target_link_libraries(${test_target_name} PRIVATE DLAF_gtest_mpi_main)
+    elseif (DLAF_AT_USE_MAIN STREQUAL MPIHPX)
+      message(FATAL_ERROR "USE_MAIN=${DLAF_AT_USE_MAIN} is not yet supported")
+    else()
+      message(FATAL_ERROR "USE_MAIN=${DLAF_AT_USE_MAIN} is not a supported option")
+    endif()
   else()
     target_link_libraries(${test_target_name} PRIVATE gtest)
   endif()
@@ -86,9 +118,13 @@ function(DLAF_addTest test_target_name)
       message(FATAL_ERROR "Wrong MPIRANKS number ${DLAF_AT_MPIRANKS}")
     endif()
 
-    if (DLAF_AT_MPIRANKS GREATER MPIEXEC_MAX_NUMPROCS)
-      message(FATAL_ERROR "Impossible to have more than ${MPIEXEC_MAX_NUMPROCS}")
+    if (DLAF_AT_MPIRANKS GREATER MPIEXEC_MAX_NUMPROCS AND NOT DLAF_AT_MPI_OVERSUBSCRIBE)
+      message(WARNING "\
+        YOU ARE ASKING FOR ${DLAF_AT_MPIRANKS} RANKS, BUT THERE ARE JUST ${MPIEXEC_MAX_NUMPROCS} CORES.
+        Use MPI_OVERSUBSCRIBE flag to overcome this: be careful, since this may lead to deadlocks.")
     endif()
+
+    target_compile_definitions(${test_target_name} PRIVATE NUM_MPI_RANKS=${DLAF_AT_MPIRANKS})
 
     target_link_libraries(${test_target_name}
       PRIVATE MPI::MPI_CXX

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -10,5 +10,17 @@
 
 add_library(DLAF_gtest_hpx_main STATIC gtest_hpx_main.cpp)
 target_include_directories(DLAF_gtest_hpx_main PRIVATE ${HPX_INCLUDE_DIRS})
-target_link_libraries(DLAF_gtest_hpx_main PRIVATE ${HPX_LIBRARIES})
-target_link_libraries(DLAF_gtest_hpx_main PRIVATE gtest)
+target_link_libraries(DLAF_gtest_hpx_main
+  PUBLIC
+    gtest
+  PRIVATE
+    ${HPX_LIBRARIES}
+)
+
+add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp)
+target_link_libraries(DLAF_gtest_mpi_main
+  PUBLIC
+    gtest
+  PRIVATE
+    MPI::MPI_CXX
+)

--- a/test/src/gtest_mpi_main.cpp
+++ b/test/src/gtest_mpi_main.cpp
@@ -1,0 +1,56 @@
+// Copyright 2006, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+GTEST_API_ int main(int argc, char* argv[]) {
+  std::printf("Running main() from gtest_mpi_main.cpp\n");
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  MPI_Init(&argc, &argv);
+
+  int result = 0;
+  result = RUN_ALL_TESTS();
+
+  MPI_Finalize();
+
+  return result;
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_util_math SOURCES test_util_math.cpp USE_GTEST_MAIN)
-DLAF_addTest(test_tile SOURCES test_tile.cpp LIBRARIES PRIVATE DLAF_gtest_hpx_main)
+DLAF_addTest(test_util_math SOURCES test_util_math.cpp USE_MAIN PLAIN)
+DLAF_addTest(test_tile SOURCES test_tile.cpp USE_MAIN HPX)
 
 add_subdirectory(memory)

--- a/test/unit/memory/CMakeLists.txt
+++ b/test/unit/memory/CMakeLists.txt
@@ -8,5 +8,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_memory_chunk SOURCES test_memory_chunk.cpp USE_GTEST_MAIN)
-DLAF_addTest(test_memory_view SOURCES test_memory_view.cpp USE_GTEST_MAIN)
+DLAF_addTest(test_memory_chunk SOURCES test_memory_chunk.cpp USE_MAIN PLAIN)
+DLAF_addTest(test_memory_view SOURCES test_memory_view.cpp USE_MAIN PLAIN)


### PR DESCRIPTION
Close #43 

- new option MPI_OVERSUBSCRIBE
- changed option from USE_GTEST_MAIN to USE_MAIN, which allows to
select different types of external main (PLAIN, HPX, MPI, MPIHPX)
- update related documentation