### PR TITLE
Constrain SizeType and other fixes

### DIFF
--- a/include/dlaf/common/vector.h
+++ b/include/dlaf/common/vector.h
@@ -22,13 +22,13 @@ namespace internal {
 /// It is an std::vector with overloads for working seamlessly with unsigned integers as parameters
 template <typename T>
 struct vector : public std::vector<T> {
-  vector(int size) : std::vector<T>(to_sizet(size)) {}
+  vector(SizeType size) : std::vector<T>(to_sizet(size)) {}
 
-  T& operator[](int index) {
+  T& operator[](SizeType index) {
     return std::vector<T>::operator[](to_sizet(index));
   }
 
-  const T& operator[](int index) const {
+  const T& operator[](SizeType index) const {
     return std::vector<T>::operator[](to_sizet(index));
   }
 };

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -30,7 +30,6 @@ void reduce(int rank_root, Communicator& communicator, MPI_Op reduce_operation, 
   MPI_Reduce(input.data(), output.data(), input.count(), input.mpi_type(), reduce_operation, rank_root,
              communicator);
 }
-
 }
 }
 }

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -22,7 +22,7 @@ Matrix<T, device>::Matrix(matrix::Distribution&& distribution)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
   const SizeType alignment = 64;
   const SizeType ld =
