### PR TITLE
Workload managers presets and HPX extra arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
 endif()
 
 # ----- HPX
-find_package(HPX REQUIRED)
+find_package(HPX 1.4.0 REQUIRED)
 
 # In HPX 1.3.0 there is compiler matching check, but it does not check matching of build types.
 # Since it is source of headaches, waiting for HPX to add this check, we check on our own

--- a/ci/daint-mc_compile.sbatch
+++ b/ci/daint-mc_compile.sbatch
@@ -23,8 +23,8 @@ cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DHPX_DIR=$EBROOTHPX             \
       -Dblaspp_DIR=$EBROOTBLASPP       \
       -Dlapackpp_DIR=$EBROOTLAPACKPP   \
-      -DMPIEXEC_EXECUTABLE=`which srun`\
-      -DMPIEXEC_NUMPROC_FLAG="-n"      \
+      -DMPIEXEC_PRESET=slurm           \
+      -DMPIEXEC_NUMCORES=36            \
       ../
 make -j 50 VERBOSE=1
 

--- a/ci/daint-mc_compile.sbatch
+++ b/ci/daint-mc_compile.sbatch
@@ -23,7 +23,7 @@ cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DHPX_DIR=$EBROOTHPX             \
       -Dblaspp_DIR=$EBROOTBLASPP       \
       -Dlapackpp_DIR=$EBROOTLAPACKPP   \
-      -DMPIEXEC_PRESET=slurm           \
+      -DDLAF_MPI_PRESET=slurm          \
       -DMPIEXEC_NUMCORES=36            \
       ../
 make -j 50 VERBOSE=1

--- a/ci/daint-mc_env.sh
+++ b/ci/daint-mc_env.sh
@@ -17,9 +17,9 @@ module load BLASPP/20190829-CrayGNU-19.10
 module load LAPACKPP/20190829-CrayGNU-19.10
 if [ "${BUILD_TYPE,,}" = debug ]
 then
-  module load HPX/20190830-CrayGNU-19.10-jemalloc-debug
+  module load HPX/1.4.0-CrayGNU-19.10-jemalloc-debug
 else
-  module load HPX/20190830-CrayGNU-19.10-jemalloc
+  module load HPX/1.4.0-CrayGNU-19.10-jemalloc
 fi
 
 export CRAYPE_LINK_TYPE=dynamic

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -168,7 +168,8 @@ function(DLAF_addTest test_target_name)
   endif()
 
   if (IS_AN_HPX_TEST)
-    list(APPEND _TEST_ARGUMENTS ${DLAF_HPXTEST_EXTRA_ARGS})
+    separate_arguments(_HPX_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_HPXTEST_EXTRA_ARGS})
+    list(APPEND _TEST_ARGUMENTS ${_HPX_EXTRA_ARGS_LIST})
   endif()
 
   add_test(

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -171,6 +171,7 @@ function(DLAF_addTest test_target_name)
 
   if (IS_AN_HPX_TEST)
     separate_arguments(_HPX_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_HPXTEST_EXTRA_ARGS})
+    list(APPEND _TEST_ARGUMENTS "--hpx:use-process-mask")
     list(APPEND _TEST_ARGUMENTS ${_HPX_EXTRA_ARGS_LIST})
   endif()
 

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -156,12 +156,12 @@ function(DLAF_addTest test_target_name)
       if (NOT DLAF_CORE_PER_RANK)
         set(DLAF_CORE_PER_RANK 1)
       endif()
-    
+
       set(_MPI_CORE_ARGS ${MPIEXEC_NUMCORE_FLAG} ${DLAF_CORE_PER_RANK})
     else()
       set(_MPI_CORE_ARGS "")
     endif()
-    
+
     set(_TEST_COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${DLAF_AT_MPIRANKS} ${_MPI_CORE_ARGS}
         ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${test_target_name}> ${MPIEXEC_POSTFLAGS})
   # ----- Classic test

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -144,7 +144,7 @@ function(DLAF_addTest test_target_name)
       PRIVATE MPI::MPI_CXX
     )
 
-    if (IS_AN_HPX_TEST AND MPIEXEC_NUMCORE_FLAG)
+    if (MPIEXEC_NUMCORE_FLAG)
       if (MPIEXEC_NUMCORES)
         set(_CORES_PER_RANK ${MPIEXEC_NUMCORES})
       else()
