### PR TITLE
Proposal of additional checks for compute indexes functions

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -267,8 +267,8 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
 
 /// Compute linear index of an Index2D in a row-major ordered 2D grid
 ///
-/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to internalize
-/// the casting of the value before returning it, not leaving the burden to the user.
+/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to
+/// internalize the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre LinearIndexT must be able to store the result
@@ -289,8 +289,8 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
 
 /// Compute linear index of an Index2D in a column-major ordered 2D grid
 ///
-/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to internalize
-/// the casting of the value before returning it, not leaving the burden to the user.
+/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to
+/// internalize the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre LinearIndexT must be able to store the result
@@ -314,8 +314,8 @@ LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
 /// It acts as dispatcher for computeLinearIndexColMajor() and computeLinearIndexRowMajor()
 /// depending on given @p ordering.
 ///
-/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to internalize
-/// the casting of the value before returning it, not leaving the burden to the user.
+/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to
+/// internalize the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned (it must be explicitly specified)
 /// @pre LinearIndexT must be able to store the result

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -187,15 +187,51 @@ public:
 };
 
 template <class IndexT, class Tag, class LinearIndexT>
-Index2D<IndexT, Tag> computeCoordsRowMajor(LinearIndexT index,
+Index2D<IndexT, Tag> computeCoordsRowMajor(LinearIndexT linear_index,
                                            const Size2D<IndexT, Tag>& dims) noexcept {
-  return {static_cast<IndexT>(index / dims.cols()), static_cast<IndexT>(index % dims.cols())};
+  static_assert(std::is_integral<LinearIndexT>::value, "linear_index must be an integral type");
+
+  using dlaf::util::size_t::mul;
+
+  DLAF_ASSERT_MODERATE(linear_index >= 0, "The linear index cannot be negative (",
+                       std::to_string(linear_index), ")");
+  DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
+                       "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
+
+  LinearIndexT leading_size = dims.cols();
+
+  Index2D<IndexT, Tag> index;
+
+  index = {to_signed<IndexT>(linear_index / leading_size), to_signed<IndexT>(linear_index % leading_size)};
+
+  if (!index.isIn(dims))
+    return {};
+
+  return index;
 }
 
 template <class IndexT, class Tag, class LinearIndexT>
-Index2D<IndexT, Tag> computeCoordsColMajor(LinearIndexT index,
+Index2D<IndexT, Tag> computeCoordsColMajor(LinearIndexT linear_index,
                                            const Size2D<IndexT, Tag>& dims) noexcept {
-  return {static_cast<IndexT>(index % dims.rows()), static_cast<IndexT>(index / dims.rows())};
+  static_assert(std::is_integral<LinearIndexT>::value, "linear_index must be an integral type");
+
+  using dlaf::util::size_t::mul;
+
+  DLAF_ASSERT_MODERATE(linear_index >= 0, "The linear index cannot be negative (",
+                       std::to_string(linear_index), ")");
+  DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
+                       "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
+
+  LinearIndexT leading_size = dims.rows();
+
+  Index2D<IndexT, Tag> index;
+
+  index = {to_signed<IndexT>(linear_index % leading_size), to_signed<IndexT>(linear_index / leading_size)};
+
+  if (!index.isIn(dims))
+    return {};
+
+  return index;
 }
 
 /// Compute coords of the @p index -th cell in a grid with @p ordering and sizes @p dims

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -212,8 +212,8 @@ Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
 
   DLAF_ASSERT_MODERATE(linear_index >= 0, "The linear index cannot be negative (",
                        std::to_string(linear_index), ")");
-  DLAF_ASSERT_MODERATE(linear_index < mul(dims.rows(), dims.cols()),
-                       "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
+  DLAF_ASSERT_MODERATE(linear_index < mul(dims.rows(), dims.cols()), "Linear index ",
+                       std::to_string(linear_index), " does not fit into grid ", dims);
 
   std::ptrdiff_t leading_size = dims.cols();
   return {to_signed<IndexT>(linear_index / leading_size),
@@ -234,8 +234,8 @@ Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
 
   DLAF_ASSERT_MODERATE(linear_index >= 0, "The linear index cannot be negative (",
                        std::to_string(linear_index), ")");
-  DLAF_ASSERT_MODERATE(linear_index < mul(dims.rows(), dims.cols()),
-                       "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
+  DLAF_ASSERT_MODERATE(linear_index < mul(dims.rows(), dims.cols()), "Linear index ",
+                       std::to_string(linear_index), " does not fit into grid ", dims);
 
   std::ptrdiff_t leading_size = dims.rows();
   return {to_signed<IndexT>(linear_index % leading_size),

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -215,7 +215,7 @@ Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
   DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
-  std::ptrdiff_t leading_size = to_signed<std::ptrdiff_t>(dims.cols());
+  std::ptrdiff_t leading_size = dims.cols();
   return {to_signed<IndexT>(linear_index / leading_size),
           to_signed<IndexT>(linear_index % leading_size)};
 }
@@ -237,7 +237,7 @@ Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
   DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
-  std::ptrdiff_t leading_size = to_signed<std::ptrdiff_t>(dims.rows());
+  std::ptrdiff_t leading_size = dims.rows();
   return {to_signed<IndexT>(linear_index % leading_size),
           to_signed<IndexT>(linear_index / leading_size)};
 }

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -256,6 +256,7 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
 
 /// Compute linear index of an Index2D in a row-major ordered 2D grid
 ///
+/// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
@@ -273,6 +274,7 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
 
 /// Compute linear index of an Index2D in a column-major ordered 2D grid
 ///
+/// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
@@ -293,6 +295,7 @@ LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
 /// It acts as dispatcher for computeLinearIndexColMajor() and computeLinearIndexRowMajor()
 /// depending on given @p ordering
 ///
+/// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndex(Ordering ordering, const Index2D<IndexT, Tag>& index,

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -208,11 +208,11 @@ std::ostream& operator<<(std::ostream& os, const Index2D<T, Tag>& size) {
 template <class IndexT, class Tag>
 Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
                                            const Size2D<IndexT, Tag>& dims) noexcept {
-  using dlaf::util::size_t::mul;
+  using dlaf::util::ptrdiff_t::mul;
 
   DLAF_ASSERT_MODERATE(linear_index >= 0, "The linear index cannot be negative (",
                        std::to_string(linear_index), ")");
-  DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
+  DLAF_ASSERT_MODERATE(linear_index < mul(dims.rows(), dims.cols()),
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
   std::ptrdiff_t leading_size = dims.cols();
@@ -230,11 +230,11 @@ Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
 template <class IndexT, class Tag>
 Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
                                            const Size2D<IndexT, Tag>& dims) noexcept {
-  using dlaf::util::size_t::mul;
+  using dlaf::util::ptrdiff_t::mul;
 
   DLAF_ASSERT_MODERATE(linear_index >= 0, "The linear index cannot be negative (",
                        std::to_string(linear_index), ")");
-  DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
+  DLAF_ASSERT_MODERATE(linear_index < mul(dims.rows(), dims.cols()),
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
   std::ptrdiff_t leading_size = dims.rows();
@@ -276,14 +276,14 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
                                         const Size2D<IndexT, Tag>& dims) noexcept {
-  using dlaf::util::size_t::mul;
-  using dlaf::util::size_t::sum;
+  using dlaf::util::ptrdiff_t::mul;
+  using dlaf::util::ptrdiff_t::sum;
 
   static_assert(std::is_integral<LinearIndexT>::value, "LinearIndexT must be an integral type");
 
   DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
 
-  std::size_t linear_index = sum(mul(index.row(), dims.cols()), index.col());
+  std::ptrdiff_t linear_index = sum(mul(index.row(), dims.cols()), index.col());
   return integral_cast<LinearIndexT>(linear_index);
 }
 
@@ -298,14 +298,14 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
                                         const Size2D<IndexT, Tag>& dims) noexcept {
-  using dlaf::util::size_t::mul;
-  using dlaf::util::size_t::sum;
+  using dlaf::util::ptrdiff_t::mul;
+  using dlaf::util::ptrdiff_t::sum;
 
   static_assert(std::is_integral<LinearIndexT>::value, "LinearIndexT must be an integral type");
 
   DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
 
-  std::size_t linear_index = sum(mul(index.col(), dims.rows()), index.row());
+  std::ptrdiff_t linear_index = sum(mul(index.col(), dims.rows()), index.row());
   return integral_cast<LinearIndexT>(linear_index);
 }
 

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -205,12 +205,8 @@ Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
   std::ptrdiff_t leading_size = dims.cols();
-  Index2D<IndexT, Tag> index{to_signed<IndexT>(linear_index / leading_size),
-                             to_signed<IndexT>(linear_index % leading_size)};
-
-  DLAF_ASSERT_HEAVY(index.isIn(dims), "Computed index is outside the given grid.");
-
-  return index;
+  return {to_signed<IndexT>(linear_index / leading_size),
+          to_signed<IndexT>(linear_index % leading_size)};
 }
 
 /// Compute coords of the @p index -th cell in a column-major ordered 2D grid with size op dims
@@ -231,12 +227,8 @@ Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
   std::ptrdiff_t leading_size = dims.rows();
-  Index2D<IndexT, Tag> index{to_signed<IndexT>(linear_index % leading_size),
-                             to_signed<IndexT>(linear_index / leading_size)};
-
-  DLAF_ASSERT_HEAVY(index.isIn(dims), "Computed index is outside the given grid.");
-
-  return index;
+  return {to_signed<IndexT>(linear_index % leading_size),
+          to_signed<IndexT>(linear_index / leading_size)};
 }
 
 /// Compute coords of the @p index -th cell in a grid with @p ordering and size @p dims
@@ -276,7 +268,6 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
   DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
 
   std::size_t linear_index = sum(mul(index.row(), dims.cols()), index.col());
-
   return integral_cast<LinearIndexT>(linear_index);
 }
 
@@ -294,7 +285,6 @@ LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
   DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
 
   std::size_t linear_index = sum(mul(index.col(), dims.rows()), index.row());
-
   return integral_cast<LinearIndexT>(linear_index);
 }
 

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -247,27 +247,31 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
                                         const Size2D<IndexT, Tag>& dims) noexcept {
-  DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
-
   using dlaf::util::size_t::mul;
   using dlaf::util::size_t::sum;
 
+  static_assert(std::is_integral<LinearIndexT>::value, "LinearIndexT must be an integral type");
+
+  DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
+
   std::size_t linear_index = sum(mul(index.row(), dims.cols()), index.col());
 
-  return to_signed<LinearIndexT>(linear_index);
+  return integral_cast<LinearIndexT>(linear_index);
 }
 
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
                                         const Size2D<IndexT, Tag>& dims) noexcept {
-  DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
-
   using dlaf::util::size_t::mul;
   using dlaf::util::size_t::sum;
 
+  static_assert(std::is_integral<LinearIndexT>::value, "LinearIndexT must be an integral type");
+
+  DLAF_ASSERT_MODERATE(index.isIn(dims), "Index ", index, " is not in the grid ", dims);
+
   std::size_t linear_index = sum(mul(index.col(), dims.rows()), index.row());
 
-  return to_signed<LinearIndexT>(linear_index);
+  return integral_cast<LinearIndexT>(linear_index);
 }
 
 /// Compute linear index of an Index2D

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -267,6 +267,9 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
 
 /// Compute linear index of an Index2D in a row-major ordered 2D grid
 ///
