### PR TITLE
Fix set_random_hermitian_positive_definite for matrix size which are not multiple of block size

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -85,9 +85,7 @@ public:
 
   /// Given a coordinate, returns its transposed with the same type
   template <class Coords2DType>
-  friend Coords2DType transposed(const Coords2DType& coords) {
-    return {coords.col_, coords.row_};
-  }
+  friend Coords2DType transposed(const Coords2DType& coords);
 
   /// Adds "(<row_>, <col_>)" to out.
   friend std::ostream& operator<<(std::ostream& out, const basic_coords& index) {
@@ -102,6 +100,11 @@ protected:
   IndexT col_;
 };
 
+template <class Coords2DType>
+Coords2DType transposed(const Coords2DType& coords) {
+  return {coords.col_, coords.row_};
+}
+
 }
 
 /// A strong-type for 2D sizes
@@ -109,8 +112,6 @@ protected:
 /// @tparam Tag for strong-typing
 template <typename IndexT, class Tag>
 class Size2D : public internal::basic_coords<IndexT> {
-  template <typename, class>
-  friend class Index2D;
 
 public:
   using internal::basic_coords<IndexT>::basic_coords;

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -83,6 +83,12 @@ public:
     std::swap(row_, col_);
   }
 
+  /// Given a coordinate, returns its transposed with the same type
+  template <class Coords2DType>
+  friend Coords2DType transposed(const Coords2DType& coords) {
+    return {coords.col_, coords.row_};
+  }
+
   /// Adds "(<row_>, <col_>)" to out.
   friend std::ostream& operator<<(std::ostream& out, const basic_coords& index) {
     if (std::is_same<IndexT, signed char>::value) {

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -104,7 +104,6 @@ template <class Coords2DType>
 Coords2DType transposed(const Coords2DType& coords) {
   return {coords.col_, coords.row_};
 }
-
 }
 
 /// A strong-type for 2D sizes

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -111,7 +111,6 @@ Coords2DType transposed(const Coords2DType& coords) {
 /// @tparam Tag for strong-typing
 template <typename IndexT, class Tag>
 class Size2D : public internal::basic_coords<IndexT> {
-
 public:
   using internal::basic_coords<IndexT>::basic_coords;
 

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -163,6 +163,7 @@ TYPED_TEST(MatrixUtilsTest, SetRandomHermitianPositiveDefinite) {
   std::vector<TestSizes> square_blocks_configs({
       {{0, 0}, {13, 13}},  // square null matrix
       {{5, 5}, {26, 26}},  // square matrix single block
+      {{9, 9}, {3, 3}},    // square matrix multi block "full-tile"
       {{13, 13}, {3, 3}},  // square matrix multi block
   });
 

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -122,16 +122,17 @@ void check_is_hermitian(dlaf::Matrix<const T, Device::CPU>& matrix,
       if (current_rank == owner_original) {
         const auto& tile_original = matrix.read(index_tile_original).get();
         hpx::shared_future<dlaf::Tile<const T, Device::CPU>> tile_transposed;
+        auto size_tile_transposed = transposed(tile_original.size());
 
         if (current_rank == owner_transposed) {
           tile_transposed = matrix.read(index_tile_transposed);
         }
         else {
-          dlaf::Tile<T, Device::CPU> workspace(matrix.blockSize(),
+          dlaf::Tile<T, Device::CPU> workspace(size_tile_transposed,
                                                dlaf::memory::MemoryView<T, Device::CPU>(
-                                                   matrix.blockSize().rows() *
-                                                   matrix.blockSize().cols()),
-                                               matrix.blockSize().rows());
+                                                   size_tile_transposed.rows() *
+                                                   size_tile_transposed.cols()),
+                                               size_tile_transposed.rows());
 
           // recv from owner_transposed
           const auto sender_rank = comm_grid.rankFullCommunicator(owner_transposed);

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -161,9 +161,8 @@ void check_is_hermitian(dlaf::Matrix<const T, Device::CPU>& matrix,
 TYPED_TEST(MatrixUtilsTest, SetRandomHermitianPositiveDefinite) {
   std::vector<TestSizes> square_blocks_configs({
       {{0, 0}, {13, 13}},  // square null matrix
-      {{26, 26}, {2, 2}},  // square matrix multi block
-      {{2, 2}, {6, 6}},    // square matrix single block
-      {{4, 4}, {13, 13}},  // square matrix single block
+      {{5, 5}, {26, 26}},  // square matrix single block
+      {{13, 13}, {3, 3}},  // square matrix multi block
   });
 
   auto globalSquareTestSize = [](const LocalElementSize& size, const Size2D& grid_size) {


### PR DESCRIPTION
Close #161 

This PR fixes the problem about set_random_hermitian_matrix.

It is still open to discussion how to solve the problem of testing edge configuration cases.