### PR TITLE
Adapt MPI_Reduce wrapper to the new API and enable non-contiguous data

### DIFF
--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -13,6 +13,7 @@
 /// @file
 
 #include <mpi.h>
+#include "dlaf/common/data_descriptor.h"
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/message.h"
 
@@ -20,17 +21,82 @@ namespace dlaf {
 namespace comm {
 namespace sync {
 
-/// MPI_Reduce wrapper
+namespace internal {
+namespace reduce {
+
+/// @brief MPI_Reduce wrapper (sender side)
+/// MPI Reduce(see MPI documentation for additional info)
+/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
+template <class DataIn, class DataOut>
+void collector(Communicator& communicator, MPI_Op reduce_operation, DataIn input, DataOut output) {
+  using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
+
+  common::BufferWithMemory<T> tmp_mem_input;
+  common::BufferWithMemory<T> tmp_mem_output;
+
+  common::DataDescriptor<const T> tmp_in = input;
+  common::DataDescriptor<T> tmp_out = output;
+
+  // if input is not contiguous, copy it in a contiguous temporary buffer
+  if (!input.is_contiguous()) {
+    tmp_in = tmp_mem_input = common::create_temporary_buffer(tmp_in);
+    common::copy(input, tmp_mem_input);
+  }
+
+  // if output is not contiguous, create an intermediate buffer
+  if (!output.is_contiguous())
+    tmp_out = tmp_mem_output = common::create_temporary_buffer(tmp_out);
+
+  auto&& message_input = comm::make_message(std::move(tmp_in));
+  auto&& message_output = comm::make_message(DataOut(tmp_out));
+
+  MPI_Reduce(message_input.data(), message_output.data(), message_input.count(),
+             message_input.mpi_type(), reduce_operation, communicator.rank(), communicator);
+
+  // if output was not contiguous, copy it back!
+  if (!output.is_contiguous())
+    common::copy(tmp_out, output);
+}
+
+/// @brief MPI_Reduce wrapper (receiver side)
 /// MPI Reduce(see MPI documentation for additional info)
 /// @param rank_root  the rank that will collect the result in output
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
-template <class T>
-void reduce(int rank_root, Communicator& communicator, MPI_Op reduce_operation, Message<T>&& input,
-            Message<T>&& output) {
-  MPI_Reduce(input.data(), output.data(), input.count(), input.mpi_type(), reduce_operation, rank_root,
-             communicator);
+template <class DataIn>
+void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operation, DataIn input) {
+  using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
+
+  common::BufferWithMemory<T> tmp_mem_input;
+
+  common::DataDescriptor<const T> tmp_in = input;
+
+  // if input is not contiguous, copy it in a contiguous temporary buffer
+  if (!input.is_contiguous()) {
+    tmp_in = tmp_mem_input = common::create_temporary_buffer(tmp_in);
+    common::copy(input, tmp_mem_input);
+  }
+
+  auto&& message_input = comm::make_message(std::move(tmp_in));
+
+  MPI_Reduce(message_input.data(), nullptr, message_input.count(), message_input.mpi_type(),
+             reduce_operation, rank_root, communicator);
 }
 
+}
+}
+
+/// @brief MPI_Reduce wrapper
+/// MPI Reduce(see MPI documentation for additional info)
+/// @param rank_root  the rank that will collect the result in output
+/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
+template <class DataIn, class DataOut>
+void reduce(const int rank_root, Communicator& communicator, MPI_Op reduce_operation, DataIn input,
+            DataOut output) {
+  if (rank_root == communicator.rank())
+    internal::reduce::collector(communicator, reduce_operation, input, output);
+  else
+    internal::reduce::participant(rank_root, communicator, reduce_operation, input);
+}
 }
 }
 }

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -29,7 +29,8 @@ namespace reduce {
 /// MPI Reduce(see MPI documentation for additional info)
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
 template <class DataIn, class DataOut>
-void collector(Communicator& communicator, MPI_Op reduce_operation, const DataIn input, DataOut output) {
+void collector(Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
+               const DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
   // Wayout for single rank communicator, just copy data
@@ -98,7 +99,7 @@ void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operat
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
 template <class DataIn, class DataOut>
 void reduce(const int rank_root, Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
-            DataOut output) {
+            const DataOut output) {
   DLAF_ASSERT_HEAVY((rank_root < communicator.size() && rank_root != MPI_UNDEFINED), rank_root,
                     " is not a valid rank in the specified Communicator with size ",
                     communicator.size());

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -13,6 +13,7 @@
 /// @file
 
 #include <mpi.h>
+#include "dlaf/common/assert.h"
 #include "dlaf/common/data_descriptor.h"
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/message.h"
@@ -28,7 +29,7 @@ namespace reduce {
 /// MPI Reduce(see MPI documentation for additional info)
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
 template <class DataIn, class DataOut>
-void collector(Communicator& communicator, MPI_Op reduce_operation, DataIn input, DataOut output) {
+void collector(Communicator& communicator, MPI_Op reduce_operation, const DataIn input, DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
   common::Buffer<T> tmp_mem_input;
@@ -63,7 +64,8 @@ void collector(Communicator& communicator, MPI_Op reduce_operation, DataIn input
 /// @param rank_root  the rank that will collect the result in output
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
 template <class DataIn>
-void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operation, DataIn input) {
+void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operation,
+                 const DataIn input) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
   common::Buffer<T> tmp_mem_input;
@@ -81,7 +83,6 @@ void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operat
   MPI_Reduce(message_input.data(), nullptr, message_input.count(), message_input.mpi_type(),
              reduce_operation, rank_root, communicator);
 }
-
 }
 }
 
@@ -90,7 +91,7 @@ void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operat
 /// @param rank_root  the rank that will collect the result in output
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator
 template <class DataIn, class DataOut>
-void reduce(const int rank_root, Communicator& communicator, MPI_Op reduce_operation, DataIn input,
+void reduce(const int rank_root, Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
             DataOut output) {
   if (rank_root == communicator.rank())
     internal::reduce::collector(communicator, reduce_operation, input, output);

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -31,8 +31,8 @@ template <class DataIn, class DataOut>
 void collector(Communicator& communicator, MPI_Op reduce_operation, DataIn input, DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  common::BufferWithMemory<T> tmp_mem_input;
-  common::BufferWithMemory<T> tmp_mem_output;
+  common::Buffer<T> tmp_mem_input;
+  common::Buffer<T> tmp_mem_output;
 
   common::DataDescriptor<const T> tmp_in = input;
   common::DataDescriptor<T> tmp_out = output;
@@ -66,7 +66,7 @@ template <class DataIn>
 void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operation, DataIn input) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  common::BufferWithMemory<T> tmp_mem_input;
+  common::Buffer<T> tmp_mem_input;
 
   common::DataDescriptor<const T> tmp_in = input;
 

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -100,9 +100,8 @@ void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operat
 template <class DataIn, class DataOut>
 void reduce(const int rank_root, Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
             const DataOut output) {
-  DLAF_ASSERT_HEAVY((rank_root < communicator.size() && rank_root != MPI_UNDEFINED), rank_root,
-                    " is not a valid rank in the specified Communicator with size ",
-                    communicator.size());
+  DLAF_ASSERT(rank_root < communicator.size() && rank_root != MPI_UNDEFINED, rank_root,
+              " is not a valid rank in the specified Communicator with size ", communicator.size());
 
   if (rank_root == communicator.rank())
     internal::reduce::collector(communicator, reduce_operation, input, output);

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -47,8 +47,8 @@ void collector(Communicator& communicator, MPI_Op reduce_operation, DataIn input
   if (!output.is_contiguous())
     tmp_out = tmp_mem_output = common::create_temporary_buffer(tmp_out);
 
-  auto&& message_input = comm::make_message(std::move(tmp_in));
-  auto&& message_output = comm::make_message(DataOut(tmp_out));
+  auto message_input = comm::make_message(std::move(tmp_in));
+  auto message_output = comm::make_message(DataOut(tmp_out));
 
   MPI_Reduce(message_input.data(), message_output.data(), message_input.count(),
              message_input.mpi_type(), reduce_operation, communicator.rank(), communicator);
@@ -76,7 +76,7 @@ void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operat
     common::copy(input, tmp_mem_input);
   }
 
-  auto&& message_input = comm::make_message(std::move(tmp_in));
+  auto message_input = comm::make_message(std::move(tmp_in));
 
   MPI_Reduce(message_input.data(), nullptr, message_input.count(), message_input.mpi_type(),
              reduce_operation, rank_root, communicator);

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -22,18 +22,18 @@ using MatrixElementTypes = ::testing::Types<float, double, std::complex<float>, 
 template <class T>
 struct TypeUtilities {
   /// @brief Returns r.
-  static T element(double r, double /* i */) {
+  static constexpr T element(double r, double /* i */) {
     return static_cast<T>(r);
   }
 
   /// @brief Returns r.
   /// @pre r > 0
-  static T polar(double r, double /* theta */) {
+  static constexpr T polar(double r, double /* theta */) {
     return static_cast<T>(r);
   }
 
   /// @brief Returns val.
-  static T conj(T val) {
+  static constexpr T conj(T val) {
     return val;
   }
 
@@ -44,18 +44,18 @@ struct TypeUtilities {
 template <class T>
 struct TypeUtilities<std::complex<T>> {
   /// @brief Returns r + I * i (I is the imaginary unit).
-  static std::complex<T> element(double r, double i) {
+  static constexpr std::complex<T> element(double r, double i) {
     return std::complex<T>(static_cast<T>(r), static_cast<T>(i));
   }
 
   /// @brief Returns r * (cos(theta) + I * sin(theta)) (I is the imaginary unit).
   /// @pre r > 0
-  static std::complex<T> polar(double r, double theta) {
+  static constexpr std::complex<T> polar(double r, double theta) {
     return std::polar<T>(static_cast<T>(r), static_cast<T>(theta));
   }
 
   /// @brief Returns std::conj(val).
-  static std::complex<T> conj(std::complex<T> val) {
+  static constexpr std::complex<T> conj(std::complex<T> val) {
     return std::conj(val);
   }
 

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -42,6 +42,9 @@ struct TypeUtilities {
 };
 
 template <class T>
+constexpr T TypeUtilities<T>::error;
+
+template <class T>
 struct TypeUtilities<std::complex<T>> {
   /// @brief Returns r + I * i (I is the imaginary unit).
   static constexpr std::complex<T> element(double r, double i) {
@@ -63,4 +66,6 @@ struct TypeUtilities<std::complex<T>> {
   static constexpr T error = 8 * std::numeric_limits<T>::epsilon();
 };
 
+template <class T>
+constexpr T TypeUtilities<std::complex<T>>::error;
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include "dlaf_test/helper_communicators.h"
+#include "dlaf_test/util_types.h"
 
 using namespace dlaf;
 using namespace dlaf_test;
@@ -27,8 +28,7 @@ TEST_F(ReduceTest, Basic) {
   int value = 1;
   int result = 0;
 
-  sync::reduce(root, world, MPI_SUM, make_message(common::make_data(&value, 1)),
-               make_message(common::make_data(&result, 1)));
+  sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
   // check that the root rank has the reduced results
   if (world.rank() == root) {
@@ -47,8 +47,7 @@ TEST_F(ReduceTest, Multiple) {
   int input[N] = {1, 2, 3};
   int reduced[N];
 
-  sync::reduce(root, world, MPI_SUM, make_message(common::make_data(input, N)),
-               make_message(common::make_data(reduced, N)));
+  sync::reduce(root, world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   // check that the root rank has the reduced results
   if (world.rank() == root) {
@@ -59,4 +58,201 @@ TEST_F(ReduceTest, Multiple) {
   // check that input has not been modified
   for (std::size_t index = 0; index < N; ++index)
     EXPECT_EQ(index + 1, input[index]);
+}
+
+TEST_F(ReduceTest, ContiguousToContiguous) {
+  using TypeParam = int;
+
+  const int N = 10;
+  const TypeParam value = 13;
+
+  TypeParam data_A[N];
+  TypeParam data_B[N];
+
+  for (auto i = 0; i < N; ++i)
+    data_A[i] = value;
+
+  const int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(data_A, N);
+  auto&& message_output = common::make_data(data_B, N);
+  MPI_Op op = MPI_SUM;
+
+  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+
+  if (root == world.rank())
+    for (auto i = 0; i < N; ++i)
+      EXPECT_EQ(value * NUM_MPI_RANKS, data_B[i]);
+}
+
+TEST_F(ReduceTest, ConstContiguousToContiguous) {
+  using TypeParam = int;
+
+  const int N = 10;
+  const TypeParam value = 13;
+
+  TypeParam data_A[N];
+  const TypeParam* const_data_A = data_A;
+  TypeParam data_B[N];
+
+  for (auto i = 0; i < N; ++i)
+    data_A[i] = value;
+
+  const int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(const_data_A, N);
+  auto&& message_output = common::make_data(data_B, N);
+  MPI_Op op = MPI_SUM;
+
+  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+
+  if (root == world.rank())
+    for (auto i = 0; i < N; ++i)
+      EXPECT_EQ(value * NUM_MPI_RANKS, data_B[i]);
+}
+
+TEST_F(ReduceTest, StridedToContiguous) {
+  using TypeParam = int;
+
+  const TypeParam value = 13;
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  const std::size_t nblocks = 3;
+  const std::size_t block_size = 2;
+  const std::size_t block_distance = 5;
+
+  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  const int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  for (int i_block = 0; i_block < nblocks; ++i_block)
+    for (int i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
+    }
+
+  const int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(data_strided, nblocks, block_size, block_distance);
+  auto&& message_output = common::make_data(data_contiguous, N);
+  MPI_Op op = MPI_SUM;
+
+  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+
+  if (root == world.rank())
+    for (auto i = 0; i < N; ++i)
+      EXPECT_EQ(value * NUM_MPI_RANKS, data_contiguous[i]);
+}
+
+TEST_F(ReduceTest, ConstStridedToContiguous) {
+  using TypeParam = int;
+
+  const TypeParam value = 13;
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  const std::size_t nblocks = 3;
+  const std::size_t block_size = 2;
+  const std::size_t block_distance = 5;
+
+  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+  const TypeParam* const_data_strided = data_strided;
+
+  const int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  for (int i_block = 0; i_block < nblocks; ++i_block)
+    for (int i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
+    }
+
+  const int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(const_data_strided, nblocks, block_size, block_distance);
+  auto&& message_output = common::make_data(data_contiguous, N);
+  MPI_Op op = MPI_SUM;
+
+  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+
+  if (root == world.rank())
+    for (auto i = 0; i < N; ++i)
+      EXPECT_EQ(value * NUM_MPI_RANKS, data_contiguous[i]);
+}
+
+TEST_F(ReduceTest, ContiguousToStrided) {
+  using TypeParam = int;
+
+  const TypeParam value = 13;
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  const std::size_t nblocks = 3;
+  const std::size_t block_size = 2;
+  const std::size_t block_distance = 5;
+
+  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  const int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  for (auto i = 0; i < N; ++i)
+    data_contiguous[i] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
+
+  const int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(data_contiguous, N);
+  auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
+  MPI_Op op = MPI_SUM;
+
+  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+  if (world.rank() == root) {
+    for (int i_block = 0; i_block < nblocks; ++i_block)
+      for (int i_element = 0; i_element < block_size; ++i_element) {
+        auto mem_pos = i_block * block_distance + i_element;
+        EXPECT_EQ(value * NUM_MPI_RANKS, data_strided[mem_pos]);
+      }
+  }
+}
+
+TEST_F(ReduceTest, ConstContiguousToStrided) {
+  using TypeParam = int;
+
+  const TypeParam value = 13;
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  const std::size_t nblocks = 3;
+  const std::size_t block_size = 2;
+  const std::size_t block_distance = 5;
+
+  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  const int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+  const TypeParam* const_data_contiguous = data_contiguous;
+
+  for (auto i = 0; i < N; ++i)
+    data_contiguous[i] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
+
+  const int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(const_data_contiguous, N);
+  auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
+  MPI_Op op = MPI_SUM;
+
+  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+  if (world.rank() == root) {
+    for (int i_block = 0; i_block < nblocks; ++i_block)
+      for (int i_element = 0; i_element < block_size; ++i_element) {
+        auto mem_pos = i_block * block_distance + i_element;
+        EXPECT_EQ(value * NUM_MPI_RANKS, data_strided[mem_pos]);
+      }
+  }
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -128,8 +128,8 @@ TEST_F(ReduceTest, StridedToContiguous) {
   const int N = nblocks * block_size;
   TypeParam data_contiguous[N];
 
-  for (int i_block = 0; i_block < nblocks; ++i_block)
-    for (int i_element = 0; i_element < block_size; ++i_element) {
+  for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+    for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
       auto mem_pos = i_block * block_distance + i_element;
       data_strided[mem_pos] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
     }
@@ -165,8 +165,8 @@ TEST_F(ReduceTest, ConstStridedToContiguous) {
   const int N = nblocks * block_size;
   TypeParam data_contiguous[N];
 
-  for (int i_block = 0; i_block < nblocks; ++i_block)
-    for (int i_element = 0; i_element < block_size; ++i_element) {
+  for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+    for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
       auto mem_pos = i_block * block_distance + i_element;
       data_strided[mem_pos] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
     }
@@ -212,8 +212,8 @@ TEST_F(ReduceTest, ContiguousToStrided) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
   if (world.rank() == root) {
-    for (int i_block = 0; i_block < nblocks; ++i_block)
-      for (int i_element = 0; i_element < block_size; ++i_element) {
+    for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+      for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
         auto mem_pos = i_block * block_distance + i_element;
         EXPECT_EQ(value * NUM_MPI_RANKS, data_strided[mem_pos]);
       }
@@ -249,8 +249,8 @@ TEST_F(ReduceTest, ConstContiguousToStrided) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
   if (world.rank() == root) {
-    for (int i_block = 0; i_block < nblocks; ++i_block)
-      for (int i_element = 0; i_element < block_size; ++i_element) {
+    for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+      for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
         auto mem_pos = i_block * block_distance + i_element;
         EXPECT_EQ(value * NUM_MPI_RANKS, data_strided[mem_pos]);
       }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -80,9 +80,10 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank())
+  if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
       EXPECT_EQ(value * NUM_MPI_RANKS, data_B[i]);
+  }
 }
 
 TEST_F(ReduceTest, ConstContiguousToContiguous) {
@@ -106,9 +107,10 @@ TEST_F(ReduceTest, ConstContiguousToContiguous) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank())
+  if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
       EXPECT_EQ(value * NUM_MPI_RANKS, data_B[i]);
+  }
 }
 
 TEST_F(ReduceTest, StridedToContiguous) {
@@ -142,9 +144,10 @@ TEST_F(ReduceTest, StridedToContiguous) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank())
+  if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
       EXPECT_EQ(value * NUM_MPI_RANKS, data_contiguous[i]);
+  }
 }
 
 TEST_F(ReduceTest, ConstStridedToContiguous) {
@@ -179,9 +182,10 @@ TEST_F(ReduceTest, ConstStridedToContiguous) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank())
+  if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
       EXPECT_EQ(value * NUM_MPI_RANKS, data_contiguous[i]);
+  }
 }
 
 TEST_F(ReduceTest, ContiguousToStrided) {

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -24,6 +24,16 @@ using namespace dlaf::comm;
 
 using ReduceTest = SplittedCommunicatorsTest;
 
+template <class T, class = std::enable_if_t<std::is_arithmetic<T>::value>>
+void DLAF_EXPECT_NEAR(const T a, const T b, const T abs_err) {
+  EXPECT_NEAR(a, b, abs_err);
+}
+
+template <class T>
+void DLAF_EXPECT_NEAR(const std::complex<T>& a, const std::complex<T>& b, const T abs_err) {
+  EXPECT_NEAR(std::abs(a - b), 0, abs_err);
+}
+
 using TypeParam = std::complex<double>;
 
 TEST_F(ReduceTest, ValueOnSingleRank) {
@@ -43,7 +53,7 @@ TEST_F(ReduceTest, ValueOnSingleRank) {
 
   sync::reduce(root, alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  EXPECT_NEAR(value, result, TypeUtilities<TypeParam>::error);
+  DLAF_EXPECT_NEAR(value, result, TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, CArrayOnSingleRank) {
@@ -67,7 +77,7 @@ TEST_F(ReduceTest, CArrayOnSingleRank) {
   sync::reduce(root, alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (std::size_t index = 0; index < N; ++index)
-    EXPECT_NEAR(input[index], reduced[index], TypeUtilities<TypeParam>::error);
+    DLAF_EXPECT_NEAR(input[index], reduced[index], TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, Value) {
@@ -78,8 +88,8 @@ TEST_F(ReduceTest, Value) {
   sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
   if (world.rank() == root)
-    EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), result,
-                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), result,
+                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, CArray) {
@@ -96,8 +106,8 @@ TEST_F(ReduceTest, CArray) {
 
   if (world.rank() == root) {
     for (std::size_t index = 0; index < N; ++index)
-      EXPECT_NEAR(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index],
-                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      DLAF_EXPECT_NEAR(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index],
+                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -123,8 +133,8 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
 
   if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
-      EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i],
-                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i],
+                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -161,8 +171,8 @@ TEST_F(ReduceTest, StridedToContiguous) {
 
   if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
-      EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
-                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
+                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -197,8 +207,8 @@ TEST_F(ReduceTest, ContiguousToStrided) {
     for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
       for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
         auto mem_pos = i_block * block_distance + i_element;
-        EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
-                    NUM_MPI_RANKS * TypeUtilities<TypeParam>::error););
+        DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
+                         NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
       }
   }
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -46,7 +46,7 @@ TEST_F(ReduceTest, ValueOnSingleRank) {
     return;
 
   constexpr int root = 0;
-  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
   TypeParam result = 0;
 
   ASSERT_EQ(alone_world.rank(), root);
@@ -67,9 +67,9 @@ TEST_F(ReduceTest, CArrayOnSingleRank) {
 
   constexpr int root = 0;
   constexpr std::size_t N = 3;
-  constexpr TypeParam input[N] = {dlaf_test::TypeUtilities<TypeParam>::element(0, 1),
-                                  dlaf_test::TypeUtilities<TypeParam>::element(1, 2),
-                                  dlaf_test::TypeUtilities<TypeParam>::element(2, 3)};
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
   TypeParam reduced[N];
 
   ASSERT_EQ(alone_world.rank(), root);
@@ -82,7 +82,7 @@ TEST_F(ReduceTest, CArrayOnSingleRank) {
 
 TEST_F(ReduceTest, Value) {
   const int root = 0;
-  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
   TypeParam result = 0;
 
   sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
@@ -97,9 +97,9 @@ TEST_F(ReduceTest, CArray) {
   int root = 1;
 
   constexpr std::size_t N = 3;
-  constexpr TypeParam input[N] = {dlaf_test::TypeUtilities<TypeParam>::element(0, 1),
-                                  dlaf_test::TypeUtilities<TypeParam>::element(1, 2),
-                                  dlaf_test::TypeUtilities<TypeParam>::element(2, 3)};
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
   TypeParam reduced[N];
 
   sync::reduce(root, world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
@@ -115,7 +115,7 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
   static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
 
   constexpr int N = 10;
-  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
 
   TypeParam data_A[N];
   TypeParam data_B[N];
@@ -153,7 +153,7 @@ TEST_F(ReduceTest, StridedToContiguous) {
   constexpr int N = nblocks * block_size;
   TypeParam data_contiguous[N];
 
-  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
   for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
     for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
       auto mem_pos = i_block * block_distance + i_element;
@@ -191,7 +191,7 @@ TEST_F(ReduceTest, ContiguousToStrided) {
   constexpr int N = nblocks * block_size;
   TypeParam data_contiguous[N];
 
-  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
   for (auto i = 0; i < N; ++i)
     data_contiguous[i] = value;
 

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -93,9 +93,10 @@ TEST_F(ReduceTest, CArray) {
 
   sync::reduce(root, world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
-  if (world.rank() == root)
+  if (world.rank() == root) {
     for (std::size_t index = 0; index < N; ++index)
       EXPECT_EQ(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index]);
+  }
 }
 
 TEST_F(ReduceTest, ContiguousToContiguous) {
@@ -118,9 +119,10 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank())
+  if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
       EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i]);
+  }
 }
 
 TEST_F(ReduceTest, StridedToContiguous) {
@@ -154,9 +156,10 @@ TEST_F(ReduceTest, StridedToContiguous) {
   MPI_Op op = MPI_SUM;
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank())
+  if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
       EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i]);
+  }
 }
 
 TEST_F(ReduceTest, ContiguousToStrided) {

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -8,10 +8,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/common/data_descriptor.h"
 #include "dlaf/communication/sync/reduce.h"
 
 #include <gtest/gtest.h>
+
+#include "dlaf/common/data_descriptor.h"
+#include "dlaf/communication/communicator_grid.h"
 
 #include "dlaf_test/helper_communicators.h"
 #include "dlaf_test/util_types.h"
@@ -22,49 +24,85 @@ using namespace dlaf::comm;
 
 using ReduceTest = SplittedCommunicatorsTest;
 
-TEST_F(ReduceTest, Basic) {
-  int root = 0;
+using TypeParam = std::complex<double>;
 
-  int value = 1;
-  int result = 0;
+TEST_F(ReduceTest, ValueOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = 0;
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::reduce(root, alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
+
+  EXPECT_EQ(value, result);
+}
+
+TEST_F(ReduceTest, CArrayOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr std::size_t N = 3;
+  constexpr TypeParam input[N] = {dlaf_test::TypeUtilities<TypeParam>::element(0, 1),
+                                  dlaf_test::TypeUtilities<TypeParam>::element(1, 2),
+                                  dlaf_test::TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::reduce(root, alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
+
+  for (std::size_t index = 0; index < N; ++index)
+    EXPECT_EQ(input[index], reduced[index]);
+}
+
+TEST_F(ReduceTest, Value) {
+  const int root = 0;
+  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = 0;
 
   sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  // check that the root rank has the reduced results
-  if (world.rank() == root) {
-    EXPECT_EQ(NUM_MPI_RANKS * value, result);
-  }
-
-  // check that input has not been modified
-  EXPECT_EQ(1, value);
+  if (world.rank() == root)
+    EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), result);
 }
 
-TEST_F(ReduceTest, Multiple) {
+TEST_F(ReduceTest, CArray) {
   static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
   int root = 1;
 
-  const std::size_t N = 3;
-  int input[N] = {1, 2, 3};
-  int reduced[N];
+  constexpr std::size_t N = 3;
+  constexpr TypeParam input[N] = {dlaf_test::TypeUtilities<TypeParam>::element(0, 1),
+                                  dlaf_test::TypeUtilities<TypeParam>::element(1, 2),
+                                  dlaf_test::TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
 
   sync::reduce(root, world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
-  // check that the root rank has the reduced results
-  if (world.rank() == root) {
+  if (world.rank() == root)
     for (std::size_t index = 0; index < N; ++index)
-      EXPECT_EQ(NUM_MPI_RANKS * input[index], reduced[index]);
-  }
-
-  // check that input has not been modified
-  for (std::size_t index = 0; index < N; ++index)
-    EXPECT_EQ(index + 1, input[index]);
+      EXPECT_EQ(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index]);
 }
 
 TEST_F(ReduceTest, ContiguousToContiguous) {
-  using TypeParam = int;
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
 
-  const int N = 10;
-  const TypeParam value = 13;
+  constexpr int N = 10;
+  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
 
   TypeParam data_A[N];
   TypeParam data_B[N];
@@ -72,191 +110,87 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
   for (auto i = 0; i < N; ++i)
     data_A[i] = value;
 
-  const int root = 0;
+  constexpr int root = 0;
   auto& communicator = world;
-  auto&& message_input = common::make_data(data_A, N);
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_A), N);
   auto&& message_output = common::make_data(data_B, N);
   MPI_Op op = MPI_SUM;
 
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank()) {
+  if (root == world.rank())
     for (auto i = 0; i < N; ++i)
-      EXPECT_EQ(value * NUM_MPI_RANKS, data_B[i]);
-  }
-}
-
-TEST_F(ReduceTest, ConstContiguousToContiguous) {
-  using TypeParam = int;
-
-  const int N = 10;
-  const TypeParam value = 13;
-
-  TypeParam data_A[N];
-  const TypeParam* const_data_A = data_A;
-  TypeParam data_B[N];
-
-  for (auto i = 0; i < N; ++i)
-    data_A[i] = value;
-
-  const int root = 0;
-  auto& communicator = world;
-  auto&& message_input = common::make_data(const_data_A, N);
-  auto&& message_output = common::make_data(data_B, N);
-  MPI_Op op = MPI_SUM;
-
-  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
-
-  if (root == world.rank()) {
-    for (auto i = 0; i < N; ++i)
-      EXPECT_EQ(value * NUM_MPI_RANKS, data_B[i]);
-  }
+      EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i]);
 }
 
 TEST_F(ReduceTest, StridedToContiguous) {
-  using TypeParam = int;
-
-  const TypeParam value = 13;
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
 
   // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
   // E E - - - E E - - - E E    (without padding at the end)
-  const std::size_t nblocks = 3;
-  const std::size_t block_size = 2;
-  const std::size_t block_distance = 5;
+  constexpr std::size_t nblocks = 3;
+  constexpr std::size_t block_size = 2;
+  constexpr std::size_t block_distance = 5;
 
-  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  constexpr std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
   TypeParam data_strided[memory_footprint];
 
-  const int N = nblocks * block_size;
+  constexpr int N = nblocks * block_size;
   TypeParam data_contiguous[N];
 
+  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
   for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
     for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
       auto mem_pos = i_block * block_distance + i_element;
-      data_strided[mem_pos] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
+      data_strided[mem_pos] = value;
     }
 
-  const int root = 0;
-  auto& communicator = world;
-  auto&& message_input = common::make_data(data_strided, nblocks, block_size, block_distance);
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_strided), nblocks,
+                                           block_size, block_distance);
   auto&& message_output = common::make_data(data_contiguous, N);
-  MPI_Op op = MPI_SUM;
 
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank()) {
+  if (root == world.rank())
     for (auto i = 0; i < N; ++i)
-      EXPECT_EQ(value * NUM_MPI_RANKS, data_contiguous[i]);
-  }
-}
-
-TEST_F(ReduceTest, ConstStridedToContiguous) {
-  using TypeParam = int;
-
-  const TypeParam value = 13;
-
-  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
-  // E E - - - E E - - - E E    (without padding at the end)
-  const std::size_t nblocks = 3;
-  const std::size_t block_size = 2;
-  const std::size_t block_distance = 5;
-
-  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
-  TypeParam data_strided[memory_footprint];
-  const TypeParam* const_data_strided = data_strided;
-
-  const int N = nblocks * block_size;
-  TypeParam data_contiguous[N];
-
-  for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
-    for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
-      auto mem_pos = i_block * block_distance + i_element;
-      data_strided[mem_pos] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
-    }
-
-  const int root = 0;
-  auto& communicator = world;
-  auto&& message_input = common::make_data(const_data_strided, nblocks, block_size, block_distance);
-  auto&& message_output = common::make_data(data_contiguous, N);
-  MPI_Op op = MPI_SUM;
-
-  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
-
-  if (root == world.rank()) {
-    for (auto i = 0; i < N; ++i)
-      EXPECT_EQ(value * NUM_MPI_RANKS, data_contiguous[i]);
-  }
+      EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i]);
 }
 
 TEST_F(ReduceTest, ContiguousToStrided) {
-  using TypeParam = int;
-
-  const TypeParam value = 13;
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
 
   // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
   // E E - - - E E - - - E E    (without padding at the end)
-  const std::size_t nblocks = 3;
-  const std::size_t block_size = 2;
-  const std::size_t block_distance = 5;
+  constexpr std::size_t nblocks = 3;
+  constexpr std::size_t block_size = 2;
+  constexpr std::size_t block_distance = 5;
 
-  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  constexpr std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
   TypeParam data_strided[memory_footprint];
 
-  const int N = nblocks * block_size;
+  constexpr int N = nblocks * block_size;
   TypeParam data_contiguous[N];
 
+  constexpr TypeParam value = dlaf_test::TypeUtilities<TypeParam>::element(13, 26);
   for (auto i = 0; i < N; ++i)
-    data_contiguous[i] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
+    data_contiguous[i] = value;
 
-  const int root = 0;
-  auto& communicator = world;
-  auto&& message_input = common::make_data(data_contiguous, N);
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_contiguous), N);
   auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
-  MPI_Op op = MPI_SUM;
 
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
   sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
+
   if (world.rank() == root) {
     for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
       for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
         auto mem_pos = i_block * block_distance + i_element;
-        EXPECT_EQ(value * NUM_MPI_RANKS, data_strided[mem_pos]);
-      }
-  }
-}
-
-TEST_F(ReduceTest, ConstContiguousToStrided) {
-  using TypeParam = int;
-
-  const TypeParam value = 13;
-
-  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
-  // E E - - - E E - - - E E    (without padding at the end)
-  const std::size_t nblocks = 3;
-  const std::size_t block_size = 2;
-  const std::size_t block_distance = 5;
-
-  const std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
-  TypeParam data_strided[memory_footprint];
-
-  const int N = nblocks * block_size;
-  TypeParam data_contiguous[N];
-  const TypeParam* const_data_contiguous = data_contiguous;
-
-  for (auto i = 0; i < N; ++i)
-    data_contiguous[i] = dlaf_test::TypeUtilities<TypeParam>::element(value, 0);
-
-  const int root = 0;
-  auto& communicator = world;
-  auto&& message_input = common::make_data(const_data_contiguous, N);
-  auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
-  MPI_Op op = MPI_SUM;
-
-  sync::reduce(root, communicator, op, std::move(message_input), std::move(message_output));
-  if (world.rank() == root) {
-    for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
-      for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
-        auto mem_pos = i_block * block_distance + i_element;
-        EXPECT_EQ(value * NUM_MPI_RANKS, data_strided[mem_pos]);
+        EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos]);
       }
   }
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -43,7 +43,7 @@ TEST_F(ReduceTest, ValueOnSingleRank) {
 
   sync::reduce(root, alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  EXPECT_EQ(value, result);
+  EXPECT_NEAR(value, result, TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, CArrayOnSingleRank) {
@@ -67,7 +67,7 @@ TEST_F(ReduceTest, CArrayOnSingleRank) {
   sync::reduce(root, alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (std::size_t index = 0; index < N; ++index)
-    EXPECT_EQ(input[index], reduced[index]);
+    EXPECT_NEAR(input[index], reduced[index], TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, Value) {
@@ -78,7 +78,8 @@ TEST_F(ReduceTest, Value) {
   sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
   if (world.rank() == root)
-    EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), result);
+    EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), result,
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, CArray) {
@@ -95,7 +96,8 @@ TEST_F(ReduceTest, CArray) {
 
   if (world.rank() == root) {
     for (std::size_t index = 0; index < N; ++index)
-      EXPECT_EQ(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index]);
+      EXPECT_NEAR(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index],
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -121,7 +123,8 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
 
   if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
-      EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i]);
+      EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i],
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -158,7 +161,8 @@ TEST_F(ReduceTest, StridedToContiguous) {
 
   if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
-      EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i]);
+      EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -193,7 +197,8 @@ TEST_F(ReduceTest, ContiguousToStrided) {
     for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
       for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
         auto mem_pos = i_block * block_distance + i_element;
-        EXPECT_EQ(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos]);
+        EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
+                    NUM_MPI_RANKS * TypeUtilities<TypeParam>::error););
       }
   }
 }


### PR DESCRIPTION
Close #148 

This PR adapts the MPI_Reduce wrapper to the new API accepting the Data concept instead of `dlaf::comm::Message`.

Moreover, it now trivially manages reduce with non-contiguous buffers by internally using a contiguous buffer for input and/or output in case of need.