+/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to internalize
+/// the casting of the value before returning it, not leaving the burden to the user.
+///
 /// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
@@ -284,6 +287,9 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
 }
 
 /// Compute linear index of an Index2D in a column-major ordered 2D grid
+///
+/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to internalize
+/// the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned
 /// @pre index.isIn(dims)
@@ -304,9 +310,12 @@ LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
 /// Compute linear index of an Index2D
 ///
 /// It acts as dispatcher for computeLinearIndexColMajor() and computeLinearIndexRowMajor()
-/// depending on given @p ordering
+/// depending on given @p ordering.
 ///
-/// @tparam LinearIndexT can be any integral type signed or unsigned
+/// The @tparam LinearIndexT cannot be deduced and it must be explicitly specified. It allows to internalize
+/// the casting of the value before returning it, not leaving the burden to the user.
+///
+/// @tparam LinearIndexT can be any integral type signed or unsigned (it must be explicitly specified)
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndex(Ordering ordering, const Index2D<IndexT, Tag>& index,

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -109,6 +109,7 @@ template <class Coords2DType>
 Coords2DType transposed(const Coords2DType& coords) {
   return {coords.col_, coords.row_};
 }
+
 }
 
 /// A strong-type for 2D sizes
@@ -138,6 +139,11 @@ public:
     return out << static_cast<internal::basic_coords<IndexT>>(index);
   }
 };
