### PR TITLE
Bump the version to CMake 12

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -122,7 +122,7 @@ Note: Mixing GCC and Intel OpenMP backends is a bad idea.
 
 #]=======================================================================]
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 # Modules
 #


### PR DESCRIPTION
- The version sets policy CMP0074 allowing to specify a custom MPI
  directory via MPI_ROOT. The top CMake file already sets the version to
  12