### PR TITLE
Fixes and changes for dla-future spack package

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -35,17 +35,17 @@ class DlaFuture(CMakePackage):
 
         # BLAS/LAPACK
         if '^mkl' in spec:
-            args = ['-DDLAF_WITH_MKL=ON']
+            args = [ self.define('DLAF_WITH_MKL', True) ]
         else:
             args = [
-                    '-DDLAF_WITH_MKL=OFF',
-                    '-DLAPACK_TYPE=Custom',
-                    '-DLAPACK_LIBRARY={} {}'.format(
-                        spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags)
+                    self.define('DLAF_WITH_MKL', False),
+                    self.define('LAPACK_TYPE', 'Custom'),
+                    self.define('LAPACK_LIBRARY',
+                        ' '.join([spec[dep].libs.ld_flags for dep in ['blas', 'lapack']]))
                    ]
 
         # CUDA
-        args.append(self.define_from_variant("DLAF_WITH_CUDA", 'cuda'))
+        args.append(self.define_from_variant('DLAF_WITH_CUDA', 'cuda'))
 
         # DOC
         args.append(self.define_from_variant('BUILD_DOC', 'doc'))

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -20,6 +20,8 @@ class DlaFuture(CMakePackage):
     variant('doc', default=False,
             description='Build documentation.')
 
+    depends_on('cmake@3.14:', type='build')
+
     depends_on('mpi')
     depends_on('blaspp')
     depends_on('lapackpp')

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -8,8 +8,8 @@ from spack import *
 class DlaFuture(CMakePackage):
     """The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"""
 
-    homepage = "https://github.com/eth-cscs/DLA-Future.git/wiki"
-    git      = "https://github.com/eth-cscs/DLA-Future.git"
+    homepage = "https://github.com/eth-cscs/DLA-Future/wiki"
+    git      = "https://github.com/eth-cscs/DLA-Future"
 
     maintainers = ['teonnik', 'Sely85']
 

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -12,7 +12,7 @@ class DlaFuture(CMakePackage):
     homepage = "https://github.com/eth-cscs/DLA-Future/wiki"
     git      = "https://github.com/eth-cscs/DLA-Future"
 
-    maintainers = ['teonnik', 'Sely85']
+    maintainers = ['teonnik', 'albestro', 'Sely85']
 
     version('develop', branch='master')
 

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -5,8 +5,9 @@
 
 from spack import *
 
+
 class DlaFuture(CMakePackage):
-    """The DLAF package provides DLA-Future library: Distributed Linear Algebra with Future"""
+    """DLA-Future library: Distributed Linear Algebra with Future"""
 
     homepage = "https://github.com/eth-cscs/DLA-Future/wiki"
     git      = "https://github.com/eth-cscs/DLA-Future"
@@ -21,6 +22,7 @@ class DlaFuture(CMakePackage):
             description='Build documentation.')
 
     depends_on('cmake@3.14:', type='build')
+    depends_on('doxygen', type='build', when='+doc')
 
     depends_on('mpi')
     depends_on('blaspp')
@@ -29,24 +31,26 @@ class DlaFuture(CMakePackage):
     depends_on('cuda', when='+cuda')
 
     def cmake_args(self):
-       spec = self.spec
+        spec = self.spec
 
-       if '^mkl' in spec:
-           args = ['-DDLAF_WITH_MKL=ON']
-       else:
-           args = ['-DDLAF_WITH_MKL=OFF']
-           args.append('-DLAPACK_TYPE=Custom')
-           args.append('-DLAPACK_LIBRARY={} {}'.format(spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags))
+        # BLAS/LAPACK
+        if '^mkl' in spec:
+            args = ['-DDLAF_WITH_MKL=ON']
+        else:
+            args = [
+                    '-DDLAF_WITH_MKL=OFF',
+                    '-DLAPACK_TYPE=Custom',
+                    '-DLAPACK_LIBRARY={} {}'.format(
+                        spec['lapack'].libs.ld_flags, spec['blas'].libs.ld_flags)
+                   ]
 
-       if '+cuda' in spec:
-           args.append('-DDLAF_WITH_CUDA=ON')
+        # CUDA
+        args.append(self.define_from_variant("DLAF_WITH_CUDA", 'cuda'))
 
-       if self.run_tests:
-           args.append('-DDLAF_WITH_TEST=ON')
-       else:
-           args.append('-DDLAF_WITH_TEST=OFF')
+        # DOC
+        args.append(self.define_from_variant('BUILD_DOC', 'doc'))
 
-       if '+doc' in spec:
-           args.append('-DBUILD_DOC=on')
+        # TESTs
+        args.append(self.define('DLAF_WITH_TEST', self.run_tests))
 
-       return args
+        return args


### PR DESCRIPTION
Add missing build dependencies/constraints:
- Add the missing version constraint about `cmake` version ([reference](https://spack.readthedocs.io/en/latest/build_systems/cmakepackage.html#build-system-dependencies))
- Add `doxygen` build requirement when building documentation

Additionally:
- the package file was bad indented, so I quickly fixed it (it should be compliant also to spack rules, I didn't check thoroughly)
- fix project urls (wiki link is empty anyway, but it was not working before)
- use `self.define` and `self.define_from_variant` helpers