### PR TITLE
MPI Pretty printer for GTest

### DIFF
--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(DLAF_gtest_hpx_main
     ${HPX_LIBRARIES}
 )
 
-add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp)
+add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp gtest_mpi_listener.cpp)
 target_link_libraries(DLAF_gtest_mpi_main
   PUBLIC
     gtest

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -94,9 +94,7 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
     }
   }
 
-  makeMasterFailIfAnyoneFailed(test_info);
-
-  MASTER_CALLS_DEFAULT_LISTENER(OnTestEnd, test_info);
+  OnTestEndAllRanks(test_info);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -117,7 +115,7 @@ bool MPIListener::isMasterRank() const {
   return rank_ == 0;
 }
 
-void MPIListener::makeMasterFailIfAnyoneFailed(const ::testing::TestInfo& test_info) const {
+void MPIListener::OnTestEndAllRanks(const ::testing::TestInfo& test_info) const {
   bool is_local_passed = test_info.result()->Passed();
 
   bool all_tests_passed[world_size_];
@@ -134,10 +132,12 @@ void MPIListener::makeMasterFailIfAnyoneFailed(const ::testing::TestInfo& test_i
   // and they have been already printed, it won't generate output in any case
   EXPECT_EQ(0, how_many_ranks_failed);
 
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestEnd, test_info);
+
   if (how_many_ranks_failed == 0)
     return;
 
-  printf("[  FAILED  ] %ld of %d ranks failed\n", how_many_ranks_failed, world_size_);
+  printf("[  INFO    ] %ld of %d ranks failed\n", how_many_ranks_failed, world_size_);
   fflush(stdout);
 }
 

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -126,13 +126,18 @@ void MPIListener::makeMasterFailIfAnyoneFailed(const ::testing::TestInfo& test_i
   if (!isMasterRank())
     return;
 
-  auto all_passed =
-      std::all_of(all_tests_passed, all_tests_passed + world_size_, [](bool result) { return result; });
+  auto how_many_ranks_failed = std::count(all_tests_passed, all_tests_passed + world_size_, false);
 
   // exploit this to make the master rank fail if any rank failed
   // as a side-effect it calls OnTestPartResult, but since it just collects error messages,
   // and they have been already printed, it won't generate output in any case
-  EXPECT_TRUE(all_passed);
+  EXPECT_EQ(0, how_many_ranks_failed);
+
+  if (how_many_ranks_failed == 0)
+    return;
+
+  printf("[  FAILED  ] %ld of %d ranks failed\n", how_many_ranks_failed, world_size_);
+  fflush(stdout);
 }
 
 namespace internal {

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -1,0 +1,90 @@
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "gtest_mpi_listener.h"
+
+#include <vector>
+#include <algorithm>
+
+MPIListener::MPIListener(int argc, char** argv) : argc_(argc), argv_(argv) {}
+
+void MPIListener::OnTestProgramStart(const ::testing::UnitTest& unit_test) {
+  MPI_Init(&argc_, &argv_);
+
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size_);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+}
+
+void MPIListener::OnTestProgramEnd(const ::testing::UnitTest& unit_test) {
+  MPI_Finalize();
+}
+
+// Called before a test starts.
+void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
+  if (!isMainRank())
+    return;
+}
+
+// Called after a failed assertion or a SUCCESS().
+void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {
+  std::ostringstream error_description;
+
+  error_description
+    << (test_part_result.failed() ? "Failure" : "Success")
+    << " in " << test_part_result.file_name() << ":" << test_part_result.line_number() << std::endl
+    << test_part_result.summary() << std::endl;
+
+  last_test_result_ = error_description.str();
+}
+
+// Called after a test ends.
+void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
+  int result = test_info.result()->Passed();
+
+  std::vector<int> results(world_size_, 0);
+  MPI_Gather(&result, 1, MPI_INT, results.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  if (isMainRank()) {
+    bool final_result = std::all_of(results.begin(), results.end(), [](bool r) { return r; });
+
+    printf("*** Test %s.%s RESULT = %s\n", test_info.test_case_name(), test_info.name(), final_result ? "OK" : "FAILED");
+
+    // RANK 0
+    assert(result == results[rank_]);
+
+    if (!result)
+      printf("[R%d] %s\n", rank_, last_test_result_.c_str());
+  }
+
+  for (int rank = 1; rank < world_size_; rank++) {
+    if (isMainRank()) {
+      if(!results[rank]) {
+        MPI_Status status;
+        MPI_Probe(rank, 0, MPI_COMM_WORLD, &status);
+
+        int number_amount;
+        MPI_Get_count(&status, MPI_CHAR, &number_amount);
+
+        char rank_error_message[number_amount];
+        MPI_Recv(rank_error_message, number_amount, MPI_CHAR, rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+        printf("[R%d] %s\n", rank, rank_error_message);
+      }
+    }
+    else if(rank_ == rank) {
+      if (!result) {
+        MPI_Send(last_test_result_.c_str(), last_test_result_.size() + 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+      }
+    }
+  }
+}
+
+bool MPIListener::isMainRank() const {
+  return rank_ == 0;
+}

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -10,79 +10,147 @@
 #include "gtest_mpi_listener.h"
 
 #include <algorithm>
-#include <vector>
 
-MPIListener::MPIListener(int argc, char** argv) : argc_(argc), argv_(argv) {}
+#define MASTER_CALLS_DEFAULT_LISTENER(name, ...) \
+  if (isMasterRank())                            \
+    listener_->name(__VA_ARGS__);
 
-void MPIListener::OnTestProgramStart(const ::testing::UnitTest& unit_test) {
-  MPI_Init(&argc_, &argv_);
+namespace internal {
+void mpi_send_string(const std::string& message, int to_rank);
+std::string mpi_receive_string(int from_rank);
+}
 
+MPIListener::MPIListener(int argc, char** argv, ::testing::TestEventListener* other)
+    : listener_(std::move(other)) {
+  MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &world_size_);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+}
+
+void MPIListener::OnTestProgramStart(const ::testing::UnitTest& unit_test) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestProgramStart, unit_test);
+}
+
+void MPIListener::OnTestIterationStart(const ::testing::UnitTest& unit_test, int iteration) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestIterationStart, unit_test, iteration);
+}
+
+void MPIListener::OnEnvironmentsSetUpStart(const ::testing::UnitTest& unit_test) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnEnvironmentsSetUpStart, unit_test);
+}
+
+void MPIListener::OnEnvironmentsSetUpEnd(const ::testing::UnitTest& unit_test) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnEnvironmentsSetUpEnd, unit_test);
+}
+
+void MPIListener::OnTestCaseStart(const ::testing::TestCase& test_case) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestCaseStart, test_case);
+}
+
+void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestStart, test_info);
+}
+
+void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {
+  std::ostringstream os;
+  os << test_part_result;
+  last_test_part_results_.push_back(os.str());
+}
+
+void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
+  auto print_partial_results = [this](int rank, int total_results,
+                                      std::function<std::string(int)> get_result) {
+    if (total_results <= 0)
+      return;
+
+    printf("[ RANK  %2d ]\n", rank);
+    for (auto index_result = 0; index_result < total_results; ++index_result)
+      printf("%s", get_result(index_result).c_str());
+  };
+
+  for (int rank = 0; rank < world_size_; ++rank) {
+    if (isMasterRank()) {
+      int number_of_results;
+      std::function<std::string(int)> get_result;
+
+      if (rank == 0) {
+        number_of_results = last_test_part_results_.size();
+        get_result = [this](int index) { return last_test_part_results_[index]; };
+      }
+      else {
+        MPI_Recv(&number_of_results, 1, MPI_INT, rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        get_result = [rank](int) { return internal::mpi_receive_string(rank); };
+      }
+
+      print_partial_results(rank, number_of_results, get_result);
+    }
+    else if (rank_ == rank) {
+      int num_partial_results = last_test_part_results_.size();
+      MPI_Send(&num_partial_results, 1, MPI_INT, 0, 0, MPI_COMM_WORLD);
+
+      for (const auto& partial_result : last_test_part_results_)
+        internal::mpi_send_string(partial_result, 0);
+    }
+  }
+
+  OnAllRanksTestEnd(test_info);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+void MPIListener::OnEnvironmentsTearDownStart(const ::testing::UnitTest& unit_test) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnEnvironmentsTearDownStart, unit_test);
+}
+
+void MPIListener::OnEnvironmentsTearDownEnd(const ::testing::UnitTest& unit_test) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnEnvironmentsTearDownEnd, unit_test);
 }
 
 void MPIListener::OnTestProgramEnd(const ::testing::UnitTest& unit_test) {
   MPI_Finalize();
 }
 
