### PR TITLE
Add back warnings as errors for CI

### DIFF
--- a/ci/docker/debug/deploy.Dockerfile
+++ b/ci/docker/debug/deploy.Dockerfile
@@ -25,7 +25,7 @@ SHELL ["/bin/bash", "-c"]
 RUN mkdir ${BUILD} && cd ${BUILD} && \
     CC=/usr/local/mpich/bin/mpicc CXX=/usr/local/mpich/bin/mpicxx cmake ${SOURCE} \
       -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_CXX_FLAGS_DEBUG="-g -Og -fno-omit-frame-pointer" \
+      -DCMAKE_CXX_FLAGS_DEBUG="-Werror -g -Og -fno-omit-frame-pointer" \
       -DLAPACK_CUSTOM_TYPE=Custom \
       -DLAPACK_CUSTOM_INCLUDE_DIR=/usr/local/include \
       -DLAPACK_CUSTOM_LIBRARY=openblas \

--- a/ci/docker/release/deploy.Dockerfile
+++ b/ci/docker/release/deploy.Dockerfile
@@ -26,6 +26,7 @@ RUN mkdir ${BUILD} && cd ${BUILD} && \
     CC=/usr/local/mpich/bin/mpicc CXX=/usr/local/mpich/bin/mpicxx cmake ${SOURCE} \
       -DMKL_ROOT=/opt/intel/compilers_and_libraries/linux/mkl \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_CXX_FLAGS_RELEASE="-Werror" \
       -DDLAF_WITH_CUDA=OFF \
       -DDLAF_WITH_MKL=ON \
       -DDLAF_WITH_TEST=ON \


### PR DESCRIPTION
Add back warnings as errors, it has been missed and left out during migration from previous CI system.

I will address in this PR also minor changes needed to solve warnings, if present.