### PR TITLE
Implement a version header for DLAF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 cmake_minimum_required(VERSION 3.12.4)
 
-project(DLAF)
+project(DLAF VERSION 0.1.0)
 
 # ---------------------------------------------------------------------------
 # CMake configurations

--- a/include/dlaf/version.h.in
+++ b/include/dlaf/version.h.in
@@ -14,6 +14,8 @@
 
 namespace dlaf {
 
+// clang-format off
+
 const std::string git_hash = "@DLAF_SHA@";
 const std::string build_date = "@DLAF_TIMESTAMP@";
 constexpr int major_version = @DLAF_VERSION_MAJOR@;
@@ -23,5 +25,7 @@ constexpr int revision = @DLAF_VERSION_PATCH@;
 #define DLAF_VERSION_MAJOR @DLAF_VERSION_MAJOR@
 #define DLAF_VERSION_MINOR @DLAF_VERSION_MINOR@
 #define DLAF_VERSION_PATCH @DLAF_VERSION_PATCH@
+
+// clang-format on
 
 }

--- a/include/dlaf/version.h.in
+++ b/include/dlaf/version.h.in
@@ -1,0 +1,27 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <string>
+
+namespace dlaf {
+
+const std::string git_hash = "@DLAF_SHA@";
+const std::string build_date = "@DLAF_TIMESTAMP@";
+constexpr int major_version = @DLAF_VERSION_MAJOR@;
+constexpr int minor_version = @DLAF_VERSION_MINOR@;
+constexpr int revision = @DLAF_VERSION_PATCH@;
+
+#define DLAF_VERSION_MAJOR @DLAF_VERSION_MAJOR@
+#define DLAF_VERSION_MINOR @DLAF_VERSION_MINOR@
+#define DLAF_VERSION_PATCH @DLAF_VERSION_PATCH@
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ if(DEFINED GIT_EXE AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
                   ERROR_QUIET
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
-  set(SIRIUS_SHA "N/A : archive")
+  set(DLAF_SHA "N/A : archive")
 endif()
 configure_file("${PROJECT_SOURCE_DIR}/include/dlaf/version.h.in"
                "${PROJECT_BINARY_DIR}/include/dlaf/version.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+# Generate version header
+find_program(GIT_EXE NAMES git)
+string(TIMESTAMP DLAF_TIMESTAMP "%Y-%m-%d %H:%M:%S")
+if(DEFINED GIT_EXE AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  execute_process(COMMAND git rev-parse HEAD
+                  OUTPUT_VARIABLE DLAF_SHA
+                  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+                  ERROR_QUIET
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  set(SIRIUS_SHA "N/A : archive")
+endif()
+configure_file("${PROJECT_SOURCE_DIR}/include/dlaf/version.h.in"
+               "${PROJECT_BINARY_DIR}/include/dlaf/version.h"
+               @ONLY)
+
 add_library(DLAF
   communication/communicator_impl.cpp
   communication/communicator.cpp
@@ -24,7 +40,8 @@ add_library(DLAF
 
 target_include_directories(DLAF
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${HPX_INCLUDE_DIRS}
   PRIVATE
@@ -94,6 +111,10 @@ install(DIRECTORY ../cmake/
   FILES_MATCHING PATTERN "Find*.cmake"
   PATTERN "template" EXCLUDE
 )
+
+# install version header
+install(FILES "${PROJECT_BINARY_DIR}/include/dlaf/version.h"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # ----- CMake INTEGRATION
 include(CMakePackageConfigHelpers)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,14 @@ if(DEFINED GIT_EXE AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
                   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
                   ERROR_QUIET
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND git diff --quiet HEAD
+                  RESULT_VARIABLE DLAF_GIT_CHANGES
+                  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+                  ERROR_QUIET)
+  # Add a * to git SHA if there are changes
+  if (DLAF_GIT_CHANGES EQUAL 1)
+    set(DLAF_SHA "${DLAF_SHA} *")
+  endif()
 else()
   set(DLAF_SHA "N/A : archive")
 endif()


### PR DESCRIPTION
- The version header is generated and placed in the binary directory
- The header provides information within the code about the version, git sha
  and build timestamp.
- The information can be used in assertions or to specialize parts of
  the code for different versions of DLAF (with macros)