-void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
-  last_test_result_ = "";
-}
-
-void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {
-  std::ostringstream error_description;
-
-  error_description << "- " << (test_part_result.failed() ? "Failure" : "Success") << " in "
-                    << test_part_result.file_name() << ":" << test_part_result.line_number() << std::endl
-                    << test_part_result.summary() << std::endl;
-
-  last_test_result_ += error_description.str();
-}
-
-void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
-  int result = test_info.result()->Passed();
-
-  std::vector<int> results(world_size_, 0);
-  MPI_Gather(&result, 1, MPI_INT, results.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-  if (isMainRank()) {
-    bool final_result = std::all_of(results.begin(), results.end(), [](bool r) { return r; });
-
-    printf("*** Test %s.%s RESULT = %s\n", test_info.test_case_name(), test_info.name(),
-           final_result ? "OK" : "FAILED");
-  }
-
-  for (int rank = 0; rank < world_size_; rank++) {
-    if (isMainRank()) {
-      std::string rank_error_message;
-      if (!results[rank]) {
-        if (rank != 0) {
-          MPI_Status status;
-          MPI_Probe(rank, 0, MPI_COMM_WORLD, &status);
-
-          int number_amount;
-          MPI_Get_count(&status, MPI_CHAR, &number_amount);
-
-          char buffer[number_amount];
-          MPI_Recv(buffer, number_amount, MPI_CHAR, rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-          rank_error_message = buffer;
-        }
-        else
-          rank_error_message = last_test_result_;
-
-        printf("[R%d]\n%s", rank, rank_error_message.c_str());
-      }
-    }
-    else if (rank_ == rank) {
-      if (!result) {
-        MPI_Send(last_test_result_.c_str(), last_test_result_.size() + 1, MPI_CHAR, 0, 0,
-                 MPI_COMM_WORLD);
-      }
-    }
-  }
-}
-
-bool MPIListener::isMainRank() const {
+bool MPIListener::isMasterRank() const {
   return rank_ == 0;
+}
+
+void MPIListener::OnAllRanksTestEnd(const ::testing::TestInfo& test_info) const {
+  bool is_local_passed = test_info.result()->Passed();
+
+  bool all_tests_passed[world_size_];
+  MPI_Gather(&is_local_passed, 1, MPI_BYTE, isMasterRank() ? &all_tests_passed : nullptr, 1, MPI_BYTE, 0,
+             MPI_COMM_WORLD);
+
+  if (!isMasterRank())
+    return;
+
+  auto all_passed =
+      std::all_of(all_tests_passed, all_tests_passed + world_size_, [](bool result) { return result; });
+
+  if (all_passed)
+    printf("[       OK ] ");
+  else
+    printf("[  FAILED  ] ");
+
+  printf("%s.%s\n", test_info.test_case_name(), test_info.name());
+  fflush(stdout);
+}
+
+namespace internal {
+void mpi_send_string(const std::string& message, int to_rank) {
+  MPI_Send(message.c_str(), message.size() + 1, MPI_CHAR, to_rank, 0, MPI_COMM_WORLD);
+}
+
+std::string mpi_receive_string(int from_rank) {
+  MPI_Status status;
+  MPI_Probe(from_rank, 0, MPI_COMM_WORLD, &status);
+
+  int message_length;
+  MPI_Get_count(&status, MPI_CHAR, &message_length);
+
+  char message_buffer[message_length];
+  MPI_Recv(message_buffer, message_length, MPI_CHAR, from_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+  return message_buffer;
+}
 }

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -25,15 +25,10 @@ void MPIListener::OnTestProgramEnd(const ::testing::UnitTest& unit_test) {
   MPI_Finalize();
 }
 
-// Called before a test starts.
 void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
   last_test_result_ = "";
-
-  if (!isMainRank())
-    return;
 }
 
-// Called after a failed assertion or a SUCCESS().
 void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {
   std::ostringstream error_description;
 
@@ -44,7 +39,6 @@ void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_re
   last_test_result_ += error_description.str();
 }
 
-// Called after a test ends.
 void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
   int result = test_info.result()->Passed();
 
@@ -56,7 +50,6 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
 
     printf("*** Test %s.%s RESULT = %s\n", test_info.test_case_name(), test_info.name(),
            final_result ? "OK" : "FAILED");
-
   }
 
   for (int rank = 0; rank < world_size_; rank++) {

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -9,8 +9,8 @@
 
 #include "gtest_mpi_listener.h"
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 MPIListener::MPIListener(int argc, char** argv) : argc_(argc), argv_(argv) {}
 
@@ -37,10 +37,9 @@ void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
 void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {
   std::ostringstream error_description;
 
-  error_description
-    << "- " << (test_part_result.failed() ? "Failure" : "Success")
-    << " in " << test_part_result.file_name() << ":" << test_part_result.line_number() << std::endl
-    << test_part_result.summary() << std::endl;
+  error_description << "- " << (test_part_result.failed() ? "Failure" : "Success") << " in "
+                    << test_part_result.file_name() << ":" << test_part_result.line_number() << std::endl
+                    << test_part_result.summary() << std::endl;
 
   last_test_result_ += error_description.str();
 }
@@ -55,14 +54,15 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
   if (isMainRank()) {
     bool final_result = std::all_of(results.begin(), results.end(), [](bool r) { return r; });
 
-    printf("*** Test %s.%s RESULT = %s\n", test_info.test_case_name(), test_info.name(), final_result ? "OK" : "FAILED");
+    printf("*** Test %s.%s RESULT = %s\n", test_info.test_case_name(), test_info.name(),
+           final_result ? "OK" : "FAILED");
 
   }
 
   for (int rank = 0; rank < world_size_; rank++) {
     if (isMainRank()) {
       std::string rank_error_message;
-      if(!results[rank]) {
+      if (!results[rank]) {
         if (rank != 0) {
           MPI_Status status;
           MPI_Probe(rank, 0, MPI_COMM_WORLD, &status);
@@ -81,9 +81,10 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
         printf("[R%d]\n%s", rank, rank_error_message.c_str());
       }
     }
-    else if(rank_ == rank) {
+    else if (rank_ == rank) {
       if (!result) {
-        MPI_Send(last_test_result_.c_str(), last_test_result_.size() + 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
+        MPI_Send(last_test_result_.c_str(), last_test_result_.size() + 1, MPI_CHAR, 0, 0,
+                 MPI_COMM_WORLD);
       }
     }
   }

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -99,12 +99,20 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
+void MPIListener::OnTestCaseEnd(const ::testing::TestCase& test_case) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestCaseEnd, test_case);
+}
+
 void MPIListener::OnEnvironmentsTearDownStart(const ::testing::UnitTest& unit_test) {
   MASTER_CALLS_DEFAULT_LISTENER(OnEnvironmentsTearDownStart, unit_test);
 }
 
 void MPIListener::OnEnvironmentsTearDownEnd(const ::testing::UnitTest& unit_test) {
   MASTER_CALLS_DEFAULT_LISTENER(OnEnvironmentsTearDownEnd, unit_test);
+}
+
+void MPIListener::OnTestIterationEnd(const ::testing::UnitTest& unit_test, int iteration) {
+  MASTER_CALLS_DEFAULT_LISTENER(OnTestIterationEnd, unit_test, iteration);
 }
 
 void MPIListener::OnTestProgramEnd(const ::testing::UnitTest& unit_test) {

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -49,6 +49,7 @@ void MPIListener::OnTestCaseStart(const ::testing::TestCase& test_case) {
 
 void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
   MASTER_CALLS_DEFAULT_LISTENER(OnTestStart, test_info);
+  last_test_part_results_.clear();
 }
 
 void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -27,6 +27,8 @@ void MPIListener::OnTestProgramEnd(const ::testing::UnitTest& unit_test) {
 
 // Called before a test starts.
 void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
+  last_test_result_ = "";
+
   if (!isMainRank())
     return;
 }
@@ -36,11 +38,11 @@ void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_re
   std::ostringstream error_description;
 
   error_description
-    << (test_part_result.failed() ? "Failure" : "Success")
+    << "- " << (test_part_result.failed() ? "Failure" : "Success")
     << " in " << test_part_result.file_name() << ":" << test_part_result.line_number() << std::endl
     << test_part_result.summary() << std::endl;
 
-  last_test_result_ = error_description.str();
+  last_test_result_ += error_description.str();
 }
 
 // Called after a test ends.
@@ -59,7 +61,7 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
     assert(result == results[rank_]);
 
     if (!result)
-      printf("[R%d] %s\n", rank_, last_test_result_.c_str());
+      printf("[R%d]\n%s", rank_, last_test_result_.c_str());
   }
 
   for (int rank = 1; rank < world_size_; rank++) {
@@ -74,7 +76,7 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
         char rank_error_message[number_amount];
         MPI_Recv(rank_error_message, number_amount, MPI_CHAR, rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
-        printf("[R%d] %s\n", rank, rank_error_message);
+        printf("[R%d]\n%s", rank, rank_error_message);
       }
     }
     else if(rank_ == rank) {

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -29,8 +29,6 @@ protected:
 private:
   bool isMainRank() const;
 
-  void printTestFailure(const ::testing::TestPartResult& test_result) const;
-
   int argc_;
   char** argv_;
 

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -10,30 +10,37 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <mpi.h>
 
-class MPIListener : public ::testing::EmptyTestEventListener {
+class MPIListener : public ::testing::TestEventListener {
 public:
-  MPIListener(int argc, char** argv);
+  MPIListener(int argc, char** argv, ::testing::TestEventListener* other);
 
 protected:
   virtual void OnTestProgramStart(const ::testing::UnitTest& unit_test) override;
-  virtual void OnTestProgramEnd(const ::testing::UnitTest& unit_test) override;
-
+  virtual void OnTestIterationStart(const ::testing::UnitTest& unit_test, int iteration) override;
+  virtual void OnEnvironmentsSetUpStart(const ::testing::UnitTest& unit_test) override;
+  virtual void OnEnvironmentsSetUpEnd(const ::testing::UnitTest& unit_test) override;
+  virtual void OnTestCaseStart(const ::testing::TestCase& test_case) override;
   virtual void OnTestStart(const ::testing::TestInfo& test_info) override;
   virtual void OnTestPartResult(const ::testing::TestPartResult& test_part_result) override;
   virtual void OnTestEnd(const ::testing::TestInfo& test_info) override;
+  virtual void OnTestCaseEnd(const ::testing::TestCase& test_case) override {}
+  virtual void OnEnvironmentsTearDownStart(const ::testing::UnitTest& unit_test) override;
+  virtual void OnEnvironmentsTearDownEnd(const ::testing::UnitTest& unit_test) override;
+  virtual void OnTestIterationEnd(const ::testing::UnitTest& unit_test, int iteration) override {}
+  virtual void OnTestProgramEnd(const ::testing::UnitTest& unit_test) override;
 
 private:
-  bool isMainRank() const;
-
-  int argc_;
-  char** argv_;
+  bool isMasterRank() const;
+  void OnAllRanksTestEnd(const ::testing::TestInfo& test_info) const;
 
   int rank_;
   int world_size_;
 
-  std::string last_test_result_;
+  std::vector<std::string> last_test_part_results_;
+  std::unique_ptr<::testing::TestEventListener> listener_;
 };

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -36,7 +36,7 @@ protected:
 
 private:
   bool isMasterRank() const;
-  void makeMasterFailIfAnyoneFailed(const ::testing::TestInfo& test_info) const;
+  void OnTestEndAllRanks(const ::testing::TestInfo& test_info) const;
 
   int rank_;
   int world_size_;

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -28,10 +28,10 @@ protected:
   virtual void OnTestStart(const ::testing::TestInfo& test_info) override;
   virtual void OnTestPartResult(const ::testing::TestPartResult& test_part_result) override;
   virtual void OnTestEnd(const ::testing::TestInfo& test_info) override;
-  virtual void OnTestCaseEnd(const ::testing::TestCase& test_case) override {}
+  virtual void OnTestCaseEnd(const ::testing::TestCase& test_case) override;
   virtual void OnEnvironmentsTearDownStart(const ::testing::UnitTest& unit_test) override;
   virtual void OnEnvironmentsTearDownEnd(const ::testing::UnitTest& unit_test) override;
-  virtual void OnTestIterationEnd(const ::testing::UnitTest& unit_test, int iteration) override {}
+  virtual void OnTestIterationEnd(const ::testing::UnitTest& unit_test, int iteration) override;
   virtual void OnTestProgramEnd(const ::testing::UnitTest& unit_test) override;
 
 private:

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -36,7 +36,7 @@ protected:
 
 private:
   bool isMasterRank() const;
-  void OnAllRanksTestEnd(const ::testing::TestInfo& test_info) const;
+  void makeMasterFailIfAnyoneFailed(const ::testing::TestInfo& test_info) const;
 
   int rank_;
   int world_size_;

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -1,0 +1,41 @@
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+class MPIListener : public ::testing::EmptyTestEventListener {
+public:
+  MPIListener(int argc, char** argv);
+
+protected:
+  virtual void OnTestProgramStart(const ::testing::UnitTest& unit_test) override;
+  virtual void OnTestProgramEnd(const ::testing::UnitTest& unit_test) override;
+
+  virtual void OnTestStart(const ::testing::TestInfo& test_info) override;
+  virtual void OnTestPartResult(const ::testing::TestPartResult& test_part_result) override;
+  virtual void OnTestEnd(const ::testing::TestInfo& test_info) override;
+
+private:
+  bool isMainRank() const;
+
+  void printTestFailure(const ::testing::TestPartResult & test_result) const;
+
+  int argc_;
+  char** argv_;
+
+  int rank_;
+  int world_size_;
+
+  std::string last_test_result_;
+};

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -29,7 +29,7 @@ protected:
 private:
   bool isMainRank() const;
 
-  void printTestFailure(const ::testing::TestPartResult & test_result) const;
+  void printTestFailure(const ::testing::TestPartResult& test_result) const;
 
   int argc_;
   char** argv_;

--- a/test/src/gtest_mpi_main.cpp
+++ b/test/src/gtest_mpi_main.cpp
@@ -40,17 +40,22 @@
 #include <gtest/gtest.h>
 #include <mpi.h>
 
-GTEST_API_ int main(int argc, char* argv[]) {
-  std::printf("Running main() from gtest_mpi_main.cpp\n");
+#include "gtest_mpi_listener.h"
 
+GTEST_API_ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
 
-  MPI_Init(&argc, &argv);
+  // Gets hold of the event listener list.
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+
+  // Delete the default one
+  delete listeners.Release(listeners.default_result_printer());
+
+  // Adds MPIListener to the end. googletest takes the ownership.
+  listeners.Append(new MPIListener(argc, argv));
 
   int result = 0;
   result = RUN_ALL_TESTS();
-
-  MPI_Finalize();
 
   return result;
 }

--- a/test/src/gtest_mpi_main.cpp
+++ b/test/src/gtest_mpi_main.cpp
@@ -48,11 +48,9 @@ GTEST_API_ int main(int argc, char* argv[]) {
   // Gets hold of the event listener list.
   ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
 
-  // Delete the default one
-  delete listeners.Release(listeners.default_result_printer());
-
   // Adds MPIListener to the end. googletest takes the ownership.
-  listeners.Append(new MPIListener(argc, argv));
+  auto default_listener = listeners.Release(listeners.default_result_printer());
+  listeners.Append(new MPIListener(argc, argv, default_listener));
 
   int result = 0;
   result = RUN_ALL_TESTS();


### PR DESCRIPTION
Close #50 

Implement a GTest listener for MPI as a wrapper of the default one; It manages MPI library initialization and finalization and, in addition, it does all the output stuff on master rank 0.

Since it is not possible to fully serialize googletest data structures, it was not possible to collect original information from all ranks; For this reason, the output is pretty similar but not perfectly equal to the default one.

It collects failing assertion messages from all ranks, and once the test reaches the end, it prints a summary rank-by-rank.

Tested just with very trivial example and basic TEST type (e.g. not tested with TEST_SUITE, TYPED_TEST, ...).