### PR TITLE
Add wrapper for collective MPI operation "MPI_Reduce"

### DIFF
--- a/include/dlaf/communication/functions_sync.h
+++ b/include/dlaf/communication/functions_sync.h
@@ -12,3 +12,4 @@
 
 #include "dlaf/communication/sync/basic.h"
 #include "dlaf/communication/sync/broadcast.h"
+#include "dlaf/communication/sync/reduce.h"

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -1,0 +1,36 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <mpi.h>
+#include "dlaf/communication/communicator.h"
+#include "dlaf/communication/message.h"
+
+namespace dlaf {
+namespace comm {
+namespace sync {
+
+/// @brief MPI_Reduce wrapper
+/// MPI Reduce(see MPI documentation for additional info)
+/// @param rank_root  the rank that will collect the result in output
+/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
+template <class T>
+void reduce(int rank_root, Communicator& communicator, MPI_Op reduce_operation, Message<T>&& input,
+            Message<T>&& output) {
+  MPI_Reduce(input.data(), output.data(), input.count(), input.mpi_type(), reduce_operation, rank_root,
+             communicator);
+}
+
+}
+}
+}

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -32,6 +32,12 @@ DLAF_addTest(test_broadcast
   USE_MAIN MPI
 )
 
+DLAF_addTest(test_reduce
+  SOURCES test_reduce.cpp
+  MPIRANKS 4
+  USE_MAIN MPI
+)
+
 DLAF_addTest(test_broadcast_tile
   SOURCES test_broadcast_tile.cpp
   MPIRANKS 5

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -1,0 +1,56 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/communication/sync/reduce.h"
+
+#include <gtest/gtest.h>
+
+#include "dlaf_test/helper_communicators.h"
+
+using namespace dlaf_test;
+using namespace dlaf::comm;
+
+using ReduceTest = SplittedCommunicatorsTest;
+
+TEST_F(ReduceTest, Basic) {
+  int root = 0;
+
+  int value = 1;
+  int result = 0;
+
+  sync::reduce(root, world, MPI_SUM, make_message(&value, 1), make_message(&result, 1));
+
+  // check that the root rank has the reduced results
+  if (world.rank() == root)
+    EXPECT_EQ(NUM_MPI_RANKS * value, result);
+
+  // check that input has not been modified
+  EXPECT_EQ(1, value);
+}
+
+TEST_F(ReduceTest, Multiple) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+  int root = 1;
+
+  const std::size_t N = 3;
+  int input[N] = {1, 2, 3};
+  int reduced[N];
+
+  sync::reduce(root, world, MPI_SUM, make_message(input, N), make_message(reduced, N));
+
+  // check that the root rank has the reduced results
+  if (world.rank() == root)
+    for (auto index = 0; index < N; ++index)
+      EXPECT_EQ(NUM_MPI_RANKS * input[index], reduced[index]);
+
+  // check that input has not been modified
+  for (auto index = 0; index < N; ++index)
+    EXPECT_EQ(index + 1, input[index]);
+}


### PR DESCRIPTION
Close #122 

Add basic implementation of `MPI_Reduce` wrapper with basic tests.