### PR TITLE
LayoutInfo and MatrixBase objects

### DIFF
--- a/include/dlaf/matrix/index.h
+++ b/include/dlaf/matrix/index.h
@@ -1,0 +1,35 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include "dlaf/common/index2d.h"
+#include "dlaf/types.h"
+
+namespace dlaf {
+namespace matrix {
+struct GlobalElement_TAG;
+struct GlobalTile_TAG;
+struct LocalTile_TAG;
+struct TileElement_TAG;
+}
+
+using GlobalElementIndex = common::Index2D<SizeType, matrix::GlobalElement_TAG>;
+using GlobalElementSize = common::Size2D<SizeType, matrix::GlobalElement_TAG>;
+
+using GlobalTileIndex = common::Index2D<SizeType, matrix::GlobalTile_TAG>;
+using GlobalTileSize = common::Size2D<SizeType, matrix::GlobalTile_TAG>;
+
+using LocalTileIndex = common::Index2D<SizeType, matrix::LocalTile_TAG>;
+using LocalTileSize = common::Size2D<SizeType, matrix::LocalTile_TAG>;
+
+using TileElementIndex = common::Index2D<SizeType, matrix::TileElement_TAG>;
+using TileElementSize = common::Size2D<SizeType, matrix::TileElement_TAG>;
+}

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -1,0 +1,80 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+#include "dlaf/matrix/index.h"
+#include "dlaf/util_math.h"
+
+namespace dlaf {
+namespace matrix {
+class LayoutInfo {
+public:
+  LayoutInfo(GlobalElementSize size, TileElementSize block_size, SizeType tile_ld,
+             std::size_t tile_offset_row, std::size_t tile_offset_col);
+
+  std::size_t tileOffset(LocalTileIndex index) const {
+    // TODO checks
+    return index.row() * tile_offset_row_ + index.col() * tile_offset_col_;
+  }
+
+  std::size_t minMemSize() const noexcept {
+    if (size_.rows() == 0 || size_.cols() == 0) {
+      return 0;
+    }
+
+    SizeType last_rows = size_.rows() - block_size_.rows() * (nr_tiles_.rows() - 1);
+    SizeType last_cols = size_.cols() - block_size_.cols() * (nr_tiles_.cols() - 1);
+
+    return tileOffset({nr_tiles_.rows() - 1, nr_tiles_.cols() - 1}) +
+           static_cast<std::size_t>(ld_tile_) * static_cast<std::size_t>(last_cols - 1) + last_rows;
+  }
+
+  GlobalElementSize size() const noexcept {
+    return size_;
+  }
+
+  LocalTileSize nrTiles() const noexcept {
+    return nr_tiles_;
+  }
+
+  TileElementSize blockSize() const noexcept {
+    return block_size_;
+  }
+
+  SizeType ldTile() const noexcept {
+    return ld_tile_;
+  }
+
+private:
+  std::size_t minTileSize(TileElementSize size) const noexcept;
+
+  GlobalElementSize size_;
+  LocalTileSize nr_tiles_;
+  TileElementSize block_size_;
+
+  SizeType ld_tile_;
+  std::size_t tile_offset_row_;
+  std::size_t tile_offset_col_;
+};
+
+inline LayoutInfo ColMajorLayout(GlobalElementSize size, TileElementSize block_size, SizeType ld) {
+  using util::size_t::mul;
+  return LayoutInfo(size, block_size, ld, static_cast<std::size_t>(block_size.rows()),
+                    mul(block_size.cols(), ld));
+}
+
+inline LayoutInfo TileLayout(GlobalElementSize size, TileElementSize block_size, SizeType ld_tile,
+                             SizeType tiles_per_col) {
+  using util::size_t::mul;
+  std::size_t tile_size = mul(ld_tile, block_size.cols());
+  return LayoutInfo(size, block_size, ld_tile, tile_size, mul(tile_size, tiles_per_col));
+}
+}
+}