+
+template <class T, class Tag>
+std::ostream& operator<<(std::ostream& os, const Size2D<T, Tag>& size) {
+  return os << static_cast<internal::basic_coords<T>>(size);
+}
 
 /// A strong-type for 2D coordinates
 /// @tparam IndexT type for row and column coordinates
@@ -187,6 +193,11 @@ public:
   }
 };
 
+template <class T, class Tag>
+std::ostream& operator<<(std::ostream& os, const Index2D<T, Tag>& size) {
+  return os << static_cast<internal::basic_coords<T>>(size);
+}
+
 /// Compute coords of the @p index -th cell in a row-major ordered 2D grid with size @p dims
 ///
 /// @return an Index2D matching the Size2D (same IndexT and Tag)
@@ -204,7 +215,7 @@ Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
   DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
-  std::ptrdiff_t leading_size = dims.cols();
+  std::ptrdiff_t leading_size = to_signed<std::ptrdiff_t>(dims.cols());
   return {to_signed<IndexT>(linear_index / leading_size),
           to_signed<IndexT>(linear_index % leading_size)};
 }
@@ -226,7 +237,7 @@ Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
   DLAF_ASSERT_MODERATE(to_unsigned<size_t>(linear_index) < mul(dims.rows(), dims.cols()),
                        "Linear index ", std::to_string(linear_index), " does not fit into grid ", dims);
 
-  std::ptrdiff_t leading_size = dims.rows();
+  std::ptrdiff_t leading_size = to_signed<std::ptrdiff_t>(dims.rows());
   return {to_signed<IndexT>(linear_index % leading_size),
           to_signed<IndexT>(linear_index / leading_size)};
 }

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -271,6 +271,7 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
 /// the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned
+/// @pre LinearIndexT must be able to store the result
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
@@ -292,6 +293,7 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
 /// the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned
+/// @pre LinearIndexT must be able to store the result
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
@@ -316,6 +318,7 @@ LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
 /// the casting of the value before returning it, not leaving the burden to the user.
 ///
 /// @tparam LinearIndexT can be any integral type signed or unsigned (it must be explicitly specified)
+/// @pre LinearIndexT must be able to store the result
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndex(Ordering ordering, const Index2D<IndexT, Tag>& index,

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -187,6 +187,13 @@ public:
   }
 };
 
