### PR TITLE
API to Initialize/Finalize and Query MPI thread level

### DIFF
--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -54,27 +54,29 @@ void mpi_invoke(F f, Ts... ts) noexcept {
   }
 }
 
-/// Initialize MPI to either MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE
-inline void mpi_init(int argc, char** argv, mpi_thread_level thd_level) noexcept {
-  int required_threading;
-  if (thd_level == mpi_thread_level::serialized)
-    required_threading = MPI_THREAD_SERIALIZED;
-  else
-    required_threading = MPI_THREAD_MULTIPLE;
+struct mpi_init {
+  /// Initialize MPI to either MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE
+  mpi_init(int argc, char** argv, mpi_thread_level thd_level) noexcept {
+    int required_threading;
+    if (thd_level == mpi_thread_level::serialized)
+      required_threading = MPI_THREAD_SERIALIZED;
+    else
+      required_threading = MPI_THREAD_MULTIPLE;
 
-  int provided_threading;
-  MPI_Init_thread(&argc, &argv, required_threading, &provided_threading);
+    int provided_threading;
+    MPI_Init_thread(&argc, &argv, required_threading, &provided_threading);
 
-  if (provided_threading != required_threading) {
-    std::cerr << "Provided MPI threading model does not match the required one." << std::endl;
-    MPI_Abort(MPI_COMM_WORLD, 1);
+    if (provided_threading != required_threading) {
+      std::cerr << "Provided MPI threading model does not match the required one." << std::endl;
+      MPI_Abort(MPI_COMM_WORLD, 1);
+    }
   }
-}
 
-/// Finalize MPI
-inline void mpi_fin() noexcept {
-  MPI_Finalize();
-}
+  /// Finalize MPI
+  ~mpi_init() noexcept {
+    MPI_Finalize();
+  }
+};
 
 }
 }

--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -1,0 +1,64 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <iostream>
+
+#include <mpi.h>
+
+namespace dlaf {
+namespace comm {
+
+enum class mpi_thread_level { serialized, multiple };
+
+/// Checks if MPI was initialized with MPI_THREAD_SERIALIZED.
+inline bool mpi_serialized() noexcept {
+  // This is executed only once and is thread safe.
+  // Note that the lambda is called at the end.
+  static bool is_serialized = []() {
+    int provided;
+    MPI_Query_thread(&provided);
+    if (provided == MPI_THREAD_SERIALIZED)
+      return true;
+    else if (provided == MPI_THREAD_MULTIPLE)
+      return false;
+    else {
+      std::cerr << "MPI must be initialized to either `MPI_THREAD_SERIALIZED` or `MPI_THREAD_MULTIPLE`!";
+      MPI_Abort(MPI_COMM_WORLD, 1);
+      return false;  // unreachable - here to avoid compiler warnings
+    }
+  }();
+  return is_serialized;
+}
+
+/// Initialize MPI to either MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE
+inline void mpi_init(int argc, char** argv, mpi_thread_level thd_level) noexcept {
+  int required_threading;
+  if (thd_level == mpi_thread_level::serialized)
+    required_threading = MPI_THREAD_SERIALIZED;
+  else
+    required_threading = MPI_THREAD_MULTIPLE;
+
+  int provided_threading;
+  MPI_Init_thread(&argc, &argv, required_threading, &provided_threading);
+
+  if (provided_threading != required_threading) {
+    std::cerr << "Provided MPI threading model does not match the required one." << std::endl;
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+}
+
+/// Finalize MPI
+inline void mpi_fin() noexcept {
+  MPI_Finalize();
+}
+
+}
+}

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -15,6 +15,8 @@
 
 #include "dlaf/auxiliary/mc.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/communication/functions_sync.h"
+#include "dlaf/communication/init.h"
 #include "dlaf/factorization/mc.h"
 #include "dlaf/matrix.h"
 #include "dlaf/matrix/copy.h"
@@ -148,15 +150,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
 }
 
 int main(int argc, char** argv) {
-  // Initialize MPI
-  int threading_required = MPI_THREAD_SERIALIZED;
-  int threading_provided;
-  MPI_Init_thread(&argc, &argv, threading_required, &threading_provided);
-
-  if (threading_provided != threading_required) {
-    std::fprintf(stderr, "Provided MPI threading model does not match the required one.\n");
-    MPI_Abort(MPI_COMM_WORLD, 1);
-  }
+  dlaf::comm::mpi_init(argc, argv, dlaf::comm::mpi_thread_level::serialized);
 
   // options
   using namespace hpx::program_options;
@@ -190,7 +184,7 @@ int main(int argc, char** argv) {
 
   auto ret_code = hpx::init(hpx_main, desc_commandline, argc, argv);
 
-  MPI_Finalize();
+  dlaf::comm::mpi_fin();
 
   return ret_code;
 }

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -15,7 +15,6 @@
 
 #include "dlaf/auxiliary/mc.h"
 #include "dlaf/communication/communicator_grid.h"
-#include "dlaf/communication/functions_sync.h"
 #include "dlaf/communication/init.h"
 #include "dlaf/factorization/mc.h"
 #include "dlaf/matrix.h"
@@ -150,7 +149,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
 }
 
 int main(int argc, char** argv) {
-  dlaf::comm::mpi_init(argc, argv, dlaf::comm::mpi_thread_level::serialized);
+  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::serialized);
 
   // options
   using namespace hpx::program_options;
@@ -183,8 +182,6 @@ int main(int argc, char** argv) {
   }
 
   auto ret_code = hpx::init(hpx_main, desc_commandline, argc, argv);
-
-  dlaf::comm::mpi_fin();
 
   return ret_code;
 }


### PR DESCRIPTION
`mpi_serialized()` is useful in `mpi_invoke()` which is useful for #228 .

The PR takes care of the MPI part of : #100 