### PR TITLE
Updating spack package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@
 
 ## How to install DLA-Future with spack
 
-We provide a spack package DLA-Future that can be easily add to your own spack as follows:
+We provide a spack package DLA-Future that can be easily added to your own spack as follows:
 
-`spack repo add spack`
+`spack repo add <dlaf root>/spack`
 
 This will add a new repository with namespace `dlaf`.
 
-The command to install the library for example on an HPC cluster will be similar to:
+Example installation:
 
-`spack install -v --test=root dla-future ^mkl ^hpx max_cpu_count=256`
+`spack install dla-future ^intel-mkl`
 
+Notice that, for the package to work correctly, the HPX option `max_cpu_count` must be set accordingly to the platform, as it represents the maximum number of OS-threads. 
+
+`spack install -v dla-future ^intel-mkl ^hpx max_cpu_count=256`
 
 ## How to use the library
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@
 - [GoogleTest](https://github.com/google/googletest) (optional; bundled) - unit testing
 - Doxygen (optional) - documentation
 
+## How to install DLA-Future with spack
+
+We provide a spack package DLA-Future that can be easily add to your own spack as follows:
+
+`spack repo add spack`
+
+This will add a new repository with namespace `dlaf`.
+
+The command to install the library for example on an HPC cluster will be similar to:
+
+`spack install -v --test=root dla-future ^mkl ^hpx max_cpu_count=256`
+
+
 ## How to use the library
 
 Using DLAF in a CMake project is extremly easy!

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Example installation:
 
 `spack install dla-future ^intel-mkl`
 
-Notice that, for the package to work correctly, the HPX option `max_cpu_count` must be set accordingly to the platform, as it represents the maximum number of OS-threads. 
+Notice that, for the package to work correctly, the HPX option `max_cpu_count` must be set accordingly to the platform,
+as it represents the maximum number of OS-threads. 
 
 `spack install dla-future ^intel-mkl ^hpx max_cpu_count=256`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Example installation:
 
 Notice that, for the package to work correctly, the HPX option `max_cpu_count` must be set accordingly to the platform, as it represents the maximum number of OS-threads. 
 
-`spack install -v dla-future ^intel-mkl ^hpx max_cpu_count=256`
+`spack install dla-future ^intel-mkl ^hpx max_cpu_count=256`
 
 ## How to use the library
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 We provide a spack package DLA-Future that can be easily added to your own spack as follows:
 
-`spack repo add <dlaf root>/spack`
+`spack repo add $DLAF_ROOT/spack`
 
 This will add a new repository with namespace `dlaf`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example installation:
 `spack install dla-future ^intel-mkl`
 
 Notice that, for the package to work correctly, the HPX option `max_cpu_count` must be set accordingly to the platform,
-as it represents the maximum number of OS-threads. 
+as it represents the maximum number of OS-threads.
 
 `spack install dla-future ^intel-mkl ^hpx max_cpu_count=256`
 

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -39,7 +39,7 @@ class DlaFuture(CMakePackage):
 
        if '+cuda' in spec:
            args.append('-DDLAF_WITH_CUDA=ON')
-           args.append('-DCUDA_HOME={0}'.format(spec['cuda'].prefix))
+           #args.append('-DCUDA_HOME={0}'.format(spec['cuda'].prefix))
 
        if self.run_tests:
            args.append('-DDLAF_WITH_TEST=ON')

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -19,7 +19,7 @@ class DlaFuture(CMakePackage):
             description='Use the GPU/cuBLAS back end.')
     variant('doc', default=False,
             description='Build documentation.')
-    
+
     #depends_on('mpi@3:')
     depends_on('mpi')
     depends_on('blaspp')
@@ -29,24 +29,25 @@ class DlaFuture(CMakePackage):
 
     def cmake_args(self):
        spec = self.spec
-       
+
        if (spec.satisfies('^intel-mkl')):
            args = ['-DDLAF_WITH_MKL=ON']
        else:
            args = ['-DDLAF_WITH_MKL=OFF']
+           lapack_name = spec['lapack'].libs.ld_flags.split()[1]
+           blas_name = spec['blas'].libs.ld_flags.split()[1]
+           lapack_libs = spec['lapack'].prefix.lib
+           blas_libs = spec['blas'].prefix.lib
            args.append('-DLAPACK_TYPE=Custom')
-           args.append('-DLAPACK_LIBRARY=-L{0} -lblas -llapack'.format(spec['lapack'].prefix.lib))
+           args.append('-DLAPACK_LIBRARY=-L{0} {1} -L{2} {3}'.format(lapack_libs, lapack_name, blas_libs, blas_name))
 
        if '+cuda' in spec:
            args.append('-DDLAF_WITH_CUDA=ON')
