### PR TITLE
Add lapack tile wrappers for 'lange' and 'lantr'

### DIFF
--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -29,11 +29,17 @@ namespace tile {
 
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a general rectangular matrix.
+///
+/// @pre a.size().isValid()
 template <class T, Device device>
 dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept;
 
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a triangular matrix.
+///
+/// @pre a.size().isValid()
+/// @pre a.size().rows() >= a.size().cols() if uplo == blas::Uplo::Lower
+/// @pre a.size().rows() <= a.size().cols() if uplo == blas::Uplo::Upper
 template <class T, Device device>
 dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
                         const Tile<T, device>& a) noexcept;

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -35,7 +35,8 @@ dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept;
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a triangular matrix.
 template <class T, Device device>
-dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) noexcept;
+dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
+                        const Tile<T, device>& a) noexcept;
 
 /// Compute the cholesky decomposition of a.
 ///

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -30,12 +30,12 @@ namespace tile {
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a general rectangular matrix.
 template <class T, Device device>
-dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a);
+dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept;
 
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a triangular matrix.
 template <class T, Device device>
-dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a);
+dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) noexcept;
 
 /// Compute the cholesky decomposition of a.
 ///

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -20,26 +20,33 @@
 #endif
 
 #include "dlaf/tile.h"
+#include "dlaf/types.h"
 
 namespace dlaf {
 namespace tile {
 
 // See LAPACK documentation for more details.
 
-// Variants that throw an error on failure.
+/// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
+/// element, of a general rectangular matrix.
+template <class T, Device device>
+dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a);
+
+/// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
+/// element, of a triangular matrix.
+template <class T, Device device>
+dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a);
 
 /// Compute the cholesky decomposition of a.
-
+///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @throw std::invalid_argument if a is not square.
 /// @throw std::runtime_error if the tile was not positive definite.
 template <class T, Device device>
 void potrf(blas::Uplo uplo, const Tile<T, device>& a);
 
-// Variants that return info code.
-
 /// Compute the cholesky decomposition of a.
-
+///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @returns info = 0 on success or info > 0 if the tile is not positive definite.
 /// @throw std::runtime_error if the tile was not positive definite.

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -37,6 +37,7 @@ dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept;
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a triangular matrix.
 ///
