### PR TITLE
CI timestamps

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -28,11 +28,13 @@ stages:
 cpu debug build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/debug/build:20200625-lapackpp.f878fa
+    BUILD_DOCKER_FILE: ci/docker/debug/build.Dockerfile
+    BUILD_IMAGE_BASE: $CI_REGISTRY_IMAGE/debug/build:
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
-    - docker pull $BUILD_IMAGE
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE -f ci/docker/debug/build.Dockerfile --network=host .
+    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
+    - (docker pull $BUILD_IMAGE && BUILD_CACHE="--cache-from $BUILD_IMAGE") || (docker pull ${BUILD_IMAGE_BASE}latest && BUILD_CACHE="--cache-from ${BUILD_IMAGE_BASE}latest") || BUILD_CACHE=""
+    - docker build -t $BUILD_IMAGE $BUILD_CACHE -f $BUILD_DOCKER_FILE --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/debug/deploy.Dockerfile --network=host .
     - docker push $IMAGE
@@ -41,11 +43,13 @@ cpu debug build:
 cpu release build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:20200625-lapackpp.f878fa
+    BUILD_DOCKER_FILE: ci/docker/release/build.Dockerfile
+    BUILD_IMAGE_BASE: $CI_REGISTRY_IMAGE/release/build:
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
-    - docker pull $BUILD_IMAGE
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE -f ci/docker/release/build.Dockerfile --network=host .
+    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
+    - (docker pull $BUILD_IMAGE && BUILD_CACHE="--cache-from $BUILD_IMAGE") || (docker pull ${BUILD_IMAGE_BASE}latest && BUILD_CACHE="--cache-from ${BUILD_IMAGE_BASE}latest") || BUILD_CACHE=""
+    - docker build -t $BUILD_IMAGE $BUILD_CACHE -f $BUILD_DOCKER_FILE --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/release/deploy.Dockerfile --network=host .
     - docker push $IMAGE
@@ -54,11 +58,13 @@ cpu release build:
 cpu codecov build:
   extends: .build_common
   variables:
-    BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:20200625-lapackpp.f878fa
+    BUILD_DOCKER_FILE: ci/docker/codecov/build.Dockerfile
+    BUILD_IMAGE_BASE: $CI_REGISTRY_IMAGE/codecov/build:
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
-    - docker pull $BUILD_IMAGE
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE -f ci/docker/codecov/build.Dockerfile --network=host .
+    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
+    - (docker pull $BUILD_IMAGE && BUILD_CACHE="--cache-from $BUILD_IMAGE") || (docker pull ${BUILD_IMAGE_BASE}latest && BUILD_CACHE="--cache-from ${BUILD_IMAGE_BASE}latest") || BUILD_CACHE=""
+    - docker build -t $BUILD_IMAGE $BUILD_CACHE -f $BUILD_DOCKER_FILE --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/codecov/deploy.Dockerfile --network=host .
     - docker push $IMAGE

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -33,9 +33,7 @@ cpu debug build:
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - (docker pull $BUILD_IMAGE && BUILD_CACHE="--cache-from $BUILD_IMAGE") || (docker pull ${BUILD_IMAGE_BASE}latest && BUILD_CACHE="--cache-from ${BUILD_IMAGE_BASE}latest") || BUILD_CACHE=""
-    - docker build -t $BUILD_IMAGE $BUILD_CACHE -f $BUILD_DOCKER_FILE --network=host .
-    - docker push $BUILD_IMAGE
+    - docker pull $BUILD_IMAGE || (docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host . && docker push $BUILD_IMAGE)
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/debug/deploy.Dockerfile --network=host .
     - docker push $IMAGE
     - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
@@ -48,9 +46,7 @@ cpu release build:
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - (docker pull $BUILD_IMAGE && BUILD_CACHE="--cache-from $BUILD_IMAGE") || (docker pull ${BUILD_IMAGE_BASE}latest && BUILD_CACHE="--cache-from ${BUILD_IMAGE_BASE}latest") || BUILD_CACHE=""
-    - docker build -t $BUILD_IMAGE $BUILD_CACHE -f $BUILD_DOCKER_FILE --network=host .
-    - docker push $BUILD_IMAGE
+    - docker pull $BUILD_IMAGE || (docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host . && docker push $BUILD_IMAGE)
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/release/deploy.Dockerfile --network=host .
     - docker push $IMAGE
     - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