--- a/include/dlaf/matrix_base.h
+++ b/include/dlaf/matrix_base.h
@@ -1,0 +1,61 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+#include "dlaf/matrix/index.h"
+#include "dlaf/matrix/layout_info.h"
+#include "dlaf/util_math.h"
+
+namespace dlaf {
+
+class MatrixBase {
+public:
+  MatrixBase() noexcept;
+
+  MatrixBase(GlobalElementSize size, TileElementSize block_size);
+
+  MatrixBase(matrix::LayoutInfo layout) noexcept;
+
+  MatrixBase(const MatrixBase& rhs) = default;
+
+  MatrixBase(MatrixBase&& rhs) noexcept;
+
+  MatrixBase& operator=(const MatrixBase& rhs) = default;
+
+  MatrixBase& operator=(MatrixBase&& rhs) noexcept;
+
+  bool operator==(const MatrixBase& rhs) const noexcept {
+    return size_ == rhs.size_ && nr_tiles_ == rhs.nr_tiles_ && block_size_ == rhs.block_size_;
+  }
+
+  bool operator!=(const MatrixBase& rhs) const noexcept {
+    return !operator==(rhs);
+  }
+
+  GlobalElementSize size() const noexcept {
+    return size_;
+  }
+
+  LocalTileSize nrTiles() const noexcept {
+    return nr_tiles_;
+  }
+
+  TileElementSize blockSize() const noexcept {
+    return block_size_;
+  }
+
+private:
+  GlobalElementSize size_;
+  LocalTileSize nr_tiles_;
+  TileElementSize block_size_;
+
+  // id and size rank_src in 2D grid.
+};
+}

