### PR TITLE
Update blaspp (new master)

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
 cpu debug build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/debug/build:20200625-blaspp.c090b57
+    BUILD_IMAGE: $CI_REGISTRY_IMAGE/debug/build:20200625-lapackpp.f878fa
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
     - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/debug/build.Dockerfile --network=host .
@@ -40,7 +40,7 @@ cpu debug build:
 cpu release build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:20200625-blaspp.c090b57
+    BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:20200625-lapackpp.f878fa
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
     - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/release/build.Dockerfile --network=host .
@@ -52,7 +52,7 @@ cpu release build:
 cpu codecov build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:20200626-blaspp.c090b57
+    BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:20200625-lapackpp.f878fa
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
     - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/codecov/build.Dockerfile --network=host .

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
 cpu debug build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/debug/build:latest
+    BUILD_IMAGE: $CI_REGISTRY_IMAGE/debug/build:20200625-blaspp.c090b57
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
     - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/debug/build.Dockerfile --network=host .
@@ -40,7 +40,7 @@ cpu debug build:
 cpu release build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:latest
+    BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:20200625-blaspp.c090b57
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
     - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/release/build.Dockerfile --network=host .
@@ -52,7 +52,7 @@ cpu release build:
 cpu codecov build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:latest
+    BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:20200626-blaspp.c090b57
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
     - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/codecov/build.Dockerfile --network=host .

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -104,7 +104,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
 RUN ldconfig
 
 # Install BLASPP
-ARG BLASPP_VERSION=d83c1faa7a09
+ARG BLASPP_VERSION=c090b57
 ARG BLASPP_PATH=/usr/local/blaspp
 RUN wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O blaspp.tar.gz && \
     tar -xzf blaspp.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -121,7 +121,7 @@ RUN wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O bla
     make install && \
     rm -rf /root/blaspp.tar.gz /root/icl-blaspp-${BLASPP_VERSION}
 
-ARG LAPACKPP_VERSION=b811bd1274d5
+ARG LAPACKPP_VERSION=f878fada3765
 ARG LAPACKPP_PATH=/usr/local/lapackpp
 RUN wget -q https://bitbucket.org/icl/lapackpp/get/${LAPACKPP_VERSION}.tar.gz -O lapackpp.tar.gz && \
     tar -xzf lapackpp.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -104,7 +104,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
 RUN ldconfig
 
 # Install BLASPP
-ARG BLASPP_VERSION=c090b57
+ARG BLASPP_VERSION=c090b5738c8e
 ARG BLASPP_PATH=/usr/local/blaspp
 RUN wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O blaspp.tar.gz && \
     tar -xzf blaspp.tar.gz && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -106,7 +106,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
 RUN ldconfig
 
 # Install BLASPP
-ARG BLASPP_VERSION=d83c1faa7a09
+ARG BLASPP_VERSION=c090b57
 ARG BLASPP_PATH=/usr/local/blaspp
 RUN wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O blaspp.tar.gz && \
     tar -xzf blaspp.tar.gz && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -106,7 +106,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
 RUN ldconfig
 
 # Install BLASPP
-ARG BLASPP_VERSION=c090b57
+ARG BLASPP_VERSION=c090b5738c8e
 ARG BLASPP_PATH=/usr/local/blaspp
 RUN wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O blaspp.tar.gz && \
     tar -xzf blaspp.tar.gz && \

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -124,7 +124,7 @@ RUN wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O bla
     make install && \
     rm -rf /root/blaspp.tar.gz /root/icl-blaspp-${BLASPP_VERSION}
 
-ARG LAPACKPP_VERSION=b811bd1274d5
+ARG LAPACKPP_VERSION=f878fada3765
 ARG LAPACKPP_PATH=/usr/local/lapackpp
 RUN wget -q https://bitbucket.org/icl/lapackpp/get/${LAPACKPP_VERSION}.tar.gz -O lapackpp.tar.gz && \
    tar -xzf lapackpp.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -120,7 +120,7 @@ RUN source /opt/intel/compilers_and_libraries/linux/mkl/bin/mklvars.sh intel64 &
     make install && \
     rm -rf /root/blaspp.tar.gz /root/icl-blaspp-${BLASPP_VERSION}
 
-ARG LAPACKPP_VERSION=b811bd1274d5
+ARG LAPACKPP_VERSION=f878fada3765
 ARG LAPACKPP_PATH=/usr/local/lapackpp
 RUN source /opt/intel/compilers_and_libraries/linux/mkl/bin/mklvars.sh intel64 && \
     wget -q https://bitbucket.org/icl/lapackpp/get/${LAPACKPP_VERSION}.tar.gz -O lapackpp.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -101,7 +101,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
     rm -rf /root/hpx.tar.gz /root/hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}
 
 # Install BLASPP
-ARG BLASPP_VERSION=c090b57
+ARG BLASPP_VERSION=c090b5738c8e
 ARG BLASPP_PATH=/usr/local/blaspp
 RUN source /opt/intel/compilers_and_libraries/linux/mkl/bin/mklvars.sh intel64 && \
     wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O blaspp.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -101,7 +101,7 @@ RUN wget -q https://github.com/STEllAR-GROUP/hpx/archive/${HPX_MAJOR}.${HPX_MINO
     rm -rf /root/hpx.tar.gz /root/hpx-${HPX_MAJOR}.${HPX_MINOR}.${HPX_PATCH}
 
 # Install BLASPP
-ARG BLASPP_VERSION=d83c1faa7a09
+ARG BLASPP_VERSION=c090b57
 ARG BLASPP_PATH=/usr/local/blaspp
 RUN source /opt/intel/compilers_and_libraries/linux/mkl/bin/mklvars.sh intel64 && \
     wget -q https://bitbucket.org/icl/blaspp/get/${BLASPP_VERSION}.tar.gz -O blaspp.tar.gz && \


### PR DESCRIPTION
Close #250 

This PR just wants to update and fix the CI/CD due to the update on blaspp side.

With @haampie we started discussing about naming/tags of docker images; for the moment I choose an easy way out with `build:<date>-<note about the change>`.

I think we can discuss about them more extensively in a dedicated PR, not just on names but on housekeeping too.