### PR TITLE
Implementation of broadcast functions

### DIFF
--- a/include/dlaf/communication/functions.h
+++ b/include/dlaf/communication/functions.h
@@ -19,16 +19,16 @@ namespace comm {
 
 /// basic wrapper for MPI_Bcast
 template <typename MessageType>
-void bcast(int broadcaster_rank, MessageType& what, Communicator where) {
-  MPI_Bcast(&what, 1, mpi_datatype<MessageType>::type, broadcaster_rank, where);
+void bcast(int broadcaster_rank, MessageType& message, Communicator communicator) {
+  MPI_Bcast(&message, 1, mpi_datatype<MessageType>::type, broadcaster_rank, communicator);
 }
 
 /// basic wrapper for MPI_Ibcast
 template <typename MessageType>
-void async_bcast(int broadcaster_rank, MessageType& what, Communicator where,
+void async_bcast(int broadcaster_rank, MessageType& message, Communicator communicator,
                  std::function<void()> action_before_retrying) {
   MPI_Request request;
-  MPI_Ibcast(&what, 1, mpi_datatype<MessageType>::type, broadcaster_rank, where, &request);
+  MPI_Ibcast(&message, 1, mpi_datatype<MessageType>::type, broadcaster_rank, communicator, &request);
 
   while (true) {
     int test_flag = 1;
@@ -43,14 +43,14 @@ namespace broadcast {
 
 /// specialized wrapper for MPI_Bcast on sender side
 template <typename MessageType>
-void send(const MessageType& what, Communicator where) {
-  bcast(where.rank(), const_cast<MessageType&>(what), where);
+void send(const MessageType& message, Communicator communicator) {
+  bcast(communicator.rank(), const_cast<MessageType&>(message), communicator);
 }
 
 /// specialized wrapper for MPI_Bcast on receiver side
 template <typename MessageType>
-void receive_from(int broadcaster_rank, MessageType& what, Communicator where) {
-  bcast(broadcaster_rank, what, where);
+void receive_from(int broadcaster_rank, MessageType& message, Communicator communicator) {
+  bcast(broadcaster_rank, message, communicator);
 }
 
 }
@@ -59,15 +59,17 @@ namespace async_broadcast {
 
 /// specialized wrapper for MPI_Ibcast on sender side
 template <typename MessageType>
-void send(const MessageType& what, Communicator where, std::function<void()> action_before_retrying) {
-  async_bcast(where.rank(), const_cast<MessageType&>(what), where, action_before_retrying);
+void send(const MessageType& message, Communicator communicator,
+          std::function<void()> action_before_retrying) {
+  async_bcast(communicator.rank(), const_cast<MessageType&>(message), communicator,
+              action_before_retrying);
 }
 
 /// specialized wrapper for MPI_Ibcast on receiver side
 template <typename MessageType>
-void receive_from(int broadcaster_rank, MessageType& what, Communicator where,
+void receive_from(int broadcaster_rank, MessageType& message, Communicator communicator,
                   std::function<void()> action_before_retrying) {
-  async_bcast(broadcaster_rank, what, where, action_before_retrying);
+  async_bcast(broadcaster_rank, message, communicator, action_before_retrying);
 }
 
 }

--- a/include/dlaf/communication/functions.h
+++ b/include/dlaf/communication/functions.h
@@ -1,0 +1,76 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <functional>
+
+#include "dlaf/communication/communicator.h"
+#include "dlaf/communication/mpi_datatypes.h"
+#include "dlaf/mpi_header.h"
+
+namespace dlaf {
+namespace comm {
+
+/// basic wrapper for MPI_Bcast
+template <typename MessageType>
+void bcast(int broadcaster_rank, MessageType& what, Communicator where) {
+  MPI_Bcast(&what, 1, mpi_datatype<MessageType>::type, broadcaster_rank, where);
+}
+
+/// basic wrapper for MPI_Ibcast
+template <typename MessageType>
+void async_bcast(int broadcaster_rank, MessageType& what, Communicator where,
+                 std::function<void()> action_before_retrying) {
+  MPI_Request request;
+  MPI_Ibcast(&what, 1, mpi_datatype<MessageType>::type, broadcaster_rank, where, &request);
+
+  while (true) {
+    int test_flag = 1;
+    MPI_Test(&request, &test_flag, MPI_STATUS_IGNORE);
+    if (test_flag)
+      break;
+    action_before_retrying();  // has this to be called from both sides of the communication?
+  }
+}
+
+namespace broadcast {
+
+/// specialized wrapper for MPI_Bcast on sender side
+template <typename MessageType>
+void send(const MessageType& what, Communicator where) {
+  bcast(where.rank(), const_cast<MessageType&>(what), where);
+}
+
+/// specialized wrapper for MPI_Bcast on receiver side
+template <typename MessageType>
+void receive_from(int broadcaster_rank, MessageType& what, Communicator where) {
+  bcast(broadcaster_rank, what, where);
+}
+
+}
+
+namespace async_broadcast {
+
+/// specialized wrapper for MPI_Ibcast on sender side
+template <typename MessageType>
+void send(const MessageType& what, Communicator where, std::function<void()> action_before_retrying) {
+  async_bcast(where.rank(), const_cast<MessageType&>(what), where, action_before_retrying);
+}
+
+/// specialized wrapper for MPI_Ibcast on receiver side
+template <typename MessageType>
+void receive_from(int broadcaster_rank, MessageType& what, Communicator where,
+                  std::function<void()> action_before_retrying) {
+  async_bcast(broadcaster_rank, what, where, action_before_retrying);
+}
+
+}
+
+}
+}

--- a/include/dlaf/communication/mpi_datatypes.h
+++ b/include/dlaf/communication/mpi_datatypes.h
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#pragma once
+
 #include "dlaf/mpi_header.h"
 
 namespace dlaf {

--- a/include/dlaf/communication/mpi_datatypes.h
+++ b/include/dlaf/communication/mpi_datatypes.h
@@ -1,0 +1,25 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/mpi_header.h"
+
+namespace dlaf {
+namespace comm {
+
+template <typename T>
+struct mpi_datatype;
+
+template <>
+struct mpi_datatype<int> {
+  static constexpr MPI_Datatype type = MPI_INT;
+};
+
+}
+}

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -19,3 +19,9 @@ DLAF_addTest(test_communicator_grid
   MPIRANKS 6
   USE_MAIN MPI
 )
+
+DLAF_addTest(test_broadcast
+  SOURCES test_broadcast.cpp
+  MPIRANKS 5
+  USE_MAIN MPI
+)

--- a/test/unit/communication/test_broadcast.cpp
+++ b/test/unit/communication/test_broadcast.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+
+#include "dlaf/communication/functions.h"
+
+using dlaf::comm::Communicator;
+
+class BroadcastTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    world = Communicator(MPI_COMM_WORLD);
+
+    color = world.rank() % 2;
+    key = world.rank() / 2;
+
+    MPI_Comm mpi_splitted_comm;
+    MPI_Comm_split(world, color, key, &mpi_splitted_comm);
+
+    ASSERT_NE(MPI_COMM_NULL, mpi_splitted_comm);
+    splitted_comm = Communicator(mpi_splitted_comm);
+  }
+
+  void TearDown() override {
+    if (MPI_COMM_NULL != splitted_comm)
+      MPI_Comm_free(&splitted_comm);
+  }
+
+  bool isMasterInSplitted() {
+    return world.rank() == color;
+  }
+
+  Communicator world;
+  Communicator splitted_comm;
+
+  int color = MPI_UNDEFINED;
+  int key = MPI_UNDEFINED;
+};
+
+TEST_F(BroadcastTest, Broadcast_ClassicAPI) {
+  auto broadcaster = 0;
+  auto where = splitted_comm;
+
+  int what;
+  if (isMasterInSplitted())
+    what = color;
+  else
+    what = -1;
+
+  dlaf::comm::bcast(broadcaster, what, where);
+  EXPECT_EQ(color, what);
+}
+
+TEST_F(BroadcastTest, Broadcast_ClassicAPI_Splitted) {
+  auto broadcaster = 0;
+  auto where = splitted_comm;
+
+  if (isMasterInSplitted())
+    dlaf::comm::bcast(broadcaster, color, where);
+  else {
+    int what;
+    dlaf::comm::bcast(broadcaster, what, where);
+    EXPECT_EQ(color, what);
+  }
+}
+
+TEST_F(BroadcastTest, Broadcast_NewAPI) {
+  auto broadcaster = 0;
+  auto where = splitted_comm;
+
+  if (isMasterInSplitted())
+    dlaf::comm::broadcast::send(color, where);
+  else {
+    int what;
+    dlaf::comm::broadcast::receive_from(broadcaster, what, where);
+    EXPECT_EQ(color, what);
+  }
+}
+
+TEST_F(BroadcastTest, AsyncBroadcast_ClassicAPI) {
+  auto broadcaster = 0;
+  auto where = splitted_comm;
+
+  bool waited;
+  auto what_to_do_before_retesting = [&waited]() { waited = true; };
+
+  int what;
+  if (isMasterInSplitted())
+    what = color;
+  else
+    what = -1;
+
+  dlaf::comm::async_bcast(broadcaster, what, where, what_to_do_before_retesting);
+  EXPECT_EQ(color, what);
+}
+
+TEST_F(BroadcastTest, AsyncBroadcast_ClassicAPI_Splitted) {
+  auto broadcaster = 0;
+  auto where = splitted_comm;
+
+  bool waited;
+  auto what_to_do_before_retesting = [&waited]() { waited = true; };
+
+  if (isMasterInSplitted())
+    dlaf::comm::async_bcast(broadcaster, color, where, what_to_do_before_retesting);
+  else {
+    int what;
+    dlaf::comm::async_bcast(broadcaster, what, where, what_to_do_before_retesting);
+    EXPECT_EQ(color, what);
+  }
+}
+
+TEST_F(BroadcastTest, AsyncBroadcast_NewAPI) {
+  auto broadcaster = 0;
+  auto where = splitted_comm;
+
+  bool waited;
+  auto what_to_do_before_retesting = [&waited]() { waited = true; };
+
+  if (isMasterInSplitted())
+    dlaf::comm::async_broadcast::send(color, where, what_to_do_before_retesting);
+  else {
+    int what;
+    dlaf::comm::async_broadcast::receive_from(broadcaster, what, where, what_to_do_before_retesting);
+    EXPECT_EQ(color, what);
+  }
+}

--- a/test/unit/communication/test_broadcast.cpp
+++ b/test/unit/communication/test_broadcast.cpp
@@ -37,89 +37,90 @@ protected:
 
 TEST_F(BroadcastTest, Broadcast_ClassicAPI) {
   auto broadcaster = 0;
-  auto where = splitted_comm;
+  auto communicator = splitted_comm;
 
-  int what;
+  int message;
   if (isMasterInSplitted())
-    what = color;
+    message = color;
   else
-    what = -1;
+    message = -1;
 
-  dlaf::comm::bcast(broadcaster, what, where);
-  EXPECT_EQ(color, what);
+  dlaf::comm::bcast(broadcaster, message, communicator);
+  EXPECT_EQ(color, message);
 }
 
 TEST_F(BroadcastTest, Broadcast_ClassicAPI_Splitted) {
   auto broadcaster = 0;
-  auto where = splitted_comm;
+  auto communicator = splitted_comm;
 
   if (isMasterInSplitted())
-    dlaf::comm::bcast(broadcaster, color, where);
+    dlaf::comm::bcast(broadcaster, color, communicator);
   else {
-    int what;
-    dlaf::comm::bcast(broadcaster, what, where);
-    EXPECT_EQ(color, what);
+    int message;
+    dlaf::comm::bcast(broadcaster, message, communicator);
+    EXPECT_EQ(color, message);
   }
 }
 
 TEST_F(BroadcastTest, Broadcast_NewAPI) {
   auto broadcaster = 0;
-  auto where = splitted_comm;
+  auto communicator = splitted_comm;
 
   if (isMasterInSplitted())
-    dlaf::comm::broadcast::send(color, where);
+    dlaf::comm::broadcast::send(color, communicator);
   else {
-    int what;
-    dlaf::comm::broadcast::receive_from(broadcaster, what, where);
-    EXPECT_EQ(color, what);
+    int message;
+    dlaf::comm::broadcast::receive_from(broadcaster, message, communicator);
+    EXPECT_EQ(color, message);
   }
 }
 
 TEST_F(BroadcastTest, AsyncBroadcast_ClassicAPI) {
   auto broadcaster = 0;
-  auto where = splitted_comm;
+  auto communicator = splitted_comm;
 
   bool waited;
   auto what_to_do_before_retesting = [&waited]() { waited = true; };
 
-  int what;
+  int message;
   if (isMasterInSplitted())
-    what = color;
+    message = color;
   else
-    what = -1;
+    message = -1;
 
-  dlaf::comm::async_bcast(broadcaster, what, where, what_to_do_before_retesting);
-  EXPECT_EQ(color, what);
+  dlaf::comm::async_bcast(broadcaster, message, communicator, what_to_do_before_retesting);
+  EXPECT_EQ(color, message);
 }
 
 TEST_F(BroadcastTest, AsyncBroadcast_ClassicAPI_Splitted) {
   auto broadcaster = 0;
-  auto where = splitted_comm;
+  auto communicator = splitted_comm;
 
   bool waited;
   auto what_to_do_before_retesting = [&waited]() { waited = true; };
 
   if (isMasterInSplitted())
-    dlaf::comm::async_bcast(broadcaster, color, where, what_to_do_before_retesting);
+    dlaf::comm::async_bcast(broadcaster, color, communicator, what_to_do_before_retesting);
   else {
-    int what;
-    dlaf::comm::async_bcast(broadcaster, what, where, what_to_do_before_retesting);
-    EXPECT_EQ(color, what);
+    int message;
+    dlaf::comm::async_bcast(broadcaster, message, communicator, what_to_do_before_retesting);
+    EXPECT_EQ(color, message);
   }
 }
 
 TEST_F(BroadcastTest, AsyncBroadcast_NewAPI) {
   auto broadcaster = 0;
-  auto where = splitted_comm;
+  auto communicator = splitted_comm;
 
   bool waited;
   auto what_to_do_before_retesting = [&waited]() { waited = true; };
 
   if (isMasterInSplitted())
-    dlaf::comm::async_broadcast::send(color, where, what_to_do_before_retesting);
+    dlaf::comm::async_broadcast::send(color, communicator, what_to_do_before_retesting);
   else {
-    int what;
-    dlaf::comm::async_broadcast::receive_from(broadcaster, what, where, what_to_do_before_retesting);
-    EXPECT_EQ(color, what);
+    int message;
+    dlaf::comm::async_broadcast::receive_from(broadcaster, message, communicator,
+                                              what_to_do_before_retesting);
+    EXPECT_EQ(color, message);
   }
 }


### PR DESCRIPTION
Close #58 

Implement wrappers for `MPI_Bcast` and `MPI_Ibcast`.

It provides also a basic compile-time mapper between library types and MPI_Datatype. Initially it addresses just more common primitive types. In a separate PR I would add support for more comples types (e.g. tiles).