### PR TITLE
Update spack packages

### DIFF
--- a/spack_dlaf/packages/blaspp/package.py
+++ b/spack_dlaf/packages/blaspp/package.py
@@ -39,7 +39,7 @@ class Blaspp(CMakePackage):
         spec = self.spec
         args = ['-DBLASPP_BUILD_TESTS=OFF']
 
-        if '+gfort':
+        if '+gfort' in spec:
             args.append('-DBLAS_LIBRARY_MKL="GNU gfortran conventions"')
         else:
             args.append('-DBLAS_LIBRARY_MKL="Intel ifort conventions"')
@@ -62,7 +62,7 @@ class Blaspp(CMakePackage):
         #
         # - apple : BLAS_LIBRARY="Apple Accelerate" (veclibfort ???)
         #
-        if '^mkl' in spec :
+        if '^mkl' in spec:
             args.append('-DBLAS_LIBRARY="Intel MKL"')
         elif '^essl' in spec:
             args.append('-DBLAS_LIBRARY="IBM ESSL"')

--- a/spack_dlaf/packages/blaspp/package.py
+++ b/spack_dlaf/packages/blaspp/package.py
@@ -1,4 +1,10 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
+
 
 # 1) The CMake options exposed by `blaspp` allow for a value called `auto`. The
 #    value is not needed here as the choice of dependency in the spec determines
@@ -12,7 +18,7 @@ class Blaspp(CMakePackage):
 
     homepage = "https://bitbucket.org/icl/blaspp"
     hg       = "https://bitbucket.org/icl/blaspp"
-    maintainers = ['Sely85', 'teonnik']
+    maintainers = ['teonnik', 'Sely85']
 
     version('develop', hg=hg, revision="5191c9d")
 

--- a/spack_dlaf/packages/blaspp/package.py
+++ b/spack_dlaf/packages/blaspp/package.py
@@ -12,20 +12,42 @@ class Blaspp(CMakePackage):
 
     homepage = "https://bitbucket.org/icl/blaspp"
     hg       = "https://bitbucket.org/icl/blaspp"
-    maintainers = ['Sely85']
+    maintainers = ['Sely85', 'teonnik']
 
-    version('develop', hg=hg, revision="86ccadd")
+    version('develop', hg=hg, revision="5191c9d")
 
 
-    variant('ifort',
+    variant('gfort',
             default=False,
-            description='Use Intel Fortran conventions. Default is GNU gfortran. (Only for Intel MKL)')
+            description='Use GNU Fortran interface. Default is Intel interface. (MKL)')
+    variant('ilp64',
+            default=False,
+            description='Use 64bit integer interface. Default is 32bit. (MKL & ESSL)')
+    variant('parallel',
+            default=False,
+            description='Use OpenMP threaded backend. Default is sequential. (MKL & ESSL)')
 
     depends_on('blas')
 
     def cmake_args(self):
         spec = self.spec
         args = ['-DBLASPP_BUILD_TESTS=OFF']
+
+        if '+gfort':
+            args.append('-DBLAS_LIBRARY_MKL="GNU gfortran conventions"')
+        else:
+            args.append('-DBLAS_LIBRARY_MKL="Intel ifort conventions"')
+
+        if '+ilp64' in spec:
+            args.append('-DBLAS_LIBRARY_INTEGER="int64_t (ILP64)"')
+        else:
+            args.append('-DBLAS_LIBRARY_INTEGER="int (LP64)"')
+
+        if '+parallel' in spec:
+            args.append(['-DUSE_OPENMP=ON',
+                         '-DBLAS_LIBRARY_THREADING="threaded"'])
+        else:
+            args.append('-DBLAS_LIBRARY_THREADING="sequential"')
 
         # Missing:
         #
@@ -34,39 +56,10 @@ class Blaspp(CMakePackage):
         #
         # - apple : BLAS_LIBRARY="Apple Accelerate" (veclibfort ???)
         #
-        if '^intel-mkl' in spec or '^intel-parallel-studio+mkl' in spec:
+        if '^mkl' in spec :
             args.append('-DBLAS_LIBRARY="Intel MKL"')
-
-            if '+ifort':
-                args.append('-DBLAS_LIBRARY_MKL="Intel ifort conventions"')
-            else:
-                args.append('-DBLAS_LIBRARY_MKL="GNU gfortran conventions"')
-
-            if '+ilp64' in spec:
-                args.append('-DBLAS_LIBRARY_INTEGER="int64_t (ILP64)"')
-            else:
-                args.append('-DBLAS_LIBRARY_INTEGER="int (LP64)"')
-
-            if 'threads=openmp' in spec:
-                args.append(['-DUSE_OPENMP=ON',
-                             '-DBLAS_LIBRARY_THREADING="threaded"'])
-            else:
-                args.append('-DBLAS_LIBRARY_THREADING="sequential"')
-
         elif '^essl' in spec:
             args.append('-DBLAS_LIBRARY="IBM ESSL"')