+/// Compute coords of the @p index -th cell in a row-major ordered 2D grid with size @p dims
+///
+/// @return an Index2D matching the Size2D (same IndexT and Tag)
+/// @param dims Size2D<IndexT, Tag> representing the size of the grid
+/// @param index linear index of the cell
+///
+/// @pre 0 <= linear_index < (dims.rows() * dims.cols())
 template <class IndexT, class Tag>
 Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
                                            const Size2D<IndexT, Tag>& dims) noexcept {
@@ -206,6 +213,13 @@ Index2D<IndexT, Tag> computeCoordsRowMajor(std::ptrdiff_t linear_index,
   return index;
 }
 
+/// Compute coords of the @p index -th cell in a column-major ordered 2D grid with size op dims
+///
+/// @return an Index2D matching the Size2D (same IndexT and Tag)
+/// @param dims Size2D<IndexT, Tag> representing the size of the grid
+/// @param index linear index of the cell
+///
+/// @pre 0 <= linear_index < (dims.rows() * dims.cols())
 template <class IndexT, class Tag>
 Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
                                            const Size2D<IndexT, Tag>& dims) noexcept {
@@ -225,12 +239,16 @@ Index2D<IndexT, Tag> computeCoordsColMajor(std::ptrdiff_t linear_index,
   return index;
 }
 
-/// Compute coords of the @p index -th cell in a grid with @p ordering and sizes @p dims
+/// Compute coords of the @p index -th cell in a grid with @p ordering and size @p dims
 ///
-/// Return an Index2D matching the Size2D (same IndexT and Tag)
-/// @param ordering specify linear index layout in the grid
-/// @param dims Size2D<IndexT, Tag>
-/// @param index is the linear index of the cell with specified @p ordering
+/// It acts as dispatcher for computeCoordsColMajor() and computeCoordsRowMajor() depending on given @p ordering
+///
+/// @return an Index2D matching the Size2D (same IndexT and Tag)
+/// @param ordering specifies linear index layout in the grid
+/// @param dims Size2D<IndexT, Tag> representing the size of the grid
+/// @param index linear index of the cell (with specified @p ordering)
+///
+/// @pre 0 <= linear_index < (dims.rows() * dims.cols())
 template <class IndexT, class Tag>
 Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
                                    const Size2D<IndexT, Tag>& dims) noexcept {
@@ -244,6 +262,9 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
   }
 }
 
+/// Compute linear index of an Index2D in a row-major ordered 2D grid
+///
+/// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
                                         const Size2D<IndexT, Tag>& dims) noexcept {
@@ -259,6 +280,9 @@ LinearIndexT computeLinearIndexRowMajor(const Index2D<IndexT, Tag>& index,
   return integral_cast<LinearIndexT>(linear_index);
 }
 
+/// Compute linear index of an Index2D in a column-major ordered 2D grid
+///
+/// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>
 LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
                                         const Size2D<IndexT, Tag>& dims) noexcept {
@@ -275,6 +299,9 @@ LinearIndexT computeLinearIndexColMajor(const Index2D<IndexT, Tag>& index,
 }
 
 /// Compute linear index of an Index2D
+///
+/// It acts as dispatcher for computeLinearIndexColMajor() and computeLinearIndexRowMajor()
+/// depending on given @p ordering
 ///
 /// @pre index.isIn(dims)
 template <class LinearIndexT, class IndexT, class Tag>

--- a/include/dlaf/communication/communicator_grid.h
+++ b/include/dlaf/communication/communicator_grid.h
@@ -56,8 +56,8 @@ public:
 
   /// Return rank in the grid with all ranks given the 2D index
   IndexT_MPI rankFullCommunicator(const Index2D& index) const noexcept {
-    return common::computeLinearIndex(FULL_COMMUNICATOR_ORDER, index,
-                                      {grid_size_.rows(), grid_size_.cols()});
+    return common::computeLinearIndex<IndexT_MPI>(FULL_COMMUNICATOR_ORDER, index,
+                                                  {grid_size_.rows(), grid_size_.cols()});
   }
 
   /// @brief Return the rank of the current process in the CommunicatorGrid

--- a/src/communication/communicator_grid.cpp
+++ b/src/communication/communicator_grid.cpp
@@ -20,15 +20,15 @@ CommunicatorGrid::CommunicatorGrid(Communicator comm, IndexT_MPI nrows, IndexT_M
 
   bool is_in_grid = comm.rank() < nrows * ncols;
 
-  int index_row = MPI_UNDEFINED;
-  int index_col = MPI_UNDEFINED;
-  int key_full = MPI_UNDEFINED;
-  int key = comm.rank();
+  IndexT_MPI index_row = MPI_UNDEFINED;
+  IndexT_MPI index_col = MPI_UNDEFINED;
+  IndexT_MPI key_full = MPI_UNDEFINED;
+  IndexT_MPI key = comm.rank();
 
   comm::Size2D grid_size{nrows, ncols};
   if (is_in_grid) {
     position_ = common::computeCoords(ordering, comm.rank(), grid_size);
-    key_full = common::computeLinearIndex(FULL_COMMUNICATOR_ORDER, position_, grid_size);
+    key_full = common::computeLinearIndex<IndexT_MPI>(FULL_COMMUNICATOR_ORDER, position_, grid_size);
     index_row = position_.row();
     index_col = position_.col();
   }

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -205,8 +205,8 @@ TYPED_TEST(Index2DTest, computeCoords) {
 }
 
 TYPED_TEST(Index2DTest, computeLinearIndex) {
-   using dlaf::common::Ordering;
-   using dlaf::common::computeLinearIndex;
+  using dlaf::common::Ordering;
+  using dlaf::common::computeLinearIndex;
 
 #ifdef DLAF_ASSERT_MODERATE_ENABLE
   {
@@ -223,7 +223,8 @@ TYPED_TEST(Index2DTest, computeLinearIndex) {
 
     for (const auto& ordering : orderings) {
       for (const Size2D<TypeParam>& size : configs) {
-        EXPECT_DEATH(computeLinearIndex<int>(ordering, index, {size.rows(), size.cols()}), ERROR_MESSAGE);
+        EXPECT_DEATH(computeLinearIndex<int>(ordering, index, {size.rows(), size.cols()}),
+                     ERROR_MESSAGE);
         EXPECT_DEATH(computeLinearIndex<int>(ordering, index, Size2D<TypeParam>(size)), ERROR_MESSAGE);
       }
     }

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -141,55 +141,38 @@ TYPED_TEST(Index2DTest, Print) {
   EXPECT_EQ("(9, 6)", s.str());
 }
 
-TYPED_TEST(Index2DTest, computeCoords) {
+TYPED_TEST(Index2DTest, computeCoordsColMajor) {
+  const auto COL_MAJOR = dlaf::common::Ordering::ColumnMajor;
+
   using dlaf::common::computeCoords;
-  using dlaf::common::Ordering;
 
-  {
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::ColumnMajor, int8_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::ColumnMajor, int32_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::ColumnMajor, int64_t(0), Size2D<TypeParam>{1, 1}));
+  Size2D<TypeParam> grid_size(110, 78);
 
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::ColumnMajor, uint8_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::ColumnMajor, uint32_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::ColumnMajor, uint64_t(0), Size2D<TypeParam>{1, 1}));
+  int32_t linear_index = 0;
+  for (auto j = 0; j < grid_size.cols(); ++j) {
+    for (auto i = 0; i < grid_size.rows(); ++i) {
+      EXPECT_EQ(Index2D<TypeParam>(i, j), computeCoords(COL_MAJOR, linear_index, grid_size));
+      EXPECT_EQ(Index2D<TypeParam>(i, j), computeCoordsColMajor(linear_index, grid_size));
+      ++linear_index;
+    }
   }
+}
 
-  {
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::RowMajor, int8_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::RowMajor, int32_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::RowMajor, int64_t(0), Size2D<TypeParam>{1, 1}));
+TYPED_TEST(Index2DTest, computeCoordsRowMajor) {
+  const auto ROW_MAJOR = dlaf::common::Ordering::RowMajor;
 
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::RowMajor, uint8_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::RowMajor, uint32_t(0), Size2D<TypeParam>{1, 1}));
-    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
-              computeCoords(Ordering::RowMajor, uint64_t(0), Size2D<TypeParam>{1, 1}));
+  using dlaf::common::computeCoords;
+
+  Size2D<TypeParam> grid_size(110, 78);
+
+  int32_t linear_index = 0;
+  for (auto i = 0; i < grid_size.rows(); ++i) {
+    for (auto j = 0; j < grid_size.cols(); ++j) {
+      EXPECT_EQ(Index2D<TypeParam>(i, j), computeCoords(ROW_MAJOR, linear_index, grid_size));
+      EXPECT_EQ(Index2D<TypeParam>(i, j), computeCoordsRowMajor(linear_index, grid_size));
+      ++linear_index;
+    }
   }
