### PR TITLE
Tile improvements

### DIFF
--- a/include/dlaf/matrix/index.h
+++ b/include/dlaf/matrix/index.h
@@ -1,0 +1,35 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include "dlaf/common/index2d.h"
+#include "dlaf/types.h"
+
+namespace dlaf {
+namespace matrix {
+struct GlobalElement_TAG;
+struct GlobalTile_TAG;
+struct LocalTile_TAG;
+struct TileElement_TAG;
+}
+
+using GlobalElementIndex = common::Index2D<SizeType, matrix::GlobalElement_TAG>;
+using GlobalElementSize = common::Size2D<SizeType, matrix::GlobalElement_TAG>;
+
+using GlobalTileIndex = common::Index2D<SizeType, matrix::GlobalTile_TAG>;
+using GlobalTileSize = common::Size2D<SizeType, matrix::GlobalTile_TAG>;
+
+using LocalTileIndex = common::Index2D<SizeType, matrix::LocalTile_TAG>;
+using LocalTileSize = common::Size2D<SizeType, matrix::LocalTile_TAG>;
+
+using TileElementIndex = common::Index2D<SizeType, matrix::TileElement_TAG>;
+using TileElementSize = common::Size2D<SizeType, matrix::TileElement_TAG>;
+}

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -11,8 +11,10 @@
 #pragma once
 
 #include <hpx/hpx.hpp>
+#include "dlaf/matrix/index.h"
 #include "dlaf/memory/memory_view.h"
 #include "dlaf/types.h"
+#include "dlaf/util_math.h"
 
 namespace dlaf {
 
@@ -32,105 +34,60 @@ public:
   using ElementType = std::remove_const_t<T>;
   friend Tile<const ElementType, device>;
 
-  /// @brief Constructs a (@p m x @p n) Tile.
-  /// @throw std::invalid_argument if @p m < 0, @p n < 0 or @p ld < max(1, @p m).
+  /// @brief Constructs a (@p size.rows() x @p size.cols()) Tile.
+  /// @throw std::invalid_argument if @p size.row() < 0, @p size.cols() < 0 or @p ld < max(1, @p size.rows()).
   /// @throw std::invalid_argument if memory_view does not contain enough elements.
   /// The (i, j)-th element of the Tile is stored in the (i+ld*j)-th element of memory_view.
-  Tile(SizeType m, SizeType n, memory::MemoryView<ElementType, device> memory_view, SizeType ld)
-      : m_(m), n_(n), memory_view_(memory_view), ld_(ld) {
-    if (m_ < 0 || n_ < 0)
-      throw std::invalid_argument("Error: Invalid Tile sizes");
-    if (ld_ < m_ || ld_ < 1)
-      throw std::invalid_argument("Error: Invalid Tile leading dimension");
-    if (m_ + (n_ - 1) * ld_ > memory_view_.size())
-      throw std::invalid_argument("Error: Tile exceeds the MemoryView limits");
-  }
+  Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view, SizeType ld);
 
   Tile(const Tile&) = delete;
 
-  Tile(Tile&& rhs)
-      : m_(rhs.m_), n_(rhs.n_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_),
-        p_(std::move(rhs.p_)) {
-    rhs.m_ = 0;
-    rhs.n_ = 0;
-    rhs.ld_ = 1;
-  }
+  Tile(Tile&& rhs) noexcept;
 
   template <class U = T,
             class = typename std::enable_if_t<std::is_const<U>::value && std::is_same<T, U>::value>>
-  Tile(Tile<ElementType, device>&& rhs)
-      : m_(rhs.m_), n_(rhs.n_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_),
-        p_(std::move(rhs.p_)) {
-    rhs.m_ = 0;
-    rhs.n_ = 0;
-    rhs.ld_ = 1;
-  }
+  Tile(Tile<ElementType, device>&& rhs) noexcept;
 
   /// @brief Destroys the Tile.
   /// If a promise was set using @c setPromise its value is set to a Tile
   /// which has the same size and which references the same memory as @p *this.
-  ~Tile() {
-    if (p_) {
-      p_->set_value(Tile<ElementType, device>(m_, n_, memory_view_, ld_));
-    }
-  }
+  ~Tile();
 
   Tile& operator=(const Tile&) = delete;
 
-  Tile& operator=(Tile&& rhs) {
-    m_ = rhs.m_;
-    n_ = rhs.n_;
-    memory_view_ = std::move(rhs.memory_view_);
-    ld_ = rhs.ld_;
-    p_ = std::move(rhs.p_);
-    rhs.m_ = 0;
-    rhs.n_ = 0;
-    rhs.ld_ = 1;
-
-    return *this;
-  }
+  Tile& operator=(Tile&& rhs) noexcept;
 
   template <class U = T,
             class = typename std::enable_if_t<std::is_const<U>::value && std::is_same<T, U>::value>>