-      std::max(1, util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
+      std::max<SizeType>(1, util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
 
   auto layout = matrix::colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -20,7 +20,9 @@ Matrix<T, device>::Matrix(const GlobalElementSize& size, const TileElementSize& 
 template <class T, Device device>
 Matrix<T, device>::Matrix(matrix::Distribution&& distribution)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
-  SizeType ld = std::max(1, util::ceilDiv(this->distribution().localSize().rows(), 64) * 64);
+  const SizeType alignment = 64;
+  const SizeType ld =
+      max(1, util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
 
   auto layout = matrix::colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -22,7 +22,8 @@ Matrix<T, device>::Matrix(matrix::Distribution&& distribution)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
   const SizeType alignment = 64;
   const SizeType ld =
-      std::max<SizeType>(1, util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
+      std::max<SizeType>(1,
+                         util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
 
   auto layout = matrix::colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -22,7 +22,7 @@ Matrix<T, device>::Matrix(matrix::Distribution&& distribution)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
   const SizeType alignment = 64;
   const SizeType ld =
-      max(1, util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
+      std::max(1, util::ceilDiv(this->distribution().localSize().rows(), alignment) * alignment);
 
   auto layout = matrix::colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -147,7 +147,7 @@ inline LayoutInfo tileLayout(const matrix::Distribution& distribution, SizeType 
 
 /// Returns LayoutInfo for a local matrix which use the tile layout (Basic interface).
 inline LayoutInfo tileLayout(const LocalElementSize& size, const TileElementSize& block_size) {
-  SizeType ld = std::max(1, block_size.rows());
+  SizeType ld = std::max<SizeType>(1, block_size.rows());
   SizeType tiles_per_col = util::ceilDiv(size.rows(), block_size.rows());
   return tileLayout(size, block_size, ld, tiles_per_col);
 }

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -147,7 +147,7 @@ inline LayoutInfo tileLayout(const matrix::Distribution& distribution, SizeType 
 
 /// Returns LayoutInfo for a local matrix which use the tile layout (Basic interface).
 inline LayoutInfo tileLayout(const LocalElementSize& size, const TileElementSize& block_size) {
-  SizeType ld = std::max(1, block_size.rows());
+  SizeType ld = max(1, block_size.rows());
   SizeType tiles_per_col = util::ceilDiv(size.rows(), block_size.rows());
   return tileLayout(size, block_size, ld, tiles_per_col);
 }

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -147,7 +147,7 @@ inline LayoutInfo tileLayout(const matrix::Distribution& distribution, SizeType 
 
 /// Returns LayoutInfo for a local matrix which use the tile layout (Basic interface).
 inline LayoutInfo tileLayout(const LocalElementSize& size, const TileElementSize& block_size) {
-  SizeType ld = max(1, block_size.rows());
+  SizeType ld = std::max(1, block_size.rows());
   SizeType tiles_per_col = util::ceilDiv(size.rows(), block_size.rows());
   return tileLayout(size, block_size, ld, tiles_per_col);
 }

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -44,12 +44,12 @@ public:
   /// Memory of @p size elements of type @c T is allocated on the given device.
   template <class U = T,
             class = typename std::enable_if_t<!std::is_const<U>::value && std::is_same<T, U>::value>>
-  MemoryView(std::size_t size)
+  explicit MemoryView(std::size_t size)
       : memory_(std::make_shared<MemoryChunk<ElementType, device>>(size)), offset_(0), size_(size) {}
 
   template <class U = T,
             class = typename std::enable_if_t<!std::is_const<U>::value && std::is_same<T, U>::value>>
-  MemoryView(int size) : MemoryView(to_sizet(size)) {}
+  explicit MemoryView(int size) : MemoryView(to_sizet(size)) {}
 
   /// @brief Creates a MemoryView object from an existing memory allocation.
   ///

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -47,10 +47,6 @@ public:
   explicit MemoryView(std::size_t size)
       : memory_(std::make_shared<MemoryChunk<ElementType, device>>(size)), offset_(0), size_(size) {}
 
-  template <class U = T,
-            class = typename std::enable_if_t<!std::is_const<U>::value && std::is_same<T, U>::value>>
-  explicit MemoryView(int size) : MemoryView(to_sizet(size)) {}
-
   /// @brief Creates a MemoryView object from an existing memory allocation.
   ///
   /// @param ptr  The pointer to the already allocated memory.
@@ -59,8 +55,6 @@ public:
   MemoryView(T* ptr, std::size_t size)
       : memory_(std::make_shared<MemoryChunk<ElementType, device>>(const_cast<ElementType*>(ptr), size)),
         offset_(0), size_(size) {}
-
-  MemoryView(T* ptr, int size) : MemoryView(ptr, to_sizet(size)) {}
 
   MemoryView(const MemoryView&) = default;
   template <class U = T,

--- a/include/dlaf/tile.tpp
+++ b/include/dlaf/tile.tpp
@@ -16,7 +16,7 @@ Tile<const T, device>::Tile(const TileElementSize& size,
   using util::size_t::mul;
   if (!size_.isValid())
     throw std::invalid_argument("Error: Invalid Tile sizes");
-  if (ld_ < std::max(1, size_.rows())) {
+  if (ld_ < std::max<SizeType>(1, size_.rows())) {
     throw std::invalid_argument("Error: Invalid Tile leading dimension");
   }
   if (!size.isEmpty()) {

--- a/include/dlaf/tile.tpp
+++ b/include/dlaf/tile.tpp
@@ -16,7 +16,7 @@ Tile<const T, device>::Tile(const TileElementSize& size,
   using util::size_t::mul;
   if (!size_.isValid())
     throw std::invalid_argument("Error: Invalid Tile sizes");
-  if (ld_ < max(1, size_.rows())) {
+  if (ld_ < std::max(1, size_.rows())) {
     throw std::invalid_argument("Error: Invalid Tile leading dimension");
   }
   if (!size.isEmpty()) {

--- a/include/dlaf/tile.tpp
+++ b/include/dlaf/tile.tpp
@@ -16,7 +16,7 @@ Tile<const T, device>::Tile(const TileElementSize& size,
   using util::size_t::mul;
   if (!size_.isValid())
     throw std::invalid_argument("Error: Invalid Tile sizes");
-  if (ld_ < std::max(1, size_.rows())) {
+  if (ld_ < max(1, size_.rows())) {
     throw std::invalid_argument("Error: Invalid Tile leading dimension");
   }
   if (!size.isEmpty()) {

--- a/include/dlaf/types.h
+++ b/include/dlaf/types.h
@@ -19,6 +19,9 @@
 namespace dlaf {
 
 using SizeType = int;
+static_assert(std::is_signed<SizeType>::value && std::is_integral<SizeType>::value,
+              "SizeType should be a signed integral type");
+static_assert(sizeof(SizeType) >= 4, "SizeType should be >= 32bit");
 
 enum class Device { CPU, GPU };
 

--- a/include/dlaf/types.h
+++ b/include/dlaf/types.h
@@ -23,10 +23,6 @@ static_assert(std::is_signed<SizeType>::value && std::is_integral<SizeType>::val
               "SizeType should be a signed integral type");
 static_assert(sizeof(SizeType) >= 4, "SizeType should be >= 32bit");
 
-inline SizeType max(const SizeType a, const SizeType b) {
-  return std::max(a, b);
-}
-
 enum class Device { CPU, GPU };
 
 enum class Backend { MC, GPU };

--- a/include/dlaf/types.h
+++ b/include/dlaf/types.h
@@ -23,6 +23,10 @@ static_assert(std::is_signed<SizeType>::value && std::is_integral<SizeType>::val
               "SizeType should be a signed integral type");
 static_assert(sizeof(SizeType) >= 4, "SizeType should be >= 32bit");
 
+inline SizeType max(const SizeType a, const SizeType b) {
+  return std::max(a, b);
+}
+
 enum class Device { CPU, GPU };
 
 enum class Backend { MC, GPU };

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -130,8 +130,8 @@ void check_is_hermitian(dlaf::Matrix<const T, Device::CPU>& matrix,
         else {
           dlaf::Tile<T, Device::CPU> workspace(size_tile_transposed,
                                                dlaf::memory::MemoryView<T, Device::CPU>(
-                                                   size_tile_transposed.rows() *
-                                                   size_tile_transposed.cols()),
+                                                   dlaf::util::size_t::mul(size_tile_transposed.rows(),
+                                                                           size_tile_transposed.cols())),
                                                size_tile_transposed.rows());
 
           // recv from owner_transposed

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -38,9 +38,9 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
     size_b.transpose();
   TileElementSize size_c(m, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
+  SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM: " << op_a << ", " << op_a;
@@ -119,9 +119,9 @@ void testGemmExceptions(blas::Op op_a, blas::Op op_b, const TileElementSize& siz
   if (op_b != blas::Op::NoTrans)
     size_b.transpose();
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
+  SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM Exceptions: " << op_a << ", " << op_a;

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -27,6 +27,8 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
+using dlaf::util::size_t::mul;
+
 template <class T, class CT = const T>
 void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, SizeType extra_lda,
               SizeType extra_ldb, SizeType extra_ldc) {
@@ -48,9 +50,9 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
   s << ", lda = " << lda << ", ldb = " << ldb << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
-  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
-  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(mul(ldb, size_b.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(mul(ldc, size_c.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
@@ -129,9 +131,9 @@ void testGemmExceptions(blas::Op op_a, blas::Op op_b, const TileElementSize& siz
   s << ", lda = " << lda << ", ldb = " << ldb << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
-  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
-  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(mul(ldb, size_b.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(mul(ldc, size_c.cols()));
 
   // Create tiles.
   Tile<CT, Device::CPU> a(size_a, std::move(mem_a), lda);

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -38,9 +38,9 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
     size_b.transpose();
   TileElementSize size_c(m, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
+  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM: " << op_a << ", " << op_a;
@@ -119,9 +119,9 @@ void testGemmExceptions(blas::Op op_a, blas::Op op_b, const TileElementSize& siz
   if (op_b != blas::Op::NoTrans)
     size_b.transpose();
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
+  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM Exceptions: " << op_a << ", " << op_a;

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -48,9 +48,9 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
   s << ", lda = " << lda << ", ldb = " << ldb << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
-  memory::MemoryView<T, Device::CPU> mem_b(ldb * size_b.cols());
-  memory::MemoryView<T, Device::CPU> mem_c(ldc * size_c.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
@@ -129,9 +129,9 @@ void testGemmExceptions(blas::Op op_a, blas::Op op_b, const TileElementSize& siz
   s << ", lda = " << lda << ", ldb = " << ldb << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
-  memory::MemoryView<T, Device::CPU> mem_b(ldb * size_b.cols());
-  memory::MemoryView<T, Device::CPU> mem_c(ldc * size_c.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
 
   // Create tiles.
   Tile<CT, Device::CPU> a(size_a, std::move(mem_a), lda);

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -38,9 +38,9 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
     size_b.transpose();
   TileElementSize size_c(m, n);
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
+  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM: " << op_a << ", " << op_a;
@@ -119,9 +119,9 @@ void testGemmExceptions(blas::Op op_a, blas::Op op_b, const TileElementSize& siz
   if (op_b != blas::Op::NoTrans)
     size_b.transpose();
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
+  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM Exceptions: " << op_a << ", " << op_a;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -27,6 +27,8 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
+using dlaf::util::size_t::mul;
+
 template <class T, class CT = const T>
 void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType extra_lda,
               SizeType extra_ldc) {
@@ -44,8 +46,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
   s << ", lda = " << lda << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
-  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(mul(ldc, size_c.cols()));
 
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> c(size_c, std::move(mem_c), ldc);
@@ -110,8 +112,8 @@ void testHerkExceptions(blas::Uplo uplo, blas::Op op_a, const TileElementSize& s
   s << ", lda = " << lda << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
-  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(mul(ldc, size_c.cols()));
 
   Tile<CT, Device::CPU> a(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> c(size_c, std::move(mem_c), ldc);

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -35,8 +35,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
     size_a.transpose();
   TileElementSize size_c(n, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK: " << uplo << ", " << op_a;
@@ -101,8 +101,8 @@ void testHerkExceptions(blas::Uplo uplo, blas::Op op_a, const TileElementSize& s
   if (op_a != blas::Op::NoTrans)
     size_a.transpose();
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK Exceptions: " << uplo << ", " << op_a;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -35,8 +35,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
     size_a.transpose();
   TileElementSize size_c(n, n);
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
-  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK: " << uplo << ", " << op_a;
@@ -101,8 +101,8 @@ void testHerkExceptions(blas::Uplo uplo, blas::Op op_a, const TileElementSize& s
   if (op_a != blas::Op::NoTrans)
     size_a.transpose();
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
-  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK Exceptions: " << uplo << ", " << op_a;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -35,8 +35,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
     size_a.transpose();
   TileElementSize size_c(n, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK: " << uplo << ", " << op_a;
@@ -101,8 +101,8 @@ void testHerkExceptions(blas::Uplo uplo, blas::Op op_a, const TileElementSize& s
   if (op_a != blas::Op::NoTrans)
     size_a.transpose();
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldc = std::max(1, size_c.rows()) + extra_ldc;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType ldc = max(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK Exceptions: " << uplo << ", " << op_a;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -44,8 +44,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
   s << ", lda = " << lda << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
-  memory::MemoryView<T, Device::CPU> mem_c(ldc * size_c.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
 
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> c(size_c, std::move(mem_c), ldc);
@@ -110,8 +110,8 @@ void testHerkExceptions(blas::Uplo uplo, blas::Op op_a, const TileElementSize& s
   s << ", lda = " << lda << ", ldc = " << ldc;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
-  memory::MemoryView<T, Device::CPU> mem_c(ldc * size_c.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_c(util::size_t::mul(ldc, size_c.cols()));
 
   Tile<CT, Device::CPU> a(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> c(size_c, std::move(mem_c), ldc);

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -35,8 +35,8 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
   TileElementSize size_a = side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
   TileElementSize size_b(m, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n
@@ -75,8 +75,8 @@ template <class T, class CT = const T>
 void testTrsmExceptions(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag,
                         const TileElementSize& size_a, const TileElementSize& size_b, SizeType extra_lda,
                         SizeType extra_ldb) {
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", size_a = " << size_a

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -29,6 +29,8 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
+using dlaf::util::size_t::mul;
+
 template <class ElementIndex, class T, class CT = const T>
 void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, SizeType m, SizeType n,
               SizeType extra_lda, SizeType extra_ldb) {
@@ -43,8 +45,8 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
     << ", lda = " << lda << ", ldb = " << ldb;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
-  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(mul(ldb, size_b.cols()));
 
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> b(size_b, std::move(mem_b), ldb);
@@ -83,8 +85,8 @@ void testTrsmExceptions(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Dia
     << ", size_b = " << size_b << ", lda = " << lda << ", ldb = " << ldb;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
-  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(mul(ldb, size_b.cols()));
 
   Tile<CT, Device::CPU> a(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> b(size_b, std::move(mem_b), ldb);

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -35,8 +35,8 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
   TileElementSize size_a = side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
   TileElementSize size_b(m, n);
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n
@@ -75,8 +75,8 @@ template <class T, class CT = const T>
 void testTrsmExceptions(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag,
                         const TileElementSize& size_a, const TileElementSize& size_b, SizeType extra_lda,
                         SizeType extra_ldb) {
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", size_a = " << size_a

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -43,8 +43,8 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
     << ", lda = " << lda << ", ldb = " << ldb;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
-  memory::MemoryView<T, Device::CPU> mem_b(ldb * size_b.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
 
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> b(size_b, std::move(mem_b), ldb);
@@ -83,8 +83,8 @@ void testTrsmExceptions(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Dia
     << ", size_b = " << size_b << ", lda = " << lda << ", ldb = " << ldb;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
-  memory::MemoryView<T, Device::CPU> mem_b(ldb * size_b.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_b(util::size_t::mul(ldb, size_b.cols()));
 
   Tile<CT, Device::CPU> a(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> b(size_b, std::move(mem_b), ldb);

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -35,8 +35,8 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
   TileElementSize size_a = side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
   TileElementSize size_b(m, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n
@@ -75,8 +75,8 @@ template <class T, class CT = const T>
 void testTrsmExceptions(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag,
                         const TileElementSize& size_a, const TileElementSize& size_b, SizeType extra_lda,
                         SizeType extra_ldb) {
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max(1, size_b.rows()) + extra_ldb;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType ldb = max(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", size_a = " << size_a

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -25,6 +25,8 @@ using namespace dlaf::matrix::test;
 using namespace dlaf_test;
 using namespace testing;
 
+using dlaf::util::size_t::mul;
+
 template <class T, bool return_info>
 void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
@@ -36,7 +38,7 @@ void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   s << ", n = " << n << ", lda = " << lda;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
@@ -97,7 +99,7 @@ void testPotrfArgExceptions(blas::Uplo uplo, TileElementSize size_a, SizeType ex
   s << ", size_a = " << size_a << ", lda = " << lda;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
@@ -121,7 +123,7 @@ void testPotrfNonPosDef(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   s << ", n = " << n << ", lda = " << lda;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
+  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -29,7 +29,7 @@ template <class T, bool return_info>
 void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF: " << uplo;
@@ -90,7 +90,7 @@ void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
 
 template <class T, bool return_info>
 void testPotrfArgExceptions(blas::Uplo uplo, TileElementSize size_a, SizeType extra_lda) {
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Arguments Exceptions: " << uplo;
@@ -114,7 +114,7 @@ template <class T, bool return_info>
 void testPotrfNonPosDef(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Non Positive Definite: " << uplo;

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -36,7 +36,7 @@ void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   s << ", n = " << n << ", lda = " << lda;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
@@ -97,7 +97,7 @@ void testPotrfArgExceptions(blas::Uplo uplo, TileElementSize size_a, SizeType ex
   s << ", size_a = " << size_a << ", lda = " << lda;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
@@ -121,7 +121,7 @@ void testPotrfNonPosDef(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   s << ", n = " << n << ", lda = " << lda;
   SCOPED_TRACE(s.str());
 
-  memory::MemoryView<T, Device::CPU> mem_a(lda * size_a.cols());
+  memory::MemoryView<T, Device::CPU> mem_a(util::size_t::mul(lda, size_a.cols()));
 
   // Create tiles.
   Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -29,7 +29,7 @@ template <class T, bool return_info>
 void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF: " << uplo;
@@ -90,7 +90,7 @@ void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
 
 template <class T, bool return_info>
 void testPotrfArgExceptions(blas::Uplo uplo, TileElementSize size_a, SizeType extra_lda) {
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Arguments Exceptions: " << uplo;
@@ -114,7 +114,7 @@ template <class T, bool return_info>
 void testPotrfNonPosDef(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
-  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
+  SizeType lda = max(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Non Positive Definite: " << uplo;

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -29,7 +29,7 @@ template <class T, bool return_info>
 void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF: " << uplo;
@@ -90,7 +90,7 @@ void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
 
 template <class T, bool return_info>
 void testPotrfArgExceptions(blas::Uplo uplo, TileElementSize size_a, SizeType extra_lda) {
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Arguments Exceptions: " << uplo;
@@ -114,7 +114,7 @@ template <class T, bool return_info>
 void testPotrfNonPosDef(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
-  SizeType lda = max(1, size_a.rows()) + extra_lda;
+  SizeType lda = std::max(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Non Positive Definite: " << uplo;

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -464,7 +464,7 @@ TYPED_TEST(MatrixTest, ConstructorExistingConst) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
       LayoutInfo layout = colMajorLayout(distribution.localSize(), test.block_size,
-                                         std::max(1, distribution.localSize().rows()));
+                                         max(1, distribution.localSize().rows()));
       memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 
       // Copy distribution for testing purpose.

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -464,7 +464,7 @@ TYPED_TEST(MatrixTest, ConstructorExistingConst) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
       LayoutInfo layout = colMajorLayout(distribution.localSize(), test.block_size,
-                                         max(1, distribution.localSize().rows()));
+                                         std::max(1, distribution.localSize().rows()));
       memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 
       // Copy distribution for testing purpose.

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -464,7 +464,7 @@ TYPED_TEST(MatrixTest, ConstructorExistingConst) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
       LayoutInfo layout = colMajorLayout(distribution.localSize(), test.block_size,
-                                         std::max(1, distribution.localSize().rows()));
+                                         std::max<SizeType>(1, distribution.localSize().rows()));
       memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 
       // Copy distribution for testing purpose.

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1058,12 +1058,12 @@ auto createMatrix() -> Matrix<T, device> {
 }
 
 template <class T>
-auto createConstMatrix() -> Matrix<T, device> {
+auto createConstMatrix() {
   LayoutInfo layout({1, 1}, {1, 1}, 1, 1, 1);
   memory::MemoryView<T, device> mem(layout.minMemSize());
   const T* p = mem();
 
-  return {layout, p};
+  return Matrix<const T, device>{layout, p};
 }
 
 TEST(MatrixDestructorFutures, NonConstAfterRead) {
@@ -1107,7 +1107,7 @@ TEST(MatrixDestructorFutures, ConstAfterRead) {
 
   volatile int guard = 0;
   {
-    auto matrix = createConstMatrix<const TypeParam>();
+    auto matrix = createConstMatrix<TypeParam>();
 
     auto sf = matrix.read(LocalTileIndex(0, 0));
     last_task = sf.then(hpx::launch::async, [&guard](auto&&) {

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -64,7 +64,7 @@ TYPED_TEST(TileTest, Constructor) {
     for (const auto n : sizes) {
       SizeType min_ld = std::max(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
-        memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+        memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
         TileElementSize size(m, n);
         for (SizeType j = 0; j < size.cols(); ++j) {
           for (SizeType i = 0; i < size.rows(); ++i) {
@@ -110,7 +110,7 @@ TYPED_TEST(TileTest, ConstructorConst) {
     for (const auto n : sizes) {
       SizeType min_ld = std::max(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
-        memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+        memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
         TileElementSize size(m, n);
         for (SizeType j = 0; j < size.cols(); ++j) {
           for (SizeType i = 0; i < size.rows(); ++i) {
@@ -154,7 +154,7 @@ TYPED_TEST(TileTest, ConstructorExceptions) {
 
 TYPED_TEST(TileTest, MoveConstructor) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -170,7 +170,7 @@ TYPED_TEST(TileTest, MoveConstructor) {
 
 TYPED_TEST(TileTest, MoveConstructorConst) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -186,7 +186,7 @@ TYPED_TEST(TileTest, MoveConstructorConst) {
 
 TYPED_TEST(TileTest, MoveConstructorMix) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -202,7 +202,7 @@ TYPED_TEST(TileTest, MoveConstructorMix) {
 
 TYPED_TEST(TileTest, MoveAssignement) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -219,7 +219,7 @@ TYPED_TEST(TileTest, MoveAssignement) {
 
 TYPED_TEST(TileTest, MoveAssignementConst) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -236,7 +236,7 @@ TYPED_TEST(TileTest, MoveAssignementConst) {
 
 TYPED_TEST(TileTest, MoveAssignementMix) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -253,7 +253,7 @@ TYPED_TEST(TileTest, MoveAssignementMix) {
 
 TYPED_TEST(TileTest, ReferenceMix) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -269,7 +269,7 @@ TYPED_TEST(TileTest, ReferenceMix) {
 
 TYPED_TEST(TileTest, PointerMix) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -285,7 +285,7 @@ TYPED_TEST(TileTest, PointerMix) {
 
 TYPED_TEST(TileTest, PromiseToFuture) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -312,7 +312,7 @@ TYPED_TEST(TileTest, PromiseToFuture) {
 
 TYPED_TEST(TileTest, PromiseToFutureConst) {
   using Type = TypeParam;
-  memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
 
   TileElementSize size(m, n);
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
@@ -345,7 +345,7 @@ TYPED_TEST(TileTest, CreateBuffer) {
   SizeType n = 87;
   SizeType ld = 133;
 
-  memory::MemoryView<TypeParam, Device::CPU> memory_view(ld * n);
+  memory::MemoryView<TypeParam, Device::CPU> memory_view(util::size_t::mul(ld, n));
   auto mem_view = memory_view;
 
   TileElementSize size(m, n);

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -62,7 +62,7 @@ TYPED_TEST(TileTest, Constructor) {
 
   for (const auto m : sizes) {
     for (const auto n : sizes) {
-      SizeType min_ld = std::max(1, m);
+      SizeType min_ld = max(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
         memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
         TileElementSize size(m, n);
@@ -108,7 +108,7 @@ TYPED_TEST(TileTest, ConstructorConst) {
 
   for (const auto m : sizes) {
     for (const auto n : sizes) {
-      SizeType min_ld = std::max(1, m);
+      SizeType min_ld = max(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
         memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
         TileElementSize size(m, n);

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -62,7 +62,7 @@ TYPED_TEST(TileTest, Constructor) {
 
   for (const auto m : sizes) {
     for (const auto n : sizes) {
-      SizeType min_ld = max(1, m);
+      SizeType min_ld = std::max(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
         memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
         TileElementSize size(m, n);
@@ -108,7 +108,7 @@ TYPED_TEST(TileTest, ConstructorConst) {
 
   for (const auto m : sizes) {
     for (const auto n : sizes) {
-      SizeType min_ld = max(1, m);
+      SizeType min_ld = std::max(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
         memory::MemoryView<Type, Device::CPU> memory_view(ld * n);
         TileElementSize size(m, n);

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -62,7 +62,7 @@ TYPED_TEST(TileTest, Constructor) {
 
   for (const auto m : sizes) {
     for (const auto n : sizes) {
-      SizeType min_ld = std::max(1, m);
+      SizeType min_ld = std::max<SizeType>(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
         memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
         TileElementSize size(m, n);
@@ -108,7 +108,7 @@ TYPED_TEST(TileTest, ConstructorConst) {
 
   for (const auto m : sizes) {
     for (const auto n : sizes) {
-      SizeType min_ld = std::max(1, m);
+      SizeType min_ld = std::max<SizeType>(1, m);
       for (const SizeType ld : {min_ld, min_ld + 64}) {
         memory::MemoryView<Type, Device::CPU> memory_view(util::size_t::mul(ld, n));
         TileElementSize size(m, n);


### PR DESCRIPTION
This PR addresses https://github.com/eth-cscs/DLA-Future/pull/174#discussion_r404841788

In addition to:
- `dlaf::common::vector` wrapper now accepts `SizeType`
- `dlaf::memory::MemoryView`
  - bug-fix: without the explicit constructor it was possible to allocate a const matrix (fixed also where this constructor was used)
  - change: remove helper constructors for `int` type
- overload `max` function for `SizeType` and exploits ADL in the code