-
-#ifdef DLAF_ASSERT_MODERATE_ENABLE
-  std::array<Ordering, 2> orderings{Ordering::RowMajor, Ordering::ColumnMajor};
-
-  const char* ERROR_MESSAGE = "\\[ERROR\\]";
-
-  for (const auto& ordering : orderings) {
-    // linear index out of grid bounds
-    EXPECT_DEATH(computeCoords(ordering, -1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
-
-    // negative linear index
-    EXPECT_DEATH(computeCoords(ordering, 1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
-  }
-#endif
 }
 
 TYPED_TEST(Index2DTest, computeLinearIndex) {
@@ -207,27 +190,4 @@ TYPED_TEST(Index2DTest, computeLinearIndex) {
     EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, {26, 5}));
     EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, Size2D<TypeParam>{26, 5}));
   }
-
-#ifdef DLAF_ASSERT_MODERATE_ENABLE
-  {
-    const Index2D<TypeParam> index(13, 26);
-    std::vector<Size2D<TypeParam>> configs{{
-        Size2D<TypeParam>{13, 26},  // out-of-rows & out-of-cols
-        Size2D<TypeParam>{13, 39},  // out-of-rows
-        Size2D<TypeParam>{26, 26},  // out-of-cols
-    }};
-
-    std::array<Ordering, 2> orderings{Ordering::RowMajor, Ordering::ColumnMajor};
-
-    const char* ERROR_MESSAGE = "\\[ERROR\\]";
-
-    for (const auto& ordering : orderings) {
-      for (const Size2D<TypeParam>& size : configs) {
-        EXPECT_DEATH(computeLinearIndex<int>(ordering, index, {size.rows(), size.cols()}),
-                     ERROR_MESSAGE);
-        EXPECT_DEATH(computeLinearIndex<int>(ordering, index, Size2D<TypeParam>(size)), ERROR_MESSAGE);
-      }
-    }
-  }
-#endif
 }

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -145,10 +145,11 @@ TYPED_TEST(Index2DTest, computeCoordsColMajor) {
   const auto COL_MAJOR = dlaf::common::Ordering::ColumnMajor;
 
   using dlaf::common::computeCoords;
+  using dlaf::common::computeCoordsColMajor;
 
   Size2D<TypeParam> grid_size(110, 78);
 
-  int32_t linear_index = 0;
+  int16_t linear_index = 0;
   for (auto j = 0; j < grid_size.cols(); ++j) {
     for (auto i = 0; i < grid_size.rows(); ++i) {
       EXPECT_EQ(Index2D<TypeParam>(i, j), computeCoords(COL_MAJOR, linear_index, grid_size));
@@ -162,10 +163,11 @@ TYPED_TEST(Index2DTest, computeCoordsRowMajor) {
   const auto ROW_MAJOR = dlaf::common::Ordering::RowMajor;
 
   using dlaf::common::computeCoords;
+  using dlaf::common::computeCoordsRowMajor;
 
   Size2D<TypeParam> grid_size(110, 78);
 
-  int32_t linear_index = 0;
+  int16_t linear_index = 0;
   for (auto i = 0; i < grid_size.rows(); ++i) {
     for (auto j = 0; j < grid_size.cols(); ++j) {
       EXPECT_EQ(Index2D<TypeParam>(i, j), computeCoords(ROW_MAJOR, linear_index, grid_size));
@@ -175,19 +177,40 @@ TYPED_TEST(Index2DTest, computeCoordsRowMajor) {
   }
 }
 
-TYPED_TEST(Index2DTest, computeLinearIndex) {
+TYPED_TEST(Index2DTest, computeLinearIndexColMajor) {
+  const auto COL_MAJOR = dlaf::common::Ordering::ColumnMajor;
+
   using dlaf::common::computeLinearIndex;
-  using dlaf::common::Ordering;
+  using dlaf::common::computeLinearIndexColMajor;
 
-  {
-    const Index2D<TypeParam> index{3, 2};
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, {5, 26}));
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, Size2D<TypeParam>{5, 26}));
+  Size2D<TypeParam> grid_size(110, 78);
+
+  int16_t linear_index = 0;
+  for (auto j = 0; j < grid_size.cols(); ++j) {
+    for (auto i = 0; i < grid_size.rows(); ++i) {
+      EXPECT_EQ(linear_index,
+                computeLinearIndex<int16_t>(COL_MAJOR, Index2D<TypeParam>(i, j), grid_size));
+      EXPECT_EQ(linear_index, computeLinearIndexColMajor<int16_t>(Index2D<TypeParam>(i, j), grid_size));
+      ++linear_index;
+    }
   }
+}
 
-  {
-    const Index2D<TypeParam> index{2, 3};
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, {26, 5}));
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, Size2D<TypeParam>{26, 5}));
+TYPED_TEST(Index2DTest, computeLinearIndexRowMajor) {
+  const auto ROW_MAJOR = dlaf::common::Ordering::RowMajor;
+
+  using dlaf::common::computeLinearIndex;
+  using dlaf::common::computeLinearIndexRowMajor;
+
+  Size2D<TypeParam> grid_size(110, 78);
+
+  int16_t linear_index = 0;
+  for (auto i = 0; i < grid_size.rows(); ++i) {
+    for (auto j = 0; j < grid_size.cols(); ++j) {
+      EXPECT_EQ(linear_index,
+                computeLinearIndex<int16_t>(ROW_MAJOR, Index2D<TypeParam>(i, j), grid_size));
+      EXPECT_EQ(linear_index, computeLinearIndexRowMajor<int16_t>(Index2D<TypeParam>(i, j), grid_size));
+      ++linear_index;
+    }
   }
 }

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -145,68 +145,68 @@ TYPED_TEST(Index2DTest, computeCoords) {
   using dlaf::common::computeCoords;
   using dlaf::common::Ordering;
 
-  Ordering ordering = Ordering::ColumnMajor;
+  {
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::ColumnMajor, int8_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::ColumnMajor, int32_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::ColumnMajor, int64_t(0), Size2D<TypeParam>{1, 1}));
+
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::ColumnMajor, uint8_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::ColumnMajor, uint32_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::ColumnMajor, uint64_t(0), Size2D<TypeParam>{1, 1}));
+  }
+
+  {
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::RowMajor, int8_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::RowMajor, int32_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::RowMajor, int64_t(0), Size2D<TypeParam>{1, 1}));
+
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::RowMajor, uint8_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::RowMajor, uint32_t(0), Size2D<TypeParam>{1, 1}));
+    EXPECT_EQ((Index2D<TypeParam>{0, 0}),
+              computeCoords(Ordering::RowMajor, uint64_t(0), Size2D<TypeParam>{1, 1}));
+  }
 
 #ifdef DLAF_ASSERT_MODERATE_ENABLE
