### PR TITLE
Basic exception propagation for tiles

### DIFF
--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -60,6 +60,13 @@ hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex&
   tile_futures_[i] = p.get_future();
   tile_shared_futures_[i] = {};
   return old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileType>&& fut) mutable {
-    return std::move(fut.get().setPromise(std::move(p)));
+    try {
+      return std::move(fut.get().setPromise(std::move(p)));
+    }
+    catch (...) {
+      auto current_exception_ptr = std::current_exception();
+      p.set_exception(current_exception_ptr);
+      std::rethrow_exception(current_exception_ptr);
+    }
   });
 }

--- a/include/dlaf/matrix_const.tpp
+++ b/include/dlaf/matrix_const.tpp
@@ -32,8 +32,14 @@ template <class T, Device device>
 Matrix<const T, device>::~Matrix() {
   tile_shared_futures_.clear();
 
-  for (auto&& tile_future : tile_futures_)
-    tile_future.get();
+  for (auto&& tile_future : tile_futures_) {
+    try {
+      tile_future.get();
+    }
+    catch (...) {
+      // TODO WARNING
+    }
+  }
 }
 
 template <class T, Device device>

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -20,6 +20,10 @@
 
 namespace dlaf {
 
+struct ContinuationException final : public std::runtime_error {
+  ContinuationException() : std::runtime_error("An exception has been thrown during the execution of the previous task") {}
+};
+
 template <class T, Device device>
 class Tile;
 

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <exception>
 #include <hpx/hpx.hpp>
 #include "dlaf/common/buffer.h"
 #include "dlaf/matrix/index.h"

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -24,7 +24,8 @@ namespace dlaf {
 ///
 /// It is mainly used to enable exception propagation in the automatic-continuation mechanism
 struct ContinuationException final : public std::runtime_error {
-  ContinuationException() : std::runtime_error("An exception has been thrown during the execution of the previous task") {}
+  ContinuationException()
+      : std::runtime_error("An exception has been thrown during the execution of the previous task") {}
 };
 
 template <class T, Device device>

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -20,6 +20,9 @@
 
 namespace dlaf {
 
+/// Exception used to notify that an exception has been thrown in a continuation task
+///
+/// It is mainly used to enable exception propagation in the automatic-continuation mechanism
 struct ContinuationException final : public std::runtime_error {
   ContinuationException() : std::runtime_error("An exception has been thrown during the execution of the previous task") {}
 };

--- a/include/dlaf/tile.tpp
+++ b/include/dlaf/tile.tpp
@@ -35,8 +35,7 @@ template <class T, Device device>
 Tile<const T, device>::~Tile() {
   if (p_) {
     if (std::uncaught_exception())
-      p_->set_exception(std::make_exception_ptr(
-          std::runtime_error("An exception has been thrown and this tile destroyed")));
+      p_->set_exception(std::make_exception_ptr(ContinuationException{}));
     else
       p_->set_value(Tile<ElementType, device>(size_, std::move(memory_view_), ld_));
   }

--- a/include/dlaf/tile.tpp
+++ b/include/dlaf/tile.tpp
@@ -34,7 +34,10 @@ Tile<const T, device>::Tile(Tile&& rhs) noexcept
 template <class T, Device device>
 Tile<const T, device>::~Tile() {
   if (p_) {
-    p_->set_value(Tile<ElementType, device>(size_, std::move(memory_view_), ld_));
+    if (std::uncaught_exception())
+      p_->set_exception(std::make_exception_ptr(std::runtime_error("An exception has been thrown and this tile destroyed")));
+    else
+      p_->set_value(Tile<ElementType, device>(size_, std::move(memory_view_), ld_));
   }
 }
 

--- a/include/dlaf/tile.tpp
+++ b/include/dlaf/tile.tpp
@@ -35,7 +35,8 @@ template <class T, Device device>
 Tile<const T, device>::~Tile() {
   if (p_) {
     if (std::uncaught_exception())
-      p_->set_exception(std::make_exception_ptr(std::runtime_error("An exception has been thrown and this tile destroyed")));
+      p_->set_exception(std::make_exception_ptr(
+          std::runtime_error("An exception has been thrown and this tile destroyed")));
     else
       p_->set_value(Tile<ElementType, device>(size_, std::move(memory_view_), ld_));
   }

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1156,7 +1156,7 @@ TEST(MatrixDestructorFutures, ConstAfterRead) {
 
 struct CustomException final : public std::exception {};
 
-TEST(MatrixExceptionPropagation, PropagateOnRwWithRWAccess) {
+TEST(MatrixExceptionPropagation, RWPropagatesInRWAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f =
@@ -1166,7 +1166,7 @@ TEST(MatrixExceptionPropagation, PropagateOnRwWithRWAccess) {
   EXPECT_THROW(f.get(), CustomException);
 }
 
-TEST(MatrixExceptionPropagation, PropagateOnRwWithReadAccess) {
+TEST(MatrixExceptionPropagation, RWPropagatesInReadAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f =
@@ -1176,7 +1176,7 @@ TEST(MatrixExceptionPropagation, PropagateOnRwWithReadAccess) {
   EXPECT_THROW(f.get(), CustomException);
 }
 
-TEST(MatrixExceptionPropagation, NoPropagateOnReadOnlyWithRWAccess) {
+TEST(MatrixExceptionPropagation, ReadDoesNotPropagateInRWAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f = matrix.read(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
@@ -1187,7 +1187,7 @@ TEST(MatrixExceptionPropagation, NoPropagateOnReadOnlyWithRWAccess) {
   EXPECT_THROW(f.get(), CustomException);
 }
 
-TEST(MatrixExceptionPropagation, NoPropagateOnReadOnlyWithReadAccess) {
+TEST(MatrixExceptionPropagation, ReadDoesNotPropagateInReadAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f = matrix.read(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1154,46 +1154,48 @@ TEST(MatrixDestructorFutures, ConstAfterRead) {
   last_task.get();
 }
 
+struct CustomException final : public std::exception {};
+
 TEST(MatrixExceptionPropagation, PropagateOnRwWithRWAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f = matrix(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
-    throw std::runtime_error("exception in task");
+    throw CustomException{};
   }));
 
   EXPECT_THROW(matrix(LocalTileIndex(0, 0)).get(), dlaf::ContinuationException);
-  EXPECT_ANY_THROW(f.get());
+  EXPECT_THROW(f.get(), CustomException);
 }
 
 TEST(MatrixExceptionPropagation, PropagateOnRwWithReadAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f = matrix(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
-    throw std::runtime_error("exception in task");
+    throw CustomException{};
   }));
 
   EXPECT_THROW(matrix.read(LocalTileIndex(0, 0)).get(), dlaf::ContinuationException);
-  EXPECT_ANY_THROW(f.get());
+  EXPECT_THROW(f.get(), CustomException);
 }
 
 TEST(MatrixExceptionPropagation, NoPropagateOnReadOnlyWithRWAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f = matrix.read(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
-    throw std::runtime_error("exception in task");
+    throw CustomException{};
   }));
 
   EXPECT_NO_THROW(matrix(LocalTileIndex(0, 0)).get());
-  EXPECT_ANY_THROW(f.get());
+  EXPECT_THROW(f.get(), CustomException);
 }
 
 TEST(MatrixExceptionPropagation, NoPropagateOnReadOnlyWithReadAccess) {
   auto matrix = createMatrix<TypeParam>();
 
   auto f = matrix.read(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
-    throw std::runtime_error("exception in task");
+    throw CustomException{};
   }));
 
   EXPECT_NO_THROW(matrix.read(LocalTileIndex(0, 0)).get());
-  EXPECT_ANY_THROW(f.get());
+  EXPECT_THROW(f.get(), CustomException);
 }

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1159,9 +1159,8 @@ struct CustomException final : public std::exception {};
 TEST(MatrixExceptionPropagation, PropagateOnRwWithRWAccess) {
   auto matrix = createMatrix<TypeParam>();
 
-  auto f = matrix(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
-    throw CustomException{};
-  }));
+  auto f =
+      matrix(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) { throw CustomException{}; }));
 
   EXPECT_THROW(matrix(LocalTileIndex(0, 0)).get(), dlaf::ContinuationException);
   EXPECT_THROW(f.get(), CustomException);
@@ -1170,9 +1169,8 @@ TEST(MatrixExceptionPropagation, PropagateOnRwWithRWAccess) {
 TEST(MatrixExceptionPropagation, PropagateOnRwWithReadAccess) {
   auto matrix = createMatrix<TypeParam>();
 
-  auto f = matrix(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) {
-    throw CustomException{};
-  }));
+  auto f =
+      matrix(LocalTileIndex(0, 0)).then(hpx::util::unwrapping([](auto&&) { throw CustomException{}; }));
 
   EXPECT_THROW(matrix.read(LocalTileIndex(0, 0)).get(), dlaf::ContinuationException);
   EXPECT_THROW(f.get(), CustomException);

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1161,7 +1161,7 @@ TEST(MatrixExceptionPropagation, PropagateOnRwWithRWAccess) {
     throw std::runtime_error("exception in task");
   }));
 
-  EXPECT_ANY_THROW(matrix(LocalTileIndex(0, 0)).get());
+  EXPECT_THROW(matrix(LocalTileIndex(0, 0)).get(), dlaf::ContinuationException);
   EXPECT_ANY_THROW(f.get());
 }
 
@@ -1172,7 +1172,7 @@ TEST(MatrixExceptionPropagation, PropagateOnRwWithReadAccess) {
     throw std::runtime_error("exception in task");
   }));
 
-  EXPECT_ANY_THROW(matrix.read(LocalTileIndex(0, 0)).get());
+  EXPECT_THROW(matrix.read(LocalTileIndex(0, 0)).get(), dlaf::ContinuationException);
   EXPECT_ANY_THROW(f.get());
 }
 


### PR DESCRIPTION
The real exception is not propagated, but a fixed one is propagated in the tile chaining mechanism.