### PR TITLE
Split DLAF into OBJECT libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build Type" FORCE)
 endif()
 
+option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
+
 # ---------------------------------------------------------------------------
 # Languages
 # ---------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.14)
 
 project(DLAF VERSION 0.1.0)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,18 +99,12 @@ add_library(dlaf.core
 target_link_libraries(dlaf.core PUBLIC dlaf.prop)
 
 # Define DLAF's Factorization library
-add_library(dlaf.factorization
-  OBJECT
-    factorization/mc.cpp
-)
-target_link_libraries(dlaf.factorization PUBLIC dlaf.core dlaf.prop)
+add_library(dlaf.factorization OBJECT factorization/mc.cpp)
+target_link_libraries(dlaf.factorization PUBLIC dlaf.prop)
 
 # Define DLAF's Solver library
-add_library(dlaf.solver
-  OBJECT
-    solver/mc.cpp
-)
-target_link_libraries(dlaf.solver PUBLIC dlaf.core dlaf.prop)
+add_library(dlaf.solver OBJECT solver/mc.cpp)
+target_link_libraries(dlaf.solver PUBLIC dlaf.prop)
 
 # Define DLAF's complete library
 add_library(DLAF

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,46 +32,6 @@ configure_file("${PROJECT_SOURCE_DIR}/include/dlaf/version.h.in"
                "${PROJECT_BINARY_DIR}/include/dlaf/version.h"
                @ONLY)
 
-add_library(DLAF
-  communication/communicator_impl.cpp
-  communication/communicator.cpp
-  communication/communicator_grid.cpp
-  communication/datatypes.cpp
-  matrix/distribution.cpp
-  matrix/layout_info.cpp
-  matrix.cpp
-  memory/memory_view.cpp
-  tile.cpp
-  auxiliary/mc.cpp
-  factorization/mc.cpp
-  solver/mc.cpp
-)
-
-target_include_directories(DLAF
-  PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${HPX_INCLUDE_DIRS}
-  PRIVATE
-    include/
-)
-
-target_link_libraries(DLAF
-  PUBLIC
-    MPI::MPI_CXX
-    ${HPX_LIBRARIES}
-    ${LAPACK_TARGET}
-    lapackpp
-    blaspp
-    $<TARGET_NAME_IF_EXISTS:dlaf::cublas>
-    $<TARGET_NAME_IF_EXISTS:dlaf::cudart>
-)
-
-target_compile_features(DLAF PUBLIC cxx_std_14)
-
-target_add_warnings(DLAF)
-
 # ----- Options, Flags, Defines, ...
 
 # Check for pretty function support
@@ -140,19 +100,24 @@ add_library(dlaf.core
 )
 target_link_libraries(dlaf.core PUBLIC dlaf.prop)
 
-# Define DLAF's Factorization library
+# Define DLAF's factorization library
 add_library(dlaf.factorization OBJECT factorization/mc.cpp)
 target_link_libraries(dlaf.factorization PUBLIC dlaf.prop)
 
-# Define DLAF's Solver library
+# Define DLAF's solver library
 add_library(dlaf.solver OBJECT solver/mc.cpp)
 target_link_libraries(dlaf.solver PUBLIC dlaf.prop)
+
+# Define DLAF's auxiliary library
+add_library(dlaf.auxiliary OBJECT auxiliary/mc.cpp)
+target_link_libraries(dlaf.auxiliary PUBLIC dlaf.prop)
 
 # Define DLAF's complete library
 add_library(DLAF
   $<TARGET_OBJECTS:dlaf.core>
   $<TARGET_OBJECTS:dlaf.factorization>
   $<TARGET_OBJECTS:dlaf.solver>
+  $<TARGET_OBJECTS:dlaf.auxiliary>
 )
 target_link_libraries(DLAF PUBLIC dlaf.prop)
 target_add_warnings(DLAF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,47 +32,6 @@ configure_file("${PROJECT_SOURCE_DIR}/include/dlaf/version.h.in"
                "${PROJECT_BINARY_DIR}/include/dlaf/version.h"
                @ONLY)
 
-add_library(DLAF
-  communication/communicator_impl.cpp
-  communication/communicator.cpp
-  communication/communicator_grid.cpp
-  communication/datatypes.cpp
-  factorization/mc.cpp
-  matrix/distribution.cpp
-  matrix/layout_info.cpp
-  matrix.cpp
-  memory/memory_view.cpp
-  tile.cpp
-  solver/mc.cpp
-)
-
-target_include_directories(DLAF
-  PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${HPX_INCLUDE_DIRS}
-  PRIVATE
-    include/
-)
-
-target_link_libraries(DLAF
-  PUBLIC
-    MPI::MPI_CXX
-    ${HPX_LIBRARIES}
-    ${LAPACK_TARGET}
-    lapackpp
-    blaspp
-    $<TARGET_NAME_IF_EXISTS:dlaf::cublas>
-    $<TARGET_NAME_IF_EXISTS:dlaf::cudart>
-)
-
-target_compile_features(DLAF PUBLIC cxx_std_14)
-
-target_add_warnings(DLAF)
-
-# ----- Options, Flags, Defines, ...
-
 # Check for pretty function support
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles("int main() { const char *name = __PRETTY_FUNCTION__; }" is_pretty_function_available)
@@ -92,19 +51,81 @@ option(DLAF_ASSERT_ENABLE          "Enable low impact assertions"    ${DLAF_ASSE
 option(DLAF_ASSERT_MODERATE_ENABLE "Enable medium impact assertions" ${DLAF_ASSERT_MODERATE_DEFAULT})
 option(DLAF_ASSERT_HEAVY_ENABLE    "Enable high impact assertions"   ${DLAF_ASSERT_HEAVY_DEFAULT})
 
-target_compile_definitions(DLAF PUBLIC
-  $<$<BOOL:${DLAF_ASSERT_ENABLE}>:DLAF_ASSERT_ENABLE>
-  $<$<BOOL:${DLAF_ASSERT_MODERATE_ENABLE}>:DLAF_ASSERT_MODERATE_ENABLE>
-  $<$<BOOL:${DLAF_ASSERT_HEAVY_ENABLE}>:DLAF_ASSERT_HEAVY_ENABLE>
-  DLAF_FUNCTION_NAME=$<IF:$<BOOL:is_pretty_function_available>,__PRETTY_FUNCTION__,__func__>
-  $<$<BOOL:${DLAF_WITH_CUDA}>:DLAF_WITH_CUDA>
+# Define DLAF's PUBLIC properties
+add_library(dlaf.prop INTERFACE)
+target_include_directories(dlaf.prop
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${HPX_INCLUDE_DIRS}
 )
+target_link_libraries(dlaf.prop
+  INTERFACE
+    MPI::MPI_CXX
+    ${HPX_LIBRARIES}
+    ${LAPACK_TARGET}
+    lapackpp
+    blaspp
+    $<TARGET_NAME_IF_EXISTS:dlaf::cublas>
+    $<TARGET_NAME_IF_EXISTS:dlaf::cudart>
+)
+target_compile_features(dlaf.prop
+  INTERFACE
+    cxx_std_14
+)
+target_compile_definitions(dlaf.prop
+  INTERFACE
+    $<$<BOOL:${DLAF_ASSERT_ENABLE}>:DLAF_ASSERT_ENABLE>
+    $<$<BOOL:${DLAF_ASSERT_MODERATE_ENABLE}>:DLAF_ASSERT_MODERATE_ENABLE>
+    $<$<BOOL:${DLAF_ASSERT_HEAVY_ENABLE}>:DLAF_ASSERT_HEAVY_ENABLE>
+    DLAF_FUNCTION_NAME=$<IF:$<BOOL:is_pretty_function_available>,__PRETTY_FUNCTION__,__func__>
+    $<$<BOOL:${DLAF_WITH_CUDA}>:DLAF_WITH_CUDA>
+)
+
+# Define DLAF's CORE library
+add_library(dlaf.core
+  OBJECT
+    communication/communicator_impl.cpp
+    communication/communicator.cpp
+    communication/communicator_grid.cpp
+    communication/datatypes.cpp
+    matrix/distribution.cpp
+    matrix/layout_info.cpp
+    matrix.cpp
+    memory/memory_view.cpp
+    tile.cpp
+)
+target_link_libraries(dlaf.core PUBLIC dlaf.prop)
+
+# Define DLAF's Factorization library
+add_library(dlaf.factorization
+  OBJECT
+    factorization/mc.cpp
+)
+target_link_libraries(dlaf.factorization PUBLIC dlaf.core dlaf.prop)
+
+# Define DLAF's Solver library
+add_library(dlaf.solver
+  OBJECT
+    solver/mc.cpp
+)
+target_link_libraries(dlaf.solver PUBLIC dlaf.core dlaf.prop)
+
+# Define DLAF's complete library
+add_library(DLAF
+  $<TARGET_OBJECTS:dlaf.core>
+  $<TARGET_OBJECTS:dlaf.factorization>
+  $<TARGET_OBJECTS:dlaf.solver>
+)
+target_link_libraries(DLAF PUBLIC dlaf.prop)
+target_add_warnings(DLAF)
 
 # ----- DEPLOY
 include(GNUInstallDirs)
 
 install(TARGETS
-  DLAF
+  DLAF dlaf.prop
   EXPORT DLAF-Targets
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -8,15 +8,40 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_types SOURCES test_types.cpp USE_MAIN PLAIN)
+DLAF_addTest(test_types
+  SOURCES test_types.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
 
-DLAF_addTest(test_util_math SOURCES test_util_math.cpp USE_MAIN PLAIN)
+DLAF_addTest(test_util_math
+  SOURCES test_util_math.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
 
-DLAF_addTest(test_blas_tile SOURCES test_blas_tile.cpp USE_MAIN HPX)
-DLAF_addTest(test_lapack_tile SOURCES test_lapack_tile.cpp USE_MAIN HPX)
-DLAF_addTest(test_tile SOURCES test_tile.cpp USE_MAIN HPX)
+DLAF_addTest(test_blas_tile
+  SOURCES test_blas_tile.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN HPX
+)
+DLAF_addTest(test_lapack_tile
+  SOURCES test_lapack_tile.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN HPX
+)
+DLAF_addTest(test_tile
+  SOURCES test_tile.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN HPX
+)
 
-DLAF_addTest(test_matrix SOURCES test_matrix.cpp USE_MAIN MPIHPX MPIRANKS 6)
+DLAF_addTest(test_matrix
+  SOURCES test_matrix.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)
 
 # Generic libraries
 add_subdirectory(common)

--- a/test/unit/auxiliary/mc/CMakeLists.txt
+++ b/test/unit/auxiliary/mc/CMakeLists.txt
@@ -8,4 +8,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_norm SOURCES test_norm.cpp USE_MAIN MPIHPX MPIRANKS 6)
+DLAF_addTest(test_norm
+  SOURCES test_norm.cpp
+  LIBRARIES dlaf.auxiliary dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -8,9 +8,28 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_index2d SOURCES test_index2d.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_size2d SOURCES test_size2d.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_range2d SOURCES test_range2d.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_data_descriptor SOURCES test_data_descriptor.cpp USE_MAIN PLAIN)
-
-DLAF_addTest(test_pipeline SOURCES test_pipeline.cpp USE_MAIN HPX)
+DLAF_addTest(test_index2d
+  SOURCES test_index2d.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_size2d
+  SOURCES test_size2d.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_range2d
+  SOURCES test_range2d.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_data_descriptor
+  SOURCES test_data_descriptor.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_pipeline
+  SOURCES test_pipeline.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN HPX
+)

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -10,42 +10,49 @@
 
 DLAF_addTest(test_message
   SOURCES test_message.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 2
   USE_MAIN MPI
 )
 
 DLAF_addTest(test_communicator
   SOURCES test_communicator.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 4
   USE_MAIN MPI
 )
 
 DLAF_addTest(test_communicator_grid
   SOURCES test_communicator_grid.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 6
   USE_MAIN MPI
 )
 
 DLAF_addTest(test_broadcast
   SOURCES test_broadcast.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 5
   USE_MAIN MPI
 )
 
 DLAF_addTest(test_reduce
   SOURCES test_reduce.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 4
   USE_MAIN MPI
 )
 
 DLAF_addTest(test_broadcast_tile
   SOURCES test_broadcast_tile.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 5
   USE_MAIN MPI
 )
 
 DLAF_addTest(test_broadcast_matrix
   SOURCES test_broadcast_matrix.cpp
+  LIBRARIES dlaf.core
   MPIRANKS 4
   USE_MAIN MPIHPX
 )

--- a/test/unit/factorization/mc/CMakeLists.txt
+++ b/test/unit/factorization/mc/CMakeLists.txt
@@ -8,4 +8,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_cholesky SOURCES test_cholesky.cpp USE_MAIN MPIHPX MPIRANKS 6)
+DLAF_addTest(test_cholesky
+  SOURCES test_cholesky.cpp
+  LIBRARIES dlaf.factorization dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -8,8 +8,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_layout_info SOURCES test_layout_info.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_util_distribution SOURCES test_util_distribution.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_distribution SOURCES test_distribution.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_matrix_view SOURCES test_matrix_view.cpp USE_MAIN MPIHPX MPIRANKS 6)
-DLAF_addTest(test_util_matrix SOURCES test_util_matrix.cpp USE_MAIN MPIHPX MPIRANKS 6)
+DLAF_addTest(test_layout_info
+  SOURCES test_layout_info.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_util_distribution
+  SOURCES test_util_distribution.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_distribution
+  SOURCES test_distribution.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)
+DLAF_addTest(test_matrix_view
+  SOURCES test_matrix_view.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)
+DLAF_addTest(test_util_matrix
+  SOURCES test_util_matrix.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)

--- a/test/unit/memory/CMakeLists.txt
+++ b/test/unit/memory/CMakeLists.txt
@@ -8,5 +8,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_memory_chunk SOURCES test_memory_chunk.cpp USE_MAIN PLAIN)
-DLAF_addTest(test_memory_view SOURCES test_memory_view.cpp USE_MAIN PLAIN)
+DLAF_addTest(test_memory_chunk
+  SOURCES test_memory_chunk.cpp
+  USE_MAIN PLAIN
+  LIBRARIES dlaf.core
+)
+DLAF_addTest(test_memory_view
+  SOURCES test_memory_view.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)

--- a/test/unit/solver/mc/CMakeLists.txt
+++ b/test/unit/solver/mc/CMakeLists.txt
@@ -8,4 +8,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_triangular SOURCES test_triangular.cpp USE_MAIN MPIHPX MPIRANKS 6)
+DLAF_addTest(test_triangular
+  SOURCES test_triangular.cpp
+  LIBRARIES dlaf.solver dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)


### PR DESCRIPTION
This PR addresses : https://github.com/eth-cscs/DLA-Future/issues/226 . In particular, (incremental) compile-times for tests, miniapps and future algorithms depending only on `dlaf.core` is significantly improved. 

DLAF is split into object libraries:
- dlaf.core
- dlaf.factorization
- dlaf.solver

The combined library is still under the `DLAF` target.

DLAF_AddTest was refactored a little bit. In particular the dlaf object library is specified via the `LIBRARIES` parameter of the `DLAF_addTest()` function.

Suggestion:
- Move the CACHE varibales from `DLAF_addTest()` to the top CMakeLists.txt file?

Note: The CMake version was bumped to 3.14 as linking object libraries is supported starting 3.13.

EDIT: The PR also adds an option to build DLAF as a shared library. However, there seems to be a problem with `lapackpp`  (the problem is unrelated to this PR, it happens on master too):

```
/usr/bin/ld: /home/teonnik/software/spack/opt/spack/linux-arch-broadwell/gcc-8.4.0/lapackpp-develop-e5l4clzhnoqu5tmrpydlu65owgzy53jo/lib/liblapackpp.a(potrf.cc.o): relocation R_X86_64_PC32 against symbol `_ZTVN6lapack5ErrorE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [src/CMakeFiles/DLAF.dir/build.make:270: src/libDLAF.so] Error 1
make[2]: *** [CMakeFiles/Makefile2:1299: src/CMakeFiles/DLAF.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1306: src/CMakeFiles/DLAF.dir/rule] Error 2
make: *** [Makefile:585: DLAF] Error 2
``` 