-
-            if '+ilp64' in spec:
-                args.append('-DBLAS_LIBRARY_INTEGER="int64_t (ILP64)"')
-            else:
-                args.append('-DBLAS_LIBRARY_INTEGER="int (LP64)"')
-
-            if 'threads=openmp' in spec:
-                args.append(['-DUSE_OPENMP=ON',
-                             '-DBLAS_LIBRARY_THREADING="threaded"'])
-            else:
-                args.append('-DBLAS_LIBRARY_THREADING="sequential"')
-
         elif '^openblas' in spec:
             args.append('-DBLAS_LIBRARY="OpenBLAS"')
         elif '^cray-libsci' in spec:

--- a/spack_dlaf/packages/blaspp/package.py
+++ b/spack_dlaf/packages/blaspp/package.py
@@ -22,7 +22,6 @@ class Blaspp(CMakePackage):
 
     version('develop', hg=hg, revision="5191c9d")
 
-
     variant('gfort',
             default=False,
             description='Use GNU Fortran interface. Default is Intel interface. (MKL)')

--- a/spack_dlaf/packages/dla-future/package.py
+++ b/spack_dlaf/packages/dla-future/package.py
@@ -6,7 +6,7 @@ class DlaFuture(CMakePackage):
     homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki"
     git      = "https://github.com/eth-cscs/DLA-Future.git"
 
-    maintainers = ['Sely85']
+    maintainers = ['Sely85', 'teonnik']
 
     version('develop', branch='master')
 

--- a/spack_dlaf/packages/dla-future/package.py
+++ b/spack_dlaf/packages/dla-future/package.py
@@ -22,7 +22,7 @@ class DlaFuture(CMakePackage):
     # Until mpich is default comment this out
     #depends_on('mpi@3:')
     depends_on('mpich')
-    depends_on('intel-mkl')
+    depends_on('mkl')
     depends_on('blaspp')
     depends_on('lapackpp')
     depends_on('hpx cxxstd=14 networking=none')

--- a/spack_dlaf/packages/dla-future/package.py
+++ b/spack_dlaf/packages/dla-future/package.py
@@ -1,4 +1,10 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
+
 
 class DlaFuture(CMakePackage):
     """The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"""
@@ -6,7 +12,7 @@ class DlaFuture(CMakePackage):
     homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki"
     git      = "https://github.com/eth-cscs/DLA-Future.git"
 
-    maintainers = ['Sely85', 'teonnik']
+    maintainers = ['teonnik', 'Sely85']
 
     version('develop', branch='master')
 

--- a/spack_dlaf/packages/lapackpp/package.py
+++ b/spack_dlaf/packages/lapackpp/package.py
@@ -5,9 +5,9 @@ class Lapackpp(CMakePackage):
 
     homepage = "https://bitbucket.org/icl/lapackpp"
     hg       = "https://bitbucket.org/icl/lapackpp"
-    maintainers = ['Sely85']
+    maintainers = ['Sely85', 'teonnik']
 
-    version('develop', hg=hg)
+    version('develop', hg=hg, revision="7ffa486")
 
     depends_on('blaspp')
 

--- a/spack_dlaf/packages/lapackpp/package.py
+++ b/spack_dlaf/packages/lapackpp/package.py
@@ -1,11 +1,17 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
+
 
 class Lapackpp(CMakePackage):
     """LAPACK++: C++ API for the Basic Linear Algebra Subroutines (University of Tennessee)"""
 
     homepage = "https://bitbucket.org/icl/lapackpp"
     hg       = "https://bitbucket.org/icl/lapackpp"
-    maintainers = ['Sely85', 'teonnik']
+    maintainers = ['teonnik', 'Sely85']
 
     version('develop', hg=hg, revision="7ffa486")
 


### PR DESCRIPTION
- Pin blaspp and lapackpp to a particular version to avoid build issues.
  lapackpp was not pinned previously and followed develop. At some point
  blaspp and lapackpp became incompatible as blaspp was already pinned
  to a particular version. That was done to avoid issues with
  installation in the most recent version at the time.

- The options inherited from essl and intel-mkl are a bad practice
  because they incur unnecessary instlalls of dependent package.