### PR TITLE
Improve and fix safe integer casting helper functions

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -8,6 +8,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+DLAF_addTest(test_types SOURCES test_types.cpp USE_MAIN PLAIN)
+
 DLAF_addTest(test_util_math SOURCES test_util_math.cpp USE_MAIN PLAIN)
 
 DLAF_addTest(test_blas_tile SOURCES test_blas_tile.cpp USE_MAIN HPX)

--- a/test/unit/test_types.cpp
+++ b/test/unit/test_types.cpp
@@ -1,0 +1,158 @@
+// force enable DLAF_ASSERT_MODERATE, otherwise cast checks cannot be tested
+#ifndef DLAF_ASSERT_MODERATE_ENABLE
+#define DLAF_ASSERT_MODERATE_ENABLE
+#endif
+
+#include "dlaf/types.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "dlaf/common/utils.h"
+
+using dlaf::to_signed;
+using dlaf::to_unsigned;
+using dlaf::integral_cast;
+using dlaf::common::internal::source_location;
+
+constexpr const char* ERROR_MESSAGE = "[ERROR]";
+
+template <class T>
+const auto LOWER_BOUND = std::numeric_limits<T>::min;
+
+template <class T>
+const auto UPPER_BOUND = std::numeric_limits<T>::max;
+
+/// Check that no alteration happens during cast From -> To with @param cast_func and dlaf::integral_cast
+///
+/// Given template type parameters @tparam From and @tparam To,
+/// This function calls @p cast_func with a @tparam From parameter, then
+/// it compares the return value of @p cast_func and dlaf::integral_cast, of type To, with the
+/// static_cast<To> of the value in From
+template <class From, class To>
+void TEST_CAST(To (*cast_func)(From), const From value, const source_location origin) {
+  ::testing::ScopedTrace trace(origin.filename, static_cast<int>(origin.line), "");
+  EXPECT_EQ(static_cast<To>(value), cast_func(value));
+  EXPECT_EQ(static_cast<To>(value), (integral_cast<To, From>(value)));
+}
+
+/// Check that an error is generated during casting operation From -> To
+template <class From, class To>
+void TEST_CAST_FAIL(To (*cast_func)(From), const From value, const source_location origin) {
+  ::testing::ScopedTrace trace(origin.filename, static_cast<int>(origin.line), "");
+  EXPECT_DEATH(cast_func(value), ERROR_MESSAGE);
+  EXPECT_DEATH((integral_cast<To, From>(value)), ERROR_MESSAGE);
+}
+
+#define DLAF_TEST_CAST(From, To, ...) TEST_CAST<From, To>(__VA_ARGS__, SOURCE_LOCATION())
+#define DLAF_TEST_CAST_FAIL(From, To, ...) TEST_CAST_FAIL<From, To>(__VA_ARGS__, SOURCE_LOCATION())
+
+TEST(ToSigned, FromUnsigned) {
+  using To = int16_t;
+
+  // UP CAST
+  //       |---|
+  // |-----|-----|
+  DLAF_TEST_CAST(uint8_t, To, to_signed, 13);
+  DLAF_TEST_CAST(uint8_t, To, to_signed, LOWER_BOUND<uint8_t>());
+  DLAF_TEST_CAST(uint8_t, To, to_signed, UPPER_BOUND<uint8_t>());
+
+  // SAME CAST
+  //       |-----------|
+  // |-----|-----|
+  DLAF_TEST_CAST(uint16_t, To, to_signed, 13);
+  DLAF_TEST_CAST(uint16_t, To, to_signed, LOWER_BOUND<uint16_t>());
+  DLAF_TEST_CAST(uint16_t, To, to_signed, UPPER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(uint16_t, To, to_signed, UPPER_BOUND<uint16_t>());
+
+  // DOWN CAST
+  //       |-----------|
+  // |-----|-----|
+  DLAF_TEST_CAST(uint32_t, To, to_signed, 13);
+  DLAF_TEST_CAST(uint32_t, To, to_signed, LOWER_BOUND<uint32_t>());
+  DLAF_TEST_CAST(uint32_t, To, to_signed, UPPER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(uint32_t, To, to_signed, UPPER_BOUND<uint32_t>());
+}
+
+TEST(ToSigned, FromSigned) {
+  using To = int16_t;
+
+  // UP CAST
+  //   |---|---|
+  // |-----|-----|
+  DLAF_TEST_CAST(int8_t, To, to_signed, 13);
+  DLAF_TEST_CAST(int8_t, To, to_signed, LOWER_BOUND<int8_t>());
+  DLAF_TEST_CAST(int8_t, To, to_signed, UPPER_BOUND<int8_t>());
+
+  //  SAME CAST
+  // |-----|-----|
+  // |-----|-----|
+  DLAF_TEST_CAST(int16_t, To, to_signed, 13);
+  DLAF_TEST_CAST(int16_t, To, to_signed, LOWER_BOUND<int16_t>());
+  DLAF_TEST_CAST(int16_t, To, to_signed, UPPER_BOUND<int16_t>());
+
+  // DOWN CAST
+  // |-----|-----|
+  //   |---|---|
+  DLAF_TEST_CAST(int32_t, To, to_signed, 13);
+  DLAF_TEST_CAST(int32_t, To, to_signed, LOWER_BOUND<To>());
+  DLAF_TEST_CAST(int32_t, To, to_signed, UPPER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(int32_t, To, to_signed, LOWER_BOUND<int32_t>());
+  DLAF_TEST_CAST_FAIL(int32_t, To, to_signed, UPPER_BOUND<int32_t>());
+}
+
+TEST(ToUnsigned, FromSigned) {
+  using To = uint16_t;
+
+  // UP CAST
+  // |-----|-----|
+  //       |-----------|
+  DLAF_TEST_CAST(int8_t, To, to_unsigned, 13);
+  DLAF_TEST_CAST(int8_t, To, to_unsigned, LOWER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(int8_t, To, to_unsigned, LOWER_BOUND<int8_t>());
+  DLAF_TEST_CAST(int8_t, To, to_unsigned, UPPER_BOUND<int8_t>());
+
+  // SAME CAST
+  // |-----|-----|
+  //       |-----------|
+  DLAF_TEST_CAST(int16_t, To, to_unsigned, 13);
+  DLAF_TEST_CAST(int16_t, To, to_unsigned, LOWER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(int16_t, To, to_unsigned, LOWER_BOUND<int16_t>());
+  DLAF_TEST_CAST(int16_t, To, to_unsigned, UPPER_BOUND<int16_t>());
+
+  // DOWN CAST
+  // |-----|-----|
+  //       |---|
+  DLAF_TEST_CAST(int32_t, To, to_unsigned, 13);
+  DLAF_TEST_CAST(int32_t, To, to_unsigned, LOWER_BOUND<To>());
+  DLAF_TEST_CAST(int32_t, To, to_unsigned, UPPER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(int32_t, To, to_unsigned, LOWER_BOUND<int32_t>());
+  DLAF_TEST_CAST_FAIL(int32_t, To, to_unsigned, UPPER_BOUND<int32_t>());
+}
+
+TEST(ToUnsigned, FromUnsigned) {
+  using To = uint16_t;
+
+  // UP CAST
+  // |---|
+  // |-----|
+  DLAF_TEST_CAST(uint8_t, To, to_unsigned, 13);
+  DLAF_TEST_CAST(uint8_t, To, to_unsigned, LOWER_BOUND<uint8_t>());
+  DLAF_TEST_CAST(uint8_t, To, to_unsigned, UPPER_BOUND<uint8_t>());
+
+  // SAME CAST
+  // |-----|
+  // |-----|
+  DLAF_TEST_CAST(uint16_t, To, to_unsigned, 13);
+  DLAF_TEST_CAST(uint16_t, To, to_unsigned, LOWER_BOUND<uint16_t>());
+  DLAF_TEST_CAST(uint16_t, To, to_unsigned, UPPER_BOUND<uint16_t>());
+
+  // DOWN CAST
+  // |-----|
+  // |---|
+  DLAF_TEST_CAST(uint32_t, To, to_unsigned, 13);
+  DLAF_TEST_CAST(uint32_t, To, to_unsigned, LOWER_BOUND<uint32_t>());
+  DLAF_TEST_CAST(uint32_t, To, to_unsigned, UPPER_BOUND<To>());
+  DLAF_TEST_CAST_FAIL(uint32_t, To, to_unsigned, UPPER_BOUND<uint32_t>());
+}


### PR DESCRIPTION
Highlights:

- extend `to_signed` and `to_unsigned`: they now accept any integral type as input, while as output they accept just a signed or unsigned integral type, respectively;
- add `integral_cast` that acts as a dispatcher for the previous two, and can convert from/to any integral type.

All these helper functions are just simple `static_cast`, but they have runtime checks in case DLAF_ASSERT_MODERATE level is enabled.

The unit test `test_types` has been introduced.