+/// @pre uplo != blas::Uplo::General
 /// @pre a.size().isValid()
 /// @pre a.size().rows() >= a.size().cols() if uplo == blas::Uplo::Lower
 /// @pre a.size().rows() <= a.size().cols() if uplo == blas::Uplo::Upper

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include "dlaf/common/assert.h"
+
 template <class T, Device device>
 dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept {
   return lapack::lange(norm, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
@@ -16,6 +18,16 @@ dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept {
 template <class T, Device device>
 dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
                         const Tile<T, device>& a) noexcept {
+  switch (uplo) {
+    case blas::Uplo::Lower:
+      DLAF_ASSERT(a.size().rows() >= a.size().cols(), "Not valid ", a.size());
+      break;
+    case blas::Uplo::Upper:
+      DLAF_ASSERT(a.size().rows() <= a.size().cols(), "Not valid ", a.size());
+      break;
+    case blas::Uplo::General:
+      break;
+  }
   return lapack::lantr(norm, uplo, diag, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -9,12 +9,12 @@
 //
 
 template <class T, Device device>
-dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) {
+dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept {
   return lapack::lange(norm, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 
 template <class T, Device device>
-dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) {
+dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) noexcept {
   return lapack::lantr(norm, uplo, diag, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -10,12 +10,12 @@
 
 template <class T, Device device>
 dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) {
-  return lapack::lange(norm, a.size().cols(), a.size().rows(), a.ptr(), a.ld());
+  return lapack::lange(norm, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 
 template <class T, Device device>
 dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) {
-  return lapack::lantr(norm, uplo, diag, a.size().cols(), a.size().rows(), a.ptr(), a.ld());
+  return lapack::lantr(norm, uplo, diag, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 
 template <class T, Device device>

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -9,6 +9,23 @@
 //
 
 template <class T, Device device>
+dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) {
+  return lapack::lange(norm, a.size().cols(), a.size().rows(), a.ptr(), a.ld());
+}
+
+template <class T, Device device>
+dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) {
+  return lapack::lantr(norm, uplo, diag, a.size().cols(), a.size().rows(), a.ptr(), a.ld());
+}
+
+template <class T, Device device>
+void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
+  auto info = potrfInfo(uplo, a);
+  if (info != 0)
+    throw std::runtime_error("Error: POTRF: A is not positive definite.");
+}
+
+template <class T, Device device>
 long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a) {
   if (a.size().rows() != a.size().cols()) {
     throw std::invalid_argument("Error: POTRF: A is not square.");
@@ -18,11 +35,4 @@ long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a) {
   assert(info >= 0);
 
   return info;
-}
-
-template <class T, Device device>
-void potrf(blas::Uplo uplo, const Tile<T, device>& a) {
-  auto info = potrfInfo(uplo, a);
-  if (info != 0)
-    throw std::runtime_error("Error: POTRF: A is not positive definite.");
 }

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -26,6 +26,7 @@ dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
       DLAF_ASSERT(a.size().rows() <= a.size().cols(), "Not valid ", a.size());
       break;
     case blas::Uplo::General:
+      DLAF_ASSERT(blas::Uplo::General == uplo, "Invalid parameter");
       break;
   }
   return lapack::lantr(norm, uplo, diag, a.size().rows(), a.size().cols(), a.ptr(), a.ld());

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -14,7 +14,8 @@ dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept {
 }
 
 template <class T, Device device>
-dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, device>& a) noexcept {
+dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
+                        const Tile<T, device>& a) noexcept {
   return lapack::lantr(norm, uplo, diag, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -34,10 +34,10 @@ TYPED_TEST(TileOperationsTest, lange) {
   SizeType m, n, extra_lda;
 
   std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {{0, 0, 0},   {0, 0, 2},  // 0 size
-                                                                 {1, 1, 0},   {12, 8, 1}, {8, 12, 1}, {12, 12, 1},
-                                                                 {11, 17, 3}, {11, 17, 0},
-                                                                 {17, 11, 3}, {17, 11, 0},
-                                                                 {17, 17, 3}, {11, 11, 0}};
+                                                                 {1, 1, 0},   {12, 8, 1},  {8, 12, 1},
+                                                                 {12, 12, 1}, {11, 17, 3}, {11, 17, 0},
+                                                                 {17, 11, 3}, {17, 11, 0}, {17, 17, 3},
+                                                                 {11, 11, 0}};
 
   for (const auto& size : sizes) {
     std::tie(m, n, extra_lda) = size;

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -50,7 +50,7 @@ TYPED_TEST(TileOperationsTest, lange) {
     for (const auto& size : sizes) {
       std::tie(m, n, extra_lda) = size;
 
-      testLange<TypeParam>(norm, TileElementSize{m, n}, extra_lda);
+      dlaf::test::lange::run<TypeParam>(norm, TileElementSize{m, n}, extra_lda);
     }
   }
 }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -55,7 +55,9 @@ TYPED_TEST(TileOperationsTest, lange) {
   SizeType m, n, extra_lda;
 
   std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {{0, 0, 0},   {0, 0, 2},  // 0 size
-                                                                 {1, 1, 0},   {12, 12, 1},
+                                                                 {1, 1, 0},   {12, 8, 1}, {8, 12, 1}, {12, 12, 1},
+                                                                 {11, 17, 3}, {11, 17, 0},
+                                                                 {17, 11, 3}, {17, 11, 0},
                                                                  {17, 17, 3}, {11, 11, 0}};
 
   for (const auto& size : sizes) {

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -52,31 +52,36 @@ TYPED_TEST(TileOperationsTest, Potrf) {
 }
 
 TYPED_TEST(TileOperationsTest, lange) {
-  SizeType n, extra_lda;
+  SizeType m, n, extra_lda;
 
-  std::vector<std::tuple<SizeType, SizeType>> sizes = {{0, 0}, {0, 2},  // 0 size
-                                                       {1, 0}, {12, 1}, {17, 3}, {11, 0}};
+  std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {{0, 0, 0},   {0, 0, 2},  // 0 size
+                                                                 {1, 1, 0},   {12, 12, 1},
+                                                                 {17, 17, 3}, {11, 11, 0}};
 
-  for (const auto uplo : blas_uplos) {
-    for (const auto& size : sizes) {
-      std::tie(n, extra_lda) = size;
+  for (const auto& size : sizes) {
+    std::tie(m, n, extra_lda) = size;
 
-      testLange<TypeParam, false>(uplo, n, extra_lda);
-    }
+    auto norm = lapack::Norm::Max;
+
+    testLange<TypeParam>(norm, m, n, extra_lda);
   }
 }
 
 TYPED_TEST(TileOperationsTest, lantr) {
-  SizeType n, extra_lda;
+  SizeType m, n, extra_lda;
 
-  std::vector<std::tuple<SizeType, SizeType>> sizes = {{0, 0}, {0, 2},  // 0 size
-                                                       {1, 0}, {12, 1}, {17, 3}, {11, 0}};
+  std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {{0, 0, 0},   {0, 0, 2},  // 0 size
+                                                                 {1, 1, 0},   {12, 12, 1},
+                                                                 {17, 17, 3}, {11, 11, 0}};
 
   for (const auto uplo : blas_uplos) {
     for (const auto& size : sizes) {
-      std::tie(n, extra_lda) = size;
+      std::tie(m, n, extra_lda) = size;
 
-      testLantr<TypeParam, false>(uplo, n, extra_lda);
+      auto diag = blas::Diag::NonUnit;
+      auto norm = lapack::Norm::Max;
+
+      testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
     }
   }
 }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -30,27 +30,6 @@ class TileOperationsTest : public ::testing::Test {};
 
 TYPED_TEST_SUITE(TileOperationsTest, MatrixElementTypes);
 
-TYPED_TEST(TileOperationsTest, Potrf) {
-  using Type = TypeParam;
-
-  SizeType n, extra_lda;
-
-  std::vector<std::tuple<SizeType, SizeType>> sizes = {{0, 0}, {0, 2},  // 0 size
-                                                       {1, 0}, {12, 1}, {17, 3}, {11, 0}};
-
-  for (const auto uplo : blas_uplos) {
-    for (const auto& size : sizes) {
-      std::tie(n, extra_lda) = size;
-
-      // Test version non returning info
-      testPotrf<Type, false>(uplo, n, extra_lda);
-
-      // Test version returning info
-      testPotrf<Type, true>(uplo, n, extra_lda);
-    }
-  }
-}
-
 TYPED_TEST(TileOperationsTest, lange) {
   SizeType m, n, extra_lda;
 
@@ -84,6 +63,27 @@ TYPED_TEST(TileOperationsTest, lantr) {
       auto norm = lapack::Norm::Max;
 
       testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
+    }
+  }
+}
+
+TYPED_TEST(TileOperationsTest, Potrf) {
+  using Type = TypeParam;
+
+  SizeType n, extra_lda;
+
+  std::vector<std::tuple<SizeType, SizeType>> sizes = {{0, 0}, {0, 2},  // 0 size
+                                                       {1, 0}, {12, 1}, {17, 3}, {11, 0}};
+
+  for (const auto uplo : blas_uplos) {
+    for (const auto& size : sizes) {
+      std::tie(n, extra_lda) = size;
+
+      // Test version non returning info
+      testPotrf<Type, false>(uplo, n, extra_lda);
+
+      // Test version returning info
+      testPotrf<Type, true>(uplo, n, extra_lda);
     }
   }
 }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -24,6 +24,7 @@ using namespace dlaf_test;
 using namespace testing;
 
 const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
+const std::vector<blas::Diag> blas_diags({blas::Diag::NonUnit, blas::Diag::Unit});
 
 template <typename Type>
 class TileOperationsTest : public ::testing::Test {};
@@ -55,18 +56,19 @@ TYPED_TEST(TileOperationsTest, lantr) {
                                                                  {1, 1, 0},   {17, 11, 3}, {17, 11, 0},
                                                                  {17, 17, 3}, {17, 17, 3}, {11, 11, 0}};
 
-  for (const auto uplo : blas_uplos) {
-    for (const auto& size : sizes) {
-      std::tie(m, n, extra_lda) = size;
+  for (const auto diag : blas_diags) {
+    for (const auto uplo : blas_uplos) {
+      for (const auto& size : sizes) {
+        std::tie(m, n, extra_lda) = size;
 
-      // transpose rectangular matrix to be useful for upper triangular case
-      if (blas::Uplo::Upper == uplo)
-        std::swap(m, n);
+        // transpose rectangular matrix to be useful for upper triangular case
+        if (blas::Uplo::Upper == uplo)
+          std::swap(m, n);
 
-      auto diag = blas::Diag::NonUnit;
-      auto norm = lapack::Norm::Max;
+        auto norm = lapack::Norm::Max;
 
-      testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
+        testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
+      }
     }
   }
 }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -52,12 +52,16 @@ TYPED_TEST(TileOperationsTest, lantr) {
   SizeType m, n, extra_lda;
 
   std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {{0, 0, 0},   {0, 0, 2},  // 0 size
-                                                                 {1, 1, 0},   {12, 12, 1},
-                                                                 {17, 17, 3}, {11, 11, 0}};
+                                                                 {1, 1, 0},   {17, 11, 3}, {17, 11, 0},
+                                                                 {17, 17, 3}, {17, 17, 3}, {11, 11, 0}};
 
   for (const auto uplo : blas_uplos) {
     for (const auto& size : sizes) {
       std::tie(m, n, extra_lda) = size;
+
+      // transpose rectangular matrix to be useful for upper triangular case
+      if (blas::Uplo::Upper == uplo)
+        std::swap(m, n);
 
       auto diag = blas::Diag::NonUnit;
       auto norm = lapack::Norm::Max;

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -63,6 +63,10 @@ TYPED_TEST(TileOperationsTest, lantr) {
                                                                  {17, 17, 3}, {17, 17, 3}, {11, 11, 0}};
 
   for (const auto norm : lapack_norms) {
+    // lange cannot be tested for norm2
+    if (norm == lapack::Norm::Two)
+      continue;
+
     for (const auto uplo : blas_uplos) {
       for (const auto diag : blas_diags) {
         for (const auto& size : sizes) {
@@ -72,7 +76,7 @@ TYPED_TEST(TileOperationsTest, lantr) {
           if (blas::Uplo::Upper == uplo)
             std::swap(m, n);
 
-          testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
+          dlaf::test::lantr::run<TypeParam>(norm, uplo, diag, TileElementSize{m, n}, extra_lda);
         }
       }
     }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -42,12 +42,16 @@ TYPED_TEST(TileOperationsTest, lange) {
                                                                  {17, 11, 3}, {17, 11, 0}, {17, 17, 3},
                                                                  {11, 11, 0}};
 
-  for (const auto& size : sizes) {
-    std::tie(m, n, extra_lda) = size;
+  for (const auto norm : lapack_norms) {
+    // lange cannot be tested for norm2
+    if (norm == lapack::Norm::Two)
+      continue;
 
-    auto norm = lapack::Norm::Max;
+    for (const auto& size : sizes) {
+      std::tie(m, n, extra_lda) = size;
 
-    testLange<TypeParam>(norm, m, n, extra_lda);
+      testLange<TypeParam>(norm, TileElementSize{m, n}, extra_lda);
+    }
   }
 }
 

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(TileOperationsTest, lange) {
     auto tile = allocate_tile<TypeParam>(TileElementSize{m, n}, extra_lda);
 
     for (const auto norm : lapack_norms) {
-      // lange cannot be tested for norm2
+      // lange does not support norm2
       if (norm == lapack::Norm::Two)
         continue;
 
@@ -85,7 +85,7 @@ TYPED_TEST(TileOperationsTest, lantr) {
       auto tile = allocate_tile<TypeParam>(TileElementSize{m, n}, extra_lda);
 
       for (const auto norm : lapack_norms) {
-        // lange cannot be tested for norm2
+        // lantr does not support norm2
         if (norm == lapack::Norm::Two)
           continue;
 

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -13,6 +13,8 @@
 #include "gtest/gtest.h"
 #include "dlaf_test/util_types.h"
 
+#include "test_lapack_tile/test_lange.h"
+#include "test_lapack_tile/test_lantr.h"
 #include "test_lapack_tile/test_potrf.h"
 
 using namespace dlaf;
@@ -45,6 +47,36 @@ TYPED_TEST(TileOperationsTest, Potrf) {
 
       // Test version returning info
       testPotrf<Type, true>(uplo, n, extra_lda);
+    }
+  }
+}
+
+TYPED_TEST(TileOperationsTest, lange) {
+  SizeType n, extra_lda;
+
+  std::vector<std::tuple<SizeType, SizeType>> sizes = {{0, 0}, {0, 2},  // 0 size
+                                                       {1, 0}, {12, 1}, {17, 3}, {11, 0}};
+
+  for (const auto uplo : blas_uplos) {
+    for (const auto& size : sizes) {
+      std::tie(n, extra_lda) = size;
+
+      testLange<TypeParam, false>(uplo, n, extra_lda);
+    }
+  }
+}
+
+TYPED_TEST(TileOperationsTest, lantr) {
+  SizeType n, extra_lda;
+
+  std::vector<std::tuple<SizeType, SizeType>> sizes = {{0, 0}, {0, 2},  // 0 size
+                                                       {1, 0}, {12, 1}, {17, 3}, {11, 0}};
+
+  for (const auto uplo : blas_uplos) {
+    for (const auto& size : sizes) {
+      std::tie(n, extra_lda) = size;
+
+      testLantr<TypeParam, false>(uplo, n, extra_lda);
     }
   }
 }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -25,6 +25,8 @@ using namespace testing;
 
 const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
 const std::vector<blas::Diag> blas_diags({blas::Diag::NonUnit, blas::Diag::Unit});
+const std::vector<lapack::Norm> lapack_norms({lapack::Norm::Fro, lapack::Norm::Inf, lapack::Norm::Max,
+                                              lapack::Norm::One, lapack::Norm::Two});
 
 template <typename Type>
 class TileOperationsTest : public ::testing::Test {};
@@ -56,18 +58,18 @@ TYPED_TEST(TileOperationsTest, lantr) {
                                                                  {1, 1, 0},   {17, 11, 3}, {17, 11, 0},
                                                                  {17, 17, 3}, {17, 17, 3}, {11, 11, 0}};
 
-  for (const auto diag : blas_diags) {
+  for (const auto norm : lapack_norms) {
     for (const auto uplo : blas_uplos) {
-      for (const auto& size : sizes) {
-        std::tie(m, n, extra_lda) = size;
+      for (const auto diag : blas_diags) {
+        for (const auto& size : sizes) {
+          std::tie(m, n, extra_lda) = size;
 
-        // transpose rectangular matrix to be useful for upper triangular case
-        if (blas::Uplo::Upper == uplo)
-          std::swap(m, n);
+          // transpose rectangular matrix to be useful for upper triangular case
+          if (blas::Uplo::Upper == uplo)
+            std::swap(m, n);
 
-        auto norm = lapack::Norm::Max;
-
-        testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
+          testLantr<TypeParam>(norm, uplo, diag, m, n, extra_lda);
+        }
       }
     }
   }

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -21,7 +21,9 @@
 #include "dlaf_test/matrix/util_tile.h"
 #include "dlaf_test/util_types.h"
 
-namespace {
+namespace dlaf {
+namespace test {
+namespace lange {
 
 using dlaf::SizeType;
 using dlaf::TileElementSize;
@@ -90,7 +92,7 @@ void test_lange(lapack::Norm norm, TileElementSize size, SizeType extra_lda, Nor
 }
 
 template <class T>
-void testLange(lapack::Norm norm, TileElementSize size, SizeType extra_lda) {
+void run(lapack::Norm norm, TileElementSize size, SizeType extra_lda) {
   NormT<T> value = std::abs(TileSetter<T>::value);
   NormT<T> norm_expected;
 
@@ -108,11 +110,13 @@ void testLange(lapack::Norm norm, TileElementSize size, SizeType extra_lda) {
       norm_expected = size != TileElementSize{1, 1} ? std::sqrt(17) : std::sqrt(4);
       break;
     case lapack::Norm::Two:
-      FAIL() << "not valid norm for lange" << lapack::norm2str(norm);
+      FAIL() << "not valid norm for lange " << lapack::norm2str(norm);
   }
 
   norm_expected *= value;
   test_lange<T>(norm, size, extra_lda, norm_expected);
 }
 
+}
+}
 }

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -1,0 +1,94 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <sstream>
+#include "gtest/gtest.h"
+#include "dlaf/lapack_tile.h"
+#include "dlaf/memory/memory_view.h"
+#include "dlaf/tile.h"
+#include "dlaf/util_blas.h"
+#include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf_test;
+using namespace testing;
+
+using dlaf::util::size_t::mul;
+
+template <class T, bool return_info>
+void testLange(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
+  (void) uplo;
+  (void) n;
+  (void) extra_lda;
+  //  TileElementSize size_a = TileElementSize(n, n);
+  //
+  //  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  //
+  //  std::stringstream s;
+  //  s << "POTRF: " << uplo;
+  //  s << ", n = " << n << ", lda = " << lda;
+  //  SCOPED_TRACE(s.str());
+  //
+  //  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+  //
+  //  // Create tiles.
+  //  Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
+  //
+  //  // Note: The tile elements are chosen such that:
+  //  // - res_ij = 1 / 2^(|i-j|) * exp(I*(-i+j)),
+  //  // where I = 0 for real types or I is the complex unit for complex types.
+  //  // Therefore the result should be:
+  //  // a_ij = Sum_k(res_ik * ConjTrans(res)_kj) =
+  //  //      = Sum_k(1 / 2^(|i-k| + |j-k|) * exp(I*(-i+j))),
+  //  // where k = 0 .. min(i,j)
+  //  // Therefore,
+  //  // a_ij = (4^(min(i,j)+1) - 1) / (3 * 2^(i+j)) * exp(I*(-i+j))
+  //  auto el_a = [uplo](const TileElementIndex& index) {
+  //    if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
+  //        (uplo == blas::Uplo::Upper && index.row() > index.col()))
+  //      return TypeUtilities<T>::element(-9.9, 0);
+  //
+  //    double i = index.row();
+  //    double j = index.col();
+  //
+  //    return TypeUtilities<T>::polar(std::exp2(-(i + j)) / 3 * (std::exp2(2 * (std::min(i, j) + 1)) - 1),
+  //                                   -i + j);
+  //  };
+  //
+  //  auto res_a = [uplo](const TileElementIndex& index) {
+  //    if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
+  //        (uplo == blas::Uplo::Upper && index.row() > index.col()))
+  //      return TypeUtilities<T>::element(-9.9, 0);
+  //
+  //    double i = index.row();
+  //    double j = index.col();
+  //
+  //    return TypeUtilities<T>::polar(std::exp2(-std::abs(i - j)), -i + j);
+  //  };
+  //
+  //  // Set tile elements.
+  //  set(a, el_a);
+  //
+  //  if (return_info) {
+  //    EXPECT_EQ(0, tile::potrfInfo(uplo, a));
+  //  }
+  //  else {
+  //    tile::potrf(uplo, a);
+  //  }
+  //
+  //  // Check result against analytical result.
+  //  CHECK_TILE_NEAR(res_a, a, 4 * (n + 1) * TypeUtilities<T>::error,
+  //                  4 * (n + 1) * TypeUtilities<T>::error);
+}

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -84,9 +84,6 @@ void test_lange(lapack::Norm norm, const Tile<T, Device::CPU>& a, NormT<T> norm_
   SCOPED_TRACE(::testing::Message() << "LANGE: " << lapack::norm2str(norm) << ", " << a.size()
                                     << ", ld = " << a.ld());
 
-  // by LAPACK documentation, if it is an empty matrix return 0
-  norm_expected = (a.size().isEmpty()) ? 0 : norm_expected;
-
   EXPECT_FLOAT_EQ(norm_expected, lange(norm, a));
 }
 
@@ -111,10 +108,14 @@ void run(lapack::Norm norm, const Tile<T, Device::CPU>& a) {
       norm_expected = size != TileElementSize{1, 1} ? std::sqrt(17) : std::sqrt(4);
       break;
     case lapack::Norm::Two:
-      FAIL() << "not valid norm for lange " << lapack::norm2str(norm);
+      FAIL() << "norm " << lapack::norm2str(norm) << " is not supported by lange";
   }
 
   norm_expected *= value;
+
+  // by LAPACK documentation, if it is an empty matrix return 0
+  norm_expected = (a.size().isEmpty()) ? 0 : norm_expected;
+
   test_lange<T>(norm, a, norm_expected);
 }
 

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -11,84 +11,94 @@
 #pragma once
 
 #include <sstream>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <lapack.hh>
+
 #include "dlaf/lapack_tile.h"
+#include "dlaf/matrix/index.h"
 #include "dlaf/memory/memory_view.h"
 #include "dlaf/tile.h"
-#include "dlaf/util_blas.h"
+#include "dlaf/types.h"
+
 #include "dlaf_test/matrix/util_tile.h"
 #include "dlaf_test/util_types.h"
 
-using namespace dlaf;
-using namespace dlaf::matrix;
-using namespace dlaf::matrix::test;
-using namespace dlaf_test;
-using namespace testing;
+namespace {
 
-using dlaf::util::size_t::mul;
+using dlaf::SizeType;
 
-template <class T, bool return_info>
-void testLange(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
-  (void) uplo;
-  (void) n;
-  (void) extra_lda;
-  //  TileElementSize size_a = TileElementSize(n, n);
-  //
-  //  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
-  //
-  //  std::stringstream s;
-  //  s << "POTRF: " << uplo;
-  //  s << ", n = " << n << ", lda = " << lda;
-  //  SCOPED_TRACE(s.str());
-  //
-  //  memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
-  //
-  //  // Create tiles.
-  //  Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
-  //
-  //  // Note: The tile elements are chosen such that:
-  //  // - res_ij = 1 / 2^(|i-j|) * exp(I*(-i+j)),
-  //  // where I = 0 for real types or I is the complex unit for complex types.
-  //  // Therefore the result should be:
-  //  // a_ij = Sum_k(res_ik * ConjTrans(res)_kj) =
-  //  //      = Sum_k(1 / 2^(|i-k| + |j-k|) * exp(I*(-i+j))),
-  //  // where k = 0 .. min(i,j)
-  //  // Therefore,
-  //  // a_ij = (4^(min(i,j)+1) - 1) / (3 * 2^(i+j)) * exp(I*(-i+j))
-  //  auto el_a = [uplo](const TileElementIndex& index) {
-  //    if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
-  //        (uplo == blas::Uplo::Upper && index.row() > index.col()))
-  //      return TypeUtilities<T>::element(-9.9, 0);
-  //
-  //    double i = index.row();
-  //    double j = index.col();
-  //
-  //    return TypeUtilities<T>::polar(std::exp2(-(i + j)) / 3 * (std::exp2(2 * (std::min(i, j) + 1)) - 1),
-  //                                   -i + j);
-  //  };
-  //
-  //  auto res_a = [uplo](const TileElementIndex& index) {
-  //    if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
-  //        (uplo == blas::Uplo::Upper && index.row() > index.col()))
-  //      return TypeUtilities<T>::element(-9.9, 0);
-  //
-  //    double i = index.row();
-  //    double j = index.col();
-  //
-  //    return TypeUtilities<T>::polar(std::exp2(-std::abs(i - j)), -i + j);
-  //  };
-  //
-  //  // Set tile elements.
-  //  set(a, el_a);
-  //
-  //  if (return_info) {
-  //    EXPECT_EQ(0, tile::potrfInfo(uplo, a));
-  //  }
-  //  else {
-  //    tile::potrf(uplo, a);
-  //  }
-  //
-  //  // Check result against analytical result.
-  //  CHECK_TILE_NEAR(res_a, a, 4 * (n + 1) * TypeUtilities<T>::error,
-  //                  4 * (n + 1) * TypeUtilities<T>::error);
+template <class T>
+void testLange(lapack::Norm norm, SizeType m, SizeType n, SizeType extra_lda) {
+  using dlaf::TileElementSize;
+  using dlaf::TileElementIndex;
+  using dlaf::Tile;
+  using dlaf::Device;
+  using dlaf::memory::MemoryView;
+
+  using dlaf::tile::lange;
+  using dlaf::util::size_t::mul;
+  using dlaf::matrix::test::set;
+
+  using NormT = dlaf::BaseType<T>;
+
+  TileElementSize size = TileElementSize(m, n);
+
+  SizeType lda = std::max<SizeType>(1, size.rows()) + extra_lda;
+
+  std::stringstream s;
+  s << "LANGE: " << lapack::norm2str(norm);
+  s << ", " << size << ", lda = " << lda;
+  SCOPED_TRACE(s.str());
+
+  MemoryView<T, Device::CPU> mem_a(mul(lda, size.cols()));
+
+  // Create tiles.
+  Tile<T, Device::CPU> a(size, std::move(mem_a), lda);
+
+  const T max_value = dlaf_test::TypeUtilities<T>::element(13, -13);
+
+  // by LAPACK documentation, if it is an empty matrix return 0
+  const NormT norm_expected = (size.isEmpty()) ? 0 : std::abs(max_value);
+
+  {
+    SCOPED_TRACE("Max in Lower Triangular");
+
+    auto el_L = [size, max_value](const TileElementIndex& index) {
+      if (TileElementIndex{size.rows() - 1, 0} == index)
+        return max_value;
+      return T(0);
+    };
+
+    set(a, el_L);
+    EXPECT_FLOAT_EQ(norm_expected, lange(norm, a));
+  }
+
+  {
+    SCOPED_TRACE("Max in Upper Triangular");
+
+    auto el_U = [size, max_value](const TileElementIndex& index) {
+      if (TileElementIndex{0, size.cols() - 1} == index)
+        return max_value;
+      return T(0);
+    };
+
+    set(a, el_U);
+    EXPECT_FLOAT_EQ(norm_expected, lange(norm, a));
+  }
+
+  {
+    SCOPED_TRACE("Max on Diagonal");
+
+    auto el_D = [size, max_value](const TileElementIndex& index) {
+      if (TileElementIndex{size.rows() - 1, size.cols() - 1} == index)
+        return max_value;
+      return T(0);
+    };
+
+    set(a, el_D);
+    EXPECT_FLOAT_EQ(norm_expected, lange(norm, a));
+  }
+}
+
 }

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -49,6 +49,18 @@ Tile<T, Device::CPU> allocate_tile(TileElementSize size, SizeType extra_lda) {
   return std::move(a);
 }
 
+// This setter returns values of an abstract matrix like this
+//
+// 0v  0   0   3v
+// 0   0   0   0
+// 0   0   0   0
+// 2v  0   0   2v
+// 0   0   0   0
+// 0   0   0   0
+// 0   0   0   0
+// 0   0   0   0
+//
+// If the matrix is 1x1, its only value will be 2v
 template <class T>
 struct TileSetter {
   static const T value;

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -49,6 +49,27 @@ Tile<T, Device::CPU> allocate_tile(TileElementSize size, SizeType extra_lda) {
   return std::move(a);
 }
 
+// This setter returns values of an abstract matrix like this
+//
+// if (uplo == Lower)
+//
+// 2v  0   0   0
+// 0   0   0   0
+// 0   0   0   0
+// 3v  0   0   2v
+// 0   0   0   0
+// 0   0   0   0
+// 0   0   0   0
+// 0   0   0   0
+//
+// if (uplo == Upper)
+//
+// 2v  0   0   3v  0   0   0   0
+// 0   0   0   0   0   0   0   0
+// 0   0   0   0   0   0   0   0
+// 0   0   0   2v  0   0   0   0
+//
+// If the matrix is 1x1, its only value will be 2v
 template <class T>
 struct TileSetter {
   static const T value;

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -1,0 +1,94 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <sstream>
+#include "gtest/gtest.h"
+#include "dlaf/lapack_tile.h"
+#include "dlaf/memory/memory_view.h"
+#include "dlaf/tile.h"
+#include "dlaf/util_blas.h"
+#include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf_test;
+using namespace testing;
+
+using dlaf::util::size_t::mul;
+
+template <class T, bool return_info>
+void testLantr(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
+  (void) uplo;
+  (void) n;
+  (void) extra_lda;
+  // TileElementSize size_a = TileElementSize(n, n);
+
+  // SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+
+  // std::stringstream s;
+  // s << "POTRF: " << uplo;
+  // s << ", n = " << n << ", lda = " << lda;
+  // SCOPED_TRACE(s.str());
+
+  // memory::MemoryView<T, Device::CPU> mem_a(mul(lda, size_a.cols()));
+
+  //// Create tiles.
+  // Tile<T, Device::CPU> a(size_a, std::move(mem_a), lda);
+
+  //// Note: The tile elements are chosen such that:
+  //// - res_ij = 1 / 2^(|i-j|) * exp(I*(-i+j)),
+  //// where I = 0 for real types or I is the complex unit for complex types.
+  //// Therefore the result should be:
+  //// a_ij = Sum_k(res_ik * ConjTrans(res)_kj) =
+  ////      = Sum_k(1 / 2^(|i-k| + |j-k|) * exp(I*(-i+j))),
+  //// where k = 0 .. min(i,j)
+  //// Therefore,
+  //// a_ij = (4^(min(i,j)+1) - 1) / (3 * 2^(i+j)) * exp(I*(-i+j))
+  // auto el_a = [uplo](const TileElementIndex& index) {
+  //  if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
+  //      (uplo == blas::Uplo::Upper && index.row() > index.col()))
+  //    return TypeUtilities<T>::element(-9.9, 0);
+
+  //  double i = index.row();
+  //  double j = index.col();
+
+  //  return TypeUtilities<T>::polar(std::exp2(-(i + j)) / 3 * (std::exp2(2 * (std::min(i, j) + 1)) - 1),
+  //                                 -i + j);
+  //};
+
+  // auto res_a = [uplo](const TileElementIndex& index) {
+  //  if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
+  //      (uplo == blas::Uplo::Upper && index.row() > index.col()))
+  //    return TypeUtilities<T>::element(-9.9, 0);
+
+  //  double i = index.row();
+  //  double j = index.col();
+
+  //  return TypeUtilities<T>::polar(std::exp2(-std::abs(i - j)), -i + j);
+  //};
+
+  //// Set tile elements.
+  // set(a, el_a);
+
+  // if (return_info) {
+  //  EXPECT_EQ(0, tile::potrfInfo(uplo, a));
+  //}
+  // else {
+  //  tile::potrf(uplo, a);
+  //}
+
+  //// Check result against analytical result.
+  // CHECK_TILE_NEAR(res_a, a, 4 * (n + 1) * TypeUtilities<T>::error,
+  //                4 * (n + 1) * TypeUtilities<T>::error);
+}

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -111,9 +111,6 @@ void test_lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<
                                     << ", ld = " << a.ld() << " uplo = " << blas::uplo2str(uplo)
                                     << " diag = " << blas::diag2str(diag));
 
-  // by LAPACK documentation, if it is an empty matrix return 0
-  norm_expected = (a.size().isEmpty()) ? 0 : norm_expected;
-
   EXPECT_FLOAT_EQ(norm_expected, lantr(norm, uplo, diag, a));
 }
 
@@ -159,8 +156,11 @@ void run(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, Devi
       }
       break;
     case lapack::Norm::Two:
-      FAIL() << "not valid norm for lantr " << lapack::norm2str(norm);
+      FAIL() << "norm " << lapack::norm2str(norm) << " is not supported by lantr";
   }
+
+  // by LAPACK documentation, if it is an empty matrix return 0
+  norm_expected = (a.size().isEmpty()) ? 0 : norm_expected;
 
   test_lantr<T>(norm, uplo, diag, a, norm_expected);
 }

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -30,7 +30,6 @@ using dlaf::TileElementSize;
 using dlaf::TileElementIndex;
 using dlaf::Tile;
 using dlaf::Device;
-using dlaf::memory::MemoryView;
 
 using dlaf::tile::lantr;
 using dlaf::util::size_t::mul;
@@ -38,16 +37,6 @@ using dlaf::matrix::test::set;
 
 template <class T>
 using NormT = dlaf::BaseType<T>;
-
-template <class T>
-Tile<T, Device::CPU> allocate_tile(TileElementSize size, SizeType extra_lda) {
-  SizeType lda = std::max<SizeType>(1, size.rows()) + extra_lda;
-
-  MemoryView<T, Device::CPU> mem_a(mul(lda, size.cols()));
-  Tile<T, Device::CPU> a(size, std::move(mem_a), lda);
-
-  return std::move(a);
-}
 
 // This setter returns values of an abstract matrix like this
 //
@@ -114,11 +103,9 @@ template <class T>
 const T TileSetter<T>::value = dlaf_test::TypeUtilities<T>::element(13, -13);
 
 template <class T>
-void test_lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, TileElementSize size,
-                SizeType extra_lda, NormT<T> norm_expected) {
-  auto a = allocate_tile<T>(size, extra_lda);
-
-  set(a, TileSetter<T>{size, uplo});
+void test_lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, Device::CPU>& a,
+                NormT<T> norm_expected) {
+  set(a, TileSetter<T>{a.size(), uplo});
 
   SCOPED_TRACE(::testing::Message() << "LANTR: " << lapack::norm2str(norm) << ", " << a.size()
                                     << ", ld = " << a.ld() << " uplo = " << blas::uplo2str(uplo)
@@ -131,7 +118,9 @@ void test_lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, TileElement
 }
 
 template <class T>
-void run(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, TileElementSize size, SizeType extra_lda) {
+void run(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, Device::CPU>& a) {
+  const TileElementSize size = a.size();
+
   NormT<T> value = std::abs(TileSetter<T>::value);
   NormT<T> norm_expected;
 
@@ -173,7 +162,7 @@ void run(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, TileElementSize si
       FAIL() << "not valid norm for lantr " << lapack::norm2str(norm);
   }
 
-  test_lantr<T>(norm, uplo, diag, size, extra_lda, norm_expected);
+  test_lantr<T>(norm, uplo, diag, a, norm_expected);
 }
 
 }


### PR DESCRIPTION
Add wrappers and related tests for:
- `lange`
- `lantr`

These functions will be used starting from `miniapp_cholesky` in #197