@@ -158,6 +158,8 @@ function(DLAF_addTest test_target_name)
       endif()
     
       set(_MPI_CORE_ARGS ${MPIEXEC_NUMCORE_FLAG} ${DLAF_CORE_PER_RANK})
+    else()
+      set(_MPI_CORE_ARGS "")
     endif()
     
     set(_TEST_COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${DLAF_AT_MPIRANKS} ${_MPI_CORE_ARGS}

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -146,15 +146,15 @@ function(DLAF_addTest test_target_name)
 
     if (IS_AN_HPX_TEST AND MPIEXEC_NUMCORE_FLAG)
       if (MPIEXEC_NUMCORES)
-	set(_CORES_PER_RANK ${MPIEXEC_NUMCORES})
+        set(_CORES_PER_RANK ${MPIEXEC_NUMCORES})
       else()
-	set(_CORES_PER_RANK 1)
+        set(_CORES_PER_RANK 1)
       endif()
 
       math(EXPR DLAF_CORE_PER_RANK "${_CORES_PER_RANK}/${DLAF_AT_MPIRANKS}")
 
       if (NOT DLAF_CORE_PER_RANK)
-	set(DLAF_CORE_PER_RANK 1)
+        set(DLAF_CORE_PER_RANK 1)
       endif()
     
       set(_MPI_CORE_ARGS ${MPIEXEC_NUMCORE_FLAG} ${DLAF_CORE_PER_RANK})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,14 +8,54 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-# ----- MPI
-set(MPIEXEC_NUMCORE_FLAG "" CACHE STRING "Flag used by MPI to specify the number of cores per rank for mpiexec. If not empty, you have to specify also the number of cores available per node in MPIEXEC_NUMCORES.")
-set(MPIEXEC_NUMCORES "" CACHE STRING "Number of cores available for each MPI rank.")
+set(DLAF_PRESET_OPTIONS "plain-mpi" "slurm" "custom")
+set(DLAF_MPI_PRESET "plain-mpi" CACHE STRING "Select a preset to use")
+set_property(CACHE DLAF_MPI_PRESET PROPERTY STRINGS ${DLAF_PRESET_OPTIONS})
 
+# if a preset has been selected and it has been changed from previous configurations
+if (NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
+
+  if(DLAF_MPI_PRESET STREQUAL "plain-mpi")
+    # set(MPIEXEC_EXECUTABLE "" CACHE STRING "Executable for running MPI programs")
+    # set(MPIEXEC_NUMPROC_FLAG "" CACHE STRING "Flag used by MPI to specify the number of processes for mpiexec; the next option will be the number of processes." FORCE)
+    set(MPIEXEC_NUMCORE_FLAG "" CACHE STRING "Flag used by MPI to specify the number of cores per rank for mpiexec. If not empty, you have to specify also the number of cores available per node in MPIEXEC_NUMCORES." FORCE)
+    set(MPIEXEC_NUMCORES "" CACHE STRING "Number of cores available for each MPI rank." FORCE)
+
+  elseif(DLAF_MPI_PRESET STREQUAL "slurm")
+    execute_process(COMMAND which srun OUTPUT_VARIABLE SLURM_EXECUTABLE OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(MPIEXEC_EXECUTABLE ${SLURM_EXECUTABLE} CACHE STRING "Executable for running MPI programs" FORCE)
+    set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "Flag used by MPI to specify the number of processes for mpiexec; the next option will be the number of processes." FORCE)
+    set(MPIEXEC_NUMCORE_FLAG "-c" CACHE STRING "Flag used by MPI to specify the number of cores per rank for mpiexec. If not empty, you have to specify also the number of cores available per node in MPIEXEC_NUMCORES." FORCE)
+    set(MPIEXEC_NUMCORES "1" CACHE STRING "Number of cores available for each MPI rank.")
+
+  elseif(DLAF_MPI_PRESET STREQUAL "custom")
+    set(MPIEXEC_EXECUTABLE "" CACHE STRING "Executable for running MPI programs")
+    set(MPIEXEC_NUMPROC_FLAG "" CACHE STRING "Flag used by MPI to specify the number of processes for mpiexec; the next option will be the number of processes.")
+    set(MPIEXEC_NUMCORE_FLAG "" CACHE STRING "Flag used by MPI to specify the number of cores per rank for mpiexec. If not empty, you have to specify also the number of cores available per node in MPIEXEC_NUMCORES.")
+    set(MPIEXEC_NUMCORES "" CACHE STRING "Number of cores available for each MPI rank.")
+
+  else()
+    message(FATAL_ERROR "Preset ${DLAF_MPI_PRESET} is not supported")
+  endif()
+
+  message(STATUS "MPI preset: ${DLAF_MPI_PRESET}")
+
+  # make mpi preset selection persistent (with the aim to not overwrite each time, user may have changed some values (see custom)
+  set(_DLAF_MPI_PRESET ${DLAF_MPI_PRESET} CACHE INTERNAL "Store what preset is being used")
+
+  mark_as_advanced(MPIEXEC_EXECUTABLE MPIEXEC_NUMPROC_FLAG MPIEXEC_NUMCORE_FLAG MPIEXEC_NUMCORES)
+endif()
+
+# ----- MPI
+# there must be an mpiexec, otherwise it will not be possible to run MPI based tests
+if (NOT MPIEXEC_EXECUTABLE)
+  message(FATAL_ERROR "Please set MPIEXEC_EXECUTABLE to run MPI tests.")
+endif()
+
+# if a numcore flag is specified, it must be specified also the number of cores per node (and viceversa)
 if ((MPIEXEC_NUMCORE_FLAG OR MPIEXEC_NUMCORES) AND NOT (MPIEXEC_NUMCORE_FLAG AND MPIEXEC_NUMCORES))
   message(FATAL_ERROR "MPIEXEC_NUMCORES and MPIEXEC_NUMCORE_FLAG must be either both sets or both empty.")
 endif()
-
 
 # ----- HPX
 set(DLAF_HPXTEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with HPX")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+# ----- MPI
+set(MPIEXEC_NUMCORE_FLAG "" CACHE STRING "Flag used by MPI to specify the number of cores per rank for mpiexec. If not empty, you have to specify also the number of cores available per node in MPIEXEC_NUMCORES.")
+set(MPIEXEC_NUMCORES "" CACHE STRING "Number of cores available for each MPI rank.")
+
+if ((MPIEXEC_NUMCORE_FLAG OR MPIEXEC_NUMCORES) AND NOT (MPIEXEC_NUMCORE_FLAG AND MPIEXEC_NUMCORES))
+  message(FATAL_ERROR "MPIEXEC_NUMCORES and MPIEXEC_NUMCORE_FLAG must be either both sets or both empty.")
+endif()
+
+
+# ----- HPX
+set(DLAF_HPXTEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with HPX")
+
+
 add_library(DLAF_test src/util_mpi.cpp)
 
 target_include_directories(DLAF_test


### PR DESCRIPTION
Close #106 

Add CMake cache variable allowing to add HPX arguments to all HPX-based tests.
- `DLAF_HPXTEST_EXTRA_ARGS`:	(default=""	optional) e.g. "--hpx:print-bind"

### Presets
It is possible to select a workload manager through `DLAF_MPI_PRESET` by setting one of the following values:
- **plain-mpi**:
	`MPIEXEC_EXECUTABLE`: `<unchanged>`
	`MPIEXEC_NUMPROC_FLAG`: `<unchanged>`
	`MPIEXEC_NUMCORE_FLAG`: ""
	`MPIEXEC_NUMCORES`: ""
- **slurm**:
	`MPIEXEC_EXECUTABLE`: `which srun`
	`MPIEXEC_NUMPROC_FLAG`: "-n"
	`MPIEXEC_NUMCORE_FLAG`: "-c"
	`MPIEXEC_NUMCORES`: `<must be set by the user>`
- **custom**
	`MPIEXEC_EXECUTABLE`: `<must be set by the user>`
	`MPIEXEC_NUMPROC_FLAG`: `<can be set by the user>`
	`MPIEXEC_NUMCORE_FLAG`: `<can be set by the user>`
	`MPIEXEC_NUMCORES`: `<can be set by the user>`

**CONSTRAINT**: `MPIEXEC_NUMCORES` and `MPIEXEC_NUMCORE_FLAG` must be either both sets or both empty.

If `MPIEXEC_NUMCORE_FLAG` is set, the number of cores per rank is computed as
`cores_per_rank = max(1, MPIEXEC_NUMCORES / NUM_MPIRANKS)`

See https://github.com/eth-cscs/DLA-Future/issues/106#issuecomment-563177625 for complete specifications.