### PR TITLE
Add MPI executor for Cholesky Factorization

### DIFF
--- a/include/dlaf/mc/cholesky.h
+++ b/include/dlaf/mc/cholesky.h
@@ -112,6 +112,14 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, Device::CP
   hpx::threads::scheduled_executor executor_normal =
       hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
 
+  hpx::threads::scheduled_executor executor_mpi;
+  try {
+    executor_mpi = hpx::threads::executors::pool_executor("mpi", hpx::threads::thread_priority_high);
+  }
+  catch (...) {
+    executor_mpi = executor_hp;
+  }
+
   auto col_comm_size = grid.colCommunicator().size();
   auto row_comm_size = grid.rowCommunicator().size();
 
@@ -170,17 +178,21 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, Device::CP
           // Avoid useless communications if one-column communicator and if on the last column
           if (col_comm_size > 1 && k != (mat.nrTiles().cols() - 1)) {
             // Receive the diagonal tile
-            kk_tile = hpx::dataflow(  //
-                hpx::util::unwrapping(
-                    [](auto index, auto&& tile_size, auto&& comm_wrapper) -> Tile<const T, Device::CPU> {
-                      memory::MemoryView<T, Device::CPU> mem_view(
-                          util::size_t::mul(tile_size.rows(), tile_size.cols()));
-                      Tile<T, Device::CPU> tile(tile_size, std::move(mem_view), tile_size.rows());
-                      dlaf::comm::sync::broadcast::receive_from(index, comm_wrapper().colCommunicator(),
-                                                                tile);
-                      return std::move(tile);
-                    }),
-                k_rank_row, mat.tileSize(GlobalTileIndex(k, k)), serial_comm());
+            kk_tile =
+                hpx::dataflow(executor_mpi,  //
+                              hpx::util::unwrapping([](auto index, auto&& tile_size, auto&& comm_wrapper)
+                                                        -> Tile<const T, Device::CPU> {
+                                memory::MemoryView<T, Device::CPU> mem_view(
+                                    util::size_t::mul(tile_size.rows(), tile_size.cols()));
+                                Tile<T, Device::CPU> tile(tile_size, std::move(mem_view),
+                                                          tile_size.rows());
+                                dlaf::comm::sync::broadcast::receive_from(index,
+                                                                          comm_wrapper()
+                                                                              .colCommunicator(),
+                                                                          tile);
+                                return std::move(tile);
+                              }),
+                              k_rank_row, mat.tileSize(GlobalTileIndex(k, k)), serial_comm());
           }
         }
 
@@ -194,9 +206,12 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, Device::CP
           // Avoid useless communications if one-row communicator grid
           if (row_comm_size > 1) {
             // Broadcast the panel row-wise
-            hpx::dataflow(hpx::util::unwrapping([](auto&& tile, auto&& comm_wrapper) {
-                            dlaf::comm::sync::broadcast::send(comm_wrapper().rowCommunicator(), tile);
-                          }),
+            hpx::dataflow(executor_mpi,           //
+                          hpx::util::unwrapping(  //
+                              [](auto&& tile, auto&& comm_wrapper) {
+                                dlaf::comm::sync::broadcast::send(comm_wrapper().rowCommunicator(),
+                                                                  tile);
+                              }),
                           mat.read(LocalTileIndex{i_local, k_local_col}), serial_comm());
           }
 
@@ -211,17 +226,21 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, Device::CP
           // Avoid useless communications if one-row communicator grid
           if (row_comm_size > 1) {
             // Receiving the panel
-            panel[i_local] = hpx::dataflow(  //
-                hpx::util::unwrapping(
-                    [](auto index, auto&& tile_size, auto&& comm_wrapper) -> Tile<const T, Device::CPU> {
-                      memory::MemoryView<T, Device::CPU> mem_view(
-                          util::size_t::mul(tile_size.rows(), tile_size.cols()));
-                      Tile<T, Device::CPU> tile(tile_size, std::move(mem_view), tile_size.rows());
-                      dlaf::comm::sync::broadcast::receive_from(index, comm_wrapper().rowCommunicator(),
-                                                                tile);
-                      return std::move(tile);
-                    }),
-                k_rank_col, mat.tileSize(GlobalTileIndex(i, k)), serial_comm());
+            panel[i_local] =
+                hpx::dataflow(executor_mpi,  //
+                              hpx::util::unwrapping([](auto index, auto&& tile_size, auto&& comm_wrapper)
+                                                        -> Tile<const T, Device::CPU> {
+                                memory::MemoryView<T, Device::CPU> mem_view(
+                                    util::size_t::mul(tile_size.rows(), tile_size.cols()));
+                                Tile<T, Device::CPU> tile(tile_size, std::move(mem_view),
+                                                          tile_size.rows());
+                                dlaf::comm::sync::broadcast::receive_from(index,
+                                                                          comm_wrapper()
+                                                                              .rowCommunicator(),
+                                                                          tile);
+                                return std::move(tile);
+                              }),
+                              k_rank_col, mat.tileSize(GlobalTileIndex(i, k)), serial_comm());
           }
         }
       }
