### PR TITLE
Add test log to output of the ci tests.

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
     always {
       sh '''
          mkdir ${OUTDIR}
-         cp *.out.txt ${OUTDIR}
+         find . -name "*.out.txt" -exec cp {} $OUTDIR ";"
          '''
       archiveArtifacts artifacts: '**/*.out.txt', fingerprint: true
     }

--- a/ci/daint-mc_test.sbatch
+++ b/ci/daint-mc_test.sbatch
@@ -26,11 +26,7 @@ set -e
 # add test log to output
 cat Testing/Temporary/LastTest.log*
 
-if [ $RETCODE -ne 0 ]
-then
-  echo "Test Failed"
-  false
-fi
+(exit $RETCODE)
 
 # only executed if tests passed
 echo "Test Successful"

--- a/ci/daint-mc_test.sbatch
+++ b/ci/daint-mc_test.sbatch
@@ -14,9 +14,25 @@ set -x
 DIR=build_${BUILD_TYPE}
 
 cd $DIR
+
+# make sure no test log exists
+rm -f Testing/Temporary/LastTest.log*
+
+set +e
 make test
+RETCODE=$?
+set -e
+
+# add test log to output
+cat Testing/Temporary/LastTest.log*
+
+if [ $RETCODE -ne 0 ]
+then
+  echo "Test Failed"
+  false
+fi
 
 # only executed if tests passed
-echo "test successful"
+echo "Test Successful"
 cd ..
 rm -rf $DIR


### PR DESCRIPTION
The test log has been added to the output of the ci tests.

They now include:
- summary of the results of the tests.
- detailed execution result of each test.