### PR TITLE
Proposal: Copy matrices

### DIFF
--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -36,6 +36,16 @@ namespace tile {
 template <class T, Device device>
 void potrf(blas::Uplo uplo, const Tile<T, device>& a);
 
+/// Copy
+template <class T>
+void lacpy(const Tile<const T, Device::CPU>& src, const Tile<T, Device::CPU>& dst) {
+  SizeType m = src.size().rows();
+  SizeType n = src.size().cols();
+  SizeType lda = src.ld();
+  SizeType ldb = dst.ld();
+  lapack::lacpy(lapack::MatrixType::General, m, n, src.ptr(), lda, dst.ptr(), ldb);
+}
+
 // Variants that return info code.
 
 /// Compute the cholesky decomposition of a.

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -26,7 +26,11 @@ namespace tile {
 
 // See LAPACK documentation for more details.
 
-// Variants that throw an error on failure.
+/// Copies all elements from Tile a to Tile b
+///
+/// @pre @param a and @param b must have the same size (number of elements)
+template <class T>
+void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b);
 
 /// Compute the cholesky decomposition of a.
 ///
@@ -36,15 +40,7 @@ namespace tile {
 template <class T, Device device>
 void potrf(blas::Uplo uplo, const Tile<T, device>& a);
 
-/// Copies all elements from Tile a to Tile b
-///
-/// @pre @param a and @param b must have the same size (number of elements)
-template <class T>
-void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b);
-
-// Variants that return info code.
-
-/// Compute the cholesky decomposition of a.
+/// Compute the cholesky decomposition of a. (with return code)
 ///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @returns info = 0 on success or info > 0 if the tile is not positive definite.

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -29,33 +29,30 @@ namespace tile {
 // Variants that throw an error on failure.
 
 /// Compute the cholesky decomposition of a.
-
+///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @throw std::invalid_argument if a is not square.
 /// @throw std::runtime_error if the tile was not positive definite.
 template <class T, Device device>
 void potrf(blas::Uplo uplo, const Tile<T, device>& a);
 
-/// Copy
+/// Copies all elements from Tile a to Tile b
+///
+/// @pre @param a and @param b must have the same size (number of elements)
 template <class T>
-void lacpy(const Tile<const T, Device::CPU>& src, const Tile<T, Device::CPU>& dst) {
-  SizeType m = src.size().rows();
-  SizeType n = src.size().cols();
-  SizeType lda = src.ld();
-  SizeType ldb = dst.ld();
-  lapack::lacpy(lapack::MatrixType::General, m, n, src.ptr(), lda, dst.ptr(), ldb);
-}
+void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b);
 
 // Variants that return info code.
 
 /// Compute the cholesky decomposition of a.
-
+///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @returns info = 0 on success or info > 0 if the tile is not positive definite.
 /// @throw std::runtime_error if the tile was not positive definite.
 template <class T, Device device>
 long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a);
 
+}
+}
+
 #include "dlaf/lapack_tile.tpp"
-}
-}

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -13,13 +13,6 @@
 namespace dlaf {
 namespace tile {
 
-template <class T, Device device>
-void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
-  auto info = potrfInfo(uplo, a);
-  if (info != 0)
-    throw std::runtime_error("Error: POTRF: A is not positive definite.");
-}
-
 template <class T>
 void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
   DLAF_ASSERT_HEAVY(a.size() == b.size(),
@@ -30,6 +23,13 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
   SizeType n = a.size().cols();
 
   lapack::lacpy(lapack::MatrixType::General, m, n, a.ptr(), a.ld(), b.ptr(), b.ld());
+}
+
+template <class T, Device device>
+void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
+  auto info = potrfInfo(uplo, a);
+  if (info != 0)
+    throw std::runtime_error("Error: POTRF: A is not positive definite.");
 }
 
 template <class T, Device device>

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -8,6 +8,28 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include "dlaf/common/assert.h"
+
+namespace dlaf {
+namespace tile {
+
+template <class T, Device device>
+void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
+  auto info = potrfInfo(uplo, a);
+  if (info != 0)
+    throw std::runtime_error("Error: POTRF: A is not positive definite.");
+}
+
+template <class T>
+void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
+  DLAF_ASSERT_HEAVY(a.size() == b.size(), "Source and destination tile must have the same size. A=", a.size(), " B=", b.size());
+
+  SizeType m = a.size().rows();
+  SizeType n = a.size().cols();
+
+  lapack::lacpy(lapack::MatrixType::General, m, n, a.ptr(), a.ld(), b.ptr(), b.ld());
+}
+
 template <class T, Device device>
 long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a) {
   if (a.size().rows() != a.size().cols()) {
@@ -20,9 +42,5 @@ long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a) {
   return info;
 }
 
-template <class T, Device device>
-void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
-  auto info = potrfInfo(uplo, a);
-  if (info != 0)
-    throw std::runtime_error("Error: POTRF: A is not positive definite.");
+}
 }

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -22,7 +22,9 @@ void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
 
 template <class T>
 void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