--- a/include/dlaf/matrix_base.h
+++ b/include/dlaf/matrix_base.h
@@ -15,12 +15,18 @@
 
 namespace dlaf {
 
+/// @brief MatrixBase contains the information about the size (TODO: and distribution) of a matrix.
+/// It is used as base for the Matrix class.
 class MatrixBase {
 public:
   MatrixBase() noexcept;
 
+  /// @brief Construct matrix information for a matrix of size @p size and block size @p block_size.yy
+  /// @throw std::invalid_argument if size.rows() < 0 or size.cols() < 0.
+  /// @throw std::invalid_argument if block_size.rows() < 1 or block_size.cols() < 1.
   MatrixBase(GlobalElementSize size, TileElementSize block_size);
 
+  /// @brief Construct matrix information from the layout informations.
   MatrixBase(matrix::LayoutInfo layout) noexcept;
 
   MatrixBase(const MatrixBase& rhs) = default;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(DLAF
   communication/communicator_impl.cpp
   communication/communicator.cpp
   communication/communicator_grid.cpp
+  matrix/layout_info.cpp
+  matrix_base.cpp
 )
 
 target_include_directories(DLAF

--- a/src/matrix/layout_info.cpp
+++ b/src/matrix/layout_info.cpp
@@ -1,0 +1,73 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/matrix/layout_info.h"
+#include "dlaf/util_math.h"
+
+namespace dlaf {
+namespace matrix {
+LayoutInfo::LayoutInfo(GlobalElementSize size, TileElementSize block_size, SizeType tile_ld,
+                       std::size_t tile_offset_row, std::size_t tile_offset_col)
+    : size_(size), nr_tiles_(0, 0), block_size_(block_size), ld_tile_(tile_ld),
+      tile_offset_row_(tile_offset_row), tile_offset_col_(tile_offset_col) {
+  using util::size_t::sum;
+  using util::size_t::mul;
+
+  if (size_.rows() < 0 || size_.cols() < 0)
+    throw std::invalid_argument("Error: Invalid Matrix size");
+  if (block_size_.rows() < 1 || block_size_.cols() < 1)
+    throw std::invalid_argument("Error: Invalid Block size");
+
+  nr_tiles_ = {util::ceilDiv(size_.rows(), block_size_.rows()),
+               util::ceilDiv(size_.cols(), block_size_.cols())};
+
+  if (size_.rows() == 0 || size_.cols() == 0) {
+    if (ld_tile_ < 1) {
+      throw std::invalid_argument("Error: Invalid Leading Dimension");
+    }
+    if (tile_offset_row_ < 1) {
+      throw std::invalid_argument("Error: Invalid Tile Row Offset");
+    }
+    if (tile_offset_col_ < 1) {
+      throw std::invalid_argument("Error: Invalid Tile Col Offset");
+    }
+  }
+  else {
+    SizeType last_rows = size_.rows() - block_size_.rows() * (nr_tiles_.rows() - 1);
+
+    if (ld_tile_ < block_size_.rows()) {
+      throw std::invalid_argument("Error: Invalid Leading Dimension");
+    }
+    if (tile_offset_row_ < static_cast<std::size_t>(block_size_.rows())) {
+      throw std::invalid_argument("Error: Invalid Tile Row Offset");
+    }
+    if (tile_offset_row_ < minTileSize(block_size_) &&
+        static_cast<std::size_t>(ld_tile_) <
+            sum(mul((nr_tiles_.rows() - 1), tile_offset_row_), last_rows)) {
+      throw std::invalid_argument("Error: Invalid Leading Dimension & Tile Row Offset combination");
+    }
+    if (tile_offset_col_ <
+        mul(nr_tiles_.rows() - 1, tile_offset_row_) + minTileSize({last_rows, block_size_.cols()})) {
+      throw std::invalid_argument("Error: Invalid Tile Col Offset");
+    }
+  }
+}
+
+std::size_t LayoutInfo::minTileSize(TileElementSize size) const noexcept {
+  using util::size_t::sum;
+  using util::size_t::mul;
+
+  if (size_.rows() == 0 || size_.cols() == 0)
+    return 0;
+
+  return sum(size.rows(), mul(ld_tile_, size.cols() - 1));
+}
+}
+}

--- a/src/matrix/layout_info.cpp
+++ b/src/matrix/layout_info.cpp
@@ -60,11 +60,22 @@ LayoutInfo::LayoutInfo(GlobalElementSize size, TileElementSize block_size, SizeT
   }
 }
 
+std::size_t LayoutInfo::minMemSize() const noexcept {
+  if (size_.rows() == 0 || size_.cols() == 0) {
+    return 0;
+  }
+
+  SizeType last_rows = size_.rows() - block_size_.rows() * (nr_tiles_.rows() - 1);
+  SizeType last_cols = size_.cols() - block_size_.cols() * (nr_tiles_.cols() - 1);
+
+  return tileOffset({nr_tiles_.rows() - 1, nr_tiles_.cols() - 1}) + minTileSize({last_rows, last_cols});
+}
+
 std::size_t LayoutInfo::minTileSize(TileElementSize size) const noexcept {
   using util::size_t::sum;
   using util::size_t::mul;
 
-  if (size_.rows() == 0 || size_.cols() == 0)
+  if (size.rows() == 0 || size.cols() == 0)
     return 0;
 
   return sum(size.rows(), mul(ld_tile_, size.cols() - 1));

--- a/src/matrix_base.cpp
+++ b/src/matrix_base.cpp
@@ -1,0 +1,48 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/matrix_base.h"
+
+namespace dlaf {
+MatrixBase::MatrixBase() noexcept : size_(0, 0), nr_tiles_(0, 0), block_size_(1, 1) {}
+
+MatrixBase::MatrixBase(GlobalElementSize size, TileElementSize block_size)
+    : size_(size), nr_tiles_(0, 0), block_size_(block_size) {
+  if (size_.rows() < 0 || size_.cols() < 0)
+    throw std::invalid_argument("Error: Invalid Matrix size");
+  if (block_size_.rows() < 1 || block_size_.cols() < 1)
+    throw std::invalid_argument("Error: Invalid Block size");
+
+  nr_tiles_ = {util::ceilDiv(size.rows(), block_size.rows()),
+               util::ceilDiv(size.cols(), block_size.cols())};
+}
+
+MatrixBase::MatrixBase(matrix::LayoutInfo layout) noexcept
+    : size_(layout.size()), nr_tiles_(layout.nrTiles()), block_size_(layout.blockSize()) {}
+
+MatrixBase::MatrixBase(MatrixBase&& rhs) noexcept
+    : size_(rhs.size_), nr_tiles_(rhs.nr_tiles_), block_size_(rhs.block_size_) {
+  rhs.size_ = {0, 0};
+  rhs.nr_tiles_ = {0, 0};
+  rhs.block_size_ = {1, 1};
+}
+
+MatrixBase& MatrixBase::operator=(MatrixBase&& rhs) noexcept {
+  size_ = rhs.size_;
+  nr_tiles_ = rhs.nr_tiles_;
+  block_size_ = rhs.block_size_;
+
+  rhs.size_ = {0, 0};
+  rhs.nr_tiles_ = {0, 0};
+  rhs.block_size_ = {1, 1};
+
+  return *this;
+}
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -9,8 +9,10 @@
 #
 
 DLAF_addTest(test_util_math SOURCES test_util_math.cpp USE_MAIN PLAIN)
+DLAF_addTest(test_matrix_base SOURCES test_matrix_base.cpp USE_MAIN PLAIN)
+
 DLAF_addTest(test_tile SOURCES test_tile.cpp USE_MAIN HPX)
 
-add_subdirectory(common)
-add_subdirectory(memory)
 add_subdirectory(communication)
+add_subdirectory(matrix)
+add_subdirectory(memory)

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2019, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+DLAF_addTest(test_layout_info SOURCES test_layout_info.cpp USE_MAIN PLAIN)

--- a/test/unit/matrix/test_layout_info.cpp
+++ b/test/unit/matrix/test_layout_info.cpp
@@ -1,0 +1,90 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <stdexcept>
+#include "gtest/gtest.h"
+#include "dlaf/matrix/index.h"
+#include "dlaf/matrix/layout_info.h"
+#include "dlaf/util_math.h"
+
+using namespace dlaf;
+using namespace testing;
+
+std::vector<
+    std::tuple<GlobalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, std::size_t>>
+    values({{{31, 17}, {7, 11}, 31, 7, 341, 527},      // Scalapack like layout
+            {{31, 17}, {7, 11}, 33, 7, 363, 559},      // with padding (ld)
+            {{31, 17}, {7, 11}, 47, 11, 517, 799},     // with padding (row)
+            {{31, 17}, {7, 11}, 31, 7, 348, 534},      // with padding (col)
+            {{29, 41}, {13, 11}, 13, 143, 429, 1667},  // Tile like layout
+            {{29, 41}, {13, 11}, 17, 183, 549, 2135},  // with padding (ld)
+            {{29, 41}, {13, 11}, 13, 146, 438, 1700},  // with padding (row)
+            {{29, 41}, {13, 11}, 13, 143, 436, 1688},  // with padding (col)
+            {{29, 41}, {13, 11}, 13, 143, 419, 1637},  // compressed col_offset
+            {{0, 0}, {1, 1}, 1, 1, 1, 0}});
+std::vector<std::tuple<GlobalElementSize, TileElementSize, SizeType, std::size_t, std::size_t>> wrong_values(
+    {
+        {{31, 17}, {7, 11}, 30, 7, 341},     // ld, row_offset combo is wrong
+        {{31, 17}, {7, 11}, 31, 6, 341},     // row_offset is wrong
+        {{31, 17}, {7, 11}, 31, 7, 340},     // col_offset is wrong
+        {{29, 41}, {13, 11}, 12, 143, 419},  // ld is wrong
+        {{29, 41}, {13, 11}, 13, 142, 419},  // ld, row_offset combo is wrong
+        {{29, 41}, {13, 11}, 13, 143, 418},  // col_offset is wrong
+        {{-1, 0}, {1, 1}, 1, 1, 1},          // wrong size
+        {{0, -1}, {1, 1}, 1, 1, 1},          // wrong size
+        {{0, 0}, {0, 1}, 1, 1, 1},           // wrong block_size
+        {{0, 0}, {1, 0}, 1, 1, 1},           // wrong block_size
+        {{0, 0}, {1, 1}, 0, 1, 1},           // wrong ld
+        {{0, 0}, {1, 1}, 1, 0, 1},           // wrong row_offset
+        {{0, 0}, {1, 1}, 1, 1, 0}            // wrong col_offset
+    });
+
+TEST(LayoutInfoTest, Constructor) {
+  using util::size_t::mul;
+
+  for (auto& v : values) {
+    auto size = std::get<0>(v);
+    auto block_size = std::get<1>(v);
+    auto ld = std::get<2>(v);
+    auto row_offset = std::get<3>(v);
+    auto col_offset = std::get<4>(v);
+    auto min_memory = std::get<5>(v);
+
+    matrix::LayoutInfo layout(size, block_size, ld, row_offset, col_offset);
+
+    EXPECT_EQ(size, layout.size());
+    EXPECT_EQ(LocalTileSize(util::ceilDiv(size.rows(), block_size.rows()),
+                            util::ceilDiv(size.cols(), block_size.cols())),
+              layout.nrTiles());
+    EXPECT_EQ(block_size, layout.blockSize());
+    EXPECT_EQ(ld, layout.ldTile());
+
+    EXPECT_EQ(min_memory, layout.minMemSize());
+    for (SizeType j = 0; j < layout.nrTiles().cols(); ++j) {
+      for (SizeType i = 0; i < layout.nrTiles().rows(); ++i) {
+        std::size_t offset = mul(i, row_offset) + mul(j, col_offset);
+        EXPECT_EQ(offset, layout.tileOffset(LocalTileIndex(i, j)));
+      }
+    }
+  }
+}
+
+TEST(LayoutInfoTest, ConstructorException) {
+  for (auto& v : wrong_values) {
+    auto size = std::get<0>(v);
+    auto block_size = std::get<1>(v);
+    auto ld = std::get<2>(v);
+    auto row_offset = std::get<3>(v);
+    auto col_offset = std::get<4>(v);
+
+    EXPECT_THROW(matrix::LayoutInfo layout(size, block_size, ld, row_offset, col_offset),
+                 std::invalid_argument);
+  }
+}

--- a/test/unit/test_matrix_base.cpp
+++ b/test/unit/test_matrix_base.cpp
@@ -1,0 +1,142 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <stdexcept>
+#include "gtest/gtest.h"
+#include "dlaf/matrix_base.h"
+
+using namespace dlaf;
+using namespace testing;
+
+std::vector<SizeType> ms({0, 1, 13, 32, 128});
+std::vector<SizeType> ns({0, 1, 16, 32, 128});
+std::vector<SizeType> mbs({13, 128});
+std::vector<SizeType> nbs({16, 64});
+
+TEST(MatrixBaseTest, DefaultConstructor) {
+  MatrixBase obj;
+
+  EXPECT_EQ(GlobalElementSize(0, 0), obj.size());
+  EXPECT_EQ(LocalTileSize(0, 0), obj.nrTiles());
+  EXPECT_EQ(TileElementSize(1, 1), obj.blockSize());
+}
+
+TEST(MatrixBaseTest, Constructor) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          MatrixBase obj({m, n}, {mb, nb});
+
+          EXPECT_EQ(GlobalElementSize(m, n), obj.size());
+          EXPECT_EQ(LocalTileSize(util::ceilDiv(m, mb), util::ceilDiv(n, nb)), obj.nrTiles());
+          EXPECT_EQ(TileElementSize(mb, nb), obj.blockSize());
+        }
+}
+
+TEST(MatrixBaseTest, ConstructorExceptions) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          EXPECT_THROW(MatrixBase obj({-1, n}, {mb, nb}), std::invalid_argument);
+          EXPECT_THROW(MatrixBase obj({m, -1}, {mb, nb}), std::invalid_argument);
+          EXPECT_THROW(MatrixBase obj({m, n}, {0, nb}), std::invalid_argument);
+          EXPECT_THROW(MatrixBase obj({m, n}, {mb, 0}), std::invalid_argument);
+          EXPECT_THROW(MatrixBase obj({m, n}, {-1, nb}), std::invalid_argument);
+          EXPECT_THROW(MatrixBase obj({m, n}, {mb, -1}), std::invalid_argument);
+        }
+}
+
+TEST(MatrixBaseTest, EqualityOperator) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          MatrixBase obj({m, n}, {mb, nb});
+          MatrixBase obj_eq({m, n}, {mb, nb});
+
+          EXPECT_TRUE(obj == obj_eq);
+          EXPECT_FALSE(obj != obj_eq);
+
+          std::vector<MatrixBase> objs_ne;
+          objs_ne.emplace_back(GlobalElementSize(m + 1, n), TileElementSize(mb, nb));
+          objs_ne.emplace_back(GlobalElementSize(m, n + 1), TileElementSize(mb, nb));
+          objs_ne.emplace_back(GlobalElementSize(m, n), TileElementSize(mb + 1, nb));
+          objs_ne.emplace_back(GlobalElementSize(m, n), TileElementSize(mb, nb + 1));
+
+          for (auto& obj_ne : objs_ne) {
+            EXPECT_TRUE(obj != obj_ne);
+            EXPECT_FALSE(obj == obj_ne);
+          }
+        }
+}
+
+TEST(MatrixBaseTest, CopyConstructor) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          MatrixBase obj0({m, n}, {mb, nb});
+          MatrixBase obj({m, n}, {mb, nb});
+          EXPECT_EQ(obj0, obj);
+
+          MatrixBase obj_copy = obj;
+          EXPECT_EQ(obj0, obj);
+          EXPECT_EQ(obj, obj_copy);
+        }
+}
+
+TEST(MatrixBaseTest, MoveConstructor) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          MatrixBase obj0({m, n}, {mb, nb});
+          MatrixBase obj({m, n}, {mb, nb});
+          EXPECT_EQ(obj0, obj);
+
+          MatrixBase obj_move = std::move(obj);
+          EXPECT_EQ(MatrixBase(), obj);
+          EXPECT_EQ(obj0, obj_move);
+        }
+}
+
+TEST(MatrixBaseTest, CopyAssignment) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          MatrixBase obj0({m, n}, {mb, nb});
+          MatrixBase obj({m, n}, {mb, nb});
+          EXPECT_EQ(obj0, obj);
+
+          MatrixBase obj_copy;
+          obj_copy = obj;
+          EXPECT_EQ(obj0, obj);
+          EXPECT_EQ(obj, obj_copy);
+        }
+}
+
+TEST(MatrixBaseTest, MoveAssignment) {
+  for (auto& m : ms)
+    for (auto& n : ns)
+      for (auto& mb : mbs)
+        for (auto& nb : nbs) {
+          MatrixBase obj0({m, n}, {mb, nb});
+          MatrixBase obj({m, n}, {mb, nb});
+          EXPECT_EQ(obj0, obj);
+
+          MatrixBase obj_move;
+          obj_move = std::move(obj);
+          EXPECT_EQ(MatrixBase(), obj);
+          EXPECT_EQ(obj0, obj_move);
+        }
+}


### PR DESCRIPTION
`LayoutInfo`:
 - object which contains the information about the local matrix layout from which the matrix will be built.

`MatrixBase`:
- contains the information about the sizes of the matrix
- It will be modified later to contain also the information of the distribution.