+  std::array<Ordering, 2> orderings{Ordering::RowMajor, Ordering::ColumnMajor};
+
   const char* ERROR_MESSAGE = "\\[ERROR\\]";
 
-  EXPECT_DEATH(computeCoords(ordering, 1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
-  EXPECT_DEATH(computeCoords(ordering, -1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
+  for (const auto& ordering : orderings) {
+    // linear index out of grid bounds
+    EXPECT_DEATH(computeCoords(ordering, -1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
+
+    // negative linear index
+    EXPECT_DEATH(computeCoords(ordering, 1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
+  }
 #endif
-
-  // TEST index with type that cannot span the entire grid size
-  {
-    using linear_index_t = int8_t;
-
-    linear_index_t upper_bound = std::numeric_limits<int8_t>::max();
-
-    EXPECT_EQ((Index2D<TypeParam>{0, 1}),
-              computeCoords(ordering, upper_bound, Size2D<TypeParam>{upper_bound, 2}));
-  }
-
-  {
-    using linear_index_t = uint8_t;
-
-    linear_index_t upper_bound = std::numeric_limits<int8_t>::max();
-
-    EXPECT_EQ((Index2D<TypeParam>{0, 1}),
-              computeCoords(ordering, upper_bound,
-                            Size2D<TypeParam>{static_cast<TypeParam>(upper_bound), 2}));
-  }
-
-  // linear index with a different type
-  EXPECT_EQ((Index2D<TypeParam>{0, 0}), computeCoords(ordering, int8_t(0), Size2D<TypeParam>{1, 1}));
-  EXPECT_EQ((Index2D<TypeParam>{0, 0}), computeCoords(ordering, int64_t(0), Size2D<TypeParam>{1, 1}));
-
-  EXPECT_EQ((Index2D<TypeParam>{0, 0}), computeCoords(ordering, uint8_t(0), Size2D<TypeParam>{1, 1}));
-  EXPECT_EQ((Index2D<TypeParam>{0, 0}), computeCoords(ordering, uint64_t(0), Size2D<TypeParam>{1, 1}));
-
-  // check that returns the components with the right type
-  EXPECT_TRUE((
-      std::is_same<TypeParam,
-                   decltype(computeCoords(ordering, int64_t{0}, Size2D<TypeParam>{1, 1}).row())>::value));
-  EXPECT_TRUE((
-      std::is_same<TypeParam,
-                   decltype(computeCoords(ordering, int64_t{0}, Size2D<TypeParam>{1, 1}).col())>::value));
-  EXPECT_TRUE(
-      (std::is_same<TypeParam, decltype(computeCoords(ordering, uint64_t{0}, Size2D<TypeParam>{1, 1})
-                                            .row())>::value));
-  EXPECT_TRUE(
-      (std::is_same<TypeParam, decltype(computeCoords(ordering, uint64_t{0}, Size2D<TypeParam>{1, 1})
-                                            .col())>::value));
-
-  // check that it returns the right type
-  EXPECT_TRUE(
-      (std::is_same<Index2D<TypeParam>,
-                    decltype(computeCoords(ordering, int64_t(0), Size2D<TypeParam>{1, 1}))>::value));
-  EXPECT_TRUE(
-      (std::is_same<Index2D<TypeParam>,
-                    decltype(computeCoords(ordering, uint64_t(0), Size2D<TypeParam>{1, 1}))>::value));
 }
 
 TYPED_TEST(Index2DTest, computeLinearIndex) {
-  using dlaf::common::Ordering;
   using dlaf::common::computeLinearIndex;
+  using dlaf::common::Ordering;
+
+  {
+    const Index2D<TypeParam> index{3, 2};
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, {5, 26}));
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, Size2D<TypeParam>{5, 26}));
+  }
+
+  {
+    const Index2D<TypeParam> index{2, 3};
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, {26, 5}));
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, Size2D<TypeParam>{26, 5}));
+  }
 
 #ifdef DLAF_ASSERT_MODERATE_ENABLE
   {
@@ -230,16 +230,4 @@ TYPED_TEST(Index2DTest, computeLinearIndex) {
     }
   }
 #endif
