### PR TITLE
Porting to HPX 1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ set(CMAKE_CXX_STANDARD 14)
 # ---- CUDA
 set(DLAF_WITH_CUDA OFF CACHE BOOL "Enable CUDA support")
 if (DLAF_WITH_CUDA)
-  enable_language(CUDA)
   find_package(CUDALIBS REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
 endif()
 
 # ----- HPX
-find_package(HPX 1.4.0 REQUIRED)
+find_package(HPX 1.5.0 REQUIRED)
 
 # ----- BLASPP/LAPACKPP
 find_package(OpenMP REQUIRED)

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -77,9 +77,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_MAJOR=1
-ARG HPX_MINOR=4
-ARG HPX_PATCH=1
+ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -79,7 +79,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 # Install HPX
 ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
 ARG HPX_PATH=/usr/local/hpx
-RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
+RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
     cd hpx-${HPX_VERSION} && \
     mkdir build && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -83,7 +83,7 @@ ARG HPX_PATCH=1
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
-    cd hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH} && \
+    cd hpx-${HPX_VERSION} && \
     mkdir build && \
     cd build && \
     cmake .. \
@@ -99,7 +99,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
       -DHPX_WITH_EXAMPLES=OFF && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /root/hpx.tar.gz /root/hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}
+    rm -rf /root/hpx.tar.gz /root/hpx-${HPX_VERSION}
 
 RUN ldconfig
 

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -77,9 +77,10 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
+ARG HPX_FORK=msimberg
+ARG HPX_VERSION=95000f4cbd15ee725054a62ce5b2d65523902876
 ARG HPX_PATH=/usr/local/hpx
-RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
+RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
     cd hpx-${HPX_VERSION} && \
     mkdir build && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -77,8 +77,8 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_FORK=msimberg
-ARG HPX_VERSION=95000f4cbd15ee725054a62ce5b2d65523902876
+ARG HPX_FORK=STEllAR-GROUP
+ARG HPX_VERSION=1.5.0-rc1
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -78,7 +78,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.5.0-rc1
+ARG HPX_VERSION=1.5.0
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -83,7 +83,7 @@ ARG HPX_PATCH=1
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
-    cd hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH} && \
+    cd hpx-${HPX_VERSION} && \
     mkdir build && \
     cd build && \
     cmake .. \
@@ -101,7 +101,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
       -DHPX_WITH_EXAMPLES=OFF && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /root/hpx.tar.gz /root/hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}
+    rm -rf /root/hpx.tar.gz /root/hpx-${HPX_VERSION}
 
 RUN ldconfig
 

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -77,9 +77,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_MAJOR=1
-ARG HPX_MINOR=4
-ARG HPX_PATCH=1
+ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -79,7 +79,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 # Install HPX
 ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
 ARG HPX_PATH=/usr/local/hpx
-RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
+RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
     cd hpx-${HPX_VERSION} && \
     mkdir build && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -77,9 +77,10 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
+ARG HPX_FORK=msimberg
+ARG HPX_VERSION=95000f4cbd15ee725054a62ce5b2d65523902876
 ARG HPX_PATH=/usr/local/hpx
-RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
+RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
     cd hpx-${HPX_VERSION} && \
     mkdir build && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -77,8 +77,8 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_FORK=msimberg
-ARG HPX_VERSION=95000f4cbd15ee725054a62ce5b2d65523902876
+ARG HPX_FORK=STEllAR-GROUP
+ARG HPX_VERSION=1.5.0-rc1
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -78,7 +78,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.5.0-rc1
+ARG HPX_VERSION=1.5.0
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -77,7 +77,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_VERSION=master
+ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -77,13 +77,11 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_MAJOR=1
-ARG HPX_MINOR=4
-ARG HPX_PATCH=1
+ARG HPX_VERSION=master
 ARG HPX_PATH=/usr/local/hpx
-RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}.tar.gz -O hpx.tar.gz && \
+RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
-    cd hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH} && \
+    cd hpx-${HPX_VERSION} && \
     mkdir build && \
     cd build && \
     cmake .. \
@@ -98,7 +96,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
       -DHPX_WITH_EXAMPLES=OFF && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /root/hpx.tar.gz /root/hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}
