### PR TITLE
Basic arithmetic for ptrdiff_t

### DIFF
--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -65,7 +65,7 @@ namespace size_t {
 /// @brief Perform the sum on integer types in size_t arithmetic
 ///
 /// It casts operands to std::size_t type and then performs the sum
-/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @tparam TA and @tparam TB must be integer types (signed or unsigned)
 /// @return @p a + @p b
 /// @pre @p a >=0 and @p b >= 0
 /// @pre it must be possible to store the result in std::size_t
@@ -77,7 +77,7 @@ std::size_t sum(const TA a, const TB b) {
 /// @brief Perform the multiplication on integer types in size_t arithmetic
 ///
 /// It casts operands to std::size_t type and then performs the multiplication
-/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @tparam TA and @tparam TB must be integer types (signed or unsigned)
 /// @return @p a * @p b
 /// @pre @p a >=0 and @p b >= 0
 /// @pre it must be possible to store the result in std::size_t
@@ -93,7 +93,7 @@ namespace ptrdiff_t {
 /// @brief Perform the sum on integer types in ptrdiff_t arithmetic
 ///
 /// It casts operands to std::ptrdiff_t type and then performs the sum
-/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @tparam TA and @tparam TB must be integer types (signed or unsigned)
 /// @return @p a + @p b
 /// @pre @p a and @p b can be stored in std::ptrdiff_t
 /// @pre it must be possible to store the result in std::ptrdiff_t
@@ -105,7 +105,7 @@ std::ptrdiff_t sum(const TA a, const TB b) {
 /// @brief Perform the multiplication on integer types in ptrdiff_t arithmetic
 ///
 /// It casts operands to std::ptrdiff_t type and then performs the multiplication
-/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @tparam TA and @tparam TB must be integer types (signed or unsigned)
 /// @return @p a * @p b
 /// @pre @p a and @p b can be stored in std::ptrdiff_t
 /// @pre it must be possible to store the result in std::ptrdiff_t

--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -49,7 +49,7 @@ namespace internal {
 /// @brief Perform the given binary operation on integer types in @tparam ArithmeticT arithmetic
 ///
 /// It casts operands to @tparam ArithmeticT type and then performs the given binary operation @p op
-/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @tparam TA and @tparam TB must be integer types (signed or unsigned)
 /// @return @p a @p op @p b
 /// @pre @p a and @p b can be stored in the type @tparam ArithmeticT
 /// @pre it must be possible to store the result in @tparam ArithemticT

--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -10,8 +10,11 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <type_traits>
+
+#include "dlaf/types.h"
 
 /// @file
 
@@ -41,27 +44,29 @@ constexpr auto ceilDiv(const IntType num, const IntType den)
 }
 #endif
 
-namespace size_t {
 namespace internal {
 
-/// @brief Perform the given binary operation on integer types in size_t arithmetic
+/// @brief Perform the given binary operation on integer types in @tparam ArithmeticT arithmetic
 ///
-/// It casts operands to size_t type and then performs the given binary operation @p op
+/// It casts operands to @tparam ArithmeticT type and then performs the given binary operation @p op
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a @p op @p b
-/// @pre @p a >=0 and @p b >= 0
+/// @pre @p a and @p b can be stored in the type @tparam ArithmeticT
+/// @pre it must be possible to store the result in @tparam ArithemticT
 #ifdef DLAF_DOXYGEN
-template <typename TA, typename TB, typename BinaryOp>
+template <class ArithmeticT, class TA, class TB, class BinaryOp>
 constexpr std::size_t generic_integer_op(const TA a, const TB b, BinaryOp op);
 #else
-template <typename TA, typename TB, typename BinaryOp>
+template <class ArithmeticT, class TA, class TB, class BinaryOp>
 constexpr auto generic_integer_op(const TA a, const TB b, BinaryOp op)
-    -> std::enable_if_t<std::is_integral<TA>::value && std::is_integral<TB>::value, std::size_t> {
-  return op(static_cast<std::size_t>(a), static_cast<std::size_t>(b));
+    -> std::enable_if_t<std::is_integral<TA>::value && std::is_integral<TB>::value, ArithmeticT> {
+  return op(integral_cast<ArithmeticT>(a), integral_cast<ArithmeticT>(b));
 }
 #endif
 
 }
+
+namespace size_t {
 
 /// @brief Perform the sum on integer types in size_t arithmetic
 ///
@@ -69,9 +74,10 @@ constexpr auto generic_integer_op(const TA a, const TB b, BinaryOp op)
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a + @p b
 /// @pre @p a >=0 and @p b >= 0
+/// @pre it must be possible to store the result in std::size_t
 template <typename TA, typename TB>
 std::size_t sum(const TA a, const TB b) {
-  return internal::generic_integer_op(a, b, std::plus<std::size_t>());
+  return dlaf::util::internal::generic_integer_op<std::size_t>(a, b, std::plus<std::size_t>());
 }
 
 /// @brief Perform the multiplication on integer types in size_t arithmetic
@@ -80,9 +86,39 @@ std::size_t sum(const TA a, const TB b) {
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a * @p b
 /// @pre @p a >=0 and @p b >= 0
+/// @pre it must be possible to store the result in std::size_t
 template <typename TA, typename TB>
 std::size_t mul(const TA a, const TB b) {
-  return internal::generic_integer_op(a, b, std::multiplies<std::size_t>());
+  return dlaf::util::internal::generic_integer_op<std::size_t>(a, b, std::multiplies<std::size_t>());
+}
+
+}
+
+namespace ptrdiff_t {
+
+/// @brief Perform the sum on integer types in ptrdiff_t arithmetic
+///
+/// It casts operands to ptrdiff_t type and then performs the sum
+/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @return @p a + @p b
+/// @pre @p a and @p b can be stored in std::ptrdiff_t
+/// @pre it must be possible to store the result in std::ptrdiff_t
+template <typename TA, typename TB>
+std::ptrdiff_t sum(const TA a, const TB b) {
+  return dlaf::util::internal::generic_integer_op<std::ptrdiff_t>(a, b, std::plus<std::ptrdiff_t>());
+}
+
+/// @brief Perform the multiplication on integer types in ptrdiff_t arithmetic
+///
+/// It casts operands to size_t type and then performs the multiplication
+/// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
+/// @return @p a * @p b
+/// @pre @p a and @p b can be stored in std::ptrdiff_t
+/// @pre it must be possible to store the result in std::ptrdiff_t
+template <typename TA, typename TB>
+std::ptrdiff_t mul(const TA a, const TB b) {
+  return dlaf::util::internal::generic_integer_op<std::ptrdiff_t>(a, b,
+                                                                  std::multiplies<std::ptrdiff_t>());
 }
 
 }

--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -70,7 +70,7 @@ namespace size_t {
 
 /// @brief Perform the sum on integer types in size_t arithmetic
 ///
-/// It casts operands to size_t type and then performs the sum
+/// It casts operands to std::size_t type and then performs the sum
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a + @p b
 /// @pre @p a >=0 and @p b >= 0
@@ -82,7 +82,7 @@ std::size_t sum(const TA a, const TB b) {
 
 /// @brief Perform the multiplication on integer types in size_t arithmetic
 ///
-/// It casts operands to size_t type and then performs the multiplication
+/// It casts operands to std::size_t type and then performs the multiplication
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a * @p b
 /// @pre @p a >=0 and @p b >= 0
@@ -98,7 +98,7 @@ namespace ptrdiff_t {
 
 /// @brief Perform the sum on integer types in ptrdiff_t arithmetic
 ///
-/// It casts operands to ptrdiff_t type and then performs the sum
+/// It casts operands to std::ptrdiff_t type and then performs the sum
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a + @p b
 /// @pre @p a and @p b can be stored in std::ptrdiff_t
@@ -110,7 +110,7 @@ std::ptrdiff_t sum(const TA a, const TB b) {
 
 /// @brief Perform the multiplication on integer types in ptrdiff_t arithmetic
 ///
-/// It casts operands to size_t type and then performs the multiplication
+/// It casts operands to std::ptrdiff_t type and then performs the multiplication
 /// @tparam TA and @tparam TB must be an integer types (signed or unsigned)
 /// @return @p a * @p b
 /// @pre @p a and @p b can be stored in std::ptrdiff_t

--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -53,16 +53,10 @@ namespace internal {
 /// @return @p a @p op @p b
 /// @pre @p a and @p b can be stored in the type @tparam ArithmeticT
 /// @pre it must be possible to store the result in @tparam ArithemticT
-#ifdef DLAF_DOXYGEN
 template <class ArithmeticT, class TA, class TB, class BinaryOp>
-constexpr std::size_t generic_integer_op(const TA a, const TB b, BinaryOp op);
-#else
-template <class ArithmeticT, class TA, class TB, class BinaryOp>
-constexpr auto generic_integer_op(const TA a, const TB b, BinaryOp op)
-    -> std::enable_if_t<std::is_integral<TA>::value && std::is_integral<TB>::value, ArithmeticT> {
+constexpr ArithmeticT generic_integer_op(const TA a, const TB b, BinaryOp op) {
   return op(integral_cast<ArithmeticT>(a), integral_cast<ArithmeticT>(b));
 }
-#endif
 
 }
 

--- a/test/unit/test_util_math.cpp
+++ b/test/unit/test_util_math.cpp
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstddef>
+#include <limits>
 #include "dlaf/util_math.h"
 
 #include "gtest/gtest.h"
@@ -59,7 +61,7 @@ TYPED_TEST(MathUtilTest, CeilDivType) {
   EXPECT_TRUE((std::is_same<Type, decltype(util::ceilDiv(num, den))>()));
 }
 
-TYPED_TEST(MathUtilTest, SizeTArithmetic_Sum) {
+TYPED_TEST(MathUtilTest, size_t_Arithmetic_Sum) {
   using Type = TypeParam;
 
   constexpr auto type_size = sizeof(Type);
@@ -81,7 +83,7 @@ TYPED_TEST(MathUtilTest, SizeTArithmetic_Sum) {
   EXPECT_EQ(expected_result, util::size_t::sum(a, b));
 }
 
-TYPED_TEST(MathUtilTest, SizeTArithmetic_Mul) {
+TYPED_TEST(MathUtilTest, size_t_Arithmetic_Mul) {
   using Type = TypeParam;
 
   constexpr auto type_size = sizeof(Type);
@@ -103,7 +105,7 @@ TYPED_TEST(MathUtilTest, SizeTArithmetic_Mul) {
   EXPECT_EQ(expected_result, util::size_t::mul(a, b));
 }
 
-TYPED_TEST(MathUtilTest, SizeTArithmetic_SumMul) {
+TYPED_TEST(MathUtilTest, size_t_Arithmetic_SumMul) {
   using Type = TypeParam;
 
   constexpr auto type_size = sizeof(Type);
@@ -127,4 +129,94 @@ TYPED_TEST(MathUtilTest, SizeTArithmetic_SumMul) {
   using util::size_t::mul;
 
   EXPECT_EQ(expected_result, sum(mul(a, b), c));
+}
+
+TYPED_TEST(MathUtilTest, ptrdiff_t_Arithmetic_Sum) {
+  using ArithmeticT = std::ptrdiff_t;
+
+  constexpr auto type_size = sizeof(TypeParam);
+  constexpr auto arithmetic_size = sizeof(std::ptrdiff_t);
+
+  TypeParam a, b;
+
+  if (type_size < arithmetic_size) {
+    a = std::numeric_limits<TypeParam>::max();
+    b = std::numeric_limits<TypeParam>::max();
+  }
+  else {
+    a = static_cast<TypeParam>(std::numeric_limits<ArithmeticT>::max() / 2);
+    b = static_cast<TypeParam>(std::numeric_limits<ArithmeticT>::max() / 2);
+  }
+
+  {
+    auto expected_result = static_cast<ArithmeticT>(a) + static_cast<ArithmeticT>(b);
+    EXPECT_EQ(expected_result, util::ptrdiff_t::sum(a, b));
+  }
+
+  {
+    auto expected_result = static_cast<ArithmeticT>(a) + std::numeric_limits<ArithmeticT>::max();
+    EXPECT_EQ(expected_result, util::ptrdiff_t::sum(a, std::numeric_limits<ArithmeticT>::max()));
+  }
+}
+
+TYPED_TEST(MathUtilTest, ptrdiff_t_Arithmetic_Mul) {
+  using ArithmeticT = std::ptrdiff_t;
+
+  constexpr auto type_size = sizeof(TypeParam);
+  constexpr auto arithmetic_size = sizeof(ArithmeticT);
+
+  TypeParam a, b;
+
+  if (type_size < arithmetic_size) {
+    a = std::numeric_limits<TypeParam>::max();
+    b = std::numeric_limits<TypeParam>::max();
+  }
+  else {
+    a = static_cast<TypeParam>(std::numeric_limits<ArithmeticT>::max() / 2);
+    b = 2;
+  }
+
+  {
+    auto expected_result = static_cast<ArithmeticT>(a) * static_cast<ArithmeticT>(b);
+    EXPECT_EQ(expected_result, util::ptrdiff_t::mul(a, b));
+  }
+
+  {
+    auto expected_result = static_cast<ArithmeticT>(a) * static_cast<ArithmeticT>(-1);
+    EXPECT_EQ(expected_result, util::ptrdiff_t::mul(a, -1));
+  }
+}
+
+TYPED_TEST(MathUtilTest, ptrdiff_t_Arithmetic_SumMul) {
+  using ArithmeticT = std::ptrdiff_t;
+
+  constexpr auto type_size = sizeof(TypeParam);
+  constexpr auto arithmetic_size = sizeof(ArithmeticT);
+
+  TypeParam b = 2;
+  TypeParam a, c;
+
+  if (type_size < arithmetic_size) {
+    a = std::numeric_limits<TypeParam>::max() / 2;
+    c = std::numeric_limits<TypeParam>::max();
+  }
+  else {
+    a = static_cast<TypeParam>(std::numeric_limits<ArithmeticT>::max() / 4);
+    c = static_cast<TypeParam>(std::numeric_limits<ArithmeticT>::max() / 2);
+  }
+
+  using util::ptrdiff_t::sum;
+  using util::ptrdiff_t::mul;
+
+  {
+    auto expected_result =
+        static_cast<ArithmeticT>(a) * static_cast<ArithmeticT>(b) + static_cast<ArithmeticT>(c);
+    EXPECT_EQ(expected_result, sum(mul(a, b), c));
+  }
+
+  {
+    auto expected_result =
+        static_cast<ArithmeticT>(a) * static_cast<ArithmeticT>(-1) + static_cast<ArithmeticT>(c);
+    EXPECT_EQ(expected_result, sum(mul(a, -1), c));
+  }
 }


### PR DESCRIPTION
This PR implements `sum` and `mul` for `ptrdiff_t` arithmetic.

Minor refactoring was required, `integral_cast` has been used instead of trivial `static_cast` and tests for `ptrdiff_t` have been added.