### PR TITLE
Add output on fatal failure for GTest MPI Listener

### DIFF
--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -53,6 +53,11 @@ void MPIListener::OnTestStart(const ::testing::TestInfo& test_info) {
 }
 
 void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_result) {
+  if (test_part_result.fatally_failed()) {
+    MASTER_CALLS_DEFAULT_LISTENER(OnTestPartResult, test_part_result);
+    return;
+  }
+
   std::ostringstream os;
   os << test_part_result;
   last_test_part_results_.push_back(os.str());


### PR DESCRIPTION
When a fatal failure happens, the test does not reach the end. This means that the collection of messages won't be done too, so no exception message will be printed.

This changes this behavior by immediately printing the default exception message.