### PR TITLE
Squash minor warnings and compilation errors

### DIFF
--- a/include/dlaf/communication/datatypes.h
+++ b/include/dlaf/communication/datatypes.h
@@ -19,86 +19,13 @@ namespace comm {
 
 /// @brief mapper between language types and basic MPI_Datatype
 template <typename T>
-struct mpi_datatype;
+struct mpi_datatype {
+  static MPI_Datatype type;
+};
 
 /// helper for mapping also custom types
 template <typename T>
 struct mpi_datatype<const T> : public mpi_datatype<T> {};
-
-template <>
-struct mpi_datatype<char> {
-  static constexpr MPI_Datatype type = MPI_CHAR;
-};
-
-template <>
-struct mpi_datatype<short> {
-  static constexpr MPI_Datatype type = MPI_SHORT;
-};
-
-template <>
-struct mpi_datatype<int> {
-  static constexpr MPI_Datatype type = MPI_INT;
-};
-
-template <>
-struct mpi_datatype<long> {
-  static constexpr MPI_Datatype type = MPI_LONG;
-};
-
-template <>
-struct mpi_datatype<long long> {
-  static constexpr MPI_Datatype type = MPI_LONG_LONG;
-};
-
-template <>
-struct mpi_datatype<unsigned char> {
-  static constexpr MPI_Datatype type = MPI_UNSIGNED_CHAR;
-};
-
-template <>
-struct mpi_datatype<unsigned short> {
-  static constexpr MPI_Datatype type = MPI_UNSIGNED_SHORT;
-};
-
-template <>
-struct mpi_datatype<unsigned int> {
-  static constexpr MPI_Datatype type = MPI_UNSIGNED;
-};
-
-template <>
-struct mpi_datatype<unsigned long> {
-  static constexpr MPI_Datatype type = MPI_UNSIGNED_LONG;
-};
-
-template <>
-struct mpi_datatype<unsigned long long> {
-  static constexpr MPI_Datatype type = MPI_UNSIGNED_LONG_LONG;
-};
-
-template <>
-struct mpi_datatype<float> {
-  static constexpr MPI_Datatype type = MPI_FLOAT;
-};
-
-template <>
-struct mpi_datatype<double> {
-  static constexpr MPI_Datatype type = MPI_DOUBLE;
-};
-
-template <>
-struct mpi_datatype<bool> {
-  static constexpr MPI_Datatype type = MPI_CXX_BOOL;
-};
-
-template <>
-struct mpi_datatype<std::complex<float>> {
-  static constexpr MPI_Datatype type = MPI_CXX_FLOAT_COMPLEX;
-};
-
-template <>
-struct mpi_datatype<std::complex<double>> {
-  static constexpr MPI_Datatype type = MPI_CXX_DOUBLE_COMPLEX;
-};
 
 }
 }

--- a/include/dlaf/memory/memory_chunk.h
+++ b/include/dlaf/memory/memory_chunk.h
@@ -49,7 +49,7 @@ public:
     }
 #else
     if (device == Device::CPU) {
-      ptr_ = (T*) std::malloc(size_ * sizeof(T));
+      ptr_ = static_cast<T*>(std::malloc(size_ * sizeof(T)));
     }
     else {
       std::terminate();

--- a/include/dlaf/mpi_header.h
+++ b/include/dlaf/mpi_header.h
@@ -15,8 +15,8 @@
 #include <mpi.h>
 
 #define MPI_CALL(x)                                                             \
-  {                                                                             \
+  do {                                                                          \
     auto error_code = x;                                                        \
     if (MPI_SUCCESS != error_code)                                              \
       std::cerr << "MPI error at " << __FILE__ << ":" << __LINE__ << std::endl; \
-  }
+  } while (0)

--- a/include/dlaf/util_blas.h
+++ b/include/dlaf/util_blas.h
@@ -21,9 +21,6 @@ std::ostream& operator<<(std::ostream& stream, const blas::Diag& diag) {
       break;
     case blas::Diag::NonUnit:
       stream << "NonUnit";
-      break;
-    default:
-      stream << "Unknown";
   }
   return stream;
 }
