### PR TITLE
Patch GoogleTest 1.10.0 fixing segmentation fault on exceptions

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -15,6 +15,10 @@ FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG        release-1.10.0
+
+  # Patch for TestPartResult operator<<
+  # Fixes missing filename on exceptions causing segmentation fault
+  PATCH_COMMAND git cherry-pick -n 5395345ca4f0c596110188688ed990e0de5a181c -m 1
 )
 
 FetchContent_GetProperties(googletest)


### PR DESCRIPTION
Close #101 

An exception thrown during a test was causing a segmentation fault because of a missing filename. It is fixed in the master branch of GoogleTest, but after the release of 1.10.0.

The options were:
- use an after-release commit;
- use the release patched with the commit fixing this specific problem.

This PR opts for the last option by cherry-picking the commit that fixes the problem.