### PR TITLE
Use hpx::init instead of hpx::start/stop

### DIFF
--- a/test/src/gtest_hpx_main.cpp
+++ b/test/src/gtest_hpx_main.cpp
@@ -41,8 +41,6 @@
 
 #include <gtest/gtest.h>
 #include <hpx/hpx.hpp>
-#include <hpx/hpx_start.hpp>
-#include <hpx/runtime/threads/run_as_hpx_thread.hpp>
 
 GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_hpx_main.cpp\n");
@@ -53,13 +51,5 @@ GTEST_API_ int test_main(int argc, char** argv) {
 
 GTEST_API_ int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-
-  hpx::start(nullptr, argc, argv);
-  hpx::runtime* rt = hpx::get_runtime_ptr();
-  hpx::util::yield_while([rt]() { return rt->get_state() < hpx::state_running; });
-
-  auto ret = hpx::threads::run_as_hpx_thread(test_main, argc, argv);
-  hpx::stop();
-
-  return ret;
+  return hpx::init(test_main, argc, argv);
 }

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -41,8 +41,6 @@
 
 #include <gtest/gtest.h>
 #include <hpx/hpx.hpp>
-#include <hpx/hpx_start.hpp>
-#include <hpx/runtime/threads/run_as_hpx_thread.hpp>
 
 #include "gtest_mpi_listener.h"
 
@@ -74,15 +72,8 @@ GTEST_API_ int main(int argc, char** argv) {
   listeners.Append(new MPIListener(argc, argv, default_listener));
 
   // Initialize HPX
-  hpx::start(nullptr, argc, argv);
-  hpx::runtime* rt = hpx::get_runtime_ptr();
-  hpx::util::yield_while([rt]() { return rt->get_state() < hpx::state_running; });
+  auto ret = hpx::init(test_main, argc, argv);
 
-  // Run!
-  auto ret = hpx::threads::run_as_hpx_thread(test_main, argc, argv);
-
-  // Tear-down
-  hpx::stop();
   MPI_Finalize();
 
   return ret;


### PR DESCRIPTION
The yield_while requirement was removed in 1.4.0. The start/stop
mechanism is useful if multiple functions are spawned and the
start/stop and spawning of functions are separate. This doesn't seem to
be the case for us.

From Mikael: https://github.com/eth-cscs/DLA-Future/pull/174#discussion_r417194563