### PR TITLE
Proposal for moving helper function for generating triangular systems

### DIFF
--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -34,18 +34,18 @@ using namespace dlaf_test;
 /// where I = 0 for real types or I is the complex unit for complex types.
 ///
 /// The elements of X (@p el_x) are computed as
-///   Xkj = (k+.5) / (j+2) * exp(I*(k+j)).
+///   X_kj = (k+.5) / (j+2) * exp(I*(k+j)).
 /// These data are typically used to check whether the result of the equation
 /// performed with any algorithm is consistent with the computed values.
 ///
 /// Finally, the elements of B (@p el_b) should be:
-/// B_ij = (Sum_k op(A)_ik * Xkj) / alpha
-///      = (op(A)_ii * Xij + (kk-1) * gamma) / alpha,
+/// B_ij = (Sum_k op(A)_ik * X_kj) / alpha
+///      = (op(A)_ii * X_ij + (kk-1) * gamma) / alpha,
 /// where gamma = (i+1) / (j+2) * exp(I*(2*i+j)),
 ///       kk = i+1 if op(a) is an lower triangular matrix, or
 ///       kk = m-i if op(a) is an lower triangular matrix.
 /// Therefore
-/// B_ij = (Xij + (kk-1) * gamma) / alpha, if diag == Unit
+/// B_ij = (X_ij + (kk-1) * gamma) / alpha, if diag == Unit
 /// B_ij = kk * gamma / alpha, otherwise.
 ///
 template <class ElementIndex, class T>
@@ -98,18 +98,18 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 /// where I = 0 for real types or I is the complex unit for complex types.
 ///
 /// The elements of X (@p el_x) are computed as
-///   Xik = (k+.5) / (i+2) * exp(I*(i+k)).
+///   X_ik = (k+.5) / (i+2) * exp(I*(i+k)).
 /// These data are typically used to check whether the result of the equation
 /// performed with any algorithm is consistent with the computed values.
 ///
 /// Finally, the elements of B (@p el_b) should be:
-/// B_ij = (Sum_k Xik * op(A)_kj) / alpha
-///      = (Xij * op(A)_jj + (kk-1) * gamma) / alpha,
+/// B_ij = (Sum_k X_ik * op(A)_kj) / alpha
+///      = (X_ij * op(A)_jj + (kk-1) * gamma) / alpha,
 /// where gamma = (j+1) / (i+2) * exp(I*(i+2*j)),
 ///       kk = j+1 if op(a) is an upper triangular matrix, or
 ///       kk = m-j if op(a) is an upper triangular matrix.
 /// Therefore