-  Tile& operator=(Tile<ElementType, device>&& rhs) {
-    m_ = rhs.m_;
-    n_ = rhs.n_;
-    memory_view_ = std::move(rhs.memory_view_);
-    ld_ = rhs.ld_;
-    p_ = std::move(rhs.p_);
-    rhs.m_ = 0;
-    rhs.n_ = 0;
-    rhs.ld_ = 1;
+  Tile& operator=(Tile<ElementType, device>&& rhs) noexcept;
 
-    return *this;
+  /// @brief Returns the (i, j)-th element,
+  /// where @p i := @p index.row and @p j := @p index.col.
+  /// @pre index.isValid() == true.
+  /// @pre index.isIn(size()) == true.
+  T& operator()(TileElementIndex index) const noexcept {
+    return *ptr(index);
   }
 
-  /// @brief Returns the (i, j)-th element.
-  /// @pre 0 <= @p i < @p m.
-  /// @pre 0 <= @p j < @p n.
-  T& operator()(SizeType i, SizeType j) const {
-    return *ptr(i, j);
+  /// @brief Returns the pointer to the (i, j)-th element,
+  /// where @p i := @p index.row and @p j := @p index.col.
+  /// @pre index.isValid() == true.
+  /// @pre index.isIn(size()) == true.
+  T* ptr(TileElementIndex index) const noexcept {
+    using util::size_t::sum;
+    using util::size_t::mul;
+    assert(index.isValid());
+    assert(index.isIn(size_));
+
+    return memory_view_(sum(index.row(), mul(ld_, index.col())));
   }
 
-  /// @brief Returns the pointer to the (i, j)-th element.
-  /// @pre 0 <= @p i < @p m.
-  /// @pre 0 <= @p j < @p n.
-  T* ptr(SizeType i, SizeType j) const {
-    assert(i >= 0 && i < m_);
-    assert(j >= 0 && j < n_);
-    return memory_view_(i + ld_ * j);
-  }
-
-  /// @brief Returns the number of rows.
-  SizeType m() const {
-    return m_;
-  }
-  /// @brief Returns the number of columns.
-  SizeType n() const {
-    return n_;
+  /// @brief Returns the size of the Tile.
+  TileElementSize size() const noexcept {
+    return size_;
   }
   /// @brief Returns the leading dimension.
-  SizeType ld() const {
+  SizeType ld() const noexcept {
     return ld_;
   }
 
@@ -147,12 +104,12 @@ public:
   }
 
 private:
-  SizeType m_;
-  SizeType n_;
+  TileElementSize size_;
   memory::MemoryView<ElementType, device> memory_view_;
   SizeType ld_;
 
   std::unique_ptr<hpx::promise<Tile<ElementType, device>>> p_;
 };
 
+#include <dlaf/tile.ipp>
 }

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -45,7 +45,7 @@ public:
   /// @throw std::invalid_argument if @p size.row() < 0, @p size.cols() < 0 or @p ld < max(1, @p size.rows()).
   /// @throw std::invalid_argument if memory_view does not contain enough elements.
   /// The (i, j)-th element of the Tile is stored in the (i+ld*j)-th element of memory_view.
-  Tile(const TileElementSize& size, memory::MemoryView<ElementType, device> memory_view, SizeType ld);
+  Tile(const TileElementSize& size, memory::MemoryView<ElementType, device>&& memory_view, SizeType ld);
 
   Tile(const Tile&) = delete;
 
@@ -112,8 +112,8 @@ public:
   /// @throw std::invalid_argument if @p size.row() < 0, @p size.cols() < 0 or @p ld < max(1, @p size.rows()).
   /// @throw std::invalid_argument if memory_view does not contain enough elements.
   /// The (i, j)-th element of the Tile is stored in the (i+ld*j)-th element of memory_view.
-  Tile(const TileElementSize& size, memory::MemoryView<ElementType, device> memory_view, SizeType ld)
-      : Tile<const T, device>(size, memory_view, ld) {}
+  Tile(const TileElementSize& size, memory::MemoryView<ElementType, device>&& memory_view, SizeType ld)
+      : Tile<const T, device>(size, std::move(memory_view), ld) {}
 
   Tile(const Tile&) = delete;
 

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -45,7 +45,7 @@ public:
   /// @throw std::invalid_argument if @p size.row() < 0, @p size.cols() < 0 or @p ld < max(1, @p size.rows()).
   /// @throw std::invalid_argument if memory_view does not contain enough elements.
   /// The (i, j)-th element of the Tile is stored in the (i+ld*j)-th element of memory_view.
-  Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view, SizeType ld);
+  Tile(const TileElementSize& size, memory::MemoryView<ElementType, device> memory_view, SizeType ld);
 
   Tile(const Tile&) = delete;
 
@@ -64,7 +64,7 @@ public:
   /// where @p i := @p index.row and @p j := @p index.col.
   /// @pre index.isValid() == true.
   /// @pre index.isIn(size()) == true.
