### PR TITLE
fix future management bug on matrix destruction

### DIFF
--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -45,10 +45,7 @@ protected:
   using Matrix<const T, device>::tileLinearIndex;
 
 private:
-  void setUpTiles(const memory::MemoryView<ElementType, device>& mem,
-                  const matrix::LayoutInfo& layout) noexcept;
-
-  using Matrix<const T, device>::setUpTilesInternal;
+  using Matrix<const T, device>::setUpTiles;
   using Matrix<const T, device>::futureVectorSize;
   using Matrix<const T, device>::tile_futures_;
   using Matrix<const T, device>::tile_shared_futures_;
@@ -71,6 +68,8 @@ public:
 
   Matrix(const Matrix& rhs) = delete;
   Matrix(Matrix&& rhs) = default;
+
+  virtual ~Matrix();
 
   Matrix& operator=(const Matrix& rhs) = delete;
   Matrix& operator=(Matrix&& rhs) = default;
@@ -101,13 +100,8 @@ private:
          std::vector<hpx::future<TileType>>&& tile_futures,
          std::vector<hpx::shared_future<ConstTileType>>&& tile_shared_futures);
 
-  void setUpConstTiles(const memory::MemoryView<ElementType, device>& mem,
-                       const matrix::LayoutInfo& layout) noexcept;
-
-  template <template <class> class Future, class TileT>
-  void setUpTilesInternal(std::vector<Future<TileT>>& tile_futures_vector,
-                          const memory::MemoryView<ElementType, device>& mem,
-                          const matrix::LayoutInfo& layout) noexcept;
+  void setUpTiles(const memory::MemoryView<ElementType, device>& mem,
+                  const matrix::LayoutInfo& layout) noexcept;
 
   std::size_t futureVectorSize(const matrix::LayoutInfo& layout) const noexcept;
 

--- a/include/dlaf/matrix.ipp
+++ b/include/dlaf/matrix.ipp
@@ -44,11 +44,3 @@ hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex&
     return std::move(fut.get().setPromise(std::move(p)));
   });
 }
-
-template <class T, Device device>
-void Matrix<T, device>::setUpTiles(const memory::MemoryView<T, device>& mem,
-                                   const matrix::LayoutInfo& layout) noexcept {
-  tile_shared_futures_.resize(futureVectorSize(layout));
-
-  setUpTilesInternal(tile_futures_, mem, layout);
-}

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -529,24 +529,23 @@ TYPED_TEST(MatrixTest, FromTileConst) {
   }
 }
 
-/* MatrixDestructorFutures
- *
- * These tests checks that futures management on destruction is performed correctly. The behaviour is
- * strictly related to the future/shared_futures mechanism and generally is not affected by the element
- * type of the matrix. For this reason, this kind of test will be carried out with just a (randomly
- * chosen) element type.
- *
- * Note 1:
- * In each task there is the last_task future that must depend on the launched task. This is needed in
- * order to being able to wait for it before the test ends, otherwise it may end after the test is
- * already finished (and in case of failure it may not be presented correctly)
- *
- * Note 2:
- * WAIT_GUARD is the time to wait in the launched task for assuring that Matrix d'tor has been called
- * after going out-of-scope. This duration must be kept as low as possible in order to not waste time
- * during tests, but at the same time it must be enough to let the "main" to arrive to the end of the
- * scope.
- */
+// MatrixDestructorFutures
+//
+// These tests checks that futures management on destruction is performed correctly. The behaviour is
+// strictly related to the future/shared_futures mechanism and generally is not affected by the element
+// type of the matrix. For this reason, this kind of test will be carried out with just a (randomly
+// chosen) element type.
+//
+// Note 1:
+// In each task there is the last_task future that must depend on the launched task. This is needed in
+// order to being able to wait for it before the test ends, otherwise it may end after the test is
+// already finished (and in case of failure it may not be presented correctly)
+//
+// Note 2:
+// WAIT_GUARD is the time to wait in the launched task for assuring that Matrix d'tor has been called
+// after going out-of-scope. This duration must be kept as low as possible in order to not waste time
+// during tests, but at the same time it must be enough to let the "main" to arrive to the end of the
+// scope.
 
 const auto WAIT_GUARD = std::chrono::milliseconds(10);
 const auto device = dlaf::Device::CPU;

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -528,3 +528,94 @@ TYPED_TEST(MatrixTest, FromTileConst) {
     CHECK_FROM_EXISTING(mem(), layout, mat);
   }
 }