-/// B_ij = (Xij + (kk-1) * gamma) / alpha, if diag == Unit
+/// B_ij = (X_ij + (kk-1) * gamma) / alpha, if diag == Unit
 /// B_ij = kk * gamma / alpha, otherwise.
 ///
 template <class ElementIndex, class T>

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -1,0 +1,140 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <functional>
+#include <tuple>
+
+#include <blas.hh>
+
+#include "dlaf_test/util_types.h"
+
+namespace dlaf {
+namespace matrix {
+namespace test {
+
+using namespace dlaf_test;
+
+/// @brief Returns el_op_a, el_b, res_b for side = Left.
+template <class ElementIndex, class T>
+auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType m) {
+  // Note: The tile elements are chosen such that:
+  // - op(a)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements
+  //   op(a)_ik = -9.9 otherwise,
+  // - res_kj = (k+.5) / (j+2) * exp(I*(k+j)),
+  // where I = 0 for real types or I is the complex unit for complex types.
+  // Therefore the elements of b should be:
+  // b_ij = (Sum_k op(a)_ik * res_kj) / alpha
+  //      = (op(a)_ii * res_ij + (kk-1) * gamma) / alpha,
+  // where gamma = (i+1) / (j+2) * exp(I*(2*i+j)),
+  //       kk = i+1 if op(a) is an lower triangular matrix, or
+  //       kk = m-i if op(a) is an lower triangular matrix.
+  // Therefore
+  // b_ij = (res_ij + (kk-1) * gamma) / alpha, if diag == Unit
+  // b_ij = kk * gamma / alpha, otherwise.
+  bool op_a_lower = false;
+  if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
+      (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
+    op_a_lower = true;
+
+  std::function<T(const ElementIndex&)> el_op_a = [op_a_lower, diag](const ElementIndex& index) {
+    if ((op_a_lower && index.row() < index.col()) || (!op_a_lower && index.row() > index.col()) ||
+        (diag == blas::Diag::Unit && index.row() == index.col()))
+      return TypeUtilities<T>::element(-9.9, 0);
+
+    double i = index.row();
+    double k = index.col();
+
+    return TypeUtilities<T>::polar((i + 1) / (k + .5), 2 * i - k);
+  };
+
+  std::function<T(const ElementIndex&)> res_b = [](const ElementIndex& index) {
+    double k = index.row();
+    double j = index.col();
+
+    return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
+  };
+
+  std::function<T(const ElementIndex&)> el_b = [m, alpha, diag, op_a_lower,
+                                                res_b](const ElementIndex& index) {
+    BaseType<T> kk = op_a_lower ? index.row() + 1 : m - index.row();
+
+    double i = index.row();
+    double j = index.col();
+    T gamma = TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
+    if (diag == blas::Diag::Unit)
+      return ((kk - 1) * gamma + res_b(index)) / alpha;
+    else
+      return kk * gamma / alpha;
+  };
+
+  return std::make_tuple(el_op_a, el_b, res_b);
+}
+
+/// @brief Returns el_op_a, el_b, res_b for side = Right.
+template <class ElementIndex, class T>
+auto getRightTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType n) {
+  // Note: The tile elements are chosen such that:
+  // - res_ik = (k+.5) / (i+2) * exp(I*(i+k)),
+  // - op(a)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements
+  //   op(a)_kj = -9.9 otherwise,
+  // where I = 0 for real types or I is the complex unit for complex types.
+  // Therefore the elements of b should be:
+  // b_ij = (Sum_k res_ik * op(a)_kj) / alpha
+  //      = (res_ij * op(a)_jj + (kk-1) * gamma) / alpha,
+  // where gamma = (j+1) / (i+2) * exp(I*(i+2*j)),
+  //       kk = j+1 if op(a) is an upper triangular matrix, or
+  //       kk = m-j if op(a) is an upper triangular matrix.
+  // Therefore
+  // b_ij = (res_ij + (kk-1) * gamma) / alpha, if diag == Unit
+  // b_ij = kk * gamma / alpha, otherwise.
+
+  bool op_a_lower = false;
+  if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
+      (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
+    op_a_lower = true;
+
+  auto res_b = [](const ElementIndex& index) {
+    double i = index.row();
+    double k = index.col();
+
+    return TypeUtilities<T>::polar((k + .5) / (i + 2), i + k);
+  };
+
+  auto el_op_a = [op_a_lower, diag](const ElementIndex& index) {
+    if ((op_a_lower && index.row() < index.col()) || (!op_a_lower && index.row() > index.col()) ||
+        (diag == blas::Diag::Unit && index.row() == index.col()))
+      return TypeUtilities<T>::element(-9.9, 0);
+
+    double k = index.row();
+    double j = index.col();
+
+    return TypeUtilities<T>::polar((j + 1) / (k + .5), 2 * j - k);
+  };
+
+  auto el_b = [n, alpha, diag, op_a_lower, res_b](const ElementIndex& index) {
+    BaseType<T> kk = op_a_lower ? n - index.col() : index.col() + 1;
+
+    double i = index.row();
+    double j = index.col();
+    T gamma = TypeUtilities<T>::polar((j + 1) / (i + 2), i + 2 * j);
+    if (diag == blas::Diag::Unit)
+      return ((kk - 1) * gamma + res_b(index)) / alpha;
+    else
+      return kk * gamma / alpha;
+  };
+
+  return std::make_tuple(el_op_a, el_b, res_b);
+}
+
+}
+}
+}

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -17,29 +17,39 @@
 
 #include "dlaf_test/util_types.h"
 