-           #args.append('-DCUDA_HOME={0}'.format(spec['cuda'].prefix))
 
        if self.run_tests:
            args.append('-DDLAF_WITH_TEST=ON')
-           args.append('-DDLAF_INSTALL_TESTS=ON')
-       else:
+        else:
            args.append('-DDLAF_WITH_TEST=OFF')
-           args.append('-DDLAF_INSTALL_TESTS=OFF')
 
        if '+doc' in spec:
            args.append('-DBUILD_DOC=on')

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -30,7 +30,7 @@ class DlaFuture(CMakePackage):
     def cmake_args(self):
        spec = self.spec
 
-       if (spec.satisfies('^intel-mkl')):
+       if '^mkl' in spec:
            args = ['-DDLAF_WITH_MKL=ON']
        else:
            args = ['-DDLAF_WITH_MKL=OFF']
@@ -42,7 +42,7 @@ class DlaFuture(CMakePackage):
 
        if self.run_tests:
            args.append('-DDLAF_WITH_TEST=ON')
-        else:
+       else:
            args.append('-DDLAF_WITH_TEST=OFF')
 
        if '+doc' in spec:

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -25,7 +25,7 @@ class DlaFuture(CMakePackage):
     depends_on('blaspp')
     depends_on('lapackpp')
     depends_on('hpx@1.4.0: cxxstd=14 networking=none')
-    depends_on('cuda', when='cuda=True')
+    depends_on('cuda', when='+cuda')
 
     def cmake_args(self):
        spec = self.spec

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -17,18 +17,14 @@ class DlaFuture(CMakePackage):
 
     variant('cuda', default=False,
             description='Use the GPU/cuBLAS back end.')
-    variant('test', default=False,
-            description='Run unit tests.')
     variant('doc', default=False,
             description='Build documentation.')
     
     #depends_on('mpi@3:')
     depends_on('mpi')
-    depends_on('blas')
-    depends_on('lapack')
     depends_on('blaspp')
     depends_on('lapackpp')
-    depends_on('hpx@1.4.0 cxxstd=14 networking=none')
+    depends_on('hpx@1.4.0: cxxstd=14 networking=none')
     depends_on('cuda', when='cuda=True')
 
     def cmake_args(self):
@@ -43,11 +39,14 @@ class DlaFuture(CMakePackage):
 
        if '+cuda' in spec:
            args.append('-DDLAF_WITH_CUDA=ON')
-           args.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING={0}'.format(spec['cuda'].prefix))
+           args.append('-DCUDA_HOME={0}'.format(spec['cuda'].prefix))
 
-       if '+test' in spec:
+       if self.run_tests:
            args.append('-DDLAF_WITH_TEST=ON')
            args.append('-DDLAF_INSTALL_TESTS=ON')
+       else:
+           args.append('-DDLAF_WITH_TEST=OFF')
+           args.append('-DDLAF_INSTALL_TESTS=OFF')
 
        if '+doc' in spec:
            args.append('-DBUILD_DOC=on')

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -24,7 +24,7 @@ class DlaFuture(CMakePackage):
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')
-    depends_on('hpx@1.4.0: cxxstd=14 networking=none')
+    depends_on('hpx@1.4.1: max_cpu_count=128 cxxstd=14 networking=none')
     depends_on('cuda', when='+cuda')
 
     def cmake_args(self):

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -1,46 +1,55 @@
-#Copyright 2013 - 2020 Lawrence Livermore National Security, LLC and other
-#Spack Project Developers.See the top - level COPYRIGHT file for details.
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-#SPDX - License - Identifier : (Apache - 2.0 OR MIT)
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import*
+from spack import *
 
-    class DlaFuture(CMakePackage)
-    : ""
-      "The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"
-      ""
+class DlaFuture(CMakePackage):
+    """The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"""
 
-      homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki" git =
-          "https://github.com/eth-cscs/DLA-Future.git"
+    homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki"
+    git      = "https://github.com/eth-cscs/DLA-Future.git"
 
-      maintainers = ['teonnik', 'Sely85']
+    maintainers = ['teonnik', 'Sely85']
 
-      version('develop', branch = 'master')
+    version('develop', branch='master')
 