+
+/* MatrixDestructorFutures
+ *
+ * These tests checks that futures management on destruction is performed correctly. The behaviour is
+ * strictly related to the future/shared_futures mechanism and generally is not affected by the element
+ * type of the matrix. For this reason, this kind of test will be carried out with just a (randomly
+ * chosen) element type.
+ *
+ * Note 1:
+ * In each task there is the last_task future that must depend on the launched task. This is needed in
+ * order to being able to wait for it before the test ends, otherwise it may end after the test is
+ * already finished (and in case of failure it may not be presented correctly)
+ *
+ * Note 2:
+ * WAIT_GUARD is the time to wait in the launched task for assuring that Matrix d'tor has been called
+ * after going out-of-scope. This duration must be kept as low as possible in order to not waste time
+ * during tests, but at the same time it must be enough to let the "main" to arrive to the end of the
+ * scope.
+ */
+
+const auto WAIT_GUARD = std::chrono::milliseconds(10);
+const auto device = dlaf::Device::CPU;
+using TypeParam = std::complex<float>;  // randomly chosen element type for matrix
+
+template <class T>
+auto createMatrix() -> Matrix<T, device> {
+  return {{1, 1}, {1, 1}};
+}
+
+template <class T>
+auto createConstMatrix() -> Matrix<T, device> {
+  matrix::LayoutInfo layout({1, 1}, {1, 1}, 1, 1, 1);
+  memory::MemoryView<T, device> mem(layout.minMemSize());
+  const T* p = mem();
+
+  return {layout, p, mem.size()};
+}
+
+TEST(MatrixDestructorFutures, NonConstAfterRead) {
+  hpx::future<void> last_task;
+
+  volatile int guard = 0;
+  {
+    auto matrix = createMatrix<TypeParam>();
+
+    auto shared_future = matrix.read({0, 0});
+    last_task = shared_future.then(hpx::launch::async, [&guard](auto&&) {
+      hpx::this_thread::sleep_for(WAIT_GUARD);
+      EXPECT_EQ(0, guard);
+    });
+  }
+  guard = 1;
+
+  last_task.get();
+}
+
+TEST(MatrixDestructorFutures, NonConstAfterReadWrite) {
+  hpx::future<void> last_task;
+
+  volatile int guard = 0;
+  {
+    auto matrix = createMatrix<TypeParam>();
+
+    auto future = matrix({0, 0});
+    last_task = future.then(hpx::launch::async, [&guard](auto&&) {
+      hpx::this_thread::sleep_for(WAIT_GUARD);
+      EXPECT_EQ(0, guard);
+    });
+  }
+  guard = 1;
+
+  last_task.get();
+}
+
+TEST(MatrixDestructorFutures, ConstAfterRead) {
+  hpx::future<void> last_task;
+
+  volatile int guard = 0;
+  {
+    auto matrix = createConstMatrix<const TypeParam>();
+
+    auto sf = matrix.read({0, 0});
+    last_task = sf.then(hpx::launch::async, [&guard](auto&&) {
+      hpx::this_thread::sleep_for(WAIT_GUARD);
+      EXPECT_EQ(0, guard);
+    });
+  }
+  guard = 1;
+
+  last_task.get();
+}


### PR DESCRIPTION
Close #75 

Now both matrix types (const and non-const) use futures and in case of need of a shared_future they create something similar to:

`"old future" -> "newly created shared_future" -> "new future"`

This allows waiting for futures on destruction, so until all futures and shared_futures are not finished, the matrix will not be released.