### PR TITLE
Reduce compile times and build in release mode

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -1,8 +1,9 @@
 spack:
   specs:
+    - hpx build_type=Release cxxstd=14 networking=none
+    - boost cxxstd=14 ~atomic~math~iostreams~locale~graph~random~serialization~signals~timer~test~wave~mpi~python
     - mpich
     - intel-mkl
-    - hpx cxxstd=14 networking=none
-    - blaspp
-    - lapackpp
+    - blaspp build_type=Release
+    - lapackpp build_type=Release
   concretization: together


### PR DESCRIPTION
- Only compile necessary libraries for Boost
- Build HPX, lapackpp and blaspp in release mode