@@ -36,8 +33,6 @@ std::ostream& operator<<(std::ostream& stream, const blas::Side& side) {
     case blas::Side::Right:
       stream << "Right";
       break;
-    default:
-      stream << "Unknown";
   }
   return stream;
 }
@@ -53,8 +48,6 @@ std::ostream& operator<<(std::ostream& stream, const blas::Op& trans) {
     case blas::Op::ConjTrans:
       stream << "ConjTrans";
       break;
-    default:
-      stream << "Unknown";
   }
   return stream;
 }
@@ -67,8 +60,9 @@ std::ostream& operator<<(std::ostream& stream, const blas::Uplo& uplo) {
     case blas::Uplo::Upper:
       stream << "Upper";
       break;
-    default:
-      stream << "Unknown";
+    case blas::Uplo::General:
+      stream << "General";
+      break;
   }
   return stream;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(DLAF
   communication/communicator_impl.cpp
   communication/communicator.cpp
   communication/communicator_grid.cpp
+  communication/datatypes.cpp
   matrix/distribution.cpp
   matrix/layout_info.cpp
 )

--- a/src/communication/communicator_impl.cpp
+++ b/src/communication/communicator_impl.cpp
@@ -8,7 +8,7 @@
 namespace dlaf {
 namespace comm {
 
-constexpr bool is_manageable(MPI_Comm mpi_communicator) noexcept {
+bool is_manageable(MPI_Comm mpi_communicator) noexcept {
   if (mpi_communicator == MPI_COMM_WORLD)
     return false;
   else if (mpi_communicator == MPI_COMM_NULL)

--- a/src/communication/communicator_impl.h
+++ b/src/communication/communicator_impl.h
@@ -10,7 +10,7 @@ namespace comm {
 class Communicator;
 
 /// @return true if it is a manageable communicator (i.e. it is not MPI_COMM_NULL or MPI_COMM_WORLD)
-constexpr bool is_manageable(MPI_Comm mpi_communicator) noexcept;
+bool is_manageable(MPI_Comm mpi_communicator) noexcept;
 
 /// Basic wrapper for MPI_Comm
 /// It is more or less an alias for MPI_Comm

--- a/src/communication/datatypes.cpp
+++ b/src/communication/datatypes.cpp
@@ -1,0 +1,52 @@
+#include <dlaf/communication/datatypes.h>
+
+namespace dlaf {
+namespace comm {
+
+template <>
+MPI_Datatype mpi_datatype<char>::type = MPI_CHAR;
+
+template <>
+MPI_Datatype mpi_datatype<short>::type = MPI_SHORT;
+
+template <>
+MPI_Datatype mpi_datatype<int>::type = MPI_INT;
+
+template <>
+MPI_Datatype mpi_datatype<long>::type = MPI_LONG;
+
+template <>
+MPI_Datatype mpi_datatype<long long>::type = MPI_LONG_LONG;
+
+template <>
+MPI_Datatype mpi_datatype<unsigned char>::type = MPI_UNSIGNED_CHAR;
+
+template <>
+MPI_Datatype mpi_datatype<unsigned short>::type = MPI_UNSIGNED_SHORT;
+
+template <>
+MPI_Datatype mpi_datatype<unsigned int>::type = MPI_UNSIGNED;
+
+template <>
+MPI_Datatype mpi_datatype<unsigned long>::type = MPI_UNSIGNED_LONG;
+
+template <>
+MPI_Datatype mpi_datatype<unsigned long long>::type = MPI_UNSIGNED_LONG_LONG;
+
+template <>
+MPI_Datatype mpi_datatype<float>::type = MPI_FLOAT;
+
+template <>
+MPI_Datatype mpi_datatype<double>::type = MPI_DOUBLE;
+
+template <>
+MPI_Datatype mpi_datatype<bool>::type = MPI_CXX_BOOL;
+
+template <>
+MPI_Datatype mpi_datatype<std::complex<float>>::type = MPI_CXX_FLOAT_COMPLEX;
+
+template <>
+MPI_Datatype mpi_datatype<std::complex<double>>::type = MPI_CXX_DOUBLE_COMPLEX;
+
+}
+}

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -100,7 +100,7 @@ void checkEQ(ElementGetter exp_el, MatrixType<T, Device::CPU>& mat, const char* 
   };
   internal::check(exp_el, mat, std::equal_to<T>{}, err_message, file, line);
 }
-#define CHECK_MATRIX_EQ(exp_el, mat) ::dlaf::matrix::test::checkEQ(exp_el, mat, __FILE__, __LINE__);
+#define CHECK_MATRIX_EQ(exp_el, mat) ::dlaf::matrix::test::checkEQ(exp_el, mat, __FILE__, __LINE__)
 
 /// @brief Checks the pointers to the elements of the matrix.
 ///
@@ -117,7 +117,7 @@ void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* fi
   };
   internal::check(exp_ptr, mat, comp, err_message, file, line);
 }
-#define CHECK_MATRIX_PTR(exp_ptr, mat) ::dlaf::matrix::test::checkPtr(exp_ptr, mat, __FILE__, __LINE__);
+#define CHECK_MATRIX_PTR(exp_ptr, mat) ::dlaf::matrix::test::checkPtr(exp_ptr, mat, __FILE__, __LINE__)
 
 /// @brief Checks the elements of the matrix.
 ///
@@ -152,7 +152,7 @@ void checkNear(ElementGetter expected, MatrixType<T, Device::CPU>& mat, BaseType
   internal::check(expected, mat, comp, err_message, file, line);
 }
 #define CHECK_MATRIX_NEAR(expected, mat, rel_err, abs_err) \
-  ::dlaf::matrix::test::checkNear(expected, mat, rel_err, abs_err, __FILE__, __LINE__);
+  ::dlaf::matrix::test::checkNear(expected, mat, rel_err, abs_err, __FILE__, __LINE__)
 
 template <class MatrixType>
 void checkMatrixDistribution(const Distribution& distribution, const MatrixType& matrix) {

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -134,7 +134,7 @@ void checkEQ(ElementGetter exp_el, const Tile<T, Device::CPU>& tile, const char*
   };
   internal::check(exp_el, tile, std::equal_to<T>{}, err_message, file, line);
 }
-#define CHECK_TILE_EQ(exp_el, tile) ::dlaf::matrix::test::checkEQ(exp_el, tile, __FILE__, __LINE__);
+#define CHECK_TILE_EQ(exp_el, tile) ::dlaf::matrix::test::checkEQ(exp_el, tile, __FILE__, __LINE__)
 
 /// @brief Checks the pointers to the elements of the tile.
 ///
@@ -152,7 +152,7 @@ void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const cha
   };
   internal::check(exp_ptr, tile, comp, err_message, file, line);
 }
