### PR TITLE
Test CI failure in case of error.

### DIFF
--- a/ci/mpi-ctest
+++ b/ci/mpi-ctest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
     LOCAL_REPORTS="/codecov-reports"
@@ -14,7 +14,7 @@ pushd /DLA-Future-build > /dev/null
 
 # Run the tests, only output on the first rank
 if [[ $SLURM_PROCID == "0" ]]; then
-    ctest $@
+    ctest -V $@
 else
     ctest -Q $@
 fi

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -35,7 +35,7 @@ TYPED_TEST(Index2DTest, ConstructorDefault) {
   EXPECT_LT(index.row(), 0);
   EXPECT_LT(index.col(), 0);
 
-  EXPECT_FALSE(index.isValid());
+  EXPECT_TRUE(index.isValid());
 }
 
 TYPED_TEST(Index2DTest, ConstructorFromParams) {

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -35,7 +35,7 @@ TYPED_TEST(Index2DTest, ConstructorDefault) {
   EXPECT_LT(index.row(), 0);
   EXPECT_LT(index.col(), 0);
 
-  EXPECT_TRUE(index.isValid());
+  EXPECT_FALSE(index.isValid());
 }
 
 TYPED_TEST(Index2DTest, ConstructorFromParams) {


### PR DESCRIPTION
Discovered in DLA-Interface that if tests fail the CI doesn't discover them. Let me start with a simple test.