-          variant('cuda', default = False, description = 'Use the GPU/cuBLAS back end.')
-              variant('test', default = False, description = 'Run unit tests.')
-                  variant('doc', default = False, description = 'Build documentation.')
+    variant('cuda', default=False,
+            description='Use the GPU/cuBLAS back end.')
+    variant('test', default=False,
+            description='Run unit tests.')
+    variant('doc', default=False,
+            description='Build documentation.')
+    
+    #depends_on('mpi@3:')
+    depends_on('mpi')
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('blaspp')
+    depends_on('lapackpp')
+    depends_on('hpx@1.4.0 cxxstd=14 networking=none')
+    depends_on('cuda', when='cuda=True')
 
-#depends_on('mpi@3:')
-                      depends_on('mpi') depends_on('blas') depends_on('lapack') depends_on('blaspp')
-                          depends_on('lapackpp') depends_on('hpx@1.4.0 cxxstd=14 networking=none')
-                              depends_on('cuda', when = 'cuda=True')
+    def cmake_args(self):
+       spec = self.spec
+       
+       if (spec.satisfies('^intel-mkl')):
+           args = ['-DDLAF_WITH_MKL=ON']
+       else:
+           args = ['-DDLAF_WITH_MKL=OFF']
+           args.append('-DLAPACK_TYPE=Custom')
+           args.append('-DLAPACK_LIBRARY=-L{0} -lblas -llapack'.format(spec['lapack'].prefix.lib))
 
-                                  def cmake_args(self)
-    : spec = self.spec
+       if '+cuda' in spec:
+           args.append('-DDLAF_WITH_CUDA=ON')
+           args.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING={0}'.format(spec['cuda'].prefix))
 
-             if (spec.satisfies('^intel-mkl'))
-    : args = ['-DDLAF_WITH_MKL=ON'] else
-    : args = ['-DDLAF_WITH_MKL=OFF'] args.append('-DLAPACK_TYPE=Custom')
-                 args.append('-DLAPACK_LIBRARY=-L{0} -lblas -llapack'.format(spec['lapack'].prefix.lib))
+       if '+test' in spec:
+           args.append('-DDLAF_WITH_TEST=ON')
+           args.append('-DDLAF_INSTALL_TESTS=ON')
 
-                     if '+cuda' in spec : args.append('-DDLAF_WITH_CUDA=ON') args
-                                              .append('-DCUDA_TOOLKIT_ROOT_DIR:STRING={0}'.format(
-                                                  spec['cuda'].prefix))
+       if '+doc' in spec:
+           args.append('-DBUILD_DOC=on')
 
-                                                  if '+test' in spec
-    : args.append('-DDLAF_WITH_TEST=ON') args.append('-DDLAF_INSTALL_TESTS=ON')
-
-          if '+doc' in spec : args.append('-DBUILD_DOC=on')
-
-                                  return args
+       return args

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -34,12 +34,8 @@ class DlaFuture(CMakePackage):
            args = ['-DDLAF_WITH_MKL=ON']
        else:
            args = ['-DDLAF_WITH_MKL=OFF']
-           lapack_name = spec['lapack'].libs.ld_flags.split()[1]
-           blas_name = spec['blas'].libs.ld_flags.split()[1]
-           lapack_libs = spec['lapack'].prefix.lib
-           blas_libs = spec['blas'].prefix.lib
            args.append('-DLAPACK_TYPE=Custom')
-           args.append('-DLAPACK_LIBRARY=-L{0} {1} -L{2} {3}'.format(lapack_libs, lapack_name, blas_libs, blas_name))
+           args.append('-DLAPACK_LIBRARY={} {}'.format(spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags))
 
        if '+cuda' in spec:
            args.append('-DDLAF_WITH_CUDA=ON')

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+#Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -20,7 +20,6 @@ class DlaFuture(CMakePackage):
     variant('doc', default=False,
             description='Build documentation.')
 
-    #depends_on('mpi@3:')
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -1,4 +1,4 @@
-#Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -24,7 +24,7 @@ class DlaFuture(CMakePackage):
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')
-    depends_on('hpx@1.4.1: max_cpu_count=128 cxxstd=14 networking=none')
+    depends_on('hpx@1.4.0: max_cpu_count=128 cxxstd=14 networking=none')
     depends_on('cuda', when='+cuda')
 
     def cmake_args(self):

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -1,56 +1,46 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#Copyright 2013 - 2020 Lawrence Livermore National Security, LLC and other
+#Spack Project Developers.See the top - level COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#SPDX - License - Identifier : (Apache - 2.0 OR MIT)
 
-from spack import *
+from spack import*
 
+    class DlaFuture(CMakePackage)
+    : ""
+      "The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"
+      ""
 
