### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pipeline status](https://gitlab.com/cscs-ci/eth-cscs/DLA-Future-CI/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/eth-cscs/DLA-Future-CI/-/commits/master)
+[![pipeline status](https://gitlab.com/cscs-ci/eth-cscs/DLA-Future/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/eth-cscs/DLA-Future/-/commits/master)
 
 # Distributed Linear Algebra with Futures.
 


### PR DESCRIPTION
It pointed to the wrong repo.

I've also updated the CI to run on `master` instead of just PRs