### PR TITLE
Silence pushd/popd

### DIFF
--- a/ci/mpi-ctest
+++ b/ci/mpi-ctest
@@ -10,7 +10,7 @@ if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
     lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "$LOCAL_REPORTS/baseline-codecov.info" &> /dev/null
 fi;
 
-pushd /DLA-Future-build
+pushd /DLA-Future-build > /dev/null
 
 # Run the tests, only output on the first rank
 if [[ $SLURM_PROCID == "0" ]]; then
@@ -19,7 +19,7 @@ else
     ctest -Q $@
 fi
 
-popd
+popd > /dev/null
 
 # Create coverage reports for code run
 if [[ "$ENABLE_COVERAGE" == "YES" ]]; then

--- a/ci/upload_codecov
+++ b/ci/upload_codecov
@@ -5,7 +5,7 @@ SHARED_REPORTS="$CI_PROJECT_DIR/codecov-reports"
 TRACE_FILES_ARGS=`find "$SHARED_REPORTS" -type f -iname '*.info' -exec sh -c "echo --add-tracefile {}" \;`
 lcov ${TRACE_FILES_ARGS} --output-file "$SHARED_REPORTS/combined.info"
 
-pushd /DLA-Future
+pushd /DLA-Future > /dev/null
 bash <(curl -s https://codecov.io/bash) -f "$SHARED_REPORTS/combined.info" -t $CODECOV_TOKEN_GITHUB
 bash <(curl -s https://codecov.io/bash) -f "$SHARED_REPORTS/combined.info" -t $CODECOV_TOKEN_GITLAB
-popd
+popd > /dev/null


### PR DESCRIPTION
Didn't realize pushd and popd always output the stack, so better silence them to reduce noise in CI