-
-  {
-    const Index2D<TypeParam> index{3, 2};
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, {5, 26}));
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, Size2D<TypeParam>{5, 26}));
-  }
-
-  {
-    const Index2D<TypeParam> index{2, 3};
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, {26, 5}));
-    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, Size2D<TypeParam>{26, 5}));
-  }
 }

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -148,8 +148,10 @@ TYPED_TEST(Index2DTest, computeCoords) {
   Ordering ordering = Ordering::ColumnMajor;
 
 #ifdef DLAF_ASSERT_MODERATE_ENABLE
-  EXPECT_DEATH(computeCoords(ordering, 1, Size2D<TypeParam>{1, 1}), "[ERROR]");
-  EXPECT_DEATH(computeCoords(ordering, -1, Size2D<TypeParam>{1, 1}), "[ERROR]");
+  const char* ERROR_MESSAGE = "\\[ERROR\\]";
+
+  EXPECT_DEATH(computeCoords(ordering, 1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
+  EXPECT_DEATH(computeCoords(ordering, -1, Size2D<TypeParam>{1, 1}), ERROR_MESSAGE);
 #endif
 
   // TEST index with type that cannot span the entire grid size
@@ -216,10 +218,12 @@ TYPED_TEST(Index2DTest, computeLinearIndex) {
 
     std::array<Ordering, 2> orderings{Ordering::RowMajor, Ordering::ColumnMajor};
 
+    const char* ERROR_MESSAGE = "\\[ERROR\\]";
+
     for (const auto& ordering : orderings) {
       for (const Size2D<TypeParam>& size : configs) {
-        EXPECT_DEATH(computeLinearIndex(ordering, index, {size.rows(), size.cols()}), "[ERROR]");
-        EXPECT_DEATH(computeLinearIndex(ordering, index, Size2D<TypeParam>(size)), "[ERROR]");
+        EXPECT_DEATH(computeLinearIndex(ordering, index, {size.rows(), size.cols()}), ERROR_MESSAGE);
+        EXPECT_DEATH(computeLinearIndex(ordering, index, Size2D<TypeParam>(size)), ERROR_MESSAGE);
       }
     }
   }

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -205,7 +205,8 @@ TYPED_TEST(Index2DTest, computeCoords) {
 }
 
 TYPED_TEST(Index2DTest, computeLinearIndex) {
-  using dlaf::common::Ordering;
+   using dlaf::common::Ordering;
+   using dlaf::common::computeLinearIndex;
 
 #ifdef DLAF_ASSERT_MODERATE_ENABLE
   {
@@ -222,8 +223,8 @@ TYPED_TEST(Index2DTest, computeLinearIndex) {
 
     for (const auto& ordering : orderings) {
       for (const Size2D<TypeParam>& size : configs) {
-        EXPECT_DEATH(computeLinearIndex(ordering, index, {size.rows(), size.cols()}), ERROR_MESSAGE);
-        EXPECT_DEATH(computeLinearIndex(ordering, index, Size2D<TypeParam>(size)), ERROR_MESSAGE);
+        EXPECT_DEATH(computeLinearIndex<int>(ordering, index, {size.rows(), size.cols()}), ERROR_MESSAGE);
+        EXPECT_DEATH(computeLinearIndex<int>(ordering, index, Size2D<TypeParam>(size)), ERROR_MESSAGE);
       }
     }
   }
@@ -231,13 +232,13 @@ TYPED_TEST(Index2DTest, computeLinearIndex) {
 
   {
     const Index2D<TypeParam> index{3, 2};
-    EXPECT_EQ(13, computeLinearIndex(Ordering::ColumnMajor, index, {5, 26}));
-    EXPECT_EQ(13, computeLinearIndex(Ordering::ColumnMajor, index, Size2D<TypeParam>{5, 26}));
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, {5, 26}));
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::ColumnMajor, index, Size2D<TypeParam>{5, 26}));
   }
 
   {
     const Index2D<TypeParam> index{2, 3};
-    EXPECT_EQ(13, computeLinearIndex(Ordering::RowMajor, index, {26, 5}));
-    EXPECT_EQ(13, computeLinearIndex(Ordering::RowMajor, index, Size2D<TypeParam>{26, 5}));
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, {26, 5}));
+    EXPECT_EQ(13, computeLinearIndex<int>(Ordering::RowMajor, index, Size2D<TypeParam>{26, 5}));
   }
 }

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -70,8 +70,8 @@ TYPED_TEST(MatrixUtilsTest, Set) {
       Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), layout, mem());
 
       auto linear_matrix = [size = matrix.size()](const GlobalElementIndex& index) {
-        auto linear_index = dlaf::common::computeLinearIndex(dlaf::common::Ordering::RowMajor, index,
-                                                             {size.rows(), size.cols()});
+        auto linear_index = dlaf::common::computeLinearIndex<int>(dlaf::common::Ordering::RowMajor,
+                                                                  index, {size.rows(), size.cols()});
         return TypeUtilities<TypeParam>::element(linear_index, linear_index);
       };
 

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -70,8 +70,7 @@ TYPED_TEST(MatrixUtilsTest, Set) {
       Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), layout, mem());
 
       auto linear_matrix = [size = matrix.size()](const GlobalElementIndex& index) {
-        auto linear_index = dlaf::common::computeLinearIndex<int>(dlaf::common::Ordering::RowMajor,
-                                                                  index, {size.rows(), size.cols()});
+        auto linear_index = common::computeLinearIndex<int>(common::Ordering::RowMajor, index, size);
         return TypeUtilities<TypeParam>::element(linear_index, linear_index);
       };
 

