### PR TITLE
Fix multiple definitions error with mpi_datatype

### DIFF
--- a/include/dlaf/communication/datatypes.h
+++ b/include/dlaf/communication/datatypes.h
@@ -20,29 +20,30 @@ namespace comm {
 /// @brief mapper between language types and basic MPI_Datatype
 template <typename T>
 struct mpi_datatype {
-  static MPI_Datatype type();
+  static MPI_Datatype type;
 };
 
 /// helper for mapping also const types
 template <typename T>
 struct mpi_datatype<const T> : public mpi_datatype<T> {};
 
+// Forward declare specializations
 // clang-format off
-template<> MPI_Datatype mpi_datatype<char>                 ::type() { return MPI_CHAR;               }
-template<> MPI_Datatype mpi_datatype<short>                ::type() { return MPI_SHORT;              }
-template<> MPI_Datatype mpi_datatype<int>                  ::type() { return MPI_INT;                }
-template<> MPI_Datatype mpi_datatype<long>                 ::type() { return MPI_LONG;               }
-template<> MPI_Datatype mpi_datatype<long long>            ::type() { return MPI_LONG_LONG;          }
-template<> MPI_Datatype mpi_datatype<unsigned char>        ::type() { return MPI_UNSIGNED_CHAR;      }
-template<> MPI_Datatype mpi_datatype<unsigned short>       ::type() { return MPI_UNSIGNED_SHORT;     }
-template<> MPI_Datatype mpi_datatype<unsigned int>         ::type() { return MPI_UNSIGNED;           }
-template<> MPI_Datatype mpi_datatype<unsigned long>        ::type() { return MPI_UNSIGNED_LONG;      }
-template<> MPI_Datatype mpi_datatype<unsigned long long>   ::type() { return MPI_UNSIGNED_LONG_LONG; }
-template<> MPI_Datatype mpi_datatype<float>                ::type() { return MPI_FLOAT;              }
-template<> MPI_Datatype mpi_datatype<double>               ::type() { return MPI_DOUBLE;             }
-template<> MPI_Datatype mpi_datatype<bool>                 ::type() { return MPI_CXX_BOOL;           }
-template<> MPI_Datatype mpi_datatype<std::complex<float>>  ::type() { return MPI_CXX_FLOAT_COMPLEX;  }
-template<> MPI_Datatype mpi_datatype<std::complex<double>> ::type() { return MPI_CXX_DOUBLE_COMPLEX; }
+template<> MPI_Datatype mpi_datatype<char>                 ::type;
+template<> MPI_Datatype mpi_datatype<short>                ::type;
+template<> MPI_Datatype mpi_datatype<int>                  ::type;
+template<> MPI_Datatype mpi_datatype<long>                 ::type;
+template<> MPI_Datatype mpi_datatype<long long>            ::type;
+template<> MPI_Datatype mpi_datatype<unsigned char>        ::type;
+template<> MPI_Datatype mpi_datatype<unsigned short>       ::type;
+template<> MPI_Datatype mpi_datatype<unsigned int>         ::type;
+template<> MPI_Datatype mpi_datatype<unsigned long>        ::type;
+template<> MPI_Datatype mpi_datatype<unsigned long long>   ::type;
+template<> MPI_Datatype mpi_datatype<float>                ::type;
+template<> MPI_Datatype mpi_datatype<double>               ::type;
+template<> MPI_Datatype mpi_datatype<bool>                 ::type;
+template<> MPI_Datatype mpi_datatype<std::complex<float>>  ::type;
+template<> MPI_Datatype mpi_datatype<std::complex<double>> ::type;
 // clang-format on
 
 }