@@ -63,9 +59,7 @@ cpu codecov build:
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - (docker pull $BUILD_IMAGE && BUILD_CACHE="--cache-from $BUILD_IMAGE") || (docker pull ${BUILD_IMAGE_BASE}latest && BUILD_CACHE="--cache-from ${BUILD_IMAGE_BASE}latest") || BUILD_CACHE=""
-    - docker build -t $BUILD_IMAGE $BUILD_CACHE -f $BUILD_DOCKER_FILE --network=host .
-    - docker push $BUILD_IMAGE
+    - docker pull $BUILD_IMAGE || (docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host . && docker push $BUILD_IMAGE)
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/codecov/deploy.Dockerfile --network=host .
     - docker push $IMAGE
     - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -25,12 +25,13 @@ stages:
       - pipeline.yml
 
 # Builds a Docker image for the current commit
+# Temporarly use debug/deploy2 as image name as debug/deploy has some problems with gitlab registry cleanup
 cpu debug build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/debug/build.Dockerfile
     BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/debug/build:"
-    IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
+    IMAGE: $CI_REGISTRY_IMAGE/debug/deploy2:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
     - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -33,7 +33,8 @@ cpu debug build:
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker pull $BUILD_IMAGE || (docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host . && docker push $BUILD_IMAGE)
+    - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .
+    - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/debug/deploy.Dockerfile --network=host .
     - docker push $IMAGE
     - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
@@ -46,7 +47,8 @@ cpu release build:
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker pull $BUILD_IMAGE || (docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host . && docker push $BUILD_IMAGE)
+    - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .
+    - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/release/deploy.Dockerfile --network=host .
     - docker push $IMAGE
     - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
@@ -59,7 +61,8 @@ cpu codecov build:
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker pull $BUILD_IMAGE || (docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host . && docker push $BUILD_IMAGE)
+    - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .
+    - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/codecov/deploy.Dockerfile --network=host .
     - docker push $IMAGE
     - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -29,7 +29,7 @@ cpu debug build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/debug/build.Dockerfile
-    BUILD_IMAGE_BASE: $CI_REGISTRY_IMAGE/debug/build:
+    BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/debug/build:"
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
@@ -44,7 +44,7 @@ cpu release build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/release/build.Dockerfile
-    BUILD_IMAGE_BASE: $CI_REGISTRY_IMAGE/release/build:
+    BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/release/build:"
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
@@ -59,7 +59,7 @@ cpu codecov build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/codecov/build.Dockerfile
-    BUILD_IMAGE_BASE: $CI_REGISTRY_IMAGE/codecov/build:
+    BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/codecov/build:"
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -9,7 +9,7 @@ ENV FORCE_UNSAFE_CONFIGURE 1
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     build-essential gfortran binutils lcov \
-    git tar wget curl gpg-agent jq && \
+    git tar wget curl gpg-agent jq tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/ci/docker/codecov/deploy.Dockerfile
+++ b/ci/docker/codecov/deploy.Dockerfile
@@ -60,20 +60,24 @@ RUN cd ${BUILD} && \
 # Multistage build, this is the final small image
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 ARG BUILD
 ARG SOURCE
 ARG DEPLOY
 
 # Install perl to make lcov happy
 # codecov upload needs curl + ca-certificates
+# tzdata is needed to print correct time
 # TODO: remove git after https://github.com/codecov/codecov-bash/pull/291
 #       or https://github.com/codecov/codecov-bash/pull/265 is merged
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -qq \
+    apt-get install -qq -y --no-install-recommends \
       perl \
       curl \
       ca-certificates \
-      git && \
+      git \
+      tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy the executables and the codecov gcno files

--- a/ci/docker/debug/build.Dockerfile
+++ b/ci/docker/debug/build.Dockerfile
@@ -9,7 +9,7 @@ ENV FORCE_UNSAFE_CONFIGURE 1
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     build-essential gfortran binutils \
-    git tar wget curl gpg-agent jq && \
+    git tar wget curl gpg-agent jq tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/ci/docker/debug/deploy.Dockerfile
+++ b/ci/docker/debug/deploy.Dockerfile
@@ -55,8 +55,16 @@ RUN cd ${BUILD} && \
 
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 ARG BUILD
 ARG DEPLOY
