### PR TITLE
Disable HPX thread binding options for OS X

### DIFF
--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -176,7 +176,12 @@ function(DLAF_addTest test_target_name)
 
   if (IS_AN_HPX_TEST)
     separate_arguments(_HPX_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_HPXTEST_EXTRA_ARGS})
-    list(APPEND _TEST_ARGUMENTS "--hpx:use-process-mask")
+
+    # APPLE platform does not support thread binding
+    if (NOT APPLE)
+      list(APPEND _TEST_ARGUMENTS "--hpx:use-process-mask")
+    endif()
+
     list(APPEND _TEST_ARGUMENTS ${_HPX_EXTRA_ARGS_LIST})
   endif()
 


### PR DESCRIPTION
Close #129 

HPX fixed the related error by ignoring the option and printing a warning message.

This PR disables the usage of the `hpx:use-process-mask` option on APPLE platforms.