### PR TITLE
Phase out scheduled_executor

### DIFF
--- a/include/dlaf/communication/executor.h
+++ b/include/dlaf/communication/executor.h
@@ -1,0 +1,33 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+/// @file
+
+#include <hpx/include/threads.hpp>
+#include <hpx/runtime/threads/executors/pool_executor.hpp>
+
+namespace dlaf {
+namespace comm {
+
+// Temporary workaround until HPX v1.5 which exposes a proper API
+inline bool mpi_pool_exists() {
+  using hpx::threads::executors::pool_executor;
+  try {
+    pool_executor("mpi");
+    return true;
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+}
+}

--- a/include/dlaf/communication/executor.h
+++ b/include/dlaf/communication/executor.h
@@ -16,6 +16,7 @@
 
 namespace dlaf {
 namespace comm {
+namespace internal {
 
 // Temporary workaround until HPX v1.5 which exposes a proper API
 inline bool mpi_pool_exists() {
@@ -29,5 +30,6 @@ inline bool mpi_pool_exists() {
   }
 }
 
+}
 }
 }

--- a/include/dlaf/factorization/cholesky/mc/cholesky_L.h
+++ b/include/dlaf/factorization/cholesky/mc/cholesky_L.h
@@ -92,7 +92,7 @@ void cholesky_L(comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& mat_a) {
   using hpx::threads::thread_priority_high;
   using hpx::threads::thread_priority_default;
 
-  using comm::mpi_pool_exists;
+  using comm::internal::mpi_pool_exists;
 
   constexpr auto NonUnit = blas::Diag::NonUnit;
   constexpr auto ConjTrans = blas::Op::ConjTrans;

--- a/include/dlaf/factorization/cholesky/mc/cholesky_L.h
+++ b/include/dlaf/factorization/cholesky/mc/cholesky_L.h
@@ -18,6 +18,7 @@
 #include "dlaf/common/range2d.h"
 #include "dlaf/common/vector.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/communication/executor.h"
 #include "dlaf/communication/functions_sync.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix.h"
@@ -37,13 +38,14 @@ void cholesky_L(Matrix<T, Device::CPU>& mat_a) {
   constexpr auto Right = blas::Side::Right;
   constexpr auto Lower = blas::Uplo::Lower;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -86,6 +88,12 @@ template <class T>
 void cholesky_L(comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& mat_a) {
   using common::internal::vector;
 
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
+
+  using comm::mpi_pool_exists;
+
   constexpr auto NonUnit = blas::Diag::NonUnit;
   constexpr auto ConjTrans = blas::Op::ConjTrans;
   constexpr auto NoTrans = blas::Op::NoTrans;
@@ -93,19 +101,11 @@ void cholesky_L(comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& mat_a) {
   constexpr auto Lower = blas::Uplo::Lower;
 
   // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
-
-  hpx::threads::scheduled_executor executor_mpi;
-  try {
-    executor_mpi = hpx::threads::executors::pool_executor("mpi", hpx::threads::thread_priority_high);
-  }
-  catch (...) {
-    executor_mpi = executor_hp;
-  }
+  pool_executor executor_normal("default", thread_priority_default);
+  // Set up MPI executor
+  auto executor_mpi = (mpi_pool_exists()) ? pool_executor("mpi", thread_priority_high) : executor_hp;
 
   auto col_comm_size = grid.colCommunicator().size();
   auto row_comm_size = grid.rowCommunicator().size();

--- a/include/dlaf/solver/triangular/mc/triangular_LLN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LLN.h
@@ -77,7 +77,7 @@ void triangular_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
   using hpx::threads::thread_priority_high;
   using hpx::threads::thread_priority_default;
 
-  using comm::mpi_pool_exists;
+  using comm::internal::mpi_pool_exists;
   using common::internal::vector;
 
   constexpr auto Left = blas::Side::Left;

--- a/include/dlaf/solver/triangular/mc/triangular_LLN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LLN.h
@@ -17,6 +17,7 @@
 #include "dlaf/common/pipeline.h"
 #include "dlaf/common/vector.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/communication/executor.h"
 #include "dlaf/communication/functions_sync.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix.h"
@@ -35,13 +36,14 @@ void triangular_LLN(blas::Diag diag, T alpha, Matrix<const T, Device::CPU>& mat_
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -71,6 +73,11 @@ void triangular_LLN(blas::Diag diag, T alpha, Matrix<const T, Device::CPU>& mat_
 template <class T>
 void triangular_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                     Matrix<const T, Device::CPU>& mat_a, Matrix<T, Device::CPU>& mat_b) {
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
+
+  using comm::mpi_pool_exists;
   using common::internal::vector;
 
   constexpr auto Left = blas::Side::Left;
@@ -78,21 +85,11 @@ void triangular_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
   constexpr auto NoTrans = blas::Op::NoTrans;
 
   // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
-
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
-
-  // Set up mpi executor
-  hpx::threads::scheduled_executor executor_mpi;
-  try {
-    executor_mpi = hpx::threads::executors::pool_executor("mpi", hpx::threads::thread_priority_high);
-  }
-  catch (...) {
-    executor_mpi = executor_hp;
-  }
+  pool_executor executor_normal("default", thread_priority_default);
+  // Set up MPI executor
+  auto executor_mpi = (mpi_pool_exists()) ? pool_executor("mpi", thread_priority_high) : executor_hp;
 
   auto col_comm_size = grid.colCommunicator().size();
   auto row_comm_size = grid.rowCommunicator().size();

--- a/include/dlaf/solver/triangular/mc/triangular_LLT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LLT.h
@@ -33,13 +33,14 @@ void triangular_LLT(blas::Op op, blas::Diag diag, T alpha, Matrix<const T, Devic
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();

--- a/include/dlaf/solver/triangular/mc/triangular_LUN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LUN.h
@@ -33,13 +33,14 @@ void triangular_LUN(blas::Diag diag, T alpha, Matrix<const T, Device::CPU>& mat_
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();

--- a/include/dlaf/solver/triangular/mc/triangular_LUT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LUT.h
@@ -33,13 +33,14 @@ void triangular_LUT(blas::Op op, blas::Diag diag, T alpha, Matrix<const T, Devic
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();

--- a/include/dlaf/solver/triangular/mc/triangular_RLN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RLN.h
@@ -33,13 +33,14 @@ void triangular_RLN(blas::Diag diag, T alpha, Matrix<const T, Device::CPU>& mat_
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();

--- a/include/dlaf/solver/triangular/mc/triangular_RLT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RLT.h
@@ -33,13 +33,14 @@ void triangular_RLT(blas::Op op, blas::Diag diag, T alpha, Matrix<const T, Devic
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();

--- a/include/dlaf/solver/triangular/mc/triangular_RUN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RUN.h
@@ -33,13 +33,14 @@ void triangular_RUN(blas::Diag diag, T alpha, Matrix<const T, Device::CPU>& mat_
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();

--- a/include/dlaf/solver/triangular/mc/triangular_RUT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RUT.h
@@ -33,13 +33,14 @@ void triangular_RUT(blas::Op op, blas::Diag diag, T alpha, Matrix<const T, Devic
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  // Set up executor on the default queue with high priority.
-  hpx::threads::scheduled_executor executor_hp =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_high);
+  using hpx::threads::executors::pool_executor;
+  using hpx::threads::thread_priority_high;
+  using hpx::threads::thread_priority_default;
 
+  // Set up executor on the default queue with high priority.
+  pool_executor executor_hp("default", thread_priority_high);
   // Set up executor on the default queue with default priority.
-  hpx::threads::scheduled_executor executor_normal =
-      hpx::threads::executors::pool_executor("default", hpx::threads::thread_priority_default);
+  pool_executor executor_normal("default", thread_priority_default);
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();


### PR DESCRIPTION
`scheduled_executor` will not exist in the upcoming HPX 1.5 . This PR changes how we handle `try/catch` to avoid it's usage and be compatible with both current and future HPX versions.

For more details: https://github.com/STEllAR-GROUP/hpx/issues/4535