-  DLAF_ASSERT_HEAVY(a.size() == b.size(), "Source and destination tile must have the same size. A=", a.size(), " B=", b.size());
+  DLAF_ASSERT_HEAVY(a.size() == b.size(),
+                    "Source and destination tile must have the same size. A=", a.size(),
+                    " B=", b.size());
 
   SizeType m = a.size().rows();
   SizeType n = a.size().cols();

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -15,9 +15,9 @@ namespace tile {
 
 template <class T>
 void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
-  DLAF_ASSERT_HEAVY(a.size() == b.size(),
-                    "Source and destination tile must have the same size. A=", a.size(),
-                    " B=", b.size());
+  DLAF_ASSERT_MODERATE(a.size() == b.size(),
+                       "Source and destination tile must have the same size. A=", a.size(),
+                       " B=", b.size());
 
   SizeType m = a.size().rows();
   SizeType n = a.size().cols();

--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -12,6 +12,7 @@
 #include <exception>
 #include <vector>
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/lapack_tile.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/layout_info.h"
 #include "dlaf/matrix/matrix_base.h"
@@ -357,19 +358,10 @@ void copy(MatrixTypeSrc<Tsrc, Device::CPU>& source, MatrixTypeDst<Tdst, Device::
   const SizeType local_tile_rows = distribution.localNrTiles().rows();
   const SizeType local_tile_cols = distribution.localNrTiles().cols();
 
-  auto copy_func = hpx::util::unwrapping([](auto&& tile_dst, auto&& tile_src) {
-    for (SizeType j = 0; j < tile_src.size().cols(); ++j)
-      for (SizeType i = 0; i < tile_src.size().rows(); ++i) {
-        TileElementIndex index(i, j);
-        tile_dst(index) = tile_src(index);
-      }
-  });
-
-  for (SizeType j = 0; j < local_tile_cols; ++j) {
-    for (SizeType i = 0; i < local_tile_rows; ++i) {
-      hpx::dataflow(copy_func, dest(LocalTileIndex(i, j)), source.read(LocalTileIndex(i, j)));
-    }
-  }
+  for (SizeType j = 0; j < local_tile_cols; ++j)
+    for (SizeType i = 0; i < local_tile_rows; ++i)
+      hpx::dataflow(hpx::util::unwrapping(dlaf::tile::lacpy<Tdst>), source.read(LocalTileIndex(i, j)),
+                    dest(LocalTileIndex(i, j)));
 }
 
 /// ---- ETI

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -1,0 +1,45 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <hpx/hpx.hpp>
+
+#include "dlaf/matrix/copy_tile.h"
+#include "dlaf/types.h"
+
+namespace dlaf {
+
+/// Copy values from another matrix
+///
+/// Given a matrix with the same geometries and distribution, this function submits tasks that will
+/// perform the copy of each tile
+template <template <class, Device> class MatrixTypeSrc, template <class, Device> class MatrixTypeDst,
+          class Tsrc, class Tdst>
+void copy(MatrixTypeSrc<Tsrc, Device::CPU>& source, MatrixTypeDst<Tdst, Device::CPU>& dest) {
+  static_assert(std::is_same<const Tsrc, const Tdst>::value,
+                "Source and destination matrix should have the same type");
+  static_assert(!std::is_const<Tdst>::value, "Destination matrix cannot be const");
+
+  const auto& distribution = source.distribution();
+
+  // TODO check same size and blocksize
+  // TODO check equally distributed
+
+  const SizeType local_tile_rows = distribution.localNrTiles().rows();
+  const SizeType local_tile_cols = distribution.localNrTiles().cols();
+
+  for (SizeType j = 0; j < local_tile_cols; ++j)
+    for (SizeType i = 0; i < local_tile_rows; ++i)
+      hpx::dataflow(hpx::util::unwrapping(dlaf::copy<Tsrc, Tdst>), source.read(LocalTileIndex(i, j)),
+                    dest(LocalTileIndex(i, j)));
+}
+
+}

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -14,6 +14,7 @@
 
 #include "dlaf/matrix/copy_tile.h"
 #include "dlaf/types.h"
+#include "dlaf/util_matrix.h"
 
 namespace dlaf {
 
@@ -28,8 +29,9 @@ template <
 void copy(MatrixTypeSrc<Tsrc, device_source>& source, MatrixTypeDst<Tdst, device_dest>& dest) {
   const auto& distribution = source.distribution();
 
-  // TODO check same size and blocksize
-  // TODO check equally distributed
+  DLAF_ASSERT_SIZE_EQ(source, dest);
+  DLAF_ASSERT_BLOCKSIZE_EQ(source, dest);
+  DLAF_ASSERT_DISTRIBUTED_EQ(source, dest);
 
   const SizeType local_tile_rows = distribution.localNrTiles().rows();
   const SizeType local_tile_cols = distribution.localNrTiles().cols();

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -24,9 +24,9 @@ namespace dlaf {
 /// perform the copy of each tile
 template <
     template <class, Device> class MatrixTypeSrc, template <class, Device> class MatrixTypeDst,
-    class Tsrc, class Tdst, Device device_source, Device device_dest,
+    class Tsrc, class Tdst, Device device,
     std::enable_if_t<std::is_same<const Tsrc, const Tdst>::value && !std::is_const<Tdst>::value, int> = 0>
-void copy(MatrixTypeSrc<Tsrc, device_source>& source, MatrixTypeDst<Tdst, device_dest>& dest) {
+void copy(MatrixTypeSrc<Tsrc, device>& source, MatrixTypeDst<Tdst, device>& dest) {
   const auto& distribution = source.distribution();
 
   DLAF_ASSERT_SIZE_EQ(source, dest);

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -21,13 +21,11 @@ namespace dlaf {
 ///
 /// Given a matrix with the same geometries and distribution, this function submits tasks that will
 /// perform the copy of each tile
-template <template <class, Device> class MatrixTypeSrc, template <class, Device> class MatrixTypeDst,
-          class Tsrc, class Tdst>
-void copy(MatrixTypeSrc<Tsrc, Device::CPU>& source, MatrixTypeDst<Tdst, Device::CPU>& dest) {
-  static_assert(std::is_same<const Tsrc, const Tdst>::value,
-                "Source and destination matrix should have the same type");
-  static_assert(!std::is_const<Tdst>::value, "Destination matrix cannot be const");
-
+template <
+    template <class, Device> class MatrixTypeSrc, template <class, Device> class MatrixTypeDst,
+    class Tsrc, class Tdst, Device device_source, Device device_dest,
+    std::enable_if_t<std::is_same<const Tsrc, const Tdst>::value && !std::is_const<Tdst>::value, int> = 0>
+void copy(MatrixTypeSrc<Tsrc, device_source>& source, MatrixTypeDst<Tdst, device_dest>& dest) {
   const auto& distribution = source.distribution();
 
   // TODO check same size and blocksize

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -22,11 +22,9 @@ namespace dlaf {
 ///
 /// Given a matrix with the same geometries and distribution, this function submits tasks that will
 /// perform the copy of each tile
-template <
-    template <class, Device> class MatrixTypeSrc, template <class, Device> class MatrixTypeDst,
-    class Tsrc, class Tdst, Device device,
-    std::enable_if_t<std::is_same<const Tsrc, const Tdst>::value && !std::is_const<Tdst>::value, int> = 0>
-void copy(MatrixTypeSrc<Tsrc, device>& source, MatrixTypeDst<Tdst, device>& dest) {
+template <template <class, Device> class MatrixTypeSrc, template <class, Device> class MatrixTypeDst,
+          class T, Device device>
+void copy(MatrixTypeSrc<const T, device>& source, MatrixTypeDst<T, device>& dest) {
   const auto& distribution = source.distribution();
 
   DLAF_ASSERT_SIZE_EQ(source, dest);
@@ -38,7 +36,7 @@ void copy(MatrixTypeSrc<Tsrc, device>& source, MatrixTypeDst<Tdst, device>& dest
 
   for (SizeType j = 0; j < local_tile_cols; ++j)
     for (SizeType i = 0; i < local_tile_rows; ++i)
-      hpx::dataflow(hpx::util::unwrapping(dlaf::copy<Tsrc, Tdst>), source.read(LocalTileIndex(i, j)),
+      hpx::dataflow(hpx::util::unwrapping(dlaf::copy<T>), source.read(LocalTileIndex(i, j)),
                     dest(LocalTileIndex(i, j)));
 }
 

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -17,11 +17,9 @@
 
 namespace dlaf {
 
-template <
-    class Tsrc, class Tdst,
-    std::enable_if_t<std::is_same<const Tsrc, const Tdst>::value && !std::is_const<Tdst>::value, int> = 0>
-void copy(const Tile<Tsrc, Device::CPU>& source, const Tile<Tdst, Device::CPU>& dest) {
-  dlaf::tile::lacpy<Tdst>(source, dest);
+template <class T>
+void copy(const Tile<const T, Device::CPU>& source, const Tile<T, Device::CPU>& dest) {
+  dlaf::tile::lacpy<T>(source, dest);
 }
 
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -10,12 +10,16 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "dlaf/lapack_tile.h"
 #include "dlaf/tile.h"
 
 namespace dlaf {
 
-template <class Tsrc, class Tdst>
+template <
+    class Tsrc, class Tdst,
+    std::enable_if_t<std::is_same<const Tsrc, const Tdst>::value && !std::is_const<Tdst>::value, int> = 0>
 void copy(const Tile<Tsrc, Device::CPU>& source, const Tile<Tdst, Device::CPU>& dest) {
   dlaf::tile::lacpy<Tdst>(source, dest);
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -1,0 +1,23 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include "dlaf/lapack_tile.h"
+#include "dlaf/tile.h"
+
+namespace dlaf {
+
+template <class Tsrc, class Tdst>
+void copy(const Tile<Tsrc, Device::CPU>& source, const Tile<Tdst, Device::CPU>& dest) {
+  dlaf::tile::lacpy<Tdst>(source, dest);
+}
+
+}

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -27,10 +27,12 @@ namespace test {
 /// Note: This function is interchangeable with getFuturesUsingGlobalIndex.
 template <template <class, Device> class MatrixType, class T, Device device>
 std::vector<hpx::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<T, device>& mat) {
+  using dlaf::util::size_t::mul;
+
   const matrix::Distribution& dist = mat.distribution();
 
   std::vector<hpx::future<Tile<T, device>>> result;
-  result.reserve(util::size_t::mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
+  result.reserve(mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
 
   for (SizeType j = 0; j < dist.localNrTiles().cols(); ++j) {
     for (SizeType i = 0; i < dist.localNrTiles().rows(); ++i) {
@@ -47,10 +49,12 @@ std::vector<hpx::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<T
 /// Note: This function is interchangeable with getFuturesUsingLocalIndex.
 template <template <class, Device> class MatrixType, class T, Device device>
 std::vector<hpx::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType<T, device>& mat) {
+  using dlaf::util::size_t::mul;
+
   const matrix::Distribution& dist = mat.distribution();
 
   std::vector<hpx::future<Tile<T, device>>> result;
-  result.reserve(util::size_t::mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
+  result.reserve(mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
 
   for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {
     for (SizeType i = 0; i < dist.nrTiles().rows(); ++i) {
@@ -73,10 +77,12 @@ std::vector<hpx::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType<
 template <template <class, Device> class MatrixType, class T, Device device>
 std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingLocalIndex(
     MatrixType<T, device>& mat) {
+  using dlaf::util::size_t::mul;
+
   const matrix::Distribution& dist = mat.distribution();
 
   std::vector<hpx::shared_future<Tile<const T, device>>> result;
-  result.reserve(util::size_t::mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
+  result.reserve(mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
 
   for (SizeType j = 0; j < dist.localNrTiles().cols(); ++j) {
     for (SizeType i = 0; i < dist.localNrTiles().rows(); ++i) {
@@ -95,10 +101,12 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingLoca
 template <template <class, Device> class MatrixType, class T, Device device>
 std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlobalIndex(
     MatrixType<T, device>& mat) {
+  using dlaf::util::size_t::mul;
+
   const matrix::Distribution& dist = mat.distribution();
 
   std::vector<hpx::shared_future<Tile<const T, device>>> result;
-  result.reserve(util::size_t::mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
+  result.reserve(mul(dist.localNrTiles().rows(), dist.localNrTiles().cols()));
 
   for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {
     for (SizeType i = 0; i < dist.nrTiles().rows(); ++i) {
@@ -167,8 +175,10 @@ void checkFutures(bool get_ready, const std::vector<Future1>& current, std::vect
 /// @pre Future1 should be a future or shared_future
 template <class Future1, class MatrixViewType>
 void checkFuturesDone(bool get_ready, const std::vector<Future1>& current, MatrixViewType& mat_view) {
+  using dlaf::util::size_t::mul;
+
   const auto& nr_tiles = mat_view.distribution().localNrTiles();
-  assert(current.size() == util::size_t::mul(nr_tiles.rows(), nr_tiles.cols()));
+  assert(current.size() == mul(nr_tiles.rows(), nr_tiles.cols()));
 
   for (std::size_t index = 0; index < current.size(); ++index) {
     EXPECT_TRUE(checkFuturesStep(get_ready ? index : 0, current));

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -13,11 +13,11 @@
 #include <vector>
 #include "gtest/gtest.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/util_matrix.h"
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/matrix/util_matrix_futures.h"
 #include "dlaf_test/util_types.h"
-#include "dlaf/util_matrix.h"
 
 using namespace dlaf;
 using namespace dlaf::matrix;
@@ -1047,18 +1047,20 @@ TYPED_TEST(MatrixTest, CopyFrom) {
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
       LayoutInfo layout = tileLayout(distribution.localSize(), test.block_size);
 
-      auto input_matrix = [rows=size.rows()](const GlobalElementIndex& index) {
+      auto input_matrix = [rows = size.rows()](const GlobalElementIndex& index) {
         return index.row() + index.col() * rows;
       };
 
       MemoryViewT mem_src(layout.minMemSize());
-      MatrixT mat_src = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid, static_cast<TypeParam*>(mem_src()));
+      MatrixT mat_src = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                          static_cast<TypeParam*>(mem_src()));
       dlaf::matrix::util::set(mat_src, input_matrix);
 
       MatrixConstT mat_src_const = std::move(mat_src);
 
       MemoryViewT mem_dst(layout.minMemSize());
-      MatrixT mat_dst = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid, static_cast<TypeParam*>(mem_dst()));
+      MatrixT mat_dst = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                          static_cast<TypeParam*>(mem_dst()));
       dlaf::matrix::util::set(mat_dst, [](const auto&) { return 13; });
 
       mat_dst.copyFrom(mat_src_const);

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1065,7 +1065,7 @@ TYPED_TEST(MatrixTest, CopyFrom) {
 
       mat_dst.copyFrom(mat_src_const);
 
-      CHECK_MATRIX_EQ(input_matrix, mat_dst);
+      CHECK_MATRIX_NEAR(input_matrix, mat_dst, 0, dlaf_test::TypeUtilities<TypeParam>::error);
     }
   }
 }

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -1038,7 +1038,7 @@ TYPED_TEST(MatrixTest, FromTileConst) {
 TYPED_TEST(MatrixTest, CopyFrom) {
   using MemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::CPU>;
   using MatrixT = dlaf::Matrix<TypeParam, Device::CPU>;
-  using MatrixConstT = dlaf::Matrix<TypeParam, Device::CPU>;
+  using MatrixConstT = dlaf::Matrix<const TypeParam, Device::CPU>;
 
   for (const auto& comm_grid : this->commGrids()) {
     for (const auto& test : sizes_tests) {
@@ -1066,7 +1066,7 @@ TYPED_TEST(MatrixTest, CopyFrom) {
       dlaf::matrix::util::set(mat_dst,
                               [](const auto&) { return TypeUtilities<TypeParam>::element(13, 26); });
 
-      mat_dst.copyFrom(mat_src_const);
+      copy(mat_src_const, mat_dst);
 
       CHECK_MATRIX_NEAR(input_matrix, mat_dst, 0, TypeUtilities<TypeParam>::error);
     }

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -17,6 +17,7 @@
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/matrix/util_matrix_futures.h"
 #include "dlaf_test/util_types.h"
+#include "dlaf/util_matrix.h"
 
 using namespace dlaf;
 using namespace dlaf::matrix;
@@ -165,8 +166,8 @@ TYPED_TEST(MatrixTest, ConstructorFromDistribution) {
 /// @pre index should be valid, contained in @p distribution.size() and stored in the current rank.
 std::size_t memoryIndex(const Distribution& distribution, const LayoutInfo& layout,
                         const GlobalElementIndex& index) {
-  using util::size_t::sum;
-  using util::size_t::mul;
+  using dlaf::util::size_t::sum;
+  using dlaf::util::size_t::mul;
 
   auto global_tile_index = distribution.globalTileIndex(index);
   auto tile_element_index = distribution.tileElementIndex(index);
@@ -885,6 +886,8 @@ TYPED_TEST(MatrixLocalTest, FromTileConst) {
 TYPED_TEST(MatrixTest, FromTile) {
   using Type = TypeParam;
 
+  using dlaf::util::ceilDiv;
+
   for (const auto& comm_grid : this->commGrids()) {
     for (const auto& test : sizes_tests) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
@@ -922,7 +925,7 @@ TYPED_TEST(MatrixTest, FromTile) {
 
         SizeType ld_tiles = test.block_size.rows();
         SizeType tiles_per_col =
-            util::ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 3;
+            ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 3;
         LayoutInfo layout = tileLayout(distribution, ld_tiles, tiles_per_col);
         memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 
@@ -940,7 +943,7 @@ TYPED_TEST(MatrixTest, FromTile) {
 
         SizeType ld_tiles = test.block_size.rows();
         SizeType tiles_per_col =
-            util::ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 1;
+            ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 1;
         LayoutInfo layout = tileLayout(distribution, ld_tiles, tiles_per_col);
         memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 
@@ -956,6 +959,8 @@ TYPED_TEST(MatrixTest, FromTile) {
 
 TYPED_TEST(MatrixTest, FromTileConst) {
   using Type = TypeParam;
+
+  using dlaf::util::ceilDiv;
 
   for (const auto& comm_grid : this->commGrids()) {
     for (const auto& test : sizes_tests) {
@@ -996,7 +1001,7 @@ TYPED_TEST(MatrixTest, FromTileConst) {
 
         SizeType ld_tiles = test.block_size.rows();
         SizeType tiles_per_col =
-            util::ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 3;
+            ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 3;
         LayoutInfo layout = tileLayout(distribution, ld_tiles, tiles_per_col);
         memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 
@@ -1015,7 +1020,7 @@ TYPED_TEST(MatrixTest, FromTileConst) {
 
         SizeType ld_tiles = test.block_size.rows();
         SizeType tiles_per_col =
-            util::ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 1;
+            ceilDiv(distribution.localSize().rows(), distribution.blockSize().rows()) + 1;
         LayoutInfo layout = tileLayout(distribution, ld_tiles, tiles_per_col);
         memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
 

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "dlaf/matrix.h"
+#include "dlaf/matrix/copy.h"
 
 #include <vector>
 #include "gtest/gtest.h"


### PR DESCRIPTION
Close #150 

Starting point for a method to copy values between matrices:
- non-blocking
- tile-by-tile
- element-by-element

If we want to improve this, the first way could be to optimize the copy of each tile using memory chunks (e.g. exploiting `copy` function on Data).