### PR TITLE
fixes to dlaf_test util_tile and util_matrix

### DIFF
--- a/test/include/dlaf_test/util_matrix.h
+++ b/test/include/dlaf_test/util_matrix.h
@@ -20,6 +20,7 @@ namespace matrix_test {
 using namespace dlaf;
 
 /// @brief Sets the elements of the matrix.
+///
 /// The (i, j)-element of the matrix is set to el({i, j}).
 /// @pre el argument is an index of type const GlobalElementIndex&.
 /// @pre el return type should be T.
@@ -71,6 +72,7 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFutures(Matrix<T
 }
 
 /// @brief Checks the elements of the matrix.
+///
 /// comp(expected({i, j}), (i, j)-element) is used to compare the elements.
 /// err_message(expected({i, j}), (i, j)-element) is printed for the first element
 /// that does not fulfill the comparison.
@@ -82,7 +84,7 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFutures(Matrix<T
 /// @pre The second argument of err_message should be either T, T& or const T&.
 namespace internal {
 template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGetter>
-void check(ElementGetter expected, Matrix<T, Device::CPU>& mat, ComparisonOp comp,
+void check(Matrix<T, Device::CPU>& mat, ElementGetter expected, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   for (SizeType tile_j = 0; tile_j < mat.nrTiles().cols(); ++tile_j) {
     for (SizeType tile_i = 0; tile_i < mat.nrTiles().rows(); ++tile_i) {
@@ -105,36 +107,38 @@ void check(ElementGetter expected, Matrix<T, Device::CPU>& mat, ComparisonOp com
 }
 
 /// @brief Checks the elements of the matrix (exact equality).
+///
 /// The (i, j)-element of the matrix is compared to exp_el({i, j}).
 /// @pre exp_el argument is an index of type const GlobalElementIndex&.
 /// @pre exp_el return type should be T.
 template <class T, class ElementGetter>
-void checkEQ(ElementGetter exp_el, Matrix<T, Device::CPU>& mat, const char* file, const int line) {
+void checkEQ(Matrix<T, Device::CPU>& mat, ElementGetter exp_el, const char* file, const int line) {
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
     return s.str();
   };
-  internal::check(exp_el, mat, std::equal_to<T>{}, err_message, file, line);
+  internal::check(mat, exp_el, std::equal_to<T>{}, err_message, file, line);
 }
-#define CHECK_MATRIX_EQ(exp_el, mat) ::dlaf_test::matrix_test::checkEQ(exp_el, mat, __FILE__, __LINE__);
+#define CHECK_MATRIX_EQ(mat, exp_el) ::dlaf_test::matrix_test::checkEQ(exp_el, mat, __FILE__, __LINE__);
 
 /// @brief Checks the pointers to the elements of the matrix.
+///
 /// The pointer to (i, j)-element of the matrix is compared to ptr({i, j}).
 /// @pre el argument is an index of type const GlobalElementIndex&.
 /// @pre el return type should be T*.
 template <class T, class PointerGetter>
-void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* file, const int line) {
+void checkPtr(Matrix<T, Device::CPU>& mat, PointerGetter exp_ptr, const char* file, const int line) {
   auto comp = [](T* ptr, const T& value) { return ptr == &value; };
   auto err_message = [](T* expected, const T& value) {
     std::stringstream s;
     s << "expected " << expected << " == " << &value;
     return s.str();
   };
-  internal::check(exp_ptr, mat, comp, err_message, file, line);
+  internal::check(mat, exp_ptr, comp, err_message, file, line);
 }
 #define CHECK_MATRIX_PTR(exp_ptr, mat) \
-  ::dlaf_test::matrix_test::checkPtr(exp_ptr, mat, __FILE__, __LINE__);
+  ::dlaf_test::matrix_test::checkPtr(mat, exp_ptr, __FILE__, __LINE__);
 
 }
 }

--- a/test/include/dlaf_test/util_matrix.h
+++ b/test/include/dlaf_test/util_matrix.h
@@ -84,7 +84,7 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFutures(Matrix<T
 /// @pre The second argument of err_message should be either T, T& or const T&.
 namespace internal {
 template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGetter>
-void check(Matrix<T, Device::CPU>& mat, ElementGetter expected, ComparisonOp comp,
+void check(ElementGetter expected, Matrix<T, Device::CPU>& mat, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   for (SizeType tile_j = 0; tile_j < mat.nrTiles().cols(); ++tile_j) {
     for (SizeType tile_i = 0; tile_i < mat.nrTiles().rows(); ++tile_i) {
@@ -112,33 +112,32 @@ void check(Matrix<T, Device::CPU>& mat, ElementGetter expected, ComparisonOp com
 /// @pre exp_el argument is an index of type const GlobalElementIndex&.
 /// @pre exp_el return type should be T.
 template <class T, class ElementGetter>
-void checkEQ(Matrix<T, Device::CPU>& mat, ElementGetter exp_el, const char* file, const int line) {
+void checkEQ(ElementGetter exp_el, Matrix<T, Device::CPU>& mat, const char* file, const int line) {
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
     return s.str();
   };
-  internal::check(mat, exp_el, std::equal_to<T>{}, err_message, file, line);
+  internal::check(exp_el, mat, std::equal_to<T>{}, err_message, file, line);
 }
-#define CHECK_MATRIX_EQ(mat, exp_el) ::dlaf_test::matrix_test::checkEQ(exp_el, mat, __FILE__, __LINE__);
+#define CHECK_MATRIX_EQ(exp_el, mat) ::dlaf_test::matrix_test::checkEQ(exp_el, mat, __FILE__, __LINE__);
 
 /// @brief Checks the pointers to the elements of the matrix.
 ///
-/// The pointer to (i, j)-element of the matrix is compared to ptr({i, j}).
-/// @pre el argument is an index of type const GlobalElementIndex&.
-/// @pre el return type should be T*.
+/// The pointer to (i, j)-element of the matrix is compared to exp_ptr({i, j}).
+/// @pre exp_ptr argument is an index of type const GlobalElementIndex&.
+/// @pre exp_ptr return type should be T*.
 template <class T, class PointerGetter>
-void checkPtr(Matrix<T, Device::CPU>& mat, PointerGetter exp_ptr, const char* file, const int line) {
+void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* file, const int line) {
   auto comp = [](T* ptr, const T& value) { return ptr == &value; };
   auto err_message = [](T* expected, const T& value) {
     std::stringstream s;
     s << "expected " << expected << " == " << &value;
     return s.str();
   };
-  internal::check(mat, exp_ptr, comp, err_message, file, line);
+  internal::check(exp_ptr, mat, comp, err_message, file, line);
 }
 #define CHECK_MATRIX_PTR(exp_ptr, mat) \
-  ::dlaf_test::matrix_test::checkPtr(mat, exp_ptr, __FILE__, __LINE__);
-
+  ::dlaf_test::matrix_test::checkPtr(exp_ptr, mat, __FILE__, __LINE__);
 }
 }

--- a/test/include/dlaf_test/util_tile.h
+++ b/test/include/dlaf_test/util_tile.h
@@ -29,7 +29,7 @@ using namespace dlaf;
 /// @pre el argument is an index of type const TileElementIndex&.
 /// @pre el return type should be T.
 template <class T, class Func>
-void set(Tile<T, Device::CPU>& tile, Func el) {
+void set(const Tile<T, Device::CPU>& tile, Func el) {
   for (SizeType j = 0; j < tile.size().cols(); ++j) {
     for (SizeType i = 0; i < tile.size().rows(); ++i) {
       TileElementIndex index(i, j);
@@ -46,7 +46,7 @@ void set(Tile<T, Device::CPU>& tile, Func el) {
 /// @pre el argument is an index of type const TileElementIndex&.
 /// @pre el return type should be T.
 template <class T>
-void print(Tile<T, Device::CPU>& tile, int precision = 4, std::ostream& out = std::cout) {
+void print(const Tile<T, Device::CPU>& tile, int precision = 4, std::ostream& out = std::cout) {
   auto out_precision = out.precision();
   out.precision(precision);
   // sign + number + . + exponent (e+xxx)
@@ -77,7 +77,7 @@ namespace internal {
 /// @pre The second argument of comp should be either T, T& or const T&.
 /// @pre The second argument of err_message should be either T, T& or const T&.
 template <class T, class Func1, class Func2, class Func3>
-void check(Tile<T, Device::CPU>& tile, Func1 el, Func2 comp, Func3 err_message, const char* file,
+void check(const Tile<T, Device::CPU>& tile, Func1 el, Func2 comp, Func3 err_message, const char* file,
            const int line) {
   for (SizeType j = 0; j < tile.size().cols(); ++j) {
     for (SizeType i = 0; i < tile.size().rows(); ++i) {
@@ -98,7 +98,7 @@ void check(Tile<T, Device::CPU>& tile, Func1 el, Func2 comp, Func3 err_message, 
 /// @pre el argument is an index of type const TileElementIndex&.
 /// @pre el return type should be T.
 template <class T, class Func>
-void checkEQ(Tile<T, Device::CPU>& tile, Func el, const char* file, const int line) {
+void checkEQ(const Tile<T, Device::CPU>& tile, Func el, const char* file, const int line) {
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
@@ -114,7 +114,7 @@ void checkEQ(Tile<T, Device::CPU>& tile, Func el, const char* file, const int li
 /// @pre ptr argument is an index of type const TileElementIndex&.
 /// @pre ptr return type should be T*.
 template <class T, class Func>
-void checkPtr(Tile<T, Device::CPU>& tile, Func ptr, const char* file, const int line) {
+void checkPtr(const Tile<T, Device::CPU>& tile, Func ptr, const char* file, const int line) {
   auto comp = [](T* ptr, const T& value) { return ptr == &value; };
   auto err_message = [](T* expected, const T& value) {
     std::stringstream s;
@@ -133,7 +133,7 @@ void checkPtr(Tile<T, Device::CPU>& tile, Func ptr, const char* file, const int 
 /// @pre rel_err > 0.
 /// @pre abs_err > 0.
 template <class T, class Func>
-void checkNear(Tile<T, Device::CPU>& tile, Func el, BaseType<T> rel_err, BaseType<T> abs_err,
+void checkNear(const Tile<T, Device::CPU>& tile, Func el, BaseType<T> rel_err, BaseType<T> abs_err,
                const char* file, const int line) {
   ASSERT_GT(rel_err, 0);
   ASSERT_GT(abs_err, 0);

--- a/test/include/dlaf_test/util_tile.h
+++ b/test/include/dlaf_test/util_tile.h
@@ -68,23 +68,24 @@ void print(const Tile<T, Device::CPU>& tile, int precision = 4, std::ostream& ou
 namespace internal {
 /// @brief Checks the elements of the tile.
 ///
-/// comp(el({i, j}), (i, j)-element) is used to compare the elements.
-/// err_message(el({i, j}), (i, j)-element) is printed for the first element which does not fulfill the comparison.
-/// @pre el argument is an index of type const TileElementIndex&.
+/// comp(expected({i, j}), (i, j)-element) is used to compare the elements.
+/// err_message(expected({i, j}), (i, j)-element) is printed for the first element which does not fulfill
+/// the comparison.
+/// @pre expected argument is an index of type const TileElementIndex&.
 /// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise.
 /// @pre err_message should have two arguments and return a string.
-/// @pre el return type should be the same as the type of the first argument of comp and of err_message.
+/// @pre expected return type should be the same as the type of the first argument of comp and of err_message.
 /// @pre The second argument of comp should be either T, T& or const T&.
 /// @pre The second argument of err_message should be either T, T& or const T&.
-template <class T, class Func1, class Func2, class Func3>
-void check(const Tile<T, Device::CPU>& tile, Func1 el, Func2 comp, Func3 err_message, const char* file,
-           const int line) {
+template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGetter>
+void check(ElementGetter expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
+           ErrorMessageGetter err_message, const char* file, const int line) {
   for (SizeType j = 0; j < tile.size().cols(); ++j) {
     for (SizeType i = 0; i < tile.size().rows(); ++i) {
       TileElementIndex index(i, j);
-      if (!comp(el(index), tile(index))) {
+      if (!comp(expected(index), tile(index))) {
         ADD_FAILURE_AT(file, line) << "Error at index (" << i << ", " << j
-                                   << "): " << err_message(el({i, j}), tile({i, j})) << std::endl;
+                                   << "): " << err_message(expected({i, j}), tile({i, j})) << std::endl;
         return;
       }
     }
@@ -94,47 +95,49 @@ void check(const Tile<T, Device::CPU>& tile, Func1 el, Func2 comp, Func3 err_mes
 
 /// @brief Checks the elements of the tile (exact equality).
 ///
-/// The (i, j)-element of the tile is compared to el({i, j}).
-/// @pre el argument is an index of type const TileElementIndex&.
-/// @pre el return type should be T.
-template <class T, class Func>
-void checkEQ(const Tile<T, Device::CPU>& tile, Func el, const char* file, const int line) {
+/// The (i, j)-element of the tile is compared to exp_el({i, j}).
+/// @pre exp_el argument is an index of type const TileElementIndex&.
+/// @pre exp_el return type should be T.
+template <class T, class ElementGetter>
+void checkEQ(ElementGetter exp_el, const Tile<T, Device::CPU>& tile, const char* file, const int line) {
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
     return s.str();
   };
-  internal::check(tile, el, std::equal_to<T>{}, err_message, file, line);
+  internal::check(exp_el, tile, std::equal_to<T>{}, err_message, file, line);
 }
-#define CHECK_TILE_EQ(el, tile) ::dlaf_test::tile_test::checkEQ(tile, el, __FILE__, __LINE__);
+#define CHECK_TILE_EQ(exp_el, tile) ::dlaf_test::tile_test::checkEQ(exp_el, tile, __FILE__, __LINE__);
 
 /// @brief Checks the pointers to the elements of the tile.
 ///
-/// The pointer to (i, j)-element of the matrix is compared to ptr({i, j}).
-/// @pre ptr argument is an index of type const TileElementIndex&.
-/// @pre ptr return type should be T*.
-template <class T, class Func>
-void checkPtr(const Tile<T, Device::CPU>& tile, Func ptr, const char* file, const int line) {
+/// The pointer to (i, j)-element of the matrix is compared to exp_ptr({i, j}).
+/// @pre exp_ptr argument is an index of type const TileElementIndex&.
+/// @pre exp_ptr return type should be T*.
+template <class T, class PointerGetter>
+void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const char* file,
+              const int line) {
   auto comp = [](T* ptr, const T& value) { return ptr == &value; };
   auto err_message = [](T* expected, const T& value) {
     std::stringstream s;
     s << "expected " << expected << " == " << &value;
     return s.str();
   };
-  internal::check(tile, ptr, comp, err_message, file, line);
+  internal::check(exp_ptr, tile, comp, err_message, file, line);
 }
-#define CHECK_TILE_PTR(ptr, tile) ::dlaf_test::tile_test::checkPtr(tile, ptr, __FILE__, __LINE__);
+#define CHECK_TILE_PTR(exp_ptr, tile) \
+  ::dlaf_test::tile_test::checkPtr(exp_ptr, tile, __FILE__, __LINE__);
 
 /// @brief Checks the elements of the tile.
 ///
-/// The (i, j)-element of the tile is compared to el({i, j}).
-/// @pre el argument is an index of type const TileElementIndex&.
-/// @pre el return type should be T.
+/// The (i, j)-element of the tile is compared to expected({i, j}).
+/// @pre expected argument is an index of type const TileElementIndex&.
+/// @pre expected return type should be T.
 /// @pre rel_err > 0.
 /// @pre abs_err > 0.
-template <class T, class Func>
-void checkNear(const Tile<T, Device::CPU>& tile, Func el, BaseType<T> rel_err, BaseType<T> abs_err,
-               const char* file, const int line) {
+template <class T, class ElementGetter>
+void checkNear(ElementGetter expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,
+               BaseType<T> abs_err, const char* file, const int line) {
   ASSERT_GT(rel_err, 0);
   ASSERT_GT(abs_err, 0);
 
@@ -153,10 +156,9 @@ void checkNear(const Tile<T, Device::CPU>& tile, Func el, BaseType<T> rel_err, B
       << rel_err << ", " << diff << " > " << abs_err << ")";
     return s.str();
   };
-  internal::check(tile, el, comp, err_message, file, line);
+  internal::check(expected, tile, comp, err_message, file, line);
 }
-#define CHECK_TILE_NEAR(el, tile, rel_err, abs_err) \
-  ::dlaf_test::tile_test::checkNear(tile, el, rel_err, abs_err, __FILE__, __LINE__);
-
+#define CHECK_TILE_NEAR(expected, tile, rel_err, abs_err) \
+  ::dlaf_test::tile_test::checkNear(expected, tile, rel_err, abs_err, __FILE__, __LINE__);
 }
 }


### PR DESCRIPTION
- accept const Tiles in checks
- standardize signatures between matrix and tile check functions
- fix documentation (separate brief from the description)