### PR TITLE
Small refactoring pre-MatrixView

### DIFF
--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -14,6 +14,7 @@
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/layout_info.h"
+#include "dlaf/matrix/matrix_base.h"
 #include "dlaf/tile.h"
 #include "dlaf/types.h"
 
@@ -99,7 +100,7 @@ public:
   /// @pre index.isValid() == true.
   /// @pre index.isIn(globalNrTiles()) == true.
   hpx::future<TileType> operator()(const GlobalTileIndex& index) {
-    return operator()(this->localTileIndex(index));
+    return operator()(this->distribution().localTileIndex(index));
   }
 
 protected:
@@ -115,7 +116,7 @@ private:
 #include "dlaf/matrix.tpp"
 
 template <class T, Device device>
-class Matrix<const T, device> : protected matrix::Distribution {
+class Matrix<const T, device> : public matrix::internal::MatrixBase {
 public:
   using ElementType = T;
   using TileType = Tile<ElementType, device>;
@@ -140,19 +141,6 @@ public:
   Matrix& operator=(const Matrix& rhs) = delete;
   Matrix& operator=(Matrix&& rhs) = default;
 
-  using Distribution::size;
-  using Distribution::blockSize;
-  using Distribution::nrTiles;
-
-  using Distribution::rankIndex;
-  using Distribution::commGridSize;
-
-  using Distribution::rankGlobalTile;
-
-  const matrix::Distribution& distribution() const noexcept {
-    return *this;
-  }
-
   /// Returns a read-only shared_future of the Tile with local index @p index.
   ///
   /// TODO: Sync details.
@@ -167,25 +155,13 @@ public:
   /// @pre index.isValid() == true.
   /// @pre index.isIn(globalNrTiles()) == true.
   hpx::shared_future<ConstTileType> read(const GlobalTileIndex& index) {
-    return read(localTileIndex(index));
+    return read(distribution().localTileIndex(index));
   }
 
   /// Returns the size of the Tile with global index @p index.
   TileElementSize tileSize(const GlobalTileIndex& index) noexcept {
     return {std::min(blockSize().rows(), size().rows() - index.row() * blockSize().rows()),
             std::min(blockSize().cols(), size().cols() - index.col() * blockSize().cols())};
-  }
-
-protected:
-  /// Returns the position in the vector of the index Tile.
-  ///
-  /// @pre index.isValid() == true.
-  /// @pre index.isIn(localNrTiles()) == true.
-  std::size_t tileLinearIndex(const LocalTileIndex& index) const noexcept {
-    assert(index.isValid() && index.isIn(localNrTiles()));
-    using util::size_t::sum;
-    using util::size_t::mul;
-    return sum(index.row(), mul(localNrTiles().rows(), index.col()));
   }
 
 private:

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -20,9 +20,9 @@ Matrix<T, device>::Matrix(const GlobalElementSize& size, const TileElementSize& 
 template <class T, Device device>
 Matrix<T, device>::Matrix(matrix::Distribution&& distribution)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
-  SizeType ld = std::max(1, util::ceilDiv(this->localSize().rows(), 64) * 64);
+  SizeType ld = std::max(1, util::ceilDiv(this->distribution().localSize().rows(), 64) * 64);
 
-  auto layout = matrix::colMajorLayout(this->localSize(), this->blockSize(), ld);
+  auto layout = matrix::colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 
   std::size_t memory_size = layout.minMemSize();
   memory::MemoryView<ElementType, device> mem(memory_size);
@@ -33,7 +33,7 @@ Matrix<T, device>::Matrix(matrix::Distribution&& distribution)
 template <class T, Device device>
 Matrix<T, device>::Matrix(matrix::Distribution&& distribution, const matrix::LayoutInfo& layout)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
-  if (this->localSize() != layout.size())
+  if (this->distribution().localSize() != layout.size())
     throw std::invalid_argument("Error: distribution.localSize() != layout.size()");
   if (this->blockSize() != layout.blockSize())
     throw std::invalid_argument("Error: distribution.blockSize() != layout.blockSize()");

--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -1,0 +1,89 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+#include "dlaf/matrix/distribution.h"
+
+namespace dlaf {
+namespace matrix {
+namespace internal {
+
+class MatrixBase {
+public:
+  MatrixBase(Distribution&& distribution)
+      : distribution_(std::make_shared<Distribution>(std::move(distribution))) {}
+
+  MatrixBase(const MatrixBase& rhs) = default;
+  MatrixBase& operator=(const MatrixBase& rhs) = default;
+
+  /// Returns the global size in elements of the matrix.
+  const GlobalElementSize& size() const noexcept {
+    return distribution_->size();
+  }
+
+  /// Returns the block size of the matrix.
+  const TileElementSize& blockSize() const noexcept {
+    return distribution_->blockSize();
+  }
+
+  /// Returns the number of tiles of the global matrix (2D size).
+  const GlobalTileSize& nrTiles() const noexcept {
+    return distribution_->nrTiles();
+  }
+
+  /// Returns the id associated to the matrix of this rank.
+  const comm::Index2D& rankIndex() const noexcept {
+    return distribution_->rankIndex();
+  }
+
+  /// Returns the size of the communicator grid associated to the matrix.
+  const comm::Size2D& commGridSize() const noexcept {
+    return distribution_->commGridSize();
+  }
+
+  /// Returns the 2D rank index of the process that stores the tile with global index @p global_tile.
+  ///
+  /// @pre global_tile.isValid() and global_tile.isIn(nrTiles())
+  comm::Index2D rankGlobalTile(const GlobalTileIndex& global_tile) const noexcept {
+    return distribution_->rankGlobalTile(global_tile);
+  }
+
+  /// Returns the distribution of the matrix.
+  const matrix::Distribution& distribution() const noexcept {
+    return *distribution_;
+  }
+
+protected:
+  // move constructor and assignment are protected to avoid invalidation of objects of
+  // derived classes. I.e.:
+  // class MatrixDerived : public MatrixBase;
+  // MatrixDerived derived;
+  // MatrixBase base = std::move(derived);
+  MatrixBase(MatrixBase&& rhs) = default;
+  MatrixBase& operator=(MatrixBase&& rhs) = default;
+
+  /// Returns the position in the vector of the index Tile.
+  ///
+  /// @pre index.isValid() == true.
+  /// @pre index.isIn(localNrTiles()) == true.
+  std::size_t tileLinearIndex(const LocalTileIndex& index) const noexcept {
+    assert(index.isValid() && index.isIn(distribution_->localNrTiles()));
+    using util::size_t::sum;
+    using util::size_t::mul;
+    return sum(index.row(), mul(distribution_->localNrTiles().rows(), index.col()));
+  }
+
+private:
+  std::shared_ptr<Distribution> distribution_;
+};
+
+}
+}
+}

--- a/include/dlaf/matrix_const.tpp
+++ b/include/dlaf/matrix_const.tpp
@@ -10,7 +10,7 @@
 
 template <class T, Device device>
 Matrix<const T, device>::Matrix(const matrix::LayoutInfo& layout, ElementType* ptr)
-    : Distribution(layout.size(), layout.blockSize()) {
+    : MatrixBase({layout.size(), layout.blockSize()}) {
   memory::MemoryView<ElementType, device> mem(ptr, layout.minMemSize());
   setUpTiles(mem, layout);
 }
@@ -18,8 +18,8 @@ Matrix<const T, device>::Matrix(const matrix::LayoutInfo& layout, ElementType* p
 template <class T, Device device>
 Matrix<const T, device>::Matrix(matrix::Distribution&& distribution, const matrix::LayoutInfo& layout,
                                 ElementType* ptr)
-    : Distribution(std::move(distribution)) {
-  if (this->localSize() != layout.size())
+    : MatrixBase(std::move(distribution)) {
+  if (this->distribution().localSize() != layout.size())
     throw std::invalid_argument("Error: distribution.localSize() != layout.size()");
   if (this->blockSize() != layout.blockSize())
     throw std::invalid_argument("Error: distribution.blockSize() != layout.blockSize()");
@@ -56,7 +56,7 @@ template <class T, Device device>
 Matrix<const T, device>::Matrix(matrix::Distribution&& distribution,
                                 std::vector<hpx::future<TileType>>&& tile_futures,
                                 std::vector<hpx::shared_future<ConstTileType>>&& tile_shared_futures)
-    : Distribution(std::move(distribution)), tile_futures_(std::move(tile_futures)),
+    : MatrixBase(std::move(distribution)), tile_futures_(std::move(tile_futures)),
       tile_shared_futures_(std::move(tile_shared_futures)) {}
 
 template <class T, Device device>


### PR DESCRIPTION
Matrix implementation has been reorganized to simplify (avoiding code duplication) the implementation of MatrixView (#19, #20)