### PR TITLE
Preconditions macros

### DIFF
--- a/cmake/DLAF_AddTargetWarnings.cmake
+++ b/cmake/DLAF_AddTargetWarnings.cmake
@@ -26,6 +26,7 @@ macro(target_add_warnings target_name)
       -Wunused
       -Woverloaded-virtual
       -Wdangling-else
+      -Wswitch-enum
       # Conversions
       $<${IS_COMPILER_GCC}:
         -Wsign-conversion

--- a/include/dlaf/factorization/cholesky/mc.tpp
+++ b/include/dlaf/factorization/cholesky/mc.tpp
@@ -19,11 +19,11 @@ namespace dlaf {
 template <class T>
 void Factorization<Backend::MC>::cholesky(blas::Uplo uplo, Matrix<T, Device::CPU>& mat_a) {
   // Check if matrix is square
-  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
+  DLAF_ASSERT_SIZE_SQUARE(mat_a);
   // Check if block matrix is square
-  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
+  DLAF_ASSERT_BLOCKSIZE_SQUARE(mat_a);
   // Check if matrix is stored on local memory
-  DLAF_PRECONDITION_LOCALMATRIX(mat_a);
+  DLAF_ASSERT_LOCALMATRIX(mat_a);
 
   if (uplo == blas::Uplo::Lower)
     internal::mc::cholesky_L(mat_a);
@@ -35,11 +35,11 @@ template <class T>
 void Factorization<Backend::MC>::cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo,
                                           Matrix<T, Device::CPU>& mat_a) {
   // Check if matrix is square
-  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
+  DLAF_ASSERT_SIZE_SQUARE(mat_a);
   // Check if block matrix is square
-  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
+  DLAF_ASSERT_BLOCKSIZE_SQUARE(mat_a);
   // Check compatibility of the communicator grid and the distribution
-  DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_a);
+  DLAF_ASSERT_DISTRIBUTED_ON_GRID(grid, mat_a);
 
   // Method only for Lower triangular matrix
   if (uplo == blas::Uplo::Lower)

--- a/include/dlaf/factorization/cholesky/mc.tpp
+++ b/include/dlaf/factorization/cholesky/mc.tpp
@@ -19,11 +19,11 @@ namespace dlaf {
 template <class T>
 void Factorization<Backend::MC>::cholesky(blas::Uplo uplo, Matrix<T, Device::CPU>& mat_a) {
   // Check if matrix is square
-  util_matrix::assertSizeSquare(mat_a, "Cholesky", "mat_a");
+  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
   // Check if block matrix is square
-  util_matrix::assertBlocksizeSquare(mat_a, "Cholesky", "mat_a");
+  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
   // Check if matrix is stored on local memory
-  util_matrix::assertLocalMatrix(mat_a, "Cholesky", "mat_a");
+  DLAF_PRECONDITION_LOCALMATRIX(mat_a);
 
   if (uplo == blas::Uplo::Lower)
     internal::mc::cholesky_L(mat_a);
@@ -35,11 +35,11 @@ template <class T>
 void Factorization<Backend::MC>::cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo,
                                           Matrix<T, Device::CPU>& mat_a) {
   // Check if matrix is square
-  util_matrix::assertSizeSquare(mat_a, "Cholesky", "mat_a");
+  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
   // Check if block matrix is square
-  util_matrix::assertBlocksizeSquare(mat_a, "Cholesky", "mat_a");
+  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
   // Check compatibility of the communicator grid and the distribution
-  util_matrix::assertMatrixDistributedOnGrid(grid, mat_a, "Cholesky", "mat_a", "grid");
+  DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_a);
 
   // Method only for Lower triangular matrix
   if (uplo == blas::Uplo::Lower)

--- a/include/dlaf/solver/triangular/mc.tpp
+++ b/include/dlaf/solver/triangular/mc.tpp
@@ -28,15 +28,15 @@ void Solver<Backend::MC>::triangular(blas::Side side, blas::Uplo uplo, blas::Op 
                                      T alpha, Matrix<const T, Device::CPU>& mat_a,
                                      Matrix<T, Device::CPU>& mat_b) {
   // Check if matrix A is square
-  util_matrix::assertSizeSquare(mat_a, "TriangularSolver", "mat_a");
+  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
   // Check if block matrix A is square
-  util_matrix::assertBlocksizeSquare(mat_a, "TriangularSolver", "mat_a");
+  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
   // Check if A and B dimensions are compatible
-  util_matrix::assertMultipliableMatrices(mat_a, mat_b, side, op, "TriangularSolver", "mat_a", "mat_b");
+  DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, side, op);
   // Check if matrix A is stored on local memory
-  util_matrix::assertLocalMatrix(mat_a, "TriangularSolver", "mat_a");
+  DLAF_PRECONDITION_LOCALMATRIX(mat_a);
   // Check if matrix B is stored on local memory
-  util_matrix::assertLocalMatrix(mat_b, "TriangularSolver", "mat_b");
+  DLAF_PRECONDITION_LOCALMATRIX(mat_b);
 
   if (side == blas::Side::Left) {
     if (uplo == blas::Uplo::Lower) {
@@ -90,15 +90,15 @@ void Solver<Backend::MC>::triangular(comm::CommunicatorGrid grid, blas::Side sid
                                      Matrix<const T, Device::CPU>& mat_a,
                                      Matrix<T, Device::CPU>& mat_b) {
   // Check if matrix A is square
-  util_matrix::assertSizeSquare(mat_a, "TriangularSolver", "mat_a");
+  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
   // Check if block matrix A is square
-  util_matrix::assertBlocksizeSquare(mat_a, "TriangularSolver", "mat_a");
+  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
   // Check if A and B dimensions are compatible
-  util_matrix::assertMultipliableMatrices(mat_a, mat_b, side, op, "TriangularSolver", "mat_a", "mat_b");
+  DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, side, op);
   // Check compatibility of the communicator grid and the distribution of matrix A
-  util_matrix::assertMatrixDistributedOnGrid(grid, mat_a, "TriangularSolver", "mat_a", "grid");
+  DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_a);
   // Check compatibility of the communicator grid and the distribution of matrix B
-  util_matrix::assertMatrixDistributedOnGrid(grid, mat_b, "TriangularSolver", "mat_b", "grid");
+  DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_b);
 
   if (side == blas::Side::Left) {
     if (uplo == blas::Uplo::Lower) {

--- a/include/dlaf/solver/triangular/mc.tpp
+++ b/include/dlaf/solver/triangular/mc.tpp
@@ -31,14 +31,15 @@ void Solver<Backend::MC>::triangular(blas::Side side, blas::Uplo uplo, blas::Op 
   DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
   // Check if block matrix A is square
   DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
-  // Check if A and B dimensions are compatible
-  DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, side, op);
   // Check if matrix A is stored on local memory
   DLAF_PRECONDITION_LOCALMATRIX(mat_a);
   // Check if matrix B is stored on local memory
   DLAF_PRECONDITION_LOCALMATRIX(mat_b);
 
   if (side == blas::Side::Left) {
+    // Check if A and B dimensions are compatible
+    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, op, blas::Op::NoTrans);
+
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
         // Left Lower NoTrans
@@ -61,6 +62,9 @@ void Solver<Backend::MC>::triangular(blas::Side side, blas::Uplo uplo, blas::Op 
     }
   }
   else {
+    // Check if A and B dimensions are compatible
+    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_b, mat_a, blas::Op::NoTrans, op);
+
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
         // Right Lower NoTrans
@@ -93,14 +97,15 @@ void Solver<Backend::MC>::triangular(comm::CommunicatorGrid grid, blas::Side sid
   DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
   // Check if block matrix A is square
   DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
-  // Check if A and B dimensions are compatible
-  DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, side, op);
   // Check compatibility of the communicator grid and the distribution of matrix A
   DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_a);
   // Check compatibility of the communicator grid and the distribution of matrix B
   DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_b);
 
   if (side == blas::Side::Left) {
+    // Check if A and B dimensions are compatible
+    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, op, blas::Op::NoTrans);
+
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
         // Left Lower NoTrans
@@ -123,6 +128,9 @@ void Solver<Backend::MC>::triangular(comm::CommunicatorGrid grid, blas::Side sid
     }
   }
   else {
+    // Check if A and B dimensions are compatible
+    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_b, mat_a, blas::Op::NoTrans, op);
+
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
         // Right Lower NoTrans