--- a/include/dlaf/communication/message.h
+++ b/include/dlaf/communication/message.h
@@ -39,7 +39,7 @@ public:
   /// Create a Message from a given type implementing the Data concept
   Message(Data data) : data_(data) {
     if (data_iscontiguous(data) == 1)
-      classic_type_ = dlaf::comm::mpi_datatype<T>::type();
+      classic_type_ = dlaf::comm::mpi_datatype<T>::type;
     else
       custom_type_ =
           internal::type_handler<T>(data_nblocks(data), data_blocksize(data), data_stride(data));

--- a/include/dlaf/communication/type_handler.h
+++ b/include/dlaf/communication/type_handler.h
@@ -36,7 +36,7 @@ struct type_handler {
   /// @param block_size   number of contiguous elements of type @p T in each block
   /// @param stride       stride (in elements) between starts of adjacent blocks
   type_handler(std::size_t nblocks, std::size_t block_size, std::size_t stride) {
-    MPI_Datatype element_type = dlaf::comm::mpi_datatype<std::remove_pointer_t<T>>::type();
+    MPI_Datatype element_type = dlaf::comm::mpi_datatype<std::remove_pointer_t<T>>::type;
     MPI_Type_vector(to_int(nblocks), to_int(block_size), to_int(stride), element_type, &custom_type_);
     MPI_Type_commit(&custom_type_);
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(DLAF
   communication/communicator_impl.cpp
   communication/communicator.cpp
   communication/communicator_grid.cpp
+  communication/datatypes.cpp
   matrix/distribution.cpp
   matrix/layout_info.cpp
 )

--- a/src/communication/datatypes.cpp
+++ b/src/communication/datatypes.cpp
@@ -1,0 +1,25 @@
+#include <dlaf/communication/datatypes.h>
+
+namespace dlaf {
+namespace comm {
+
+// clang-format off
+template<> MPI_Datatype mpi_datatype<char>                 ::type = MPI_CHAR;
+template<> MPI_Datatype mpi_datatype<short>                ::type = MPI_SHORT;
+template<> MPI_Datatype mpi_datatype<int>                  ::type = MPI_INT;
+template<> MPI_Datatype mpi_datatype<long>                 ::type = MPI_LONG;
+template<> MPI_Datatype mpi_datatype<long long>            ::type = MPI_LONG_LONG;
+template<> MPI_Datatype mpi_datatype<unsigned char>        ::type = MPI_UNSIGNED_CHAR;
+template<> MPI_Datatype mpi_datatype<unsigned short>       ::type = MPI_UNSIGNED_SHORT;
+template<> MPI_Datatype mpi_datatype<unsigned int>         ::type = MPI_UNSIGNED;
+template<> MPI_Datatype mpi_datatype<unsigned long>        ::type = MPI_UNSIGNED_LONG;
+template<> MPI_Datatype mpi_datatype<unsigned long long>   ::type = MPI_UNSIGNED_LONG_LONG;
+template<> MPI_Datatype mpi_datatype<float>                ::type = MPI_FLOAT;
+template<> MPI_Datatype mpi_datatype<double>               ::type = MPI_DOUBLE;
+template<> MPI_Datatype mpi_datatype<bool>                 ::type = MPI_CXX_BOOL;
+template<> MPI_Datatype mpi_datatype<std::complex<float>>  ::type = MPI_CXX_FLOAT_COMPLEX;
+template<> MPI_Datatype mpi_datatype<std::complex<double>> ::type = MPI_CXX_DOUBLE_COMPLEX;
+// clang-format on
+
+}
+}

--- a/test/unit/communication/test_message.cpp
+++ b/test/unit/communication/test_message.cpp
@@ -41,7 +41,7 @@ TYPED_TEST(MessageTest, MakeFromPointer) {
   EXPECT_EQ(value_ptr, message.data());
   EXPECT_EQ(1, message.count());
   EXPECT_EQ(sizeof(TypeParam), type_size);
-  EXPECT_EQ(static_cast<MPI_Datatype>(mpi_datatype<TypeParam>::type()), message.mpi_type());
+  EXPECT_EQ(static_cast<MPI_Datatype>(mpi_datatype<TypeParam>::type), message.mpi_type());
 }
 
 TYPED_TEST(MessageTest, MakeFromContiguousArray) {
@@ -57,7 +57,7 @@ TYPED_TEST(MessageTest, MakeFromContiguousArray) {
   EXPECT_EQ(value_array, message.data());
   EXPECT_EQ(N, message.count());
   EXPECT_EQ(sizeof(TypeParam), type_size);
-  EXPECT_EQ(static_cast<MPI_Datatype>(mpi_datatype<TypeParam>::type()), message.mpi_type());
+  EXPECT_EQ(static_cast<MPI_Datatype>(mpi_datatype<TypeParam>::type), message.mpi_type());
 }
 
 TYPED_TEST(MessageTest, MakeFromContiguousAsStridedArray) {
@@ -80,7 +80,7 @@ TYPED_TEST(MessageTest, MakeFromContiguousAsStridedArray) {
   EXPECT_EQ(value_array, message.data());
   EXPECT_EQ(total_elements, message.count());
   EXPECT_EQ(sizeof(TypeParam), type_size);
-  EXPECT_EQ(static_cast<MPI_Datatype>(mpi_datatype<TypeParam>::type()), message.mpi_type());
+  EXPECT_EQ(static_cast<MPI_Datatype>(mpi_datatype<TypeParam>::type), message.mpi_type());
 }
 
 TYPED_TEST(MessageTest, MakeFromStridedArray) {


### PR DESCRIPTION
- The previous commit related to `mpi_datatype` attempted to fix a note/warning 
but introduced multiple definitions error. This PR fixes it.

- For static member specializations, if you don't initialize the member,
  it is taken as a specialization declaration, that just says "Oh, don't
  instantiate the member from the primary template, because there is a
  specialized definition somewhere else". It should be mentioned that
  the definition should appear in a .cpp file (otherwise, you will earn
  the opposite: multiple definitions), and the declaration without
  initializer should still be placed in the header file.
  (https://stackoverflow.com/questions/2342550/static-member-initialization-for-specialized-template-class)