+    rm -rf /root/hpx.tar.gz /root/hpx-${HPX_VERSION}
 
 # Install BLASPP
 ARG BLASPP_VERSION=c090b5738c8e

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -77,9 +77,10 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_VERSION=291736b9538afed58269dd1611fd71b8ea839f1f
+ARG HPX_FORK=msimberg
+ARG HPX_VERSION=95000f4cbd15ee725054a62ce5b2d65523902876
 ARG HPX_PATH=/usr/local/hpx
-RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
+RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \
     cd hpx-${HPX_VERSION} && \
     mkdir build && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -77,8 +77,8 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
     rm -rf /root/gperftools.tar.gz /root/gperftools-${GPERFTOOLS_VERSION}
 
 # Install HPX
-ARG HPX_FORK=msimberg
-ARG HPX_VERSION=95000f4cbd15ee725054a62ce5b2d65523902876
+ARG HPX_FORK=STEllAR-GROUP
+ARG HPX_VERSION=1.5.0-rc1
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -78,7 +78,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.5.0-rc1
+ARG HPX_VERSION=1.5.0
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \
     tar -xzf hpx.tar.gz && \

--- a/include/dlaf/auxiliary/norm/mc/norm_max_L.h
+++ b/include/dlaf/auxiliary/norm/mc/norm_max_L.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <hpx/hpx.hpp>
-#include <hpx/util/unwrap.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/common/vector.h"

--- a/include/dlaf/auxiliary/norm/mc/norm_max_L.h
+++ b/include/dlaf/auxiliary/norm/mc/norm_max_L.h
@@ -9,7 +9,8 @@
 //
 #pragma once
 
-#include <hpx/hpx.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/common/vector.h"

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -10,8 +10,7 @@
 
 #pragma once
 
-#include <hpx/lcos/future.hpp>
-#include <hpx/lcos/promise.hpp>
+#include <hpx/hpx.hpp>
 
 namespace dlaf {
 namespace common {
@@ -34,7 +33,7 @@ public:
     /// Create a wrapper.
     /// @param object	the resource to wrap (the wrapper becomes the owner of the resource),
     /// @param next	the promise that has to be set on destruction.
-    Wrapper(U&& object, hpx::promise<T> next) : object_(std::move(object)), promise_(std::move(next)) {}
+    Wrapper(U&& object, hpx::lcos::local::promise<T> next) : object_(std::move(object)), promise_(std::move(next)) {}
 
   public:
     /// Trivial move constructor (that invalidates the status of the source object).
@@ -60,7 +59,7 @@ public:
 
   private:
     U object_;                 ///< the wrapped object! it is actually owned by the wrapper.
-    hpx::promise<U> promise_;  ///< promise containing the shared state that will unlock the next user.
+    hpx::lcos::local::promise<U> promise_;  ///< promise containing the shared state that will unlock the next user.
   };
 
   /// Create a Pipeline by moving in the resource (it takes the ownership).
@@ -80,7 +79,7 @@ public:
   hpx::future<Wrapper<T>> operator()() {
     auto before_last = std::move(future_);
 
-    hpx::promise<T> promise_next;
+    hpx::lcos::local::promise<T> promise_next;
     future_ = promise_next.get_future();
 
     return before_last.then(hpx::launch::sync,

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -59,7 +59,7 @@ public:
     }
 
   private:
-    U object_;                 ///< the wrapped object! it is actually owned by the wrapper.
+    U object_;  ///< the wrapped object! it is actually owned by the wrapper.
     /// promise containing the shared state that will unlock the next user.
     hpx::lcos::local::promise<U> promise_;
   };

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -33,7 +33,8 @@ public:
     /// Create a wrapper.
     /// @param object	the resource to wrap (the wrapper becomes the owner of the resource),
     /// @param next	the promise that has to be set on destruction.
-    Wrapper(U&& object, hpx::lcos::local::promise<T> next) : object_(std::move(object)), promise_(std::move(next)) {}
+    Wrapper(U&& object, hpx::lcos::local::promise<T> next)
+        : object_(std::move(object)), promise_(std::move(next)) {}
 
   public:
     /// Trivial move constructor (that invalidates the status of the source object).
@@ -59,7 +60,8 @@ public:
 
   private:
     U object_;                 ///< the wrapped object! it is actually owned by the wrapper.
-    hpx::lcos::local::promise<U> promise_;  ///< promise containing the shared state that will unlock the next user.
+    /// promise containing the shared state that will unlock the next user.
+    hpx::lcos::local::promise<U> promise_;
   };
 
   /// Create a Pipeline by moving in the resource (it takes the ownership).

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -10,7 +10,8 @@
 
 #pragma once
 