--- a/include/dlaf/solver/triangular/mc.tpp
+++ b/include/dlaf/solver/triangular/mc.tpp
@@ -28,17 +28,17 @@ void Solver<Backend::MC>::triangular(blas::Side side, blas::Uplo uplo, blas::Op 
                                      T alpha, Matrix<const T, Device::CPU>& mat_a,
                                      Matrix<T, Device::CPU>& mat_b) {
   // Check if matrix A is square
-  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
+  DLAF_ASSERT_SIZE_SQUARE(mat_a);
   // Check if block matrix A is square
-  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
+  DLAF_ASSERT_BLOCKSIZE_SQUARE(mat_a);
   // Check if matrix A is stored on local memory
-  DLAF_PRECONDITION_LOCALMATRIX(mat_a);
+  DLAF_ASSERT_LOCALMATRIX(mat_a);
   // Check if matrix B is stored on local memory
-  DLAF_PRECONDITION_LOCALMATRIX(mat_b);
+  DLAF_ASSERT_LOCALMATRIX(mat_b);
 
   if (side == blas::Side::Left) {
     // Check if A and B dimensions are compatible
-    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, op, blas::Op::NoTrans);
+    DLAF_ASSERT_MULTIPLIABLE_MATRICES(mat_a, mat_b, mat_b, op, blas::Op::NoTrans);
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
@@ -63,7 +63,7 @@ void Solver<Backend::MC>::triangular(blas::Side side, blas::Uplo uplo, blas::Op 
   }
   else {
     // Check if A and B dimensions are compatible
-    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_b, mat_a, blas::Op::NoTrans, op);
+    DLAF_ASSERT_MULTIPLIABLE_MATRICES(mat_b, mat_a, mat_b, blas::Op::NoTrans, op);
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
@@ -94,17 +94,17 @@ void Solver<Backend::MC>::triangular(comm::CommunicatorGrid grid, blas::Side sid
                                      Matrix<const T, Device::CPU>& mat_a,
                                      Matrix<T, Device::CPU>& mat_b) {
   // Check if matrix A is square
-  DLAF_PRECONDITION_SIZE_SQUARE(mat_a);
+  DLAF_ASSERT_SIZE_SQUARE(mat_a);
   // Check if block matrix A is square
-  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(mat_a);
+  DLAF_ASSERT_BLOCKSIZE_SQUARE(mat_a);
   // Check compatibility of the communicator grid and the distribution of matrix A
-  DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_a);
+  DLAF_ASSERT_DISTRIBUTED_ON_GRID(grid, mat_a);
   // Check compatibility of the communicator grid and the distribution of matrix B
-  DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, mat_b);
+  DLAF_ASSERT_DISTRIBUTED_ON_GRID(grid, mat_b);
 
   if (side == blas::Side::Left) {
     // Check if A and B dimensions are compatible
-    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_a, mat_b, op, blas::Op::NoTrans);
+    DLAF_ASSERT_MULTIPLIABLE_MATRICES(mat_a, mat_b, mat_b, op, blas::Op::NoTrans);
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
@@ -129,7 +129,7 @@ void Solver<Backend::MC>::triangular(comm::CommunicatorGrid grid, blas::Side sid
   }
   else {
     // Check if A and B dimensions are compatible
-    DLAF_PRECONDITION_MULTIPLIABLE_MATRICES(mat_b, mat_a, blas::Op::NoTrans, op);
+    DLAF_ASSERT_MULTIPLIABLE_MATRICES(mat_b, mat_a, mat_b, blas::Op::NoTrans, op);
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -36,24 +36,25 @@ namespace internal {
 /// @brief Verify if dlaf::Matrix is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_SIZE_SQUARE(matrix)                                                       \
-  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square (", \
+#define DLAF_PRECONDITION_SIZE_SQUARE(matrix)                                                         \
+  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix ", #matrix, " is not square (", \
               matrix.size().rows(), "x", matrix.size().cols(), ").")
 
 /// @brief Verify if dlaf::Matrix tile is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                                   \
-  DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix",      \
-              #matrix, "is not square (", matrix.blockSize().rows(), "x", matrix.blockSize().cols(), \
+#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                                    \
+  DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix ",      \
+              #matrix, " is not square (", matrix.blockSize().rows(), "x", matrix.blockSize().cols(), \
               ").")
 
 /// @brief Verify if dlaf::Matrix is distributed on a (1x1) grid (i.e. if it is a local matrix).
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_LOCALMATRIX(matrix)                                                  \
-  DLAF_ASSERT((matrix.distribution().commGridSize() == comm::Size2D{1, 1}), "Matrix", #matrix, \
-              "is not local.")
+#define DLAF_PRECONDITION_LOCALMATRIX(matrix)                                                   \
+  DLAF_ASSERT((matrix.distribution().commGridSize() == comm::Size2D{1, 1}), "Matrix ", #matrix, \
+              " is not local (grid size: ", matrix.distribution().commGridSize().rows(), "x",   \
+              matrix.distribution().commGridSize().cols(), ").")
 
 /// @brief Verify that the matrix is distributed according to the given communicator grid.
 ///
@@ -61,8 +62,12 @@ namespace internal {
 #define DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, matrix)                                          \
   DLAF_ASSERT(((matrix.distribution().commGridSize() == grid.size()) &&                              \
                (matrix.distribution().rankIndex() == grid.rank())),                                  \
-              "The matrix", #matrix, "is not distributed according to the communicator grid", #grid, \
-              ".")
+              "The matrix ", #matrix, " (rank: ", matrix.distribution().rankIndex(),                 \
+              ", grid size: ", matrix.distribution().commGridSize().rows(), "x",                     \
+              matrix.distribution().commGridSize().cols(),                                           \
+              ") is not distributed according to the communicator grid ", #grid,                     \
+              " (rank: ", grid.rank(), ", grid size: ", grid.size().rows(), "x", grid.size().cols(), \
+              ").")
 
 template <class MatrixConst, class Matrix, class Location>
 void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, const blas::Op opA,
@@ -85,27 +90,33 @@ void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, c
 
   switch (opA) {
     case blas::Op::NoTrans:
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices",
-                              mat_a_name, "and", mat_b_name,
-                              "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices",
-                              mat_a_name, "and", mat_b_name,
-                              "are not left multipliable (size of matrix A not equal to that of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices ",
+                              mat_a_name, " and ", mat_b_name,
+                              " are not left multipliable (cols of matrix A, ", mat_a.size().cols(),
+                              ", not equal to rows of matrix B, ", mat_b.size().rows(), ").");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices ",
+                              mat_a_name, " and ", mat_b_name,
+                              " are not left multipliable (size of matrix A, ", mat_a.size(),
+                              ", not equal to that of matrix B, ", mat_b.size(), ").");
       DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())),