-#define CHECK_TILE_PTR(exp_ptr, tile) ::dlaf::matrix::test::checkPtr(exp_ptr, tile, __FILE__, __LINE__);
+#define CHECK_TILE_PTR(exp_ptr, tile) ::dlaf::matrix::test::checkPtr(exp_ptr, tile, __FILE__, __LINE__)
 
 /// @brief Checks the elements of the tile.
 ///
@@ -185,7 +185,7 @@ void checkNear(ElementGetter expected, const Tile<T, Device::CPU>& tile, BaseTyp
   internal::check(expected, tile, comp, err_message, file, line);
 }
 #define CHECK_TILE_NEAR(expected, tile, rel_err, abs_err) \
-  ::dlaf::matrix::test::checkNear(expected, tile, rel_err, abs_err, __FILE__, __LINE__);
+  ::dlaf::matrix::test::checkNear(expected, tile, rel_err, abs_err, __FILE__, __LINE__)
 }
 }
 }

--- a/test/unit/communication/test_communicator.cpp
+++ b/test/unit/communication/test_communicator.cpp
@@ -33,7 +33,7 @@ void test_communication(const Communicator& comm) {
 
 class CommunicatorTest : public ::testing::Test {
 protected:
-  ~CommunicatorTest() noexcept {};
+  ~CommunicatorTest() noexcept override {}
 
   void SetUp() override {
     world = Communicator(MPI_COMM_WORLD);

--- a/test/unit/communication/test_communicator_grid.cpp
+++ b/test/unit/communication/test_communicator_grid.cpp
@@ -19,7 +19,7 @@ using dlaf_test::comm::computeGridDims;
 using dlaf::common::Ordering;
 using namespace dlaf::comm;
 
-auto valid_orderings = ::testing::Values(Ordering::RowMajor, Ordering::ColumnMajor);
+const auto valid_orderings = ::testing::Values(Ordering::RowMajor, Ordering::ColumnMajor);
 
 void test_grid_communication(CommunicatorGrid& grid) {
   if (MPI_COMM_NULL == grid.rowCommunicator() || MPI_COMM_NULL == grid.colCommunicator())

--- a/test/unit/factorization/mc/test_cholesky.cpp
+++ b/test/unit/factorization/mc/test_cholesky.cpp
@@ -41,8 +41,8 @@ public:
 
 TYPED_TEST_SUITE(CholeskyDistributedTest, MatrixElementTypes);
 
-std::vector<LocalElementSize> square_sizes({{10, 10}, {25, 25}, {12, 12}, {0, 0}});
-std::vector<TileElementSize> square_block_sizes({{3, 3}, {5, 5}});
+const std::vector<LocalElementSize> square_sizes({{10, 10}, {25, 25}, {12, 12}, {0, 0}});
+const std::vector<TileElementSize> square_block_sizes({{3, 3}, {5, 5}});
 
 GlobalElementSize globalTestSize(const LocalElementSize& size) {
   return {size.rows(), size.cols()};

--- a/test/unit/matrix/test_distribution.cpp
+++ b/test/unit/matrix/test_distribution.cpp
@@ -40,7 +40,7 @@ public:
   }
 };
 
-std::vector<ParametersConstructor> tests_constructor = {
+const std::vector<ParametersConstructor> tests_constructor = {
     // {size, block_size, rank, grid_size, src_rank, global_tiles, local_tiles, local_size}
     {{0, 0}, {13, 17}, {0, 0}, {1, 1}, {0, 0}, {0, 0}, {0, 0}, {0, 0}},
     {{0, 0}, {13, 17}, {2, 1}, {3, 2}, {0, 1}, {0, 0}, {0, 0}, {0, 0}},
@@ -274,7 +274,7 @@ struct ParametersIndices {
   TileElementIndex tile_element;
 };
 
-std::vector<ParametersIndices> tests_indices = {
+const std::vector<ParametersIndices> tests_indices = {
     // {size, block_size, rank, grid_size, src_rank, global_element, global_tile,
     // rank_tile, local_tile, local_tile_next, tile_element}
     {{121, 232}, {10, 25}, {0, 0}, {1, 1}, {0, 0}, {31, 231}, {3, 9}, {0, 0}, {3, 9}, {3, 9}, {1, 6}},

--- a/test/unit/matrix/test_layout_info.cpp
+++ b/test/unit/matrix/test_layout_info.cpp
@@ -17,7 +17,8 @@
 using namespace dlaf;
 using namespace testing;
 
-std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, std::size_t>>
+const std::vector<
+    std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, std::size_t>>
     values({{{31, 17}, {7, 11}, 31, 7, 341, 527},      // Scalapack like layout
             {{31, 17}, {32, 11}, 31, 31, 341, 527},    // only one row of tiles
             {{31, 17}, {7, 11}, 33, 7, 363, 559},      // with padding (ld)
@@ -30,8 +31,8 @@ std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t,
             {{29, 41}, {13, 11}, 13, 143, 419, 1637},  // compressed col_offset
             {{0, 0}, {1, 1}, 1, 1, 1, 0}});
 
-std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t>> wrong_values(
-    {
+const std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t>>
+    wrong_values({
         {{31, 17}, {7, 11}, 30, 7, 341},     // ld, row_offset combo is wrong
         {{31, 17}, {32, 11}, 30, 7, 341},    // ld is wrong
         {{31, 17}, {7, 11}, 31, 6, 341},     // row_offset is wrong
@@ -101,7 +102,7 @@ TEST(LayoutInfoTest, ConstructorException) {
   }
 }
 
-std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, bool>>
+const std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, bool>>
     comp_values({
         {{25, 25}, {5, 5}, 50, 8, 1000, true},   // Original
         {{23, 25}, {5, 5}, 50, 8, 1000, false},  // different size
@@ -135,7 +136,8 @@ TEST(LayoutInfoTest, ComparisonOperator) {
   }
 }
 
-std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, std::size_t>>
+const std::vector<
+    std::tuple<LocalElementSize, TileElementSize, SizeType, std::size_t, std::size_t, std::size_t>>
     col_major_values({
         {{31, 17}, {7, 11}, 31, 7, 341, 527},     // packed ld
         {{31, 17}, {7, 11}, 33, 7, 363, 559},     // padded ld
@@ -163,8 +165,8 @@ TEST(LayoutInfoTest, ColMajorLayout) {
   }
 }
 
-std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, SizeType, std::size_t, std::size_t,
-                       std::size_t, bool>>
+const std::vector<std::tuple<LocalElementSize, TileElementSize, SizeType, SizeType, std::size_t,
+                             std::size_t, std::size_t, bool>>
     tile_values({
         {{31, 17}, {7, 11}, 7, 5, 77, 385, 731, true},       // basic tile layout
         {{31, 17}, {7, 11}, 11, 5, 121, 605, 1147, false},   // padded ld

--- a/test/unit/matrix/test_matrix_view.cpp
+++ b/test/unit/matrix/test_matrix_view.cpp
@@ -50,9 +50,9 @@ struct TestSizes {
 };
 
 // TODO (Upper and Lower cases NOT yet implemented)
-std::vector<blas::Uplo> blas_uplos({blas::Uplo::General});
+const std::vector<blas::Uplo> blas_uplos({blas::Uplo::General});
 
-std::vector<TestSizes> sizes_tests({
+const std::vector<TestSizes> sizes_tests({
     {{0, 0}, {11, 13}},
     {{3, 0}, {1, 2}},
     {{0, 1}, {7, 32}},

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -46,7 +46,7 @@ struct TestSizes {
   TileElementSize block_size;
 };
 
-std::vector<TestSizes> sizes_tests({
+const std::vector<TestSizes> sizes_tests({
     {{0, 0}, {11, 13}},
     {{3, 0}, {1, 2}},
     {{0, 1}, {7, 32}},

--- a/test/unit/memory/test_memory_chunk.cpp
+++ b/test/unit/memory/test_memory_chunk.cpp
@@ -22,7 +22,7 @@ class MemoryChunkTest : public ::testing::Test {};
 
 TYPED_TEST_SUITE(MemoryChunkTest, ElementTypes);
 
-std::size_t size = 397;
+constexpr std::size_t size = 397;
 
 TYPED_TEST(MemoryChunkTest, ConstructorAllocates) {
   using Type = TypeParam;

--- a/test/unit/memory/test_memory_view.cpp
+++ b/test/unit/memory/test_memory_view.cpp
@@ -22,7 +22,7 @@ class MemoryViewTest : public ::testing::Test {};
 
 TYPED_TEST_SUITE(MemoryViewTest, ElementTypes);
 
-std::size_t size = 397;
+constexpr std::size_t size = 397;
 
 TYPED_TEST(MemoryViewTest, ConstructorAllocates) {
   using Type = TypeParam;

--- a/test/unit/solver/mc/test_triangular.cpp
+++ b/test/unit/solver/mc/test_triangular.cpp
@@ -43,12 +43,12 @@ public:
 };
 TYPED_TEST_SUITE(TriangularSolverDistributedTest, MatrixElementTypes);
 
-std::vector<blas::Side> blas_sides({blas::Side::Left, blas::Side::Right});
-std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
-std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
-std::vector<blas::Diag> blas_diags({blas::Diag::NonUnit, blas::Diag::Unit});
+const std::vector<blas::Side> blas_sides({blas::Side::Left, blas::Side::Right});
+const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
+const std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
+const std::vector<blas::Diag> blas_diags({blas::Diag::NonUnit, blas::Diag::Unit});
 
-std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> sizes = {
+const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> sizes = {
     {0, 0, 1, 1},                                                // m, n = 0
     {0, 2, 1, 2}, {7, 0, 2, 1},                                  // m = 0 or n = 0
     {2, 2, 5, 5}, {10, 10, 2, 3}, {7, 7, 3, 2},                  // m = n

--- a/test/unit/test_blas_tile.cpp
+++ b/test/unit/test_blas_tile.cpp
@@ -21,10 +21,10 @@ using namespace dlaf;
 using namespace dlaf_test;
 using namespace testing;
 
-std::vector<blas::Diag> blas_diags({blas::Diag::Unit, blas::Diag::NonUnit});
-std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
-std::vector<blas::Side> blas_sides({blas::Side::Left, blas::Side::Right});
-std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
+const std::vector<blas::Diag> blas_diags({blas::Diag::Unit, blas::Diag::NonUnit});
+const std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
+const std::vector<blas::Side> blas_sides({blas::Side::Left, blas::Side::Right});
+const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
 
 template <typename Type>
 class TileOperationsTest : public ::testing::Test {};

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -21,7 +21,7 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
-std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
+const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
 
 template <typename Type>
 class TileOperationsTest : public ::testing::Test {};

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -48,7 +48,7 @@ struct TestSizes {
   TileElementSize block_size;
 };
 
-std::vector<TestSizes> sizes_tests({
+const std::vector<TestSizes> sizes_tests({
     {{0, 0}, {11, 13}},
     {{3, 0}, {1, 2}},
     {{0, 1}, {7, 32}},
@@ -396,7 +396,7 @@ struct ExistingLocalTestSizes {
   std::size_t col_offset;
 };
 
-std::vector<ExistingLocalTestSizes> existing_local_tests({
+const std::vector<ExistingLocalTestSizes> existing_local_tests({
     {{10, 7}, {3, 4}, 10, 3, 40},  // Column major layout
     {{10, 7}, {3, 4}, 11, 3, 44},  // with padding (ld)
     {{10, 7}, {3, 4}, 13, 4, 52},  // with padding (row)
@@ -698,7 +698,7 @@ struct TestLocalColMajor {
   SizeType ld;
 };
 
-std::vector<TestLocalColMajor> col_major_sizes_tests({
+const std::vector<TestLocalColMajor> col_major_sizes_tests({
     {{10, 7}, {3, 4}, 10},  // packed ld
     {{10, 7}, {3, 4}, 11},  // padded ld
     {{6, 11}, {4, 3}, 6},   // packed ld
@@ -832,7 +832,7 @@ struct TestLocalTile {
   bool is_basic;
 };
 
-std::vector<TestLocalTile> tile_sizes_tests({
+const std::vector<TestLocalTile> tile_sizes_tests({
     {{10, 7}, {3, 4}, 3, 4, true},   // basic tile layout
     {{10, 7}, {3, 4}, 3, 7, false},  // padded tiles_per_col
     {{6, 11}, {4, 3}, 4, 2, true},   // basic tile layout

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -23,10 +23,10 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
-std::vector<SizeType> sizes({0, 1, 13, 32});
-SizeType m = 37;
-SizeType n = 87;
-SizeType ld = 133;
+const std::vector<SizeType> sizes({0, 1, 13, 32});
+constexpr SizeType m = 37;
+constexpr SizeType n = 87;
+constexpr SizeType ld = 133;
 
 std::size_t elIndex(TileElementIndex index, SizeType ld) {
   using util::size_t::sum;


### PR DESCRIPTION
- MPI_Datatype is not guaranteed to be constexpr. it is not for OpenMPI
  where a (void*) cast is involved

- Enumerate all cases instead of reverting to default. This has the
  advantage that if the enum is extended, we won't fall into the default
  case, instead we get a clear warning for unhandled conditions. Note
  also that blas:: uses enum classes so there are no implicit
  conversions to int/char

- `memory_chunk.h` : use static cast

- `communicator_impl` : the function is not guaranteed to be constexpr
  because MPI_COMM_WORLD has different implementations in different MPI
  libraries

- Declare global variables within tests as `const`.

- Some macros automatically place `;` at the end of expressions, a
  second `;` results in a waring for empty expression. Follow the
  GoogleTest convention and leave the user of the macro to place the `;`.