-  const T& operator()(TileElementIndex index) const noexcept {
+  const T& operator()(const TileElementIndex& index) const noexcept {
     return *ptr(index);
   }
 
@@ -72,7 +72,7 @@ public:
   /// where @p i := @p index.row and @p j := @p index.col.
   /// @pre index.isValid() == true.
   /// @pre index.isIn(size()) == true.
-  const T* ptr(TileElementIndex index) const noexcept {
+  const T* ptr(const TileElementIndex& index) const noexcept {
     using util::size_t::sum;
     using util::size_t::mul;
     assert(index.isValid());
@@ -82,7 +82,7 @@ public:
   }
 
   /// @brief Returns the size of the Tile.
-  TileElementSize size() const noexcept {
+  const TileElementSize& size() const noexcept {
     return size_;
   }
   /// @brief Returns the leading dimension.
@@ -112,7 +112,7 @@ public:
   /// @throw std::invalid_argument if @p size.row() < 0, @p size.cols() < 0 or @p ld < max(1, @p size.rows()).
   /// @throw std::invalid_argument if memory_view does not contain enough elements.
   /// The (i, j)-th element of the Tile is stored in the (i+ld*j)-th element of memory_view.
-  Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view, SizeType ld)
+  Tile(const TileElementSize& size, memory::MemoryView<ElementType, device> memory_view, SizeType ld)
       : Tile<const T, device>(size, memory_view, ld) {}
 
   Tile(const Tile&) = delete;
@@ -127,7 +127,7 @@ public:
   /// where @p i := @p index.row and @p j := @p index.col.
   /// @pre index.isValid() == true.
   /// @pre index.isIn(size()) == true.
-  T& operator()(TileElementIndex index) const noexcept {
+  T& operator()(const TileElementIndex& index) const noexcept {
     return *ptr(index);
   }
 
@@ -135,7 +135,7 @@ public:
   /// where @p i := @p index.row and @p j := @p index.col.
   /// @pre index.isValid() == true.
   /// @pre index.isIn(size()) == true.
-  T* ptr(TileElementIndex index) const noexcept {
+  T* ptr(const TileElementIndex& index) const noexcept {
     using util::size_t::sum;
     using util::size_t::mul;
     assert(index.isValid());

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -91,6 +91,9 @@ public:
   }
 
 private:
+  /// @brief Sets size to {0, 0} and ld to 1.
+  void setDefaultSizes() noexcept;
+
   TileElementSize size_;
   memory::MemoryView<ElementType, device> memory_view_;
   SizeType ld_;

--- a/include/dlaf/tile.ipp
+++ b/include/dlaf/tile.ipp
@@ -9,8 +9,8 @@
 //
 
 template <class T, Device device>
-Tile<const T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view,
-                            SizeType ld)
+Tile<const T, device>::Tile(const TileElementSize& size,
+                            memory::MemoryView<ElementType, device> memory_view, SizeType ld)
     : size_(size), memory_view_(memory_view), ld_(ld) {
   using util::size_t::sum;
   using util::size_t::mul;

--- a/include/dlaf/tile.ipp
+++ b/include/dlaf/tile.ipp
@@ -9,8 +9,8 @@
 //
 
 template <class T, Device device>
-Tile<T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view,
-                      SizeType ld)
+Tile<const T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view,
+                            SizeType ld)
     : size_(size), memory_view_(memory_view), ld_(ld) {
   using util::size_t::sum;
   using util::size_t::mul;
@@ -23,42 +23,21 @@ Tile<T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType, devi
 }
 
 template <class T, Device device>
-Tile<T, device>::Tile(Tile&& rhs) noexcept
+Tile<const T, device>::Tile(Tile&& rhs) noexcept
     : size_(rhs.size_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_), p_(std::move(rhs.p_)) {
   rhs.size_ = {0, 0};
   rhs.ld_ = 1;
 }
 
 template <class T, Device device>
-template <class U, class>
-Tile<T, device>::Tile(Tile<ElementType, device>&& rhs) noexcept
-    : size_(rhs.size_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_), p_(std::move(rhs.p_)) {
-  rhs.size_ = {0, 0};
-  rhs.ld_ = 1;
-}
-
-template <class T, Device device>
-Tile<T, device>::~Tile() {
+Tile<const T, device>::~Tile() {
   if (p_) {
     p_->set_value(Tile<ElementType, device>(size_, memory_view_, ld_));
   }
 }
 
 template <class T, Device device>
-Tile<T, device>& Tile<T, device>::operator=(Tile<T, device>&& rhs) noexcept {
-  size_ = rhs.size_;
-  memory_view_ = std::move(rhs.memory_view_);
-  ld_ = rhs.ld_;
-  p_ = std::move(rhs.p_);
-  rhs.size_ = {0, 0};
-  rhs.ld_ = 1;
-
-  return *this;
-}
-
-template <class T, Device device>
-template <class U, class>
-Tile<T, device>& Tile<T, device>::operator=(Tile<Tile<T, device>::ElementType, device>&& rhs) noexcept {
+Tile<const T, device>& Tile<const T, device>::operator=(Tile<const T, device>&& rhs) noexcept {
   size_ = rhs.size_;
   memory_view_ = std::move(rhs.memory_view_);
   ld_ = rhs.ld_;

--- a/include/dlaf/tile.ipp
+++ b/include/dlaf/tile.ipp
@@ -14,7 +14,7 @@ Tile<const T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType
     : size_(size), memory_view_(memory_view), ld_(ld) {
   using util::size_t::sum;
   using util::size_t::mul;
-  if (size_.rows() < 0 || size_.cols() < 0)
+  if (size_.isValid())
     throw std::invalid_argument("Error: Invalid Tile sizes");
   if (ld_ < size_.rows() || ld_ < 1)
     throw std::invalid_argument("Error: Invalid Tile leading dimension");

--- a/include/dlaf/tile.ipp
+++ b/include/dlaf/tile.ipp
@@ -10,8 +10,8 @@
 
 template <class T, Device device>
 Tile<const T, device>::Tile(const TileElementSize& size,
-                            memory::MemoryView<ElementType, device> memory_view, SizeType ld)
-    : size_(size), memory_view_(memory_view), ld_(ld) {
+                            memory::MemoryView<ElementType, device>&& memory_view, SizeType ld)
+    : size_(size), memory_view_(std::move(memory_view)), ld_(ld) {
   using util::size_t::sum;
   using util::size_t::mul;
   if (size_.isValid())
@@ -31,7 +31,7 @@ Tile<const T, device>::Tile(Tile&& rhs) noexcept
 template <class T, Device device>
 Tile<const T, device>::~Tile() {
   if (p_) {
-    p_->set_value(Tile<ElementType, device>(size_, memory_view_, ld_));
+    p_->set_value(Tile<ElementType, device>(size_, std::move(memory_view_), ld_));
   }
 }
 

--- a/include/dlaf/tile.ipp
+++ b/include/dlaf/tile.ipp
@@ -1,0 +1,70 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+template <class T, Device device>
+Tile<T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType, device> memory_view,
+                      SizeType ld)
+    : size_(size), memory_view_(memory_view), ld_(ld) {
+  using util::size_t::sum;
+  using util::size_t::mul;
+  if (size_.rows() < 0 || size_.cols() < 0)
+    throw std::invalid_argument("Error: Invalid Tile sizes");
+  if (ld_ < size_.rows() || ld_ < 1)
+    throw std::invalid_argument("Error: Invalid Tile leading dimension");
+  if (sum(size_.rows(), mul(ld_, (size_.cols() - 1))) > memory_view_.size())
+    throw std::invalid_argument("Error: Tile exceeds the MemoryView limits");
+}
+
+template <class T, Device device>
+Tile<T, device>::Tile(Tile&& rhs) noexcept
+    : size_(rhs.size_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_), p_(std::move(rhs.p_)) {
+  rhs.size_ = {0, 0};
+  rhs.ld_ = 1;
+}
+
+template <class T, Device device>
+template <class U, class>
+Tile<T, device>::Tile(Tile<ElementType, device>&& rhs) noexcept
+    : size_(rhs.size_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_), p_(std::move(rhs.p_)) {
+  rhs.size_ = {0, 0};
+  rhs.ld_ = 1;
+}
+
+template <class T, Device device>
+Tile<T, device>::~Tile() {
+  if (p_) {
+    p_->set_value(Tile<ElementType, device>(size_, memory_view_, ld_));
+  }
+}
+
+template <class T, Device device>
+Tile<T, device>& Tile<T, device>::operator=(Tile<T, device>&& rhs) noexcept {
+  size_ = rhs.size_;
+  memory_view_ = std::move(rhs.memory_view_);
+  ld_ = rhs.ld_;
+  p_ = std::move(rhs.p_);
+  rhs.size_ = {0, 0};
+  rhs.ld_ = 1;
+
+  return *this;
+}
+
+template <class T, Device device>
+template <class U, class>
+Tile<T, device>& Tile<T, device>::operator=(Tile<Tile<T, device>::ElementType, device>&& rhs) noexcept {
+  size_ = rhs.size_;
+  memory_view_ = std::move(rhs.memory_view_);
+  ld_ = rhs.ld_;
+  p_ = std::move(rhs.p_);
+  rhs.size_ = {0, 0};
+  rhs.ld_ = 1;
+
+  return *this;
+}

--- a/include/dlaf/tile.ipp
+++ b/include/dlaf/tile.ipp
@@ -25,8 +25,7 @@ Tile<const T, device>::Tile(TileElementSize size, memory::MemoryView<ElementType
 template <class T, Device device>
 Tile<const T, device>::Tile(Tile&& rhs) noexcept
     : size_(rhs.size_), memory_view_(std::move(rhs.memory_view_)), ld_(rhs.ld_), p_(std::move(rhs.p_)) {
-  rhs.size_ = {0, 0};
-  rhs.ld_ = 1;
+  rhs.setDefaultSizes();
 }
 
 template <class T, Device device>
@@ -42,8 +41,13 @@ Tile<const T, device>& Tile<const T, device>::operator=(Tile<const T, device>&& 
   memory_view_ = std::move(rhs.memory_view_);
   ld_ = rhs.ld_;
   p_ = std::move(rhs.p_);
-  rhs.size_ = {0, 0};
-  rhs.ld_ = 1;
+  rhs.setDefaultSizes();
 
   return *this;
+}
+
+template <class T, Device device>
+void Tile<const T, device>::setDefaultSizes() noexcept {
+  size_ = {0, 0};
+  ld_ = 1;
 }

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -22,16 +22,16 @@ using MatrixElementTypes = ::testing::Types<float, double, std::complex<float>, 
 template <class T>
 struct TypeUtilities {
   /// Returns r.
-  static T element(T r, T i) {
-    return r;
+  static T element(double r, double i) {
+    return static_cast<T>(r);
   }
 };
 
 template <class T>
 struct TypeUtilities<std::complex<T>> {
   /// Returns r + I * i (I is the imaginary unit).
-  static std::complex<T> element(T r, T i) {
-    return std::complex<T>(r, i);
+  static std::complex<T> element(double r, double i) {
+    return std::complex<T>(static_cast<T>(r), static_cast<T>(i));
   }
 };
 

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -20,9 +20,15 @@ using namespace dlaf;
 using namespace dlaf_test;
 using namespace testing;
 
-int m = 37;
-int n = 87;
-int ld = 133;
+SizeType m = 37;
+SizeType n = 87;
+SizeType ld = 133;
+
+std::size_t elIndex(SizeType i, SizeType j, SizeType ld) {
+  using util::size_t::sum;
+  using util::size_t::mul;
+  return sum(i, mul(ld, j));
+}
 
 using TileSizes = std::tuple<TileElementSize, SizeType>;
 
@@ -44,13 +50,13 @@ TYPED_TEST(TileTest, Constructor) {
   Tile<Type, Device::CPU> tile(size, memory_view, ld);
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  for (int j = 0; j < tile.size().cols(); ++j)
-    for (int i = 0; i < tile.size().rows(); ++i) {
+  for (SizeType j = 0; j < tile.size().cols(); ++j)
+    for (SizeType i = 0; i < tile.size().rows(); ++i) {
       Type el = TypeUtilities<Type>::element(i + 0.01 * j, j - 0.01 * i);
       tile(TileElementIndex(i, j)) = el;
       EXPECT_EQ(el, tile(TileElementIndex(i, j)));
-      EXPECT_EQ(el, *memory_view(i + ld * j));
-      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(TileElementIndex(i, j)));
+      EXPECT_EQ(el, *memory_view(elIndex(i, j, ld)));
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -62,9 +68,9 @@ TYPED_TEST(TileTest, ConstructorConst) {
   Tile<const Type, Device::CPU> tile(size, memory_view, ld);
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  for (int j = 0; j < tile.size().cols(); ++j)
-    for (int i = 0; i < tile.size().rows(); ++i) {
-      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(TileElementIndex(i, j)));
+  for (SizeType j = 0; j < tile.size().cols(); ++j)
+    for (SizeType i = 0; i < tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -76,13 +82,13 @@ TYPED_TEST(TileTest, ConstructorMix) {
   Tile<const Type, Device::CPU> tile(size, memory_view, ld);
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  for (int j = 0; j < tile.size().cols(); ++j)
-    for (int i = 0; i < tile.size().rows(); ++i) {
+  for (SizeType j = 0; j < tile.size().cols(); ++j)
+    for (SizeType i = 0; i < tile.size().rows(); ++i) {
       Type el = TypeUtilities<Type>::element(i + 0.01 * j, j - 0.01 * i);
-      *memory_view(i + ld * j) = el;
+      *memory_view(elIndex(i, j, ld)) = el;
       EXPECT_EQ(el, tile(TileElementIndex(i, j)));
-      EXPECT_EQ(el, *memory_view(i + ld * j));
-      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(TileElementIndex(i, j)));
+      EXPECT_EQ(el, *memory_view(elIndex(i, j, ld)));
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -114,9 +120,9 @@ TYPED_TEST(TileTest, MoveConstructor) {
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  for (int j = 0; j < tile.size().cols(); ++j)
-    for (int i = 0; i < tile.size().rows(); ++i) {
-      EXPECT_EQ(tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < tile.size().cols(); ++j)
+    for (SizeType i = 0; i < tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -131,9 +137,9 @@ TYPED_TEST(TileTest, MoveConstructorConst) {
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(const_tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  for (int j = 0; j < const_tile.size().cols(); ++j)
-    for (int i = 0; i < const_tile.size().rows(); ++i) {
-      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < const_tile.size().cols(); ++j)
+    for (SizeType i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), const_tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -148,9 +154,9 @@ TYPED_TEST(TileTest, MoveConstructorMix) {
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  for (int j = 0; j < const_tile.size().cols(); ++j)
-    for (int i = 0; i < const_tile.size().rows(); ++i) {
-      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < const_tile.size().cols(); ++j)
+    for (SizeType i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), const_tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -166,9 +172,9 @@ TYPED_TEST(TileTest, MoveAssignement) {
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  for (int j = 0; j < tile.size().cols(); ++j)
-    for (int i = 0; i < tile.size().rows(); ++i) {
-      EXPECT_EQ(tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < tile.size().cols(); ++j)
+    for (SizeType i = 0; i < tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -184,9 +190,9 @@ TYPED_TEST(TileTest, MoveAssignementConst) {
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(const_tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  for (int j = 0; j < const_tile.size().cols(); ++j)
-    for (int i = 0; i < const_tile.size().rows(); ++i) {
-      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < const_tile.size().cols(); ++j)
+    for (SizeType i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), const_tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -202,9 +208,9 @@ TYPED_TEST(TileTest, MoveAssignementMix) {
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  for (int j = 0; j < const_tile.size().cols(); ++j)
-    for (int i = 0; i < const_tile.size().rows(); ++i) {
-      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < const_tile.size().cols(); ++j)
+    for (SizeType i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), const_tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -219,9 +225,9 @@ TYPED_TEST(TileTest, ReferenceMix) {
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  for (int j = 0; j < const_tile.size().cols(); ++j)
-    for (int i = 0; i < const_tile.size().rows(); ++i) {
-      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < const_tile.size().cols(); ++j)
+    for (SizeType i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), const_tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -236,9 +242,9 @@ TYPED_TEST(TileTest, PointerMix) {
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile0));
   EXPECT_EQ(TileSizes(size, ld), getSizes(*const_tile));
 
-  for (int j = 0; j < const_tile->size().cols(); ++j)
-    for (int i = 0; i < const_tile->size().rows(); ++i) {
-      EXPECT_EQ(const_tile->ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+  for (SizeType j = 0; j < const_tile->size().cols(); ++j)
+    for (SizeType i = 0; i < const_tile->size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), const_tile->ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -264,9 +270,9 @@ TYPED_TEST(TileTest, PromiseToFuture) {
   Tile<Type, Device::CPU> tile2 = std::move(tile_future.get());
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile2));
 
-  for (int j = 0; j < tile2.size().cols(); ++j)
-    for (int i = 0; i < tile2.size().rows(); ++i) {
-      EXPECT_EQ(tile2.ptr(TileElementIndex(TileElementIndex(i, j))), memory_view(i + ld * j));
+  for (SizeType j = 0; j < tile2.size().cols(); ++j)
+    for (SizeType i = 0; i < tile2.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile2.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -292,8 +298,8 @@ TYPED_TEST(TileTest, PromiseToFutureConst) {
   Tile<Type, Device::CPU> tile2 = std::move(tile_future.get());
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile2));
 
-  for (int j = 0; j < tile2.size().cols(); ++j)
-    for (int i = 0; i < tile2.size().rows(); ++i) {
-      EXPECT_EQ(tile2.ptr(TileElementIndex(TileElementIndex(i, j))), memory_view(i + ld * j));
+  for (SizeType j = 0; j < tile2.size().cols(); ++j)
+    for (SizeType i = 0; i < tile2.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile2.ptr(TileElementIndex(TileElementIndex(i, j))));
     }
 }

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -208,6 +208,40 @@ TYPED_TEST(TileTest, MoveAssignementMix) {
     }
 }
 
+TYPED_TEST(TileTest, ReferenceMix) {
+  using Type = TypeParam;
+  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<const Type, Device::CPU>& const_tile = tile0;
+
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
+
+  for (int j = 0; j < const_tile.size().cols(); ++j)
+    for (int i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+    }
+}
+
+TYPED_TEST(TileTest, PointerMix) {
+  using Type = TypeParam;
+  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<const Type, Device::CPU>* const_tile = &tile0;
+
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(*const_tile));
+
+  for (int j = 0; j < const_tile->size().cols(); ++j)
+    for (int i = 0; i < const_tile->size().rows(); ++i) {
+      EXPECT_EQ(const_tile->ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
+    }
+}
+
 TYPED_TEST(TileTest, PromiseToFuture) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -300,6 +300,6 @@ TYPED_TEST(TileTest, PromiseToFutureConst) {
 
   for (SizeType j = 0; j < tile2.size().cols(); ++j)
     for (SizeType i = 0; i < tile2.size().rows(); ++i) {
-      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile2.ptr(TileElementIndex(TileElementIndex(i, j))));
+      EXPECT_EQ(memory_view(elIndex(i, j, ld)), tile2.ptr(TileElementIndex(i, j)));
     }
 }

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -45,9 +45,10 @@ TYPED_TEST_CASE(TileTest, MatrixElementTypes);
 TYPED_TEST(TileTest, Constructor) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile(size, std::move(mem_view), ld);
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
   for (SizeType j = 0; j < tile.size().cols(); ++j)
@@ -63,9 +64,10 @@ TYPED_TEST(TileTest, Constructor) {
 TYPED_TEST(TileTest, ConstructorConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<const Type, Device::CPU> tile(size, memory_view, ld);
+  Tile<const Type, Device::CPU> tile(size, std::move(mem_view), ld);
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
   for (SizeType j = 0; j < tile.size().cols(); ++j)
@@ -77,9 +79,10 @@ TYPED_TEST(TileTest, ConstructorConst) {
 TYPED_TEST(TileTest, ConstructorMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<const Type, Device::CPU> tile(size, memory_view, ld);
+  Tile<const Type, Device::CPU> tile(size, std::move(memory_view), ld);
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
   for (SizeType j = 0; j < tile.size().cols(); ++j)
@@ -94,27 +97,29 @@ TYPED_TEST(TileTest, ConstructorMix) {
 
 TYPED_TEST(TileTest, ConstructorExceptions) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * (n - 1) + m - 1);
+  using MemView = memory::MemoryView<Type, Device::CPU>;
+  std::size_t size = elIndex(m - 1, n - 1, ld) + 1;
 
-  EXPECT_THROW((Tile<Type, Device::CPU>({m, n}, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>({-1, n}, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>({m, -1}, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>({m, n}, memory_view, m - 1)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>({0, n}, memory_view, 0)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({m, n}, MemView(size - 1), ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({-1, n}, MemView(size), ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({m, -1}, MemView(size), ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({m, n}, MemView(size), m - 1)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({0, n}, MemView(size), 0)), std::invalid_argument);
 
-  EXPECT_THROW((Tile<const Type, Device::CPU>({m, n}, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>({-1, n}, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>({m, -1}, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>({m, n}, memory_view, m - 1)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>({0, n}, memory_view, 0)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({m, n}, MemView(size - 1), ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({-1, n}, MemView(size), ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({m, -1}, MemView(size), ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({m, n}, MemView(size), m - 1)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({0, n}, MemView(size), 0)), std::invalid_argument);
 }
 
 TYPED_TEST(TileTest, MoveConstructor) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile0(size, std::move(mem_view), ld);
 
   Tile<Type, Device::CPU> tile(std::move(tile0));
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
@@ -129,9 +134,10 @@ TYPED_TEST(TileTest, MoveConstructor) {
 TYPED_TEST(TileTest, MoveConstructorConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<const Type, Device::CPU> const_tile0(size, memory_view, ld);
+  Tile<const Type, Device::CPU> const_tile0(size, std::move(mem_view), ld);
 
   Tile<const Type, Device::CPU> const_tile(std::move(const_tile0));
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(const_tile0));
@@ -146,9 +152,10 @@ TYPED_TEST(TileTest, MoveConstructorConst) {
 TYPED_TEST(TileTest, MoveConstructorMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile0(size, std::move(mem_view), ld);
 
   Tile<const Type, Device::CPU> const_tile(std::move(tile0));
   EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
@@ -163,9 +170,10 @@ TYPED_TEST(TileTest, MoveConstructorMix) {
 TYPED_TEST(TileTest, MoveAssignement) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile0(size, std::move(mem_view), ld);
   Tile<Type, Device::CPU> tile({1, 1}, memory::MemoryView<Type, Device::CPU>(1), 1);
 
   tile = std::move(tile0);
@@ -181,9 +189,10 @@ TYPED_TEST(TileTest, MoveAssignement) {
 TYPED_TEST(TileTest, MoveAssignementConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<const Type, Device::CPU> const_tile0(size, memory_view, ld);
+  Tile<const Type, Device::CPU> const_tile0(size, std::move(mem_view), ld);
   Tile<const Type, Device::CPU> const_tile({1, 1}, memory::MemoryView<Type, Device::CPU>(1), 1);
 
   const_tile = std::move(const_tile0);
@@ -199,9 +208,10 @@ TYPED_TEST(TileTest, MoveAssignementConst) {
 TYPED_TEST(TileTest, MoveAssignementMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile0(size, std::move(mem_view), ld);
   Tile<const Type, Device::CPU> const_tile({1, 1}, memory::MemoryView<Type, Device::CPU>(1), 1);
 
   const_tile = std::move(tile0);
@@ -217,9 +227,10 @@ TYPED_TEST(TileTest, MoveAssignementMix) {
 TYPED_TEST(TileTest, ReferenceMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile0(size, std::move(mem_view), ld);
   Tile<const Type, Device::CPU>& const_tile = tile0;
 
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile0));
@@ -234,9 +245,10 @@ TYPED_TEST(TileTest, ReferenceMix) {
 TYPED_TEST(TileTest, PointerMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile0(size, std::move(mem_view), ld);
   Tile<const Type, Device::CPU>* const_tile = &tile0;
 
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile0));
@@ -251,9 +263,10 @@ TYPED_TEST(TileTest, PointerMix) {
 TYPED_TEST(TileTest, PromiseToFuture) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile(size, std::move(mem_view), ld);
 
   hpx::promise<Tile<Type, Device::CPU>> tile_promise;
   hpx::future<Tile<Type, Device::CPU>> tile_future = tile_promise.get_future();
@@ -279,9 +292,10 @@ TYPED_TEST(TileTest, PromiseToFuture) {
 TYPED_TEST(TileTest, PromiseToFutureConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  auto mem_view = memory_view;
 
   TileElementSize size(m, n);
-  Tile<Type, Device::CPU> tile(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile(size, std::move(mem_view), ld);
 
   hpx::promise<Tile<Type, Device::CPU>> tile_promise;
   hpx::future<Tile<Type, Device::CPU>> tile_future = tile_promise.get_future();

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -12,6 +12,7 @@
 
 #include <stdexcept>
 #include "gtest/gtest.h"
+#include "dlaf/matrix/index.h"
 #include "dlaf/memory/memory_view.h"
 #include "dlaf_test/util_types.h"
 
@@ -23,6 +24,13 @@ int m = 37;
 int n = 87;
 int ld = 133;
 
+using TileSizes = std::tuple<TileElementSize, SizeType>;
+
+template <class T, Device device>
+TileSizes getSizes(const Tile<T, device>& tile) {
+  return TileSizes(tile.size(), tile.ld());
+}
+
 template <typename Type>
 class TileTest : public ::testing::Test {};
 
@@ -32,19 +40,17 @@ TYPED_TEST(TileTest, Constructor) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile(size, memory_view, ld);
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  EXPECT_EQ(m, tile.m());
-  EXPECT_EQ(n, tile.n());
-  EXPECT_EQ(ld, tile.ld());
-
-  for (int j = 0; j < tile.n(); ++j)
-    for (int i = 0; i < tile.m(); ++i) {
+  for (int j = 0; j < tile.size().cols(); ++j)
+    for (int i = 0; i < tile.size().rows(); ++i) {
       Type el = TypeUtilities<Type>::element(i + 0.01 * j, j - 0.01 * i);
-      tile(i, j) = el;
-      EXPECT_EQ(el, tile(i, j));
+      tile(TileElementIndex(i, j)) = el;
+      EXPECT_EQ(el, tile(TileElementIndex(i, j)));
       EXPECT_EQ(el, *memory_view(i + ld * j));
-      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(i, j));
+      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -52,15 +58,13 @@ TYPED_TEST(TileTest, ConstructorConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<const Type, Device::CPU> tile(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<const Type, Device::CPU> tile(size, memory_view, ld);
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  EXPECT_EQ(m, tile.m());
-  EXPECT_EQ(n, tile.n());
-  EXPECT_EQ(ld, tile.ld());
-
-  for (int j = 0; j < tile.n(); ++j)
-    for (int i = 0; i < tile.m(); ++i) {
-      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(i, j));
+  for (int j = 0; j < tile.size().cols(); ++j)
+    for (int i = 0; i < tile.size().rows(); ++i) {
+      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -68,19 +72,17 @@ TYPED_TEST(TileTest, ConstructorMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<const Type, Device::CPU> tile(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<const Type, Device::CPU> tile(size, memory_view, ld);
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  EXPECT_EQ(m, tile.m());
-  EXPECT_EQ(n, tile.n());
-  EXPECT_EQ(ld, tile.ld());
-
-  for (int j = 0; j < tile.n(); ++j)
-    for (int i = 0; i < tile.m(); ++i) {
+  for (int j = 0; j < tile.size().cols(); ++j)
+    for (int i = 0; i < tile.size().rows(); ++i) {
       Type el = TypeUtilities<Type>::element(i + 0.01 * j, j - 0.01 * i);
       *memory_view(i + ld * j) = el;
-      EXPECT_EQ(el, tile(i, j));
+      EXPECT_EQ(el, tile(TileElementIndex(i, j)));
       EXPECT_EQ(el, *memory_view(i + ld * j));
-      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(i, j));
+      EXPECT_EQ(memory_view(i + ld * j), tile.ptr(TileElementIndex(i, j)));
     }
 }
 
@@ -88,37 +90,33 @@ TYPED_TEST(TileTest, ConstructorExceptions) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * (n - 1) + m - 1);
 
-  EXPECT_THROW((Tile<Type, Device::CPU>(m, n, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>(-1, n, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>(m, -1, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>(m, n, memory_view, m - 1)), std::invalid_argument);
-  EXPECT_THROW((Tile<Type, Device::CPU>(0, n, memory_view, 0)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({m, n}, memory_view, ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({-1, n}, memory_view, ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({m, -1}, memory_view, ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({m, n}, memory_view, m - 1)), std::invalid_argument);
+  EXPECT_THROW((Tile<Type, Device::CPU>({0, n}, memory_view, 0)), std::invalid_argument);
 
-  EXPECT_THROW((Tile<const Type, Device::CPU>(m, n, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>(-1, n, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>(m, -1, memory_view, ld)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>(m, n, memory_view, m - 1)), std::invalid_argument);
-  EXPECT_THROW((Tile<const Type, Device::CPU>(0, n, memory_view, 0)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({m, n}, memory_view, ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({-1, n}, memory_view, ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({m, -1}, memory_view, ld)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({m, n}, memory_view, m - 1)), std::invalid_argument);
+  EXPECT_THROW((Tile<const Type, Device::CPU>({0, n}, memory_view, 0)), std::invalid_argument);
 }
 
 TYPED_TEST(TileTest, MoveConstructor) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile0(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
 
   Tile<Type, Device::CPU> tile(std::move(tile0));
-  EXPECT_EQ(0, tile0.m());
-  EXPECT_EQ(0, tile0.n());
-  EXPECT_EQ(1, tile0.ld());
+  EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  EXPECT_EQ(m, tile.m());
-  EXPECT_EQ(n, tile.n());
-  EXPECT_EQ(ld, tile.ld());
-
-  for (int j = 0; j < tile.n(); ++j)
-    for (int i = 0; i < tile.m(); ++i) {
-      EXPECT_EQ(tile.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < tile.size().cols(); ++j)
+    for (int i = 0; i < tile.size().rows(); ++i) {
+      EXPECT_EQ(tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
     }
 }
 
@@ -126,20 +124,16 @@ TYPED_TEST(TileTest, MoveConstructorConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<const Type, Device::CPU> const_tile0(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<const Type, Device::CPU> const_tile0(size, memory_view, ld);
 
   Tile<const Type, Device::CPU> const_tile(std::move(const_tile0));
-  EXPECT_EQ(0, const_tile0.m());
-  EXPECT_EQ(0, const_tile0.n());
-  EXPECT_EQ(1, const_tile0.ld());
+  EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(const_tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  EXPECT_EQ(m, const_tile.m());
-  EXPECT_EQ(n, const_tile.n());
-  EXPECT_EQ(ld, const_tile.ld());
-
-  for (int j = 0; j < const_tile.n(); ++j)
-    for (int i = 0; i < const_tile.m(); ++i) {
-      EXPECT_EQ(const_tile.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < const_tile.size().cols(); ++j)
+    for (int i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
     }
 }
 
@@ -147,20 +141,16 @@ TYPED_TEST(TileTest, MoveConstructorMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile0(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
 
   Tile<const Type, Device::CPU> const_tile(std::move(tile0));
-  EXPECT_EQ(0, tile0.m());
-  EXPECT_EQ(0, tile0.n());
-  EXPECT_EQ(1, tile0.ld());
+  EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  EXPECT_EQ(m, const_tile.m());
-  EXPECT_EQ(n, const_tile.n());
-  EXPECT_EQ(ld, const_tile.ld());
-
-  for (int j = 0; j < const_tile.n(); ++j)
-    for (int i = 0; i < const_tile.m(); ++i) {
-      EXPECT_EQ(const_tile.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < const_tile.size().cols(); ++j)
+    for (int i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
     }
 }
 
@@ -168,21 +158,17 @@ TYPED_TEST(TileTest, MoveAssignement) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile0(m, n, memory_view, ld);
-  Tile<Type, Device::CPU> tile(1, 1, memory::MemoryView<Type, Device::CPU>(1), 1);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<Type, Device::CPU> tile({1, 1}, memory::MemoryView<Type, Device::CPU>(1), 1);
 
   tile = std::move(tile0);
-  EXPECT_EQ(0, tile0.m());
-  EXPECT_EQ(0, tile0.n());
-  EXPECT_EQ(1, tile0.ld());
+  EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile));
 
-  EXPECT_EQ(m, tile.m());
-  EXPECT_EQ(n, tile.n());
-  EXPECT_EQ(ld, tile.ld());
-
-  for (int j = 0; j < tile.n(); ++j)
-    for (int i = 0; i < tile.m(); ++i) {
-      EXPECT_EQ(tile.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < tile.size().cols(); ++j)
+    for (int i = 0; i < tile.size().rows(); ++i) {
+      EXPECT_EQ(tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
     }
 }
 
@@ -190,21 +176,17 @@ TYPED_TEST(TileTest, MoveAssignementConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<const Type, Device::CPU> const_tile0(m, n, memory_view, ld);
-  Tile<const Type, Device::CPU> const_tile(1, 1, memory::MemoryView<Type, Device::CPU>(1), 1);
+  TileElementSize size(m, n);
+  Tile<const Type, Device::CPU> const_tile0(size, memory_view, ld);
+  Tile<const Type, Device::CPU> const_tile({1, 1}, memory::MemoryView<Type, Device::CPU>(1), 1);
 
   const_tile = std::move(const_tile0);
-  EXPECT_EQ(0, const_tile0.m());
-  EXPECT_EQ(0, const_tile0.n());
-  EXPECT_EQ(1, const_tile0.ld());
+  EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(const_tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  EXPECT_EQ(m, const_tile.m());
-  EXPECT_EQ(n, const_tile.n());
-  EXPECT_EQ(ld, const_tile.ld());
-
-  for (int j = 0; j < const_tile.n(); ++j)
-    for (int i = 0; i < const_tile.m(); ++i) {
-      EXPECT_EQ(const_tile.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < const_tile.size().cols(); ++j)
+    for (int i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
     }
 }
 
@@ -212,21 +194,17 @@ TYPED_TEST(TileTest, MoveAssignementMix) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile0(m, n, memory_view, ld);
-  Tile<const Type, Device::CPU> const_tile(1, 1, memory::MemoryView<Type, Device::CPU>(1), 1);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile0(size, memory_view, ld);
+  Tile<const Type, Device::CPU> const_tile({1, 1}, memory::MemoryView<Type, Device::CPU>(1), 1);
 
   const_tile = std::move(tile0);
-  EXPECT_EQ(0, tile0.m());
-  EXPECT_EQ(0, tile0.n());
-  EXPECT_EQ(1, tile0.ld());
+  EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile0));
+  EXPECT_EQ(TileSizes(size, ld), getSizes(const_tile));
 
-  EXPECT_EQ(m, const_tile.m());
-  EXPECT_EQ(n, const_tile.n());
-  EXPECT_EQ(ld, const_tile.ld());
-
-  for (int j = 0; j < const_tile.n(); ++j)
-    for (int i = 0; i < const_tile.m(); ++i) {
-      EXPECT_EQ(const_tile.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < const_tile.size().cols(); ++j)
+    for (int i = 0; i < const_tile.size().rows(); ++i) {
+      EXPECT_EQ(const_tile.ptr(TileElementIndex(i, j)), memory_view(i + ld * j));
     }
 }
 
@@ -234,7 +212,8 @@ TYPED_TEST(TileTest, PromiseToFuture) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile(size, memory_view, ld);
 
   hpx::promise<Tile<Type, Device::CPU>> tile_promise;
   hpx::future<Tile<Type, Device::CPU>> tile_future = tile_promise.get_future();
@@ -244,21 +223,16 @@ TYPED_TEST(TileTest, PromiseToFuture) {
   {
     Tile<Type, Device::CPU> tile1 = std::move(tile);
     EXPECT_EQ(false, tile_future.is_ready());
-    EXPECT_EQ(0, tile.m());
-    EXPECT_EQ(0, tile.n());
-    EXPECT_EQ(1, tile.ld());
+    EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(tile));
   }
 
   ASSERT_EQ(true, tile_future.is_ready());
   Tile<Type, Device::CPU> tile2 = std::move(tile_future.get());
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile2));
 
-  EXPECT_EQ(m, tile2.m());
-  EXPECT_EQ(n, tile2.n());
-  EXPECT_EQ(ld, tile2.ld());
-
-  for (int j = 0; j < tile2.n(); ++j)
-    for (int i = 0; i < tile2.m(); ++i) {
-      EXPECT_EQ(tile2.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < tile2.size().cols(); ++j)
+    for (int i = 0; i < tile2.size().rows(); ++i) {
+      EXPECT_EQ(tile2.ptr(TileElementIndex(TileElementIndex(i, j))), memory_view(i + ld * j));
     }
 }
 
@@ -266,7 +240,8 @@ TYPED_TEST(TileTest, PromiseToFutureConst) {
   using Type = TypeParam;
   memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
 
-  Tile<Type, Device::CPU> tile(m, n, memory_view, ld);
+  TileElementSize size(m, n);
+  Tile<Type, Device::CPU> tile(size, memory_view, ld);
 
   hpx::promise<Tile<Type, Device::CPU>> tile_promise;
   hpx::future<Tile<Type, Device::CPU>> tile_future = tile_promise.get_future();
@@ -276,20 +251,15 @@ TYPED_TEST(TileTest, PromiseToFutureConst) {
   {
     Tile<const Type, Device::CPU> const_tile = std::move(tile);
     EXPECT_EQ(false, tile_future.is_ready());
-    EXPECT_EQ(0, tile.m());
-    EXPECT_EQ(0, tile.n());
-    EXPECT_EQ(1, tile.ld());
+    EXPECT_EQ(TileSizes({0, 0}, 1), getSizes(const_tile));
   }
 
   ASSERT_EQ(true, tile_future.is_ready());
   Tile<Type, Device::CPU> tile2 = std::move(tile_future.get());
+  EXPECT_EQ(TileSizes(size, ld), getSizes(tile2));
 
-  EXPECT_EQ(m, tile2.m());
-  EXPECT_EQ(n, tile2.n());
-  EXPECT_EQ(ld, tile2.ld());
-
-  for (int j = 0; j < tile2.n(); ++j)
-    for (int i = 0; i < tile2.m(); ++i) {
-      EXPECT_EQ(tile2.ptr(i, j), memory_view(i + ld * j));
+  for (int j = 0; j < tile2.size().cols(); ++j)
+    for (int i = 0; i < tile2.size().rows(); ++i) {
+      EXPECT_EQ(tile2.ptr(TileElementIndex(TileElementIndex(i, j))), memory_view(i + ld * j));
     }
 }


### PR DESCRIPTION
- `Tile` now use `index2D` and `size2D`
- `Tile<T, ...>` now inherits from `Tile<const T, ...>` to allow to have a reference to a const tile from a tile.