+/// @file
+
 namespace dlaf {
 namespace matrix {
 namespace test {
 
 using namespace dlaf_test;
 
-/// @brief Returns el_op_a, el_b, res_b for side = Left.
+/// Returns elements of the three matrices, solving the triangular matrix equation
+/// op(A) B = X (with A on side == Left).
+///
+/// The tile elements of A matrix (el_op_a) are chosen such that:
+///   op(A)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements
+///   op(A)_ik = -9.9 otherwise.
+///
+/// The elements of B (el_b) should be:
+/// B_ij = (Sum_k op(A)_ik * res_Xkj) / alpha
+///      = (op(A)_ii * res_Xij + (kk-1) * gamma) / alpha,
+/// where gamma = (i+1) / (j+2) * exp(I*(2*i+j)),
+///       kk = i+1 if op(a) is an lower triangular matrix, or
+///       kk = m-i if op(a) is an lower triangular matrix.
+/// Therefore
+/// B_ij = (res_Xij + (kk-1) * gamma) / alpha, if diag == Unit
+/// B_ij = kk * gamma / alpha, otherwise.
+///
+/// Finally, the X matrix elements (res_b) are computed as
+///   res_Xkj = (k+.5) / (j+2) * exp(I*(k+j)),
+/// where I = 0 for real types or I is the complex unit for complex types.
+/// These data are typically used to check whether the result of the equation
+/// performed with any algorithm is consistent with the computed values.
+///
 template <class ElementIndex, class T>
 auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType m) {
-  // Note: The tile elements are chosen such that:
-  // - op(a)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements
-  //   op(a)_ik = -9.9 otherwise,
-  // - res_kj = (k+.5) / (j+2) * exp(I*(k+j)),
-  // where I = 0 for real types or I is the complex unit for complex types.
-  // Therefore the elements of b should be:
-  // b_ij = (Sum_k op(a)_ik * res_kj) / alpha
-  //      = (op(a)_ii * res_ij + (kk-1) * gamma) / alpha,
-  // where gamma = (i+1) / (j+2) * exp(I*(2*i+j)),
-  //       kk = i+1 if op(a) is an lower triangular matrix, or
-  //       kk = m-i if op(a) is an lower triangular matrix.
-  // Therefore
-  // b_ij = (res_ij + (kk-1) * gamma) / alpha, if diag == Unit
-  // b_ij = kk * gamma / alpha, otherwise.
   bool op_a_lower = false;
   if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
       (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
@@ -79,24 +89,31 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
   return std::make_tuple(el_op_a, el_b, res_b);
 }
 
-/// @brief Returns el_op_a, el_b, res_b for side = Right.
+/// Returns elements of the three matrices, solving the triangular matrix equation
+/// B op(A) = X (with A on side == right)
+///
+/// The tile elements of A matrix (el_op_a) are chosen such that:
+///   op(A)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements
+///   op(A)_kj = -9.9 otherwise.
+///
+/// The elements of B (el_b) should be:
+/// B_ij = (Sum_k res_Xik * op(A)_kj) / alpha
+///      = (res_Xij * op(A)_jj + (kk-1) * gamma) / alpha,
+/// where gamma = (j+1) / (i+2) * exp(I*(i+2*j)),
+///       kk = j+1 if op(a) is an upper triangular matrix, or
+///       kk = m-j if op(a) is an upper triangular matrix.
+/// Therefore
+/// B_ij = (res_Xij + (kk-1) * gamma) / alpha, if diag == Unit
+/// B_ij = kk * gamma / alpha, otherwise.
+///
+/// Finally, the X matrix elements (res_b) are computed as
+///   res_Xik = (k+.5) / (i+2) * exp(I*(i+k)),
+/// where I = 0 for real types or I is the complex unit for complex types.
+/// These data are typically used to check whether the result of the equation
+/// performed with any algorithm is consistent with the computed values.
+///
 template <class ElementIndex, class T>
 auto getRightTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType n) {
-  // Note: The tile elements are chosen such that:
-  // - res_ik = (k+.5) / (i+2) * exp(I*(i+k)),
-  // - op(a)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements
-  //   op(a)_kj = -9.9 otherwise,
-  // where I = 0 for real types or I is the complex unit for complex types.
-  // Therefore the elements of b should be:
-  // b_ij = (Sum_k res_ik * op(a)_kj) / alpha
-  //      = (res_ij * op(a)_jj + (kk-1) * gamma) / alpha,
-  // where gamma = (j+1) / (i+2) * exp(I*(i+2*j)),
-  //       kk = j+1 if op(a) is an upper triangular matrix, or
-  //       kk = m-j if op(a) is an upper triangular matrix.
-  // Therefore
-  // b_ij = (res_ij + (kk-1) * gamma) / alpha, if diag == Unit
-  // b_ij = kk * gamma / alpha, otherwise.
-
   bool op_a_lower = false;
   if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
       (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -28,17 +28,17 @@ using namespace dlaf_test;
 /// Returns a tuple of element generators of three matrices A(m x m), B (m x n), X (m x n), for which it
 /// holds op(A) X = alpha B (n can be any value).
 ///
-/// The tile elements of A matrix (el_op_a) are chosen such that:
+/// The elements of op(A) (@p el_op_a) are chosen such that:
 ///   op(A)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements
-///   op(A)_ik = -9.9 otherwise.
-///
-/// The X matrix elements (el_x) are computed as
-///   Xkj = (k+.5) / (j+2) * exp(I*(k+j)),
+///   op(A)_ik = -9.9 otherwise,
 /// where I = 0 for real types or I is the complex unit for complex types.
+///
+/// The elements of X (@p el_x) are computed as
+///   Xkj = (k+.5) / (j+2) * exp(I*(k+j)).
 /// These data are typically used to check whether the result of the equation
 /// performed with any algorithm is consistent with the computed values.
 ///
-/// Finally, the elements of B (el_b) should be:
+/// Finally, the elements of B (@p el_b) should be:
 /// B_ij = (Sum_k op(A)_ik * Xkj) / alpha
 ///      = (op(A)_ii * Xij + (kk-1) * gamma) / alpha,
 /// where gamma = (i+1) / (j+2) * exp(I*(2*i+j)),
@@ -92,17 +92,17 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 /// Returns a tuple of element generators of three matrices A(m x m), B (m x n), X (m x n), for which it
 /// holds X op(A) = alpha B (n can be any value).
 ///
-/// The tile elements of A matrix (el_op_a) are chosen such that:
+/// The elements of op(A) (@p el_op_a) are chosen such that:
 ///   op(A)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements
-///   op(A)_kj = -9.9 otherwise.
-///
-/// The X matrix elements (el_x) are computed as
-///   Xik = (k+.5) / (i+2) * exp(I*(i+k)),
+///   op(A)_kj = -9.9 otherwise,
 /// where I = 0 for real types or I is the complex unit for complex types.
+///
+/// The elements of X (@p el_x) are computed as
+///   Xik = (k+.5) / (i+2) * exp(I*(i+k)).
 /// These data are typically used to check whether the result of the equation
 /// performed with any algorithm is consistent with the computed values.
 ///
-/// Finally, the elements of B (el_b) should be:
+/// Finally, the elements of B (@p el_b) should be:
 /// B_ij = (Sum_k Xik * op(A)_kj) / alpha
 ///      = (Xij * op(A)_jj + (kk-1) * gamma) / alpha,
 /// where gamma = (j+1) / (i+2) * exp(I*(i+2*j)),

--- a/test/include/dlaf_test/matrix/util_matrix_blas.h
+++ b/test/include/dlaf_test/matrix/util_matrix_blas.h
@@ -14,6 +14,7 @@
 
 #include "blas.hh"
 #include "dlaf/matrix.h"
+#include "dlaf_test/matrix/util_generic_blas.h"
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/util_types.h"
 

--- a/test/include/dlaf_test/matrix/util_tile_blas.h
+++ b/test/include/dlaf_test/matrix/util_tile_blas.h
@@ -14,6 +14,7 @@
 
 #include "blas.hh"
 #include "dlaf/tile.h"
+#include "dlaf_test/matrix/util_generic_blas.h"
 #include "dlaf_test/matrix/util_tile.h"
 #include "dlaf_test/util_types.h"
 

--- a/test/unit/mc/test_triangular_solve_local.cpp
+++ b/test/unit/mc/test_triangular_solve_local.cpp
@@ -41,7 +41,7 @@ std::vector<LocalElementSize> square_sizes(
     {{2, 2}, {3, 3}, {4, 4}, {6, 6}, {10, 10}, {25, 25}, {15, 15}, {0, 0}});
 std::vector<LocalElementSize> rectangular_sizes({{12, 20}, {50, 20}, {0, 12}, {20, 0}});
 
-std::vector<unsigned int> col_b({{1}, {3}, {10}, {20}});
+std::vector<unsigned int> col_b{1, 3, 10, 20};
 
 std::vector<TileElementSize> square_block_sizes({{2, 2}, {3, 3}, {5, 5}});
 std::vector<TileElementSize> rectangular_block_sizes({{12, 30}, {20, 12}});
@@ -79,10 +79,10 @@ void testTriangularSolve(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Di
 
   if (side == blas::Side::Left)
     std::tie(el_op_a, el_b, res_b) =
-        testTrsmElementFunctionsLeft<GlobalElementIndex, T>(uplo, op, diag, alpha, m);
+        test::getLeftTriangularSystem<GlobalElementIndex>(uplo, op, diag, alpha, m);
   else
     std::tie(el_op_a, el_b, res_b) =
-        testTrsmElementFunctionsRight<GlobalElementIndex, T>(uplo, op, diag, alpha, n);
+        test::getRightTriangularSystem<GlobalElementIndex>(uplo, op, diag, alpha, n);
 
   set(mat_a, el_op_a, op);
   set(mat_b, el_b);

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -29,118 +29,6 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
-/// @brief Returns el_op_a, el_b, res_b for side = Left.
-template <class ElementIndex, class T>
-auto testTrsmElementFunctionsLeft(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType m) {
-  // Note: The tile elements are chosen such that:
-  // - op(a)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements
-  //   op(a)_ik = -9.9 otherwise,
-  // - res_kj = (k+.5) / (j+2) * exp(I*(k+j)),
-  // where I = 0 for real types or I is the complex unit for complex types.
-  // Therefore the elements of b should be:
-  // b_ij = (Sum_k op(a)_ik * res_kj) / alpha
-  //      = (op(a)_ii * res_ij + (kk-1) * gamma) / alpha,
-  // where gamma = (i+1) / (j+2) * exp(I*(2*i+j)),
-  //       kk = i+1 if op(a) is an lower triangular matrix, or
-  //       kk = m-i if op(a) is an lower triangular matrix.
-  // Therefore
-  // b_ij = (res_ij + (kk-1) * gamma) / alpha, if diag == Unit
-  // b_ij = kk * gamma / alpha, otherwise.
-  bool op_a_lower = false;
-  if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
-      (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
-    op_a_lower = true;
-
-  std::function<T(const ElementIndex&)> el_op_a = [op_a_lower, diag](const ElementIndex& index) {
-    if ((op_a_lower && index.row() < index.col()) || (!op_a_lower && index.row() > index.col()) ||
-        (diag == blas::Diag::Unit && index.row() == index.col()))
-      return TypeUtilities<T>::element(-9.9, 0);
-
-    double i = index.row();
-    double k = index.col();
-
-    return TypeUtilities<T>::polar((i + 1) / (k + .5), 2 * i - k);
-  };
-
-  std::function<T(const ElementIndex&)> res_b = [](const ElementIndex& index) {
-    double k = index.row();
-    double j = index.col();
-
-    return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
-  };
-
-  std::function<T(const ElementIndex&)> el_b = [m, alpha, diag, op_a_lower,
-                                                res_b](const ElementIndex& index) {
-    BaseType<T> kk = op_a_lower ? index.row() + 1 : m - index.row();
-
-    double i = index.row();
-    double j = index.col();
-    T gamma = TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
-    if (diag == blas::Diag::Unit)
-      return ((kk - 1) * gamma + res_b(index)) / alpha;
-    else
-      return kk * gamma / alpha;
-  };
-
-  return std::make_tuple(el_op_a, el_b, res_b);
-}
-
-/// @brief Returns el_op_a, el_b, res_b for side = Right.
-template <class ElementIndex, class T>
-auto testTrsmElementFunctionsRight(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType n) {
-  // Note: The tile elements are chosen such that:
-  // - res_ik = (k+.5) / (i+2) * exp(I*(i+k)),
-  // - op(a)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements
-  //   op(a)_kj = -9.9 otherwise,
-  // where I = 0 for real types or I is the complex unit for complex types.
-  // Therefore the elements of b should be:
-  // b_ij = (Sum_k res_ik * op(a)_kj) / alpha
-  //      = (res_ij * op(a)_jj + (kk-1) * gamma) / alpha,
-  // where gamma = (j+1) / (i+2) * exp(I*(i+2*j)),
-  //       kk = j+1 if op(a) is an upper triangular matrix, or
-  //       kk = m-j if op(a) is an upper triangular matrix.
-  // Therefore
-  // b_ij = (res_ij + (kk-1) * gamma) / alpha, if diag == Unit
-  // b_ij = kk * gamma / alpha, otherwise.
-
-  bool op_a_lower = false;
-  if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
-      (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
-    op_a_lower = true;
-
-  auto res_b = [](const ElementIndex& index) {
-    double i = index.row();
-    double k = index.col();
-
-    return TypeUtilities<T>::polar((k + .5) / (i + 2), i + k);
-  };
-
-  auto el_op_a = [op_a_lower, diag](const ElementIndex& index) {
-    if ((op_a_lower && index.row() < index.col()) || (!op_a_lower && index.row() > index.col()) ||
-        (diag == blas::Diag::Unit && index.row() == index.col()))
-      return TypeUtilities<T>::element(-9.9, 0);
-
-    double k = index.row();
-    double j = index.col();
-
-    return TypeUtilities<T>::polar((j + 1) / (k + .5), 2 * j - k);
-  };
-
-  auto el_b = [n, alpha, diag, op_a_lower, res_b](const ElementIndex& index) {
-    BaseType<T> kk = op_a_lower ? n - index.col() : index.col() + 1;
-
-    double i = index.row();
-    double j = index.col();
-    T gamma = TypeUtilities<T>::polar((j + 1) / (i + 2), i + 2 * j);
-    if (diag == blas::Diag::Unit)
-      return ((kk - 1) * gamma + res_b(index)) / alpha;
-    else
-      return kk * gamma / alpha;
-  };
-
-  return std::make_tuple(el_op_a, el_b, res_b);
-}
-
 template <class ElementIndex, class T, class CT = const T>
 void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, SizeType m, SizeType n,
               SizeType extra_lda, SizeType extra_ldb) {
@@ -167,10 +55,10 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
 
   if (side == blas::Side::Left)
     std::tie(el_op_a, el_b, res_b) =
-        testTrsmElementFunctionsLeft<ElementIndex, T>(uplo, op, diag, alpha, m);
+        test::getLeftTriangularSystem<ElementIndex, T>(uplo, op, diag, alpha, m);
   else
     std::tie(el_op_a, el_b, res_b) =
-        testTrsmElementFunctionsRight<ElementIndex, T>(uplo, op, diag, alpha, n);
+        test::getRightTriangularSystem<ElementIndex, T>(uplo, op, diag, alpha, n);
 
   set(a0, el_op_a, op);
   set(b, el_b);


### PR DESCRIPTION
Close #151 

Moved (and renamed) helper functions for the generation of left and right triangular system.

Currently they are used just by `trsm` test, but it is useful also for other ones (e.g. see #149)