### PR TITLE
Minor bug-fix for Index2D and Size2D string-representation

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -89,7 +89,7 @@ public:
 
   /// Adds "(<row_>, <col_>)" to out.
   friend std::ostream& operator<<(std::ostream& out, const basic_coords& index) {
-    if (std::is_same<IndexT, signed char>::value) {
+    if (std::is_same<IndexT, signed char>::value || std::is_same<IndexT, char>::value) {
       return out << "(" << static_cast<int>(index.row_) << ", " << static_cast<int>(index.col_) << ")";
     }
     return out << "(" << index.row_ << ", " << index.col_ << ")";


### PR DESCRIPTION
I've just learnt that in the C++ standard

`char`, `signed char` and `unsigned char` are all distinct types (differently from other types).

See [Type `char` in Section "Character types"](https://en.cppreference.com/w/cpp/language/types)