### PR TITLE
Make CI run in parallel again

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -31,7 +31,8 @@ cpu debug build:
     BUILD_IMAGE: $CI_REGISTRY_IMAGE/debug/build:20200625-lapackpp.f878fa
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
   script:
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/debug/build.Dockerfile --network=host .
+    - docker pull $BUILD_IMAGE
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE -f ci/docker/debug/build.Dockerfile --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/debug/deploy.Dockerfile --network=host .
     - docker push $IMAGE
@@ -43,7 +44,8 @@ cpu release build:
     BUILD_IMAGE: $CI_REGISTRY_IMAGE/release/build:20200625-lapackpp.f878fa
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/release/build.Dockerfile --network=host .
+    - docker pull $BUILD_IMAGE
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE -f ci/docker/release/build.Dockerfile --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/release/deploy.Dockerfile --network=host .
     - docker push $IMAGE
@@ -55,7 +57,8 @@ cpu codecov build:
     BUILD_IMAGE: $CI_REGISTRY_IMAGE/codecov/build:20200625-lapackpp.f878fa
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/codecov/build.Dockerfile --network=host .
+    - docker pull $BUILD_IMAGE
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE -f ci/docker/codecov/build.Dockerfile --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/codecov/deploy.Dockerfile --network=host .
     - docker push $IMAGE

--- a/ci/ctest_to_gitlab.sh
+++ b/ci/ctest_to_gitlab.sh
@@ -46,8 +46,7 @@ JOB_TEMPLATE="
     PULL_IMAGE: 'NO'
     USE_MPI: 'YES'
     DISABLE_AFTER_SCRIPT: 'YES'
-  script: mpi-ctest -L {{LABEL}}
-  resource_group: daint-job"
+  script: mpi-ctest -L {{LABEL}}"
 
 JOBS=""
 

--- a/ci/ctest_to_gitlab_codecov.sh
+++ b/ci/ctest_to_gitlab_codecov.sh
@@ -38,7 +38,6 @@ upload_reports:
     SLURM_TIMELIMIT: '15:00'
     DISABLE_AFTER_SCRIPT: 'YES'
   script: upload_codecov
-  resource_group: daint-job
 
 # Remove the allocation
 deallocate:
@@ -59,7 +58,6 @@ JOB_TEMPLATE="
     USE_MPI: 'YES'
     DISABLE_AFTER_SCRIPT: 'YES'
   script: mpi-ctest -L {{LABEL}}
-  resource_group: daint-job
   artifacts:
     paths:
       - codecov-reports/"


### PR DESCRIPTION
Removes [resource_group](https://docs.gitlab.com/ee/ci/yaml/#resource_group) s.t. ci runs jobs in parallel again.