--- a/test/unit/test_types.cpp
+++ b/test/unit/test_types.cpp
@@ -21,7 +21,7 @@ using dlaf::to_unsigned;
 using dlaf::integral_cast;
 using dlaf::common::internal::source_location;
 
-constexpr const char* ERROR_MESSAGE = "[ERROR]";
+const char* ERROR_MESSAGE = "\\[ERROR\\]";
 
 template <class T>
 const auto LOWER_BOUND = std::numeric_limits<T>::min;


### PR DESCRIPTION
This is just a "branch" proposal, because I'm not sure to be on the right path and I'm willing to receive your feedbacks. @rasolca @teonnik 

### 1. `to_signed` / `to_unsigned`
Add "same signedness" fallback functions for both `to_signed` and `to_unsigned`: these will generalize the helper functions for the `static_cast` (with DLAF_ASSERT for optional checks).

### 2. `computeCoords`
It accepts any kind of integral type as linear index, and it performs some (optional) checks.
Moreover, computations are performed by forcing the "promotion" to unsigned for both types (`IndexT` and `LinearIndexT`) and then the function `to_signed` is used for a "safe cast".

I want to highlight that the type of the `Index2D` you get as result is strictly related to the Size2D you pass, i.e. you will get the matching one.

### 3. `computeLinearIndex`
Calculation of the linear index is performed with `std::size_t` arithmetics, then it is casted using `to_signed` to the `IndexT`.

This is a limitation since it may be not possible to store the 1D linear index of a generic 2D position  (i.e. we can have a grid of more than `std::numerical_limits<IndexT>::max()` using `IndexT` as size for the two components, e.g. `IndexT = int8_t` 20x20 grid, the bottom right elements can not be calculated)

We may overcome this issue by explicitly specifying the return type of the method via the template parameter.