-class DlaFuture(CMakePackage):
-    """The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"""
+      homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki" git =
+          "https://github.com/eth-cscs/DLA-Future.git"
 
-    homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki"
-    git      = "https://github.com/eth-cscs/DLA-Future.git"
+      maintainers = ['teonnik', 'Sely85']
 
-    maintainers = ['teonnik', 'Sely85']
+      version('develop', branch = 'master')
 
-    version('develop', branch='master')
+          variant('cuda', default = False, description = 'Use the GPU/cuBLAS back end.')
+              variant('test', default = False, description = 'Run unit tests.')
+                  variant('doc', default = False, description = 'Build documentation.')
 
-    variant('cuda', default=False,
-            description='Use the GPU/cuBLAS back end.')
-    variant('test', default=False,
-            description='Run unit tests.')
-    variant('doc', default=False,
-            description='Build documentation.')
-    
-    #depends_on('mpi@3:')
-    depends_on('mpi')
-    depends_on('blas')
-    depends_on('lapack')
-    depends_on('blaspp')
-    depends_on('lapackpp')
-    depends_on('hpx@1.4.0 cxxstd=14 networking=none')
-    depends_on('cuda', when='cuda=True')
+#depends_on('mpi@3:')
+                      depends_on('mpi') depends_on('blas') depends_on('lapack') depends_on('blaspp')
+                          depends_on('lapackpp') depends_on('hpx@1.4.0 cxxstd=14 networking=none')
+                              depends_on('cuda', when = 'cuda=True')
 
-    def cmake_args(self):
-       spec = self.spec
-       
-       if (spec.satisfies('^intel-mkl')):
-           args = ['-DDLAF_WITH_MKL=ON']
-       else:
-           args = ['-DDLAF_WITH_MKL=OFF']
-           args.append('-DLAPACK_TYPE=Custom')
-           args.append('-DLAPACK_LIBRARY=-L{0} -lblas -llapack'.format(spec['lapack'].prefix.lib))
+                                  def cmake_args(self)
+    : spec = self.spec
 
-       if '+cuda' in spec:
-           args.append('-DDLAF_WITH_CUDA=ON')
-           args.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING={0}'.format(spec['cuda'].prefix))
+             if (spec.satisfies('^intel-mkl'))
+    : args = ['-DDLAF_WITH_MKL=ON'] else
+    : args = ['-DDLAF_WITH_MKL=OFF'] args.append('-DLAPACK_TYPE=Custom')
+                 args.append('-DLAPACK_LIBRARY=-L{0} -lblas -llapack'.format(spec['lapack'].prefix.lib))
 
-       if '+test' in spec:
-           args.append('-DDLAF_WITH_TEST=ON')
-           args.append('-DDLAF_INSTALL_TESTS=ON')
+                     if '+cuda' in spec : args.append('-DDLAF_WITH_CUDA=ON') args
+                                              .append('-DCUDA_TOOLKIT_ROOT_DIR:STRING={0}'.format(
+                                                  spec['cuda'].prefix))
 
-       if '+doc' in spec:
-           args.append('-DBUILD_DOC=on')
+                                                  if '+test' in spec
+    : args.append('-DDLAF_WITH_TEST=ON') args.append('-DDLAF_INSTALL_TESTS=ON')
 
-       return args
+          if '+doc' in spec : args.append('-DBUILD_DOC=on')
+
+                                  return args

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -24,7 +24,7 @@ class DlaFuture(CMakePackage):
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')
-    depends_on('hpx@1.4.0:1.4.1 max_cpu_count=128 cxxstd=14 networking=none')
+    depends_on('hpx@1.4.0:1.4.1 cxxstd=14 networking=none')
     depends_on('cuda', when='+cuda')
 
     def cmake_args(self):

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -24,7 +24,7 @@ class DlaFuture(CMakePackage):
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')
-    depends_on('hpx@1.4.0: max_cpu_count=128 cxxstd=14 networking=none')
+    depends_on('hpx@1.4.0:1.4.1 max_cpu_count=128 cxxstd=14 networking=none')
     depends_on('cuda', when='+cuda')
 
     def cmake_args(self):


### PR DESCRIPTION
Proposal of spack package modification (thanks @albestro):
- renamed variant called 'gpu' to 'cuda', to align with other packages
- commented 'mpich' dependence, uncommented 'mpi'
- added '+test' variant
- added '+doc' variant
- modified blas/lapack providers, to allow both intelMKL and custom libraries
- fixed HPX version to 1.4.0 (as required at this moment)
- added CUDA_TOOLKIT_ROOT_DIR argument (required for some architectures).