### PR TITLE
Use FindMKL from cmake-recipes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,16 @@ endif()
 find_package(MPI REQUIRED)
 
 # ----- LAPACK/SCALAPACK
+set(LAPACK_TARGET "")
 set(DLAF_WITH_MKL OFF CACHE BOOL "Enable MKL as provider for LAPACK")
 if (DLAF_WITH_MKL)
   set(MKL_CUSTOM_THREADING "Sequential")
-  find_package(MKL REQUIRED COMPONENTS LAPACK)
+  find_package(MKL REQUIRED COMPONENTS BLAS_32BIT_SEQ)
   set(LAPACK_FOUND ${MKL_LAPACK_FOUND})
 
-  add_library(lapack::lapack ALIAS MKL::lapack)
+  set(LAPACK_TARGET "mkl::blas_32bit_seq")
 else()
+  set(LAPACK_TARGET "lapack::lapack")
   find_package(LAPACK REQUIRED)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(DLAF
   PUBLIC
     MPI::MPI_CXX
     ${HPX_LIBRARIES}
-    lapack::lapack
+    ${LAPACK_TARGET}
     lapackpp
     blaspp
 )


### PR DESCRIPTION
The PR replaces the existing FindMKL module with the one from `cmake-recipes` : https://github.com/eth-cscs/cmake-recipes/pull/8 . I was having linking issues on my laptop with the previous FindMKL (as discussed on Slack).