@@ -249,7 +268,7 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, Device::CP
           // Avoid useless communications if one-row communicator grid and if on the last panel
           if (col_comm_size > 1 && j != (mat.nrTiles().cols() - 1)) {
             // Broadcast the (trailing) panel column-wise
-            hpx::dataflow(hpx::util::unwrapping([k, j](auto&& tile, auto&& comm_wrapper) {
+            hpx::dataflow(executor_mpi, hpx::util::unwrapping([](auto&& tile, auto&& comm_wrapper) {
                             dlaf::comm::sync::broadcast::send(comm_wrapper().colCommunicator(), tile);
                           }),
                           panel[i_local], serial_comm());
@@ -268,17 +287,21 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, Device::CP
           // Avoid useless communications if one-row communicator grid and if on the last panel
           if (col_comm_size > 1 && j != (mat.nrTiles().cols() - 1)) {
             // Update the (trailing) panel column-wise
-            col_panel = hpx::dataflow(  //
-                hpx::util::unwrapping([k, j](auto index, auto&& tile_size,
-                                             auto&& comm_wrapper) -> Tile<const T, Device::CPU> {
-                  memory::MemoryView<T, Device::CPU> mem_view(
-                      util::size_t::mul(tile_size.rows(), tile_size.cols()));
-                  Tile<T, Device::CPU> tile(tile_size, std::move(mem_view), tile_size.rows());
-                  dlaf::comm::sync::broadcast::receive_from(index, comm_wrapper().colCommunicator(),
-                                                            tile);
-                  return std::move(tile);
-                }),
-                j_rank_row, mat.tileSize(GlobalTileIndex(j, k)), serial_comm());
+            col_panel =
+                hpx::dataflow(executor_mpi,  //
+                              hpx::util::unwrapping([](auto index, auto&& tile_size, auto&& comm_wrapper)
+                                                        -> Tile<const T, Device::CPU> {
+                                memory::MemoryView<T, Device::CPU> mem_view(
+                                    util::size_t::mul(tile_size.rows(), tile_size.cols()));
+                                Tile<T, Device::CPU> tile(tile_size, std::move(mem_view),
+                                                          tile_size.rows());
+                                dlaf::comm::sync::broadcast::receive_from(index,
+                                                                          comm_wrapper()
+                                                                              .colCommunicator(),
+                                                                          tile);
+                                return std::move(tile);
+                              }),
+                              j_rank_row, mat.tileSize(GlobalTileIndex(j, k)), serial_comm());
           }
         }
 


### PR DESCRIPTION
Introduce executor for MPI tasks in Choleksy factorization.

MPI tasks will run on the dedicated `mpi` pool if it has been created during HPX initialization, otherwise they will run with high priority in the default pool.

Credit @rasolca 