+
+# tzdata is needed to print correct time
+RUN apt-get update -qq && \
+    apt-get install -qq -y --no-install-recommends \
+      tzdata && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder ${BUILD} ${BUILD}
 COPY --from=builder ${DEPLOY} ${DEPLOY}

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -11,7 +11,7 @@ ENV FORCE_UNSAFE_CONFIGURE 1
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     software-properties-common \
     build-essential \
-    git tar wget curl gpg-agent jq && \
+    git tar wget curl gpg-agent jq tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/ci/docker/release/deploy.Dockerfile
+++ b/ci/docker/release/deploy.Dockerfile
@@ -75,8 +75,16 @@ RUN cd ${BUILD} && \
 
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 ARG BUILD
 ARG DEPLOY
+
+# tzdata is needed to print correct time
+RUN apt-get update -qq && \
+    apt-get install -qq -y --no-install-recommends \
+      tzdata && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder ${BUILD} ${BUILD}
 COPY --from=builder ${DEPLOY} ${DEPLOY}

--- a/ci/mpi-ctest
+++ b/ci/mpi-ctest
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
 if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
+    TZ=CET date +"Start initialization of codecov reports from rank $SLURM_PROCID at: %H:%M:%S %z"
+
     LOCAL_REPORTS="/codecov-reports"
     SHARED_REPORTS="$CI_PROJECT_DIR/codecov-reports"
     REPORT_NAME=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
@@ -8,15 +10,17 @@ if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
     mkdir -p "$LOCAL_REPORTS"
     mkdir -p "$SHARED_REPORTS"
     lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "$LOCAL_REPORTS/baseline-codecov.info" &> /dev/null
+
+    TZ=CET date +"Done initialization of codecov reports from rank $SLURM_PROCID at: %H:%M:%S %z"
 fi;
 
 pushd /DLA-Future-build > /dev/null
 
 # Run the tests, only output on the first rank
 if [[ $SLURM_PROCID == "0" ]]; then
-    date +"Run started at: %H:%M:%S"
+    TZ=CET date +"Run started at: %H:%M:%S %z"
     ctest -V $@
-    date +"Run finished at: %H:%M:%S"
+    TZ=CET date +"Run finished at: %H:%M:%S %z"
 else
     ctest -Q $@
 fi
@@ -25,6 +29,8 @@ popd > /dev/null
 
 # Create coverage reports for code run
 if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
+    TZ=CET date +"Start creating codecov reports from rank $SLURM_PROCID at: %H:%M:%S %z"
+
     lcov --no-external --capture --base-directory /DLA-Future --directory /DLA-Future-build --output-file "$LOCAL_REPORTS/run.info" &> /dev/null
 
     lcov --add-tracefile "$LOCAL_REPORTS/baseline-codecov.info" --add-tracefile "$LOCAL_REPORTS/run.info" --output-file "$LOCAL_REPORTS/combined.info" &> /dev/null
@@ -38,5 +44,5 @@ if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
 
     cp "$LOCAL_REPORTS/combined.info" "$SHARED_REPORTS/codecov-$REPORT_NAME.info"
 
-    echo "Done creating codecov reports from rank $SLURM_PROCID"
+    TZ=CET date +"Done creating codecov reports from rank $SLURM_PROCID at: %H:%M:%S %z"
 fi

--- a/ci/mpi-ctest
+++ b/ci/mpi-ctest
@@ -14,7 +14,9 @@ pushd /DLA-Future-build > /dev/null
 
 # Run the tests, only output on the first rank
 if [[ $SLURM_PROCID == "0" ]]; then
+    date +"Run started at: %H:%M:%S"
     ctest -V $@
+    date +"Run finished at: %H:%M:%S"
 else
     ctest -Q $@
 fi

--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -13,7 +13,7 @@
 #include <mutex>
 
 #include <mpi.h>
-#include <hpx/lcos/local/mutex.hpp>
+#include <hpx/synchronization/mutex.hpp>
 
 #include "dlaf/communication/error.h"
 


### PR DESCRIPTION
Added timestamps to CI runs to simplify the identification of the failures caused by Slurm hangs-up in case of system overload.