### PR TITLE
Remove automatic space in dlaf::common::concat

### DIFF
--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -24,11 +24,11 @@
 /// Message composition is lazily evaluated and it will not add any overhead if the condition is true.
 ///
 /// **This check cannot be disabled**
-#define DLAF_CHECK_WITH_ORIGIN(category, origin, condition, ...)               \
-  if (!(condition)) {                                                          \
-    std::cerr << "[ERROR] " << origin << std::endl                             \
-              << dlaf::common::concat(#condition, ##__VA_ARGS__) << std::endl; \
-    std::terminate();                                                          \
+#define DLAF_CHECK_WITH_ORIGIN(category, origin, condition, ...)                    \
+  if (!(condition)) {                                                               \
+    std::cerr << "[ERROR] " << origin << std::endl                                  \
+              << dlaf::common::concat(#condition, ' ', ##__VA_ARGS__) << std::endl; \
+    std::terminate();                                                               \
   }
 
 /// This macro is a shortcut for #DLAF_CHECK_WITH_ORIGIN, it sets automatically the origin to the line

--- a/include/dlaf/common/utils.h
+++ b/include/dlaf/common/utils.h
@@ -56,11 +56,11 @@ inline std::string concat() {
 /// Join a list of heterogenous parameters into a string
 ///
 /// Given a list of parameters for which a valid std::ostream& operator<<(std::ostream&, const T&)
-/// exists, it returns a std::string with all parameters joined using a space between each one
+/// exists, it returns a std::string with all parameters representations joined
 template <class T, class... Ts>
 std::string concat(const T& first, const Ts&... args) {
   std::ostringstream ss;
-  ss << first << " " << concat(std::forward<const Ts>(args)...);
+  ss << first << concat(std::forward<const Ts>(args)...);
   return ss.str();
 }
 }


### PR DESCRIPTION
`dlaf::common::concat` now does not automatically add a space between each parameter.

It was helping in a lot of situations, but it was constraining too much not allowing to have full control of the spaces.