### PR TITLE
Avoid empty variadic macro (conform to the standard)

### DIFF
--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -30,6 +30,7 @@
   if (!(condition)) {                                                \
     std::cerr << "[ERROR] " << origin << std::endl                   \
               << dlaf::common::concat(#condition, ' ', __VA_ARGS__); \
+    std::cerr.flush();                                               \
     std::terminate();                                                \
   }
 

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -23,6 +23,8 @@
 /// by the parameter and an optional custom message composed by concatenating all extra parameters.
 /// Message composition is lazily evaluated and it will not add any overhead if the condition is true.
 ///
+/// No newline is appended to the given message, which cannot be empty.
+///
 /// **This check cannot be disabled**
 #define DLAF_CHECK_WITH_ORIGIN(category, origin, condition, ...)     \
   if (!(condition)) {                                                \
@@ -31,8 +33,9 @@
     std::terminate();                                                \
   }
 
-/// This macro is a shortcut for #DLAF_CHECK_WITH_ORIGIN, it sets automatically the origin to the line
-/// from where this macro is used
+/// This macro is a shortcut for #DLAF_CHECK_WITH_ORIGIN
+/// It sets automatically the origin to the line from where this macro is used.
+/// A newline is automatically appended at the end of the (optional) message.
 #define DLAF_CHECK(category, ...) \
   DLAF_CHECK_WITH_ORIGIN(category, (SOURCE_LOCATION()), __VA_ARGS__, '\n')
 
@@ -47,7 +50,7 @@
 ///
 /// If the switch **DLAF_ASSERT_HEAVY_ENABLE** is not defined, this check will not
 /// be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_HEAVY(...) DLAF_CHECK("HEAVY", __VA_ARGS__, '\n')
+#define DLAF_ASSERT_HEAVY(...) DLAF_CHECK("HEAVY", __VA_ARGS__)
 #else
 #define DLAF_ASSERT_HEAVY(...)
 #endif
@@ -67,7 +70,7 @@
 ///
 /// If the switch **DLAF_ASSERT_MODERATE_ENABLE** is not defined, this check
 /// will not be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_MODERATE(...) DLAF_CHECK("MODERATE", __VA_ARGS__, '\n')
+#define DLAF_ASSERT_MODERATE(...) DLAF_CHECK("MODERATE", __VA_ARGS__)
 #else
 #define DLAF_ASSERT_MODERATE(...)
 #endif
@@ -103,7 +106,7 @@
 ///
 /// If the switch **DLAF_ASSERT_ENABLE** is not defined, this check will not
 /// be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT(...) DLAF_ASSERT_WITH_ORIGIN((SOURCE_LOCATION()), __VA_ARGS__, '\n')
+#define DLAF_ASSERT(...) DLAF_ASSERT_WITH_ORIGIN((SOURCE_LOCATION()), __VA_ARGS__)
 #else
 #define DLAF_ASSERT_WITH_ORIGIN(origin, ...)
 

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -47,9 +47,9 @@
 ///
 /// If the switch **DLAF_ASSERT_HEAVY_ENABLE** is not defined, this check will not
 /// be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_HEAVY(condition, ...) DLAF_CHECK("HEAVY", condition, ##__VA_ARGS__)
+#define DLAF_ASSERT_HEAVY(...) DLAF_CHECK("HEAVY", __VA_ARGS__)
 #else
-#define DLAF_ASSERT_HEAVY(condition, ...)
+#define DLAF_ASSERT_HEAVY(...)
 #endif
 
 #ifdef DLAF_ASSERT_MODERATE_ENABLE
@@ -63,9 +63,9 @@
 ///
 /// If the switch **DLAF_ASSERT_MODERATE_ENABLE** is not defined, this check
 /// will not be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_MODERATE(condition, ...) DLAF_CHECK("MODERATE", condition, ##__VA_ARGS__)
+#define DLAF_ASSERT_MODERATE(...) DLAF_CHECK("MODERATE", __VA_ARGS__)
 #else
-#define DLAF_ASSERT_MODERATE(condition, ...)
+#define DLAF_ASSERT_MODERATE(...)
 #endif
 
 #ifdef DLAF_ASSERT_ENABLE
@@ -79,8 +79,7 @@
 ///
 /// If the switch **DLAF_ASSERT_ENABLE** is not defined, this check will not be performed and it will not
 /// add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_WITH_ORIGIN(origin, condition, ...) \
-  DLAF_CHECK_WITH_ORIGIN("", (origin), condition, ##__VA_ARGS__)
+#define DLAF_ASSERT_WITH_ORIGIN(origin, ...) DLAF_CHECK_WITH_ORIGIN("", origin, __VA_ARGS__)
 
 /// **THIS MACRO MUST BE USED WHEN THE CHECK IS NEEDED TO ENSURE A CONDITION THAT HAVE
 /// VERY LOW IMPACT ON PERFORMANCES.**
@@ -92,10 +91,9 @@
 ///
 /// If the switch **DLAF_ASSERT_ENABLE** is not defined, this check will not
 /// be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT(condition, ...) \
-  DLAF_ASSERT_WITH_ORIGIN((SOURCE_LOCATION()), condition, ##__VA_ARGS__)
+#define DLAF_ASSERT(...) DLAF_ASSERT_WITH_ORIGIN((SOURCE_LOCATION()), __VA_ARGS__)
 #else
-#define DLAF_ASSERT_WITH_ORIGIN(origin, condition, ...)
+#define DLAF_ASSERT_WITH_ORIGIN(origin, ...)
 
-#define DLAF_ASSERT(condition, ...)
+#define DLAF_ASSERT(...)
 #endif

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -56,6 +56,10 @@
 /// **THIS MACRO MUST BE USED WHEN THE CHECK IS NEEDED FOR DEBUGGING PURPOSES THAT HAVE
 /// MODERATE IMPACT ON PERFORMANCES.**
 ///
+/// Parameters:
+/// 1     condition
+/// 2-*   (optional) comma separated part(s) composing the custom message in case of failure
+///
 /// If the condition is false, it will print an error report and call std::terminate()
 ///
 /// The error report can be extended with a custom message composed concatenating additional parameters
@@ -72,6 +76,10 @@
 /// **THIS MACRO MUST BE USED WHEN THE CHECK IS
 /// NEEDED TO ENSURE A CONDITION THAT HAVE VERY LOW IMPACT ON PERFORMANCES.**
 ///
+/// Parameters:
+/// 1     condition
+/// 2-*   (optional) comma separated part(s) composing the custom message in case of failure
+///
 /// If the condition is false, it will print an error report and call std::terminate()
 ///
 /// The error report will refer to the given origin and can be extended with a custom message composed
@@ -83,6 +91,10 @@
 
 /// **THIS MACRO MUST BE USED WHEN THE CHECK IS NEEDED TO ENSURE A CONDITION THAT HAVE
 /// VERY LOW IMPACT ON PERFORMANCES.**
+///
+/// Parameters:
+/// 1     condition
+/// 2-*   (optional) comma separated part(s) composing the custom message in case of failure
 ///
 /// If the condition is false, it will print an error report and call std::terminate()
 ///

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -24,17 +24,17 @@
 /// Message composition is lazily evaluated and it will not add any overhead if the condition is true.
 ///
 /// **This check cannot be disabled**
-#define DLAF_CHECK_WITH_ORIGIN(category, origin, condition, ...)                    \
-  if (!(condition)) {                                                               \
-    std::cerr << "[ERROR] " << origin << std::endl                                  \
-              << dlaf::common::concat(#condition, ' ', ##__VA_ARGS__) << std::endl; \
-    std::terminate();                                                               \
+#define DLAF_CHECK_WITH_ORIGIN(category, origin, condition, ...)     \
+  if (!(condition)) {                                                \
+    std::cerr << "[ERROR] " << origin << std::endl                   \
+              << dlaf::common::concat(#condition, ' ', __VA_ARGS__); \
+    std::terminate();                                                \
   }
 
 /// This macro is a shortcut for #DLAF_CHECK_WITH_ORIGIN, it sets automatically the origin to the line
 /// from where this macro is used
-#define DLAF_CHECK(category, condition, ...) \
-  DLAF_CHECK_WITH_ORIGIN(category, (SOURCE_LOCATION()), condition, ##__VA_ARGS__)
+#define DLAF_CHECK(category, ...) \
+  DLAF_CHECK_WITH_ORIGIN(category, (SOURCE_LOCATION()), __VA_ARGS__, '\n')
 
 #ifdef DLAF_ASSERT_HEAVY_ENABLE
 /// **THIS MACRO MUST BE USED WHEN THE CHECK IS NEEDED FOR DEBUGGING PURPOSES THAT HAS
@@ -47,7 +47,7 @@
 ///
 /// If the switch **DLAF_ASSERT_HEAVY_ENABLE** is not defined, this check will not
 /// be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_HEAVY(...) DLAF_CHECK("HEAVY", __VA_ARGS__)
+#define DLAF_ASSERT_HEAVY(...) DLAF_CHECK("HEAVY", __VA_ARGS__, '\n')
 #else
 #define DLAF_ASSERT_HEAVY(...)
 #endif
@@ -67,7 +67,7 @@
 ///
 /// If the switch **DLAF_ASSERT_MODERATE_ENABLE** is not defined, this check
 /// will not be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_MODERATE(...) DLAF_CHECK("MODERATE", __VA_ARGS__)
+#define DLAF_ASSERT_MODERATE(...) DLAF_CHECK("MODERATE", __VA_ARGS__, '\n')
 #else
 #define DLAF_ASSERT_MODERATE(...)
 #endif
@@ -87,7 +87,7 @@
 ///
 /// If the switch **DLAF_ASSERT_ENABLE** is not defined, this check will not be performed and it will not
 /// add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT_WITH_ORIGIN(origin, ...) DLAF_CHECK_WITH_ORIGIN("", origin, __VA_ARGS__)
+#define DLAF_ASSERT_WITH_ORIGIN(origin, ...) DLAF_CHECK_WITH_ORIGIN("", origin, __VA_ARGS__, '\n')
 
 /// **THIS MACRO MUST BE USED WHEN THE CHECK IS NEEDED TO ENSURE A CONDITION THAT HAVE
 /// VERY LOW IMPACT ON PERFORMANCES.**
@@ -103,7 +103,7 @@
 ///
 /// If the switch **DLAF_ASSERT_ENABLE** is not defined, this check will not
 /// be performed and it will not add any overhead, nor for the condition evaluation, nor for the message
-#define DLAF_ASSERT(...) DLAF_ASSERT_WITH_ORIGIN((SOURCE_LOCATION()), __VA_ARGS__)
+#define DLAF_ASSERT(...) DLAF_ASSERT_WITH_ORIGIN((SOURCE_LOCATION()), __VA_ARGS__, '\n')
 #else
 #define DLAF_ASSERT_WITH_ORIGIN(origin, ...)
 


### PR DESCRIPTION
Close #200 

Avoid empty variadic macro parameters by subsuming the first mandatory parameter into it.

Thanks @teonnik for the suggestion.

This PR is not going to be merged directly into `master`. instead it will be merged into another PR where the problem shown up. It will be part of it, and eventually merged to master.