### PR TITLE
Remove spack.yaml

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -1,8 +1,0 @@
-spack:
-  specs:
-    - mpich
-    - intel-mkl
-    - hpx cxxstd=14 networking=none
-    - blaspp
-    - lapackpp
-  concretization: together


### PR DESCRIPTION
- The `spack_dlaf` subdir provides the advantages of spack.yaml and
  more. This is evident by the Spack section on developing software with
  spack:
  https://spack.readthedocs.io/en/latest/workflows.html#developing-software-with-spack