### PR TITLE
Improve computeCoords API

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -178,6 +178,18 @@ public:
   }
 };
 
+template <class IndexT, class Tag, class LinearIndexT>
+Index2D<IndexT, Tag> computeCoordsRowMajor(LinearIndexT index,
+                                   const Size2D<IndexT, Tag>& dims) noexcept {
+  return {static_cast<IndexT>(index / dims.cols()), static_cast<IndexT>(index % dims.cols())};
+}
+
+template <class IndexT, class Tag, class LinearIndexT>
+Index2D<IndexT, Tag> computeCoordsColMajor(LinearIndexT index,
+                                   const Size2D<IndexT, Tag>& dims) noexcept {
+  return {static_cast<IndexT>(index % dims.rows()), static_cast<IndexT>(index / dims.rows())};
+}
+
 /// Compute coords of the @p index -th cell in a grid with @p ordering and sizes @p dims
 ///
 /// Return an Index2D matching the Size2D (same IndexT and Tag)
@@ -189,9 +201,9 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, LinearIndexT index,
                                    const Size2D<IndexT, Tag>& dims) noexcept {
   switch (ordering) {
     case Ordering::RowMajor:
-      return {static_cast<IndexT>(index / dims.cols()), static_cast<IndexT>(index % dims.cols())};
+      return computeCoordsRowMajor(index, dims);
     case Ordering::ColumnMajor:
-      return {static_cast<IndexT>(index % dims.rows()), static_cast<IndexT>(index / dims.rows())};
+      return computeCoordsColMajor(index, dims);
     default:
       return {};
   }

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -178,20 +178,20 @@ public:
   }
 };
 
-/// Compute Index2D of a linear index inside a 2D grid with specified size and ordering
+/// Compute coords of the @p index -th cell in a grid with @p ordering and sizes @p dims
+///
+/// Return an Index2D matching the Size2D (same IndexT and Tag)
 /// @param ordering specify linear index layout in the grid
-/// @param dims with number of rows at @p dims[0] and number of columns at @p dims[1]
+/// @param dims Size2D<IndexT, Tag>
 /// @param index is the linear index of the cell with specified @p ordering
-template <class Index2DType, typename LinearIndexT>
-Index2DType computeCoords(Ordering ordering, LinearIndexT index,
-                          const std::array<typename Index2DType::IndexType, 2>& dims) {
-  using IndexType = typename Index2DType::IndexType;
-
+template <class IndexT, class Tag, class LinearIndexT>
+Index2D<IndexT, Tag> computeCoords(Ordering ordering, LinearIndexT index,
+                                   const Size2D<IndexT, Tag>& dims) noexcept {
   switch (ordering) {
     case Ordering::RowMajor:
-      return {static_cast<IndexType>(index / dims[1]), static_cast<IndexType>(index % dims[1])};
+      return {static_cast<IndexT>(index / dims.cols()), static_cast<IndexT>(index % dims.cols())};
     case Ordering::ColumnMajor:
-      return {static_cast<IndexType>(index % dims[0]), static_cast<IndexType>(index / dims[0])};
+      return {static_cast<IndexT>(index % dims.rows()), static_cast<IndexT>(index / dims.rows())};
     default:
       return {};
   }

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -180,13 +180,13 @@ public:
 
 template <class IndexT, class Tag, class LinearIndexT>
 Index2D<IndexT, Tag> computeCoordsRowMajor(LinearIndexT index,
-                                   const Size2D<IndexT, Tag>& dims) noexcept {
+                                           const Size2D<IndexT, Tag>& dims) noexcept {
   return {static_cast<IndexT>(index / dims.cols()), static_cast<IndexT>(index % dims.cols())};
 }
 
 template <class IndexT, class Tag, class LinearIndexT>
 Index2D<IndexT, Tag> computeCoordsColMajor(LinearIndexT index,
-                                   const Size2D<IndexT, Tag>& dims) noexcept {
+                                           const Size2D<IndexT, Tag>& dims) noexcept {
   return {static_cast<IndexT>(index % dims.rows()), static_cast<IndexT>(index / dims.rows())};
 }
 

--- a/src/communication/communicator_grid.cpp
+++ b/src/communication/communicator_grid.cpp
@@ -25,9 +25,10 @@ CommunicatorGrid::CommunicatorGrid(Communicator comm, IndexT_MPI nrows, IndexT_M
   int key_full = MPI_UNDEFINED;
   int key = comm.rank();
 
+  comm::Size2D grid_size{nrows, ncols};
   if (is_in_grid) {
-    position_ = common::computeCoords<Index2D>(ordering, comm.rank(), {nrows, ncols});
-    key_full = common::computeLinearIndex(FULL_COMMUNICATOR_ORDER, position_, {nrows, ncols});
+    position_ = common::computeCoords(ordering, comm.rank(), grid_size);
+    key_full = common::computeLinearIndex(FULL_COMMUNICATOR_ORDER, position_, grid_size);
     index_row = position_.row();
     index_col = position_.col();
   }
@@ -40,7 +41,7 @@ CommunicatorGrid::CommunicatorGrid(Communicator comm, IndexT_MPI nrows, IndexT_M
   if (!is_in_grid)
     return;
 
-  grid_size_ = {nrows, ncols};
+  grid_size_ = grid_size;
 
   full_ = make_communicator_managed(mpi_full);
   row_ = make_communicator_managed(mpi_row);

--- a/test/unit/communication/test_communicator_grid.cpp
+++ b/test/unit/communication/test_communicator_grid.cpp
@@ -185,9 +185,9 @@ TEST_P(CommunicatorGridTest, ConstructorIncomplete) {
   Communicator world(MPI_COMM_WORLD);
   CommunicatorGrid incomplete_grid(world, grid_dims, GetParam());
 
-  auto coords = dlaf::common::computeCoords<Index2D>(GetParam(), world.rank(), grid_dims);
-
   if (world.rank() != NUM_MPI_RANKS - 1) {  // ranks in the grid
+    auto coords = dlaf::common::computeCoords(GetParam(), world.rank(), Size2D(grid_dims));
+
     EXPECT_EQ(NUM_MPI_RANKS - 1, incomplete_grid.size().rows());
     EXPECT_EQ(1, incomplete_grid.size().cols());
 
@@ -239,7 +239,7 @@ TEST_P(CommunicatorGridTest, Rank) {
   EXPECT_EQ(grid_dims[0], complete_grid.size().rows());
   EXPECT_EQ(grid_dims[1], complete_grid.size().cols());
 
-  auto coords = dlaf::common::computeCoords<Index2D>(GetParam(), world.rank(), grid_dims);
+  auto coords = dlaf::common::computeCoords(GetParam(), world.rank(), Size2D(grid_dims));
 
   check_rank_full_communicator(complete_grid);
   EXPECT_EQ(coords.row(), complete_grid.rank().row());


### PR DESCRIPTION
Adapt `computeCoords` API
- accepting `Size2D` as per https://github.com/eth-cscs/DLA-Future/pull/183#issuecomment-613978093,
- plus compile-time ordering selection as per need of https://github.com/eth-cscs/DLA-Future/pull/199#discussion_r415756795.