-#include <hpx/hpx.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 namespace dlaf {
 namespace common {
@@ -23,18 +24,20 @@ namespace common {
 /// internal Wrapper object. This Wrapper contains the real resource, and it will do what is needed to
 /// unlock the next user as soon as the Wrapper is destroyed.
 template <class T>
-struct Pipeline {
+class Pipeline {
+  template <class PT>
+  using promise_t = hpx::lcos::local::promise<PT>;
+
 public:
   /// Wrapper is the object that manages the auto-release mechanism.
   template <class U>
   class Wrapper {
-    friend struct Pipeline<U>;
+    friend class Pipeline<U>;
 
     /// Create a wrapper.
     /// @param object	the resource to wrap (the wrapper becomes the owner of the resource),
     /// @param next	the promise that has to be set on destruction.
-    Wrapper(U&& object, hpx::lcos::local::promise<T> next)
-        : object_(std::move(object)), promise_(std::move(next)) {}
+    Wrapper(U&& object, promise_t<T> next) : object_(std::move(object)), promise_(std::move(next)) {}
 
   public:
     /// Trivial move constructor (that invalidates the status of the source object).
@@ -61,7 +64,7 @@ public:
   private:
     U object_;  ///< the wrapped object! it is actually owned by the wrapper.
     /// promise containing the shared state that will unlock the next user.
-    hpx::lcos::local::promise<U> promise_;
+    promise_t<U> promise_;
   };
 
   /// Create a Pipeline by moving in the resource (it takes the ownership).
@@ -81,7 +84,7 @@ public:
   hpx::future<Wrapper<T>> operator()() {
     auto before_last = std::move(future_);
 
-    hpx::lcos::local::promise<T> promise_next;
+    promise_t<T> promise_next;
     future_ = promise_next.get_future();
 
     return before_last.then(hpx::launch::sync,
@@ -94,6 +97,5 @@ public:
 private:
   hpx::future<T> future_;  ///< This contains always the "tail" of the queue of futures.
 };
-
 }
 }

--- a/include/dlaf/communication/executor.h
+++ b/include/dlaf/communication/executor.h
@@ -12,7 +12,7 @@
 /// @file
 
 #include <hpx/include/threads.hpp>
-#include <hpx/runtime/threads/executors/pool_executor.hpp>
+#include <hpx/runtime_local/pool_executor.hpp>
 
 namespace dlaf {
 namespace comm {

--- a/include/dlaf/communication/executor.h
+++ b/include/dlaf/communication/executor.h
@@ -11,8 +11,8 @@
 
 /// @file
 
+#include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
-#include <hpx/runtime_local/pool_executor.hpp>
 
 namespace dlaf {
 namespace comm {

--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -13,7 +13,7 @@
 #include <mutex>
 
 #include <mpi.h>
-#include <hpx/synchronization/mutex.hpp>
+#include <hpx/mutex.hpp>
 
 #include "dlaf/communication/error.h"
 

--- a/include/dlaf/factorization/cholesky/mc/cholesky_L.h
+++ b/include/dlaf/factorization/cholesky/mc/cholesky_L.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -9,8 +9,12 @@
 //
 
 #pragma once
+
 #include <exception>
 #include <vector>
+
+#include <hpx/local/future.hpp>
+
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/layout_info.h"

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -61,7 +61,7 @@ template <class T, Device device>
 hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex& index) noexcept {
   std::size_t i = tileLinearIndex(index);
   hpx::future<TileType> old_future = std::move(tile_futures_[i]);
-  hpx::promise<TileType> p;
+  hpx::lcos::local::promise<TileType> p;
   tile_futures_[i] = p.get_future();
   tile_shared_futures_[i] = {};
   return old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileType>&& fut) mutable {

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -10,7 +10,8 @@
 
 #pragma once
 
-#include <hpx/hpx.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/matrix/copy_tile.h"
 #include "dlaf/types.h"

--- a/include/dlaf/matrix/matrix_view.h
+++ b/include/dlaf/matrix/matrix_view.h
@@ -9,9 +9,11 @@
 //
 
 #pragma once
-#include <exception>
+
 #include <vector>
-#include "blas.hh"
+
+#include <blas.hh>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"

--- a/include/dlaf/matrix_const.tpp
+++ b/include/dlaf/matrix_const.tpp
@@ -50,7 +50,7 @@ hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
   std::size_t i = tileLinearIndex(index);
   if (!tile_shared_futures_[i].valid()) {
     hpx::future<TileType> old_future = std::move(tile_futures_[i]);
-    hpx::promise<TileType> p;
+    hpx::lcos::local::promise<TileType> p;
     tile_futures_[i] = p.get_future();
     tile_shared_futures_[i] = std::move(
         old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileType>&& fut) mutable {

--- a/include/dlaf/solver/triangular/mc/triangular_LLN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LLN.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_LLT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LLT.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_LUN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LUN.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_LUT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_LUT.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_RLN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RLN.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_RLT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RLT.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_RUN.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RUN.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/mc/triangular_RUT.h
+++ b/include/dlaf/solver/triangular/mc/triangular_RUT.h
@@ -11,6 +11,8 @@
 
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/threads.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blas_tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -11,8 +11,9 @@
 #pragma once
 
 #include <exception>
-#include <hpx/hpx.hpp>
 #include <ostream>
+
+#include <hpx/hpx.hpp>
 
 #include "dlaf/common/data_descriptor.h"
 #include "dlaf/matrix/index.h"
@@ -123,7 +124,7 @@ private:
   memory::MemoryView<ElementType, device> memory_view_;
   SizeType ld_;
 
-  std::unique_ptr<hpx::promise<Tile<ElementType, device>>> p_;
+  std::unique_ptr<hpx::lcos::local::promise<Tile<ElementType, device>>> p_;
 };
 
 template <class T, Device device>
@@ -179,9 +180,9 @@ public:
   /// Sets the promise to which this Tile will be moved on destruction.
   ///
   /// @c setPromise can be called only once per object.
-  Tile& setPromise(hpx::promise<Tile<T, device>>&& p) {
+  Tile& setPromise(hpx::lcos::local::promise<Tile<T, device>>&& p) {
     DLAF_ASSERT(!p_, "setPromise has been already used on this object!");
-    p_ = std::make_unique<hpx::promise<Tile<T, device>>>(std::move(p));
+    p_ = std::make_unique<hpx::lcos::local::promise<Tile<T, device>>>(std::move(p));
     return *this;
   }
 

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -13,7 +13,7 @@
 #include <exception>
 #include <ostream>
 
-#include <hpx/hpx.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/common/data_descriptor.h"
 #include "dlaf/matrix/index.h"
@@ -50,6 +50,9 @@ class Tile<const T, device>;
 template <class T, Device device>
 class Tile<const T, device> {
   friend Tile<T, device>;
+
+  template <class PT>
+  using promise_t = hpx::lcos::local::promise<PT>;
 
 public:
   using ElementType = T;
@@ -124,11 +127,14 @@ private:
   memory::MemoryView<ElementType, device> memory_view_;
   SizeType ld_;
 
-  std::unique_ptr<hpx::lcos::local::promise<Tile<ElementType, device>>> p_;
+  std::unique_ptr<promise_t<Tile<ElementType, device>>> p_;
 };
 
 template <class T, Device device>
 class Tile : public Tile<const T, device> {
+  template <class PT>
+  using promise_t = hpx::lcos::local::promise<PT>;
+
   friend Tile<const T, device>;
 
 public:
@@ -180,9 +186,9 @@ public:
   /// Sets the promise to which this Tile will be moved on destruction.
   ///
   /// @c setPromise can be called only once per object.
-  Tile& setPromise(hpx::lcos::local::promise<Tile<T, device>>&& p) {
+  Tile& setPromise(promise_t<Tile<T, device>>&& p) {
     DLAF_ASSERT(!p_, "setPromise has been already used on this object!");
-    p_ = std::make_unique<hpx::lcos::local::promise<Tile<T, device>>>(std::move(p));
+    p_ = std::make_unique<promise_t<Tile<T, device>>>(std::move(p));
     return *this;
   }
 

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -19,7 +19,8 @@ constexpr double M_PI = 3.141592;
 #endif
 
 #include <blas.hh>
-#include <hpx/hpx.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/blaspp/enums.h"
 #include "dlaf/common/assert.h"

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -166,22 +166,22 @@ int main(int argc, char** argv) {
   ;
   // clang-format on
 
-  // Create the resource partitioner
-  hpx::resource::partitioner rp(desc_commandline, argc, argv);
+  hpx::init_params p;
+  p.desc_cmdline = desc_commandline;
+  p.rp_callback = [](auto& rp) {
+    int ntasks;
+    MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
+    // if the user has asked for special thread pools for communication
+    // then set them up
+    if (ntasks > 1) {
+      // Create a thread pool with a single core that we will use for all
+      // communication related tasks
+      rp.create_thread_pool("mpi", hpx::resource::scheduling_policy::local_priority_fifo);
+      rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0], "mpi");
+    }
+  };
 
-  int ntasks;
-  MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
-
-  // if the user has asked for special thread pools for communication
-  // then set them up
-  if (ntasks > 1) {
-    // Create a thread pool with a single core that we will use for all
-    // communication related tasks
-    rp.create_thread_pool("mpi", hpx::resource::scheduling_policy::local_priority_fifo);
-    rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0], "mpi");
-  }
-
-  auto ret_code = hpx::init(hpx_main, desc_commandline, argc, argv);
+  auto ret_code = hpx::init(argc, argv, p);
 
   return ret_code;
 }

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <hpx/hpx_init.hpp>
+#include <hpx/init.hpp>
 
 #include "dlaf/auxiliary/mc.h"
 #include "dlaf/communication/communicator_grid.h"

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -25,7 +25,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')
-    depends_on('hpx@1.4.0:1.4.1 cxxstd=14 networking=none')
+    depends_on('hpx@1.5.0 cxxstd=14 networking=none')
 
     depends_on('hpx build_type=Debug', when='build_type=Debug')
     depends_on('hpx build_type=Release', when='build_type=Release')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,12 +60,11 @@ target_include_directories(dlaf.prop
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
-    ${HPX_INCLUDE_DIRS}
 )
 target_link_libraries(dlaf.prop
   INTERFACE
     MPI::MPI_CXX
-    ${HPX_LIBRARIES}
+    HPX::hpx_no_wrap_main
     ${LAPACK_TARGET}
     lapackpp
     blaspp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ target_include_directories(dlaf.prop
 target_link_libraries(dlaf.prop
   INTERFACE
     MPI::MPI_CXX
-    HPX::hpx_no_wrap_main
+    HPX::hpx
     ${LAPACK_TARGET}
     lapackpp
     blaspp

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -14,6 +14,9 @@
 
 #include <sstream>
 #include <vector>
+
+#include <hpx/local/future.hpp>
+
 #include "gtest/gtest.h"
 #include "dlaf/matrix.h"
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -9,12 +9,11 @@
 #
 
 add_library(DLAF_gtest_hpx_main STATIC gtest_hpx_main.cpp)
-target_include_directories(DLAF_gtest_hpx_main PRIVATE ${HPX_INCLUDE_DIRS})
 target_link_libraries(DLAF_gtest_hpx_main
   PUBLIC
     gtest
   PRIVATE
-    ${HPX_LIBRARIES}
+    HPX::hpx_no_wrap_main
 )
 
 add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp gtest_mpi_listener.cpp)
@@ -26,11 +25,10 @@ target_link_libraries(DLAF_gtest_mpi_main
 )
 
 add_library(DLAF_gtest_mpihpx_main STATIC gtest_mpihpx_main.cpp gtest_mpi_listener.cpp)
-target_include_directories(DLAF_gtest_mpihpx_main PRIVATE ${HPX_INCLUDE_DIRS})
 target_link_libraries(DLAF_gtest_mpihpx_main
   PUBLIC
     gtest
   PRIVATE
     MPI::MPI_CXX
-    ${HPX_LIBRARIES}
+    HPX::hpx_no_wrap_main
 )

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(DLAF_gtest_hpx_main
   PUBLIC
     gtest
   PRIVATE
-    HPX::hpx_no_wrap_main
+    HPX::hpx
 )
 
 add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp gtest_mpi_listener.cpp)
@@ -30,5 +30,5 @@ target_link_libraries(DLAF_gtest_mpihpx_main
     gtest
   PRIVATE
     MPI::MPI_CXX
-    HPX::hpx_no_wrap_main
+    HPX::hpx
 )

--- a/test/src/gtest_hpx_main.cpp
+++ b/test/src/gtest_hpx_main.cpp
@@ -40,7 +40,7 @@
 #include <cstdio>
 
 #include <gtest/gtest.h>
-#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
 GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_hpx_main.cpp\n");

--- a/test/src/gtest_hpx_main.cpp
+++ b/test/src/gtest_hpx_main.cpp
@@ -40,7 +40,7 @@
 #include <cstdio>
 
 #include <gtest/gtest.h>
-#include <hpx/hpx_init.hpp>
+#include <hpx/init.hpp>
 
 GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_hpx_main.cpp\n");

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -40,7 +40,7 @@
 #include <cstdio>
 
 #include <gtest/gtest.h>
-#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
 
 #include "gtest_mpi_listener.h"
 

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -40,7 +40,7 @@
 #include <cstdio>
 
 #include <gtest/gtest.h>
-#include <hpx/hpx_init.hpp>
+#include <hpx/init.hpp>
 
 #include "gtest_mpi_listener.h"
 

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 
 #include <gtest/gtest.h>
+#include <hpx/include/util.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix.h"

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -12,7 +12,7 @@
 
 #include <gtest/gtest.h>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/hpx.hpp>
 
 using namespace dlaf;
 using dlaf::common::Pipeline;

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -12,7 +12,8 @@
 
 #include <gtest/gtest.h>
 
-#include <hpx/hpx.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
 
 using namespace dlaf;
 using dlaf::common::Pipeline;

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -10,8 +10,10 @@
 
 #include "dlaf/util_matrix.h"
 
-#include <gtest/gtest.h>
 #include <vector>
+
+#include <gtest/gtest.h>
+#include <hpx/local/future.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/sync/basic.h"

--- a/test/unit/test_matrix.cpp
+++ b/test/unit/test_matrix.cpp
@@ -12,7 +12,11 @@
 #include "dlaf/matrix/copy.h"
 
 #include <vector>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <hpx/include/util.hpp>
+#include <hpx/local/future.hpp>
+
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/util_matrix.h"
 #include "dlaf_test/comm_grids/grids_6_ranks.h"

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -273,7 +273,7 @@ TYPED_TEST(TileTest, PromiseToFuture) {
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
   Tile<Type, Device::CPU> tile(size, std::move(mem_view), ld);
 
-  hpx::promise<Tile<Type, Device::CPU>> tile_promise;
+  hpx::lcos::local::promise<Tile<Type, Device::CPU>> tile_promise;
   hpx::future<Tile<Type, Device::CPU>> tile_future = tile_promise.get_future();
   tile.setPromise(std::move(tile_promise));
   EXPECT_EQ(false, tile_future.is_ready());
@@ -300,7 +300,7 @@ TYPED_TEST(TileTest, PromiseToFutureConst) {
   auto mem_view = memory_view;  // Copy the memory view to check the elements later.
   Tile<Type, Device::CPU> tile(size, std::move(mem_view), ld);
 
-  hpx::promise<Tile<Type, Device::CPU>> tile_promise;
+  hpx::lcos::local::promise<Tile<Type, Device::CPU>> tile_promise;
   hpx::future<Tile<Type, Device::CPU>> tile_future = tile_promise.get_future();
   tile.setPromise(std::move(tile_promise));
   EXPECT_EQ(false, tile_future.is_ready());

--- a/test/unit/test_tile.cpp
+++ b/test/unit/test_tile.cpp
@@ -11,7 +11,10 @@
 #include "dlaf/tile.h"
 
 #include <stdexcept>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <hpx/local/future.hpp>
+
 #include "dlaf/matrix/index.h"
 #include "dlaf/memory/memory_view.h"
 #include "dlaf_test/matrix/util_tile.h"


### PR DESCRIPTION
This PR aims at collecting all necessary changes to address HPX 1.5.0 changes

Starting with:

- CMake targets
`HPX::` targets are available for specifying the dependency in CMake. At the moment of writing two variants exist: `HPX::hpx` and `HPX::hpx_no_wrap_main`; the latter one does not automatically add a main function that initializes HPX. However, this is valid on current master at the time of writing, but it can change in the near future.

- hpx::promise alias deprecated
_"Master and 1.5.0 hpx::promise -> hpx::lcos::promise, but the alias is deprecated. In a future version (latest 2.0.0, possibly earlier) hpx::promise -> hpx::lcos::local::promise."_

- headers
A lot of headers have been renamed/moved/reorganized. In general we include `hpx/hpx.hpp`, I don't know if in the future we will include more specific things (e.g. `hpx/futures/future.hpp`).

- resource_paritioner new api
The way the `resource_paritioner` is initialized has changed.