### PR TITLE
Bring back inline cache

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -34,7 +34,7 @@ cpu debug build:
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy2:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/debug/build.Dockerfile --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/debug/deploy.Dockerfile --network=host .
     - docker push $IMAGE
@@ -48,7 +48,7 @@ cpu release build:
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/release/build.Dockerfile --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/release/deploy.Dockerfile --network=host .
     - docker push $IMAGE
@@ -62,7 +62,7 @@ cpu codecov build:
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
   script:
     - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker pull $BUILD_IMAGE || docker build -t $BUILD_IMAGE -f $BUILD_DOCKER_FILE --network=host .
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/codecov/build.Dockerfile --network=host .
     - docker push $BUILD_IMAGE
     - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/codecov/deploy.Dockerfile --network=host .
     - docker push $IMAGE

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -20,6 +20,13 @@ stages:
     GIT_SUBMODULE_STRATEGY: recursive
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  script:
+    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
+    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f $BUILD_DOCKER_FILE --network=host .
+    - docker push $BUILD_IMAGE
+    - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f $DEPLOY_DOCKER_FILE --network=host .
+    - docker push $IMAGE
+    - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
   artifacts:
     paths:
       - pipeline.yml
@@ -30,43 +37,25 @@ cpu debug build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/debug/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/debug/deploy.Dockerfile
     BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/debug/build:"
     IMAGE: $CI_REGISTRY_IMAGE/debug/deploy2:$CI_COMMIT_SHA
-  script:
-    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/debug/build.Dockerfile --network=host .
-    - docker push $BUILD_IMAGE
-    - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/debug/deploy.Dockerfile --network=host .
-    - docker push $IMAGE
-    - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
 
 cpu release build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/release/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/release/deploy.Dockerfile
     BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/release/build:"
     IMAGE: $CI_REGISTRY_IMAGE/release/deploy:$CI_COMMIT_SHA
-  script:
-    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/release/build.Dockerfile --network=host .
-    - docker push $BUILD_IMAGE
-    - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/release/deploy.Dockerfile --network=host .
-    - docker push $IMAGE
-    - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
 
 cpu codecov build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/codecov/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/codecov/deploy.Dockerfile
     BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/codecov/build:"
     IMAGE: $CI_REGISTRY_IMAGE/codecov/deploy:$CI_COMMIT_SHA
-  script:
-    - BUILD_IMAGE=$BUILD_IMAGE_BASE`sha256sum $BUILD_DOCKER_FILE | head -c 64`
-    - docker build -t $BUILD_IMAGE --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 -f ci/docker/codecov/build.Dockerfile --network=host .
-    - docker push $BUILD_IMAGE
-    - docker build -t $IMAGE --build-arg BUILD_ENV=$BUILD_IMAGE --build-arg DEPLOY_IMAGE=$IMAGE -f ci/docker/codecov/deploy.Dockerfile --network=host .
-    - docker push $IMAGE
-    - docker run $IMAGE cat /root/DLA-Future.bundle/pipeline.yml > pipeline.yml
 
 ##
 ## RUNS

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -32,14 +32,13 @@ stages:
       - pipeline.yml
 
 # Builds a Docker image for the current commit
-# Temporarly use debug/deploy2 as image name as debug/deploy has some problems with gitlab registry cleanup
 cpu debug build:
   extends: .build_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/debug/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/debug/deploy.Dockerfile
     BUILD_IMAGE_BASE: "$CI_REGISTRY_IMAGE/debug/build:"
-    IMAGE: $CI_REGISTRY_IMAGE/debug/deploy2:$CI_COMMIT_SHA
+    IMAGE: $CI_REGISTRY_IMAGE/debug/deploy:$CI_COMMIT_SHA
 
 cpu release build:
   extends: .build_common

--- a/ci/ctest_to_gitlab.sh
+++ b/ci/ctest_to_gitlab.sh
@@ -16,6 +16,7 @@ stages:
 # Make one big allocation reused in all jobs
 variables:
   ALLOCATION_NAME: dlaf-ci-job-\$CI_PIPELINE_ID
+  SLURM_EXCLUSIVE: ''
 
 # Allocate the resources
 allocate:

--- a/ci/ctest_to_gitlab_codecov.sh
+++ b/ci/ctest_to_gitlab_codecov.sh
@@ -17,6 +17,7 @@ stages:
 # Make one big allocation reused in all jobs
 variables:
   ALLOCATION_NAME: dlaf-ci-job-\$CI_PIPELINE_ID
+  SLURM_EXCLUSIVE: ''
 
 # Allocate the resources
 allocate:


### PR DESCRIPTION
So, this is probably the best approach. I've tested inline cache locally, and in fact it does work across different machines, even different architecture, just not different patch versions of docker. Sorry for the confusion regarding this one...

This PR adds the `SLURM_EXCLUSIVE=` variable to make sure job steps are executed in parallel within a single allocation.