-                              "The matrices", mat_a_name, "and", mat_b_name,
-                              "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
+                              "The matrices ", mat_a_name, " and ", mat_b_name,
+                              " are not left multipliable (blocksize of matrix A, ", mat_a.blockSize(),
+                              ", not equal to that of matrix B, ", mat_b.blockSize(), ").");
       break;
     case blas::Op::Trans:
     case blas::Op::ConjTrans:
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices",
-                              mat_a_name, "and", mat_b_name,
-                              "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices",
-                              mat_a_name, "and", mat_b_name,
-                              "are not left multipliable (size of matrix A not equal to that of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices ",
+                              mat_a_name, " and ", mat_b_name,
+                              " are not left multipliable (cols of matrix A, ", mat_a.size().cols(),
+                              ", not equal to rows of matrix B, ", mat_b.size().rows(), ").");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices ",
+                              mat_a_name, " and ", mat_b_name,
+                              " are not left multipliable (size of matrix A, ", mat_a.size(),
+                              ", not equal to that of matrix B, ", mat_b.size(), ").");
       DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())),
-                              "The matrices", mat_a_name, "and", mat_b_name,
-                              "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
+                              "The matrices ", mat_a_name, " and ", mat_b_name,
+                              " are not left multipliable (blocksize of matrix A, ", mat_a.blockSize(),
+                              ", not equal to that of matrix B, ", mat_b.blockSize(), ").");
       break;
   }
 }

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -36,15 +36,17 @@ namespace internal {
 /// @brief Verify if dlaf::Matrix is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_SIZE_SQUARE(matrix) \
-  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square (", matrix.size().rows(), "x", matrix.size().cols(),").")
+#define DLAF_PRECONDITION_SIZE_SQUARE(matrix)                                                       \
+  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square (", \
+              matrix.size().rows(), "x", matrix.size().cols(), ").")
 
 /// @brief Verify if dlaf::Matrix tile is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                              \
-  DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix", \
-              #matrix, "is not square (", matrix.blockSize().rows(), "x", matrix.blockSize().cols(), ").")
+#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                                   \
+  DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix",      \
+              #matrix, "is not square (", matrix.blockSize().rows(), "x", matrix.blockSize().cols(), \
+              ").")
 
 /// @brief Verify if dlaf::Matrix is distributed on a (1x1) grid (i.e. if it is a local matrix).
 ///

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -37,27 +37,27 @@ namespace internal {
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
 #define DLAF_PRECONDITION_SIZE_SQUARE(matrix) \
-  DLAF_PRECONDITION((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square.")
+  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square.")
 
 /// @brief Verify if dlaf::Matrix tile is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
 #define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                                    \
-  DLAF_PRECONDITION((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix", \
+  DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix", \
                     #matrix, "is not square.")
 
 /// @brief Verify if dlaf::Matrix is distributed on a (1x1) grid (i.e. if it is a local matrix).
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
 #define DLAF_PRECONDITION_LOCALMATRIX(matrix)                                                        \
-  DLAF_PRECONDITION((matrix.distribution().commGridSize() == comm::Size2D{1, 1}), "Matrix", #matrix, \
+  DLAF_ASSERT((matrix.distribution().commGridSize() == comm::Size2D{1, 1}), "Matrix", #matrix, \
                     "is not local.")
 
 /// @brief Verify that the matrix is distributed according to the given communicator grid.
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
 #define DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, matrix)                                         \
-  DLAF_PRECONDITION(((matrix.distribution().commGridSize() == grid.size()) &&                       \
+  DLAF_ASSERT(((matrix.distribution().commGridSize() == grid.size()) &&                       \
                      (matrix.distribution().rankIndex() == grid.rank())),                           \
                     "The matrix", #matrix, "is not distributed according to the communicator grid", \
                     #grid, ".")
@@ -81,26 +81,26 @@ void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, c
 
   switch (opA) {
     case blas::Op::NoTrans:
-      DLAF_PRECONDITION_WITH_ORIGIN(
+      DLAF_ASSERT_WITH_ORIGIN(
           location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices", mat_a_name, "and",
           mat_b_name, "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
-      DLAF_PRECONDITION_WITH_ORIGIN(
+      DLAF_ASSERT_WITH_ORIGIN(
           location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices", mat_a_name, "and",
           mat_b_name, "are not left multipliable (size of matrix A not equal to that of matrix B).");
-      DLAF_PRECONDITION_WITH_ORIGIN(
+      DLAF_ASSERT_WITH_ORIGIN(
           location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())), "The matrices", mat_a_name,
           "and", mat_b_name,
           "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
       break;
     case blas::Op::Trans:
     case blas::Op::ConjTrans:
-      DLAF_PRECONDITION_WITH_ORIGIN(
+      DLAF_ASSERT_WITH_ORIGIN(
           location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices", mat_a_name, "and",
           mat_b_name, "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
-      DLAF_PRECONDITION_WITH_ORIGIN(
+      DLAF_ASSERT_WITH_ORIGIN(
           location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices", mat_a_name, "and",
           mat_b_name, "are not left multipliable (size of matrix A not equal to that of matrix B).");
-      DLAF_PRECONDITION_WITH_ORIGIN(
+      DLAF_ASSERT_WITH_ORIGIN(
           location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())), "The matrices", mat_a_name,
           "and", mat_b_name,
           "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -108,6 +108,15 @@ void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, c
                           cols(mat_a.size(), opA), ") x ", mat_b_name, " (", rows(mat_b.size(), opB),
                           ", ", cols(mat_b.size(), opB), ") --> ", mat_c_name, " ", mat_c.size(),
                           " cannot be performed.");
+
+  DLAF_ASSERT_WITH_ORIGIN(location,
+                          rows(mat_a.blockSize(), opA) == mat_c.blockSize().rows() &&
+                              cols(mat_a.blockSize(), opA) == rows(mat_b.blockSize(), opB) &&
+                              cols(mat_b.blockSize(), opB) == mat_c.blockSize().cols(),
+                          "BlockSize mismatch: ", mat_a_name, " (", rows(mat_a.blockSize(), opA), ", ",
+                          cols(mat_a.blockSize(), opA), ") x ", mat_b_name, " (",
+                          rows(mat_b.blockSize(), opB), ", ", cols(mat_b.blockSize(), opB), ") --> ",
+                          mat_c_name, " ", mat_c.blockSize(), " cannot be performed.");
 }
 /// @brief Assert that the matrices @p mat_a and @p mat_b are multipliable and that matrix @p mat_c can
 /// store the result of this multiplication.

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -37,14 +37,14 @@ namespace internal {
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
 #define DLAF_PRECONDITION_SIZE_SQUARE(matrix) \
-  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square.")
+  DLAF_ASSERT((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square (", matrix.size().rows(), "x", matrix.size().cols(),").")
 
 /// @brief Verify if dlaf::Matrix tile is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
 #define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                              \
   DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix", \
-              #matrix, "is not square.")
+              #matrix, "is not square (", matrix.blockSize().rows(), "x", matrix.blockSize().cols(), ").")
 
 /// @brief Verify if dlaf::Matrix is distributed on a (1x1) grid (i.e. if it is a local matrix).
 ///

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -66,13 +66,15 @@ template <class MatrixConst, class Matrix, class Location>
 void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, const blas::Op opA,
                                 const blas::Op opB, const Location location, std::string mat_a_name,
                                 std::string mat_b_name) {
-  auto get_k = [](const auto& size, const blas::Op op, bool first_member) {
+  auto get_k = [](const auto& size, const blas::Op op, bool first_member) -> decltype(size.rows()) {
     switch (op) {
       case blas::Op::NoTrans:
         return first_member ? size.cols() : size.rows();
       case blas::Op::Trans:
       case blas::Op::ConjTrans:
         return first_member ? size.rows() : size.cols();
+      default:
+        return {};
     }
   };
 

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -77,123 +77,37 @@ template <class MatrixConst, class Matrix, class Mat, class Location>
 void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, const Mat& mat_c,
                                 const blas::Op opA, const blas::Op opB, const Location location,
                                 std::string mat_a_name, std::string mat_b_name, std::string mat_c_name) {
-  auto get_k = [](const auto& size, const blas::Op op, bool first_member) -> decltype(size.rows()) {
+  auto rows = [](const auto& size, const blas::Op op) -> decltype(size.rows()) {
     switch (op) {
       case blas::Op::NoTrans:
-        return first_member ? size.cols() : size.rows();
+        return size.rows();
       case blas::Op::Trans:
       case blas::Op::ConjTrans:
-        return first_member ? size.rows() : size.cols();
+        return size.cols();
+      default:
+        return {};
+    }
+  };
+  auto cols = [](const auto& size, const blas::Op op) -> decltype(size.cols()) {
+    switch (op) {
+      case blas::Op::NoTrans:
+        return size.cols();
+      case blas::Op::Trans:
+      case blas::Op::ConjTrans:
+        return size.rows();
       default:
         return {};
     }
   };
 
-  auto a_k = [=](const auto& size) { return get_k(size, opA, true); };
-  auto b_k = [=](const auto& size) { return get_k(size, opB, false); };
-
-  switch (opA) {
-    case blas::Op::NoTrans:
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices ",
-                              mat_a_name, " and ", mat_b_name,
-                              " are not left multipliable (cols of matrix ", mat_a_name, ", ",
-                              a_k(mat_b.nrTiles()), ", not equal to rows of matrix ", mat_b_name, ", ",
-                              b_k(mat_b.nrTiles()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices ",
-                              mat_a_name, " and ", mat_b_name,
-                              " are not left multipliable (size of matrix ", mat_a_name, ", ",
-                              a_k(mat_a.size()), ", not equal to that of matrix ", mat_b_name, " , ",
-                              b_k(mat_b.size()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())),
-                              "The matrices ", mat_a_name, " and ", mat_b_name,
-                              " are not left multipliable (blocksize of matrix ", mat_a_name, ", ",
-                              a_k(mat_a.blockSize()), ", not equal to that of matrix ", mat_b_name, ", ",
-                              b_k(mat_b.blockSize()), ").");
-
-      DLAF_ASSERT_WITH_ORIGIN(location, (b_k(mat_a.nrTiles()) == b_k(mat_c.nrTiles())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (rows of matrix ",
-                              mat_a_name, ", ", b_k(mat_a.nrTiles()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", b_k(mat_c.nrTiles()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (b_k(mat_a.size()) == b_k(mat_c.size())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (size of matrix ",
-                              mat_a_name, ", ", b_k(mat_a.size()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", b_k(mat_c.size()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (b_k(mat_a.nrTiles()) == b_k(mat_c.nrTiles())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (blocksize of matrix ",
-                              mat_a_name, ", ", b_k(mat_a.blockSize()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", b_k(mat_c.blockSize()), ").");
-
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_b.nrTiles()) == a_k(mat_c.nrTiles())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (rows of matrix ",
-                              mat_b_name, ", ", a_k(mat_b.nrTiles()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", a_k(mat_c.nrTiles()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_b.size()) == a_k(mat_c.size())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (size of matrix ",
-                              mat_b_name, ", ", a_k(mat_b.size()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", a_k(mat_c.size()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_b.blockSize()) == a_k(mat_c.blockSize())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (blocksize of matrix ",
-                              mat_b_name, ", ", a_k(mat_b.blockSize()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", a_k(mat_c.blockSize()), ").");
-
-      break;
-    case blas::Op::Trans:
-    case blas::Op::ConjTrans:
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices ",
-                              mat_a_name, " and ", mat_b_name,
-                              " are not left multipliable (cols of matrix ", mat_a_name, ", ",
-                              a_k(mat_b.nrTiles()), ", not equal to rows of matrix ", mat_b_name, ", ",
-                              b_k(mat_b.nrTiles()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices ",
-                              mat_a_name, " and ", mat_b_name,
-                              " are not left multipliable (size of matrix ", mat_a_name, ", ",
-                              a_k(mat_a.size()), ", not equal to that of matrix ", mat_b_name, " , ",
-                              b_k(mat_b.size()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())),
-                              "The matrices ", mat_a_name, " and ", mat_b_name,
-                              " are not left multipliable (blocksize of matrix ", mat_a_name, ", ",
-                              a_k(mat_a.blockSize()), ", not equal to that of matrix ", mat_b_name, ", ",
-                              b_k(mat_b.blockSize()), ").");
-
-      DLAF_ASSERT_WITH_ORIGIN(location, (b_k(mat_a.nrTiles()) == b_k(mat_c.nrTiles())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (rows of matrix ",
-                              mat_a_name, ", ", b_k(mat_a.nrTiles()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", b_k(mat_c.nrTiles()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (b_k(mat_a.size()) == b_k(mat_c.size())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (size of matrix ",
-                              mat_a_name, ", ", b_k(mat_a.size()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", b_k(mat_c.size()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (b_k(mat_a.nrTiles()) == b_k(mat_c.nrTiles())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (blocksize of matrix ",
-                              mat_a_name, ", ", b_k(mat_a.blockSize()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", b_k(mat_c.blockSize()), ").");
-
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_b.nrTiles()) == a_k(mat_c.nrTiles())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (rows of matrix ",
-                              mat_b_name, ", ", a_k(mat_b.nrTiles()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", a_k(mat_c.nrTiles()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_b.size()) == a_k(mat_c.size())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (size of matrix ",
-                              mat_b_name, ", ", a_k(mat_b.size()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", a_k(mat_c.size()), ").");
-      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_b.blockSize()) == a_k(mat_c.blockSize())),
-                              "The result of the left multiplication between ", mat_a_name, " and ",
-                              mat_b_name, " cannot be stored in ", mat_c_name, " (blocksize of matrix ",
-                              mat_b_name, ", ", a_k(mat_b.blockSize()), ", not equal to that of matrix ",
-                              mat_c_name, ", ", a_k(mat_c.blockSize()), ").");
-      break;
-  }
+  DLAF_ASSERT_WITH_ORIGIN(location,
+                          rows(mat_a.size(), opA) == mat_c.size().rows() &&
+                              cols(mat_a.size(), opA) == rows(mat_b.size(), opB) &&
+                              cols(mat_b.size(), opB) == mat_c.size().cols(),
+                          "Size mismatch: ", mat_a_name, " (", rows(mat_a.size(), opA), ", ",
+                          cols(mat_a.size(), opA), ") x ", mat_b_name, " (", rows(mat_b.size(), opB),
+                          ", ", cols(mat_b.size(), opB), ") --> ", mat_c_name, " ", mat_c.size(),
+                          " cannot be performed.");
 }
 /// @brief Assert that the matrices @p mat_a and @p mat_b are multipliable and that matrix @p mat_c can
 /// store the result of this multiplication.

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -42,25 +42,25 @@ namespace internal {
 /// @brief Verify if dlaf::Matrix tile is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                                    \
+#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                              \
   DLAF_ASSERT((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix", \
-                    #matrix, "is not square.")
+              #matrix, "is not square.")
 
 /// @brief Verify if dlaf::Matrix is distributed on a (1x1) grid (i.e. if it is a local matrix).
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_LOCALMATRIX(matrix)                                                        \
+#define DLAF_PRECONDITION_LOCALMATRIX(matrix)                                                  \
   DLAF_ASSERT((matrix.distribution().commGridSize() == comm::Size2D{1, 1}), "Matrix", #matrix, \
-                    "is not local.")
+              "is not local.")
 
 /// @brief Verify that the matrix is distributed according to the given communicator grid.
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-#define DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, matrix)                                         \
-  DLAF_ASSERT(((matrix.distribution().commGridSize() == grid.size()) &&                       \
-                     (matrix.distribution().rankIndex() == grid.rank())),                           \
-                    "The matrix", #matrix, "is not distributed according to the communicator grid", \
-                    #grid, ".")
+#define DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, matrix)                                          \
+  DLAF_ASSERT(((matrix.distribution().commGridSize() == grid.size()) &&                              \
+               (matrix.distribution().rankIndex() == grid.rank())),                                  \
+              "The matrix", #matrix, "is not distributed according to the communicator grid", #grid, \
+              ".")
 
 template <class MatrixConst, class Matrix, class Location>
 void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, const blas::Op opA,
@@ -81,29 +81,27 @@ void assertMultipliableMatrices(const MatrixConst& mat_a, const Matrix& mat_b, c
 
   switch (opA) {
     case blas::Op::NoTrans:
-      DLAF_ASSERT_WITH_ORIGIN(
-          location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices", mat_a_name, "and",
-          mat_b_name, "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
-      DLAF_ASSERT_WITH_ORIGIN(
-          location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices", mat_a_name, "and",
-          mat_b_name, "are not left multipliable (size of matrix A not equal to that of matrix B).");
-      DLAF_ASSERT_WITH_ORIGIN(
-          location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())), "The matrices", mat_a_name,
-          "and", mat_b_name,
-          "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices",
+                              mat_a_name, "and", mat_b_name,
+                              "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices",
+                              mat_a_name, "and", mat_b_name,
+                              "are not left multipliable (size of matrix A not equal to that of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())),
+                              "The matrices", mat_a_name, "and", mat_b_name,
+                              "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
       break;
     case blas::Op::Trans:
     case blas::Op::ConjTrans:
-      DLAF_ASSERT_WITH_ORIGIN(
-          location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices", mat_a_name, "and",
-          mat_b_name, "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
-      DLAF_ASSERT_WITH_ORIGIN(
-          location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices", mat_a_name, "and",
-          mat_b_name, "are not left multipliable (size of matrix A not equal to that of matrix B).");
-      DLAF_ASSERT_WITH_ORIGIN(
-          location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())), "The matrices", mat_a_name,
-          "and", mat_b_name,
-          "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.nrTiles()) == b_k(mat_b.nrTiles())), "The matrices",
+                              mat_a_name, "and", mat_b_name,
+                              "are not left multipliable (cols of matrix A not equal to rows of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.size()) == b_k(mat_b.size())), "The matrices",
+                              mat_a_name, "and", mat_b_name,
+                              "are not left multipliable (size of matrix A not equal to that of matrix B).");
+      DLAF_ASSERT_WITH_ORIGIN(location, (a_k(mat_a.blockSize()) == b_k(mat_b.blockSize())),
+                              "The matrices", mat_a_name, "and", mat_b_name,
+                              "are not left multipliable (blocksize of matrix A not equal to that of matrix B).");
       break;
   }
 }

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -21,6 +21,7 @@ constexpr double M_PI = 3.141592;
 #include <blas.hh>
 #include <hpx/hpx.hpp>
 
+#include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
 #include "dlaf/matrix.h"
 #include "dlaf/types.h"
@@ -28,11 +29,6 @@ constexpr double M_PI = 3.141592;
 /// @file
 
 #define _DLAF_PRECONDITION_FUNCTION(condition) ::dlaf::matrix::util::internal::assert##condition
-
-#define _DLAF_PRECONDITION_1(condition, arg1) \
-  _DLAF_PRECONDITION_FUNCTION(condition)(arg1, DLAF_FUNCTION_NAME, #arg1)
-#define _DLAF_PRECONDITION_2(condition, arg1, arg2) \
-  _DLAF_PRECONDITION_FUNCTION(condition)(arg1, arg2, DLAF_FUNCTION_NAME, #arg1, #arg2)
 
 namespace dlaf {
 namespace matrix {
@@ -42,52 +38,31 @@ namespace internal {
 /// @brief Verify if dlaf::Matrix is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-/// @throws std::invalid_argument if the matrix is not squared
-template <class Matrix>
-void assertSizeSquare(const Matrix& matrix, std::string function, std::string mat_name) {
-  if (matrix.size().rows() != matrix.size().cols())
-    throw std::invalid_argument(function + ": " + "Matrix " + mat_name + " is not square.");
-}
-#define DLAF_PRECONDITION_SIZE_SQUARE(matrix) _DLAF_PRECONDITION_1(SizeSquare, matrix)
+#define DLAF_PRECONDITION_SIZE_SQUARE(matrix) \
+  DLAF_PRECONDITION((matrix.size().rows() == matrix.size().cols()), "Matrix", #matrix, "is not square.")
 
 /// @brief Verify if dlaf::Matrix tile is square
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-/// @throws std::invalid_argument if the matrix block is not squared
-template <class Matrix>
-void assertBlocksizeSquare(const Matrix& matrix, std::string function, std::string mat_name) {
-  if (matrix.blockSize().rows() != matrix.blockSize().cols())
-    throw std::invalid_argument(function + ": " + "Block size in matrix " + mat_name +
-                                " is not square.");
-}
-#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix) _DLAF_PRECONDITION_1(BlocksizeSquare, matrix)
+#define DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix)                                                    \
+  DLAF_PRECONDITION((matrix.blockSize().rows() == matrix.blockSize().cols()), "Block size in matrix", \
+                    #matrix, "is not square.")
 
 /// @brief Verify if dlaf::Matrix is distributed on a (1x1) grid (i.e. if it is a local matrix).
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-/// @throws std::invalid_argument if the matrix is not local
-template <class Matrix>
-void assertLocalMatrix(const Matrix& matrix, std::string function, std::string mat_name) {
-  if (matrix.distribution().commGridSize() != comm::Size2D{1, 1})
-    throw std::invalid_argument(function + ": " + "Matrix " + mat_name + " is not local.");
-}
-#define DLAF_PRECONDITION_LOCALMATRIX(matrix) _DLAF_PRECONDITION_1(LocalMatrix, matrix)
+#define DLAF_PRECONDITION_LOCALMATRIX(matrix)                                                        \
+  DLAF_PRECONDITION((matrix.distribution().commGridSize() == comm::Size2D{1, 1}), "Matrix", #matrix, \
+                    "is not local.")
 
 /// @brief Verify that the matrix is distributed according to the given communicator grid.
 ///
 /// @tparam Matrix refers to a dlaf::Matrix object
-/// @throws std::invalid_argument if the matrix is not distributed correctly
-template <class Matrix>
-void assertMatrixDistributedOnGrid(const comm::CommunicatorGrid& grid, const Matrix& matrix,
-                                   std::string function, std::string mat_name, std::string grid_name) {
-  if ((matrix.distribution().commGridSize() != grid.size()) ||
-      (matrix.distribution().rankIndex() != grid.rank()))
-    throw std::invalid_argument(function + ": " + "The matrix " + mat_name +
-                                " is not distributed according to the communicator grid " + grid_name +
-                                ".");
-}
-#define DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, matrix) \
-  _DLAF_PRECONDITION_2(MatrixDistributedOnGrid, grid, matrix)
+#define DLAF_PRECONDITION_DISTRIBUTED_ON_GRID(grid, matrix)                                          \
+  DLAF_PRECONDITION(((matrix.distribution().commGridSize() == grid.size()) &&                        \
+                     (matrix.distribution().rankIndex() == grid.rank())),                            \
+                    "The matrix", #matrix, "is not distributed according to the communicator grid ", \
+                    #grid, ".")
 
 /// @brief Verify that matrices A and B are multipliable,
 ///

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -43,8 +43,8 @@ T analytical_result_matrix(const GlobalElementIndex& index);
 void setup_input_matrix(Matrix<T, Device::CPU>& matrix) {
   using namespace dlaf::matrix::util;
 
-  util_matrix::assertSizeSquare(matrix, __FILE__, "matrix");
-  util_matrix::assertBlocksizeSquare(matrix, __FILE__, "matrix");
+  DLAF_PRECONDITION_SIZE_SQUARE(matrix);
+  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix);
 
   set(matrix, analytical_input_matrix);
 }

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -43,8 +43,8 @@ T analytical_result_matrix(const GlobalElementIndex& index);
 void setup_input_matrix(Matrix<T, Device::CPU>& matrix) {
   using namespace dlaf::matrix::util;
 
-  DLAF_PRECONDITION_SIZE_SQUARE(matrix);
-  DLAF_PRECONDITION_BLOCKSIZE_SQUARE(matrix);
+  DLAF_ASSERT_SIZE_SQUARE(matrix);
+  DLAF_ASSERT_BLOCKSIZE_SQUARE(matrix);
 
   set(matrix, analytical_input_matrix);
 }


### PR DESCRIPTION
Move existing preconditions functions inside `dlaf::matrix::util::details` namespace and allow to use them through macro that auto-fills information about variable names and source location.

About source location, this PR adds a CMake check that defines `DLAF_SOURCE_LOCATION` based on availability of `__PRETTY_FUNCTION__` constant (compiler-dependent). In case the compiler does not provide it, the standard `__func__` is used.