### PR TITLE
Workaround for custom operator<< in gtest

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -132,6 +132,10 @@ public:
     assert(internal::basic_coords<IndexT>::isValid());
     return rows() == 0 || cols() == 0;
   }
+
+  friend std::ostream& operator<<(std::ostream& out, const Size2D& index) {
+    return out << static_cast<internal::basic_coords<IndexT>>(index);
+  }
 };
 
 /// A strong-type for 2D coordinates
@@ -175,6 +179,10 @@ public:
 
   IndexT col() const noexcept {
     return internal::basic_coords<IndexT>::col_;
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const Index2D& index) {
+    return out << static_cast<internal::basic_coords<IndexT>>(index);
   }
 };
 


### PR DESCRIPTION
Close #215 

This is the easy workaround I was talking about in the issue.

At the moment `Index2D` and `Size2D` seem to be the only ones using base class `operator<<`.