### PR TITLE
Fixing documentation format and equation in a comment

### DIFF
--- a/include/dlaf/auxiliary/mc.h
+++ b/include/dlaf/auxiliary/mc.h
@@ -33,11 +33,10 @@ struct Auxiliary<Backend::MC> {
   /// - With @p norm_type = lapack::Norm::{One, Two, Inf, Fro}
   /// @note not yet implemented
   ///
-  /// .
-  /// @pre `A.blockSize().rows() == A.blockSize().cols()`
-  /// @pre @p A is distributed according to @p grid
+  /// @pre `A.blockSize().rows() == A.blockSize().cols()`,
+  /// @pre @p A is distributed according to @p grid,
   /// @return the norm @p norm_type of the Matrix @p A or 0 if `A.size().isEmpty()` (see LAPACK doc for
-  /// additional info)
+  /// additional info).
   template <class T>
   static dlaf::BaseType<T> norm(comm::CommunicatorGrid grid, comm::Index2D rank, lapack::Norm norm_type,
                                 blas::Uplo uplo, Matrix<const T, Device::CPU>& A);

--- a/include/dlaf/blas_tile.tpp
+++ b/include/dlaf/blas_tile.tpp
@@ -56,7 +56,7 @@ void herk(blas::Uplo uplo, blas::Op op, BaseType<T> alpha, const Tile<const T, d
 
   DLAF_ASSERT((!std::is_same<T, ComplexType<T>>::value || op != blas::Op::Trans),
               "op = Trans is not allowed for Complex values!");
-  DLAF_ASSERT(c.size().rows() == c.size().cols(), "`c` is not square!");
+  DLAF_ASSERT(c.size().rows() == c.size().cols(), "`c` is not square!", c);
   DLAF_ASSERT(c.size().rows() == n, "`c` has an invalid size!", c, n);
 
   blas::herk(blas::Layout::ColMajor, uplo, op, n, k, alpha, a.ptr(), a.ld(), beta, c.ptr(), c.ld());

--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -95,7 +95,7 @@ public:
   /// @pre index.isIn(distribution().localNrTiles()).
   hpx::future<TileType> operator()(const LocalTileIndex& index) noexcept;
 
-  /// @brief Returns a future of the Tile with global index @p index.
+  /// Returns a future of the Tile with global index @p index.
   ///
   /// TODO: Sync details.
   /// @pre the global tile is stored in the current process,

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -32,15 +32,15 @@ public:
   ///
   /// See misc/matrix_distribution.md for for more detail about the parameters.
   ///
-  /// If size.isEmpty():
+  /// @pre If size.isEmpty():
   /// @pre tile_ld >= 1,
   /// @pre tile_offset_row >= 1,
   /// @pre tile_offset_col >= 1;
-  /// if !size.isEmpty():
+  /// @pre if !size.isEmpty():
   /// @pre tile_ld >= max(size.rows(), block_size.rows()),
   /// @pre tile_row_offset >= block_size.rows(),
   /// @pre tile_col_offset >= size of the memory (in elements, padding included)
-  ///      to store a column of tiles
+  ///      to store a column of tiles;
   /// @pre the tiles should not overlap (combinations of @p tile_ld, @p tile_row_offset).
 
   LayoutInfo(const LocalElementSize& size, const TileElementSize& block_size, SizeType tile_ld,

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -36,7 +36,7 @@ public:
   /// @pre tile_ld >= 1,
   /// @pre tile_offset_row >= 1,
   /// @pre tile_offset_col >= 1;
-  /// If !size.isEmpty():
+  /// if !size.isEmpty():
   /// @pre tile_ld >= max(size.rows(), block_size.rows()),
   /// @pre tile_row_offset >= block_size.rows(),
   /// @pre tile_col_offset >= size of the memory (in elements, padding included)

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -32,16 +32,16 @@ public:
   ///
   /// See misc/matrix_distribution.md for for more detail about the parameters.
   ///
-  /// @pre If size.isEmpty():
-  /// @pre tile_ld >= 1,
-  /// @pre tile_offset_row >= 1,
-  /// @pre tile_offset_col >= 1;
-  /// @pre if !size.isEmpty():
-  /// @pre tile_ld >= max(size.rows(), block_size.rows()),
-  /// @pre tile_row_offset >= block_size.rows(),
-  /// @pre tile_col_offset >= size of the memory (in elements, padding included)
+  /// - If size.isEmpty():
+  ///   @pre tile_ld >= 1,
+  ///   @pre tile_offset_row >= 1,
+  ///   @pre tile_offset_col >= 1;
+  /// - if !size.isEmpty():
+  ///   @pre tile_ld >= max(size.rows(), block_size.rows()),
+  ///   @pre tile_row_offset >= block_size.rows(),
+  ///   @pre tile_col_offset >= size of the memory (in elements, padding included)
   ///      to store a column of tiles;
-  /// @pre the tiles should not overlap (combinations of @p tile_ld, @p tile_row_offset).
+  ///   @pre the tiles should not overlap (combinations of @p tile_ld, @p tile_row_offset).
 
   LayoutInfo(const LocalElementSize& size, const TileElementSize& block_size, SizeType tile_ld,
              std::size_t tile_offset_row, std::size_t tile_offset_col);

--- a/include/dlaf/matrix/util_distribution.h
+++ b/include/dlaf/matrix/util_distribution.h
@@ -9,7 +9,7 @@
 //
 
 /// @file
-/// More details about how a matrix is distributed can be found in `misc/matrix_distribution.md`
+/// More details about how a matrix is distributed can be found in `misc/matrix_distribution.md`.
 
 #pragma once
 #include "dlaf/common/assert.h"

--- a/include/dlaf/memory/memory_chunk.h
+++ b/include/dlaf/memory/memory_chunk.h
@@ -72,7 +72,7 @@ public:
 
   MemoryChunk(const MemoryChunk&) = delete;
 
-  /// Move constructor
+  /// Move constructor.
   MemoryChunk(MemoryChunk&& rhs) : size_(rhs.size_), ptr_(rhs.ptr_), allocated_(rhs.allocated_) {
     rhs.ptr_ = nullptr;
     rhs.size_ = 0;
@@ -81,7 +81,7 @@ public:
 
   MemoryChunk& operator=(const MemoryChunk&) = delete;
 
-  /// Move assignement
+  /// Move assignement.
   MemoryChunk& operator=(MemoryChunk&& rhs) {
     deallocate();
 

--- a/include/dlaf/tile.h
+++ b/include/dlaf/tile.h
@@ -79,7 +79,7 @@ public:
   /// Returns the (i, j)-th element,
   /// where @p i := @p index.row and @p j := @p index.col.
   ///
-  /// @pre index.isIn(size().
+  /// @pre index.isIn(size()).
   const T& operator()(const TileElementIndex& index) const noexcept {
     return *ptr(index);
   }

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -296,8 +296,8 @@ void set_random_hermitian_with_offset(Matrix<T, Device::CPU>& matrix, const std:
 /// This means that the elements of a specific tile, no matter how the matrix is distributed,
 /// will be set with the same set of values.
 ///
-/// @pre @param matrix is a square matrix
-/// @pre @param matrix has a square blocksize
+/// @pre @param matrix is a square matrix,
+/// @pre @param matrix has a square blocksize.
 template <class T>
 void set_random_hermitian(Matrix<T, Device::CPU>& matrix) {
   internal::set_random_hermitian_with_offset(matrix, 0);
@@ -317,8 +317,8 @@ void set_random_hermitian(Matrix<T, Device::CPU>& matrix) {
 /// This means that the elements of a specific tile, no matter how the matrix is distributed,
 /// will be set with the same set of values.
 ///
-/// @pre @param matrix is a square matrix
-/// @pre @param matrix has a square blocksize
+/// @pre @param matrix is a square matrix,
+/// @pre @param matrix has a square blocksize.
 template <class T>
 void set_random_hermitian_positive_definite(Matrix<T, Device::CPU>& matrix) {
   const auto offset_value = dlaf::util::size_t::mul(2, to_sizet(matrix.size().rows()));

--- a/misc/coding.md
+++ b/misc/coding.md
@@ -215,8 +215,8 @@ Doxygen commands should be specified with `@` syntax (e.g. `@param`).
 
 General rules:
 
-- no empty comment lines before and after the comment block
-- one space after the brief comment
+- no empty comment lines before and after the comment block,
+- one space after the brief comment.
 
 ```cpp
 /// Returns @c ceiling(@p num / @p den) for integer types.

--- a/misc/coding.md
+++ b/misc/coding.md
@@ -157,7 +157,7 @@ the specification if they are input (In:), output (Out:) or input-output paramet
 
 Example:
 ```c++
-/// \brief Updates foo and computes bar using in_1 .. in_5.
+/// Updates foo and computes bar using in_1 .. in_5.
 ///
 /// In: in_3, in_5
 /// In/Out: foo
@@ -216,10 +216,10 @@ Doxygen commands should be specified with `@` syntax (e.g. `@param`).
 General rules:
 
 - no empty comment lines before and after the comment block
-- one space after the @brief comment
+- one space after the brief comment
 
 ```cpp
-/// @brief Returns @c ceiling(@p num / @p den) for integer types.
+/// Returns @c ceiling(@p num / @p den) for integer types.
 ///
 /// @tparam IntType has to be an integer type
 /// @pre @a num >= 0 and @a den >= 0

--- a/test/include/dlaf_test/helper_communicators.h
+++ b/test/include/dlaf_test/helper_communicators.h
@@ -16,7 +16,7 @@ namespace dlaf_test {
 
 using dlaf::comm::Communicator;
 
-/// @brief Test fixture that split even/odd ranks (wrt rank id) in two separate communicators.
+/// Test fixture that split even/odd ranks (wrt rank id) in two separate communicators.
 class SplittedCommunicatorsTest : public ::testing::Test {
   static_assert(NUM_MPI_RANKS >= 4, "At least 4 ranks, in order to avoid single rank communicators");
 

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -29,7 +29,7 @@ using namespace dlaf_test;
 /// holds op(A) X = alpha B (n can be any value).
 ///
 /// The elements of op(A) (@p el_op_a) are chosen such that:
-///   op(A)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements
+///   op(A)_ik = (i+1) / (k+.5) * exp(I*(2*i-k)) for the referenced elements,
 ///   op(A)_ik = -9.9 otherwise,
 /// where I = 0 for real types or I is the complex unit for complex types.
 ///
@@ -45,7 +45,7 @@ using namespace dlaf_test;
 ///       kk = i+1 if op(a) is an lower triangular matrix, or
 ///       kk = m-i if op(a) is an lower triangular matrix.
 /// Therefore
-/// B_ij = (X_ij + (kk-1) * gamma) / alpha, if diag == Unit
+/// B_ij = (X_ij + (kk-1) * gamma) / alpha, if diag == Unit,
 /// B_ij = kk * gamma / alpha, otherwise.
 ///
 template <class ElementIndex, class T>
@@ -93,7 +93,7 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 /// holds X op(A) = alpha B (n can be any value).
 ///
 /// The elements of op(A) (@p el_op_a) are chosen such that:
-///   op(A)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements
+///   op(A)_kj = (j+1) / (k+.5) * exp(I*(2*j-k)) for the referenced elements,
 ///   op(A)_kj = -9.9 otherwise,
 /// where I = 0 for real types or I is the complex unit for complex types.
 ///
@@ -109,7 +109,7 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 ///       kk = j+1 if op(a) is an upper triangular matrix, or
 ///       kk = m-j if op(a) is an upper triangular matrix.
 /// Therefore
-/// B_ij = (X_ij + (kk-1) * gamma) / alpha, if diag == Unit
+/// B_ij = (X_ij + (kk-1) * gamma) / alpha, if diag == Unit,
 /// B_ij = kk * gamma / alpha, otherwise.
 ///
 template <class ElementIndex, class T>

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -27,10 +27,10 @@ namespace dlaf {
 namespace matrix {
 namespace test {
 
-/// @brief Sets the elements of the matrix.
+/// Sets the elements of the matrix.
 ///
 /// The (i, j)-element of the matrix is set to el({i, j}).
-/// @pre el argument is an index of type const GlobalElementIndex& or GlobalElementIndex.
+/// @pre el argument is an index of type const GlobalElementIndex& or GlobalElementIndex,
 /// @pre el return type should be T.
 template <template <class, Device> class MatrixType, class T, class ElementGetter>
 void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
@@ -49,16 +49,16 @@ void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
   }
 }
 
-/// @brief Checks the elements of the matrix.
+/// Checks the elements of the matrix.
 ///
 /// comp(expected({i, j}), (i, j)-element) is used to compare the elements.
 /// err_message(expected({i, j}), (i, j)-element) is printed for the first element
 /// that does not fulfill the comparison.
-/// @pre expected argument is an index of type const GlobalElementIndex&.
-/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise.
-/// @pre err_message should have two arguments and return a string.
-/// @pre expected return type should be the same as the type of the first argument of comp and of err_message.
-/// @pre The second argument of comp should be either T, T& or const T&.
+/// @pre expected argument is an index of type const GlobalElementIndex&,
+/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise,
+/// @pre err_message should have two arguments and return a string,
+/// @pre expected return type should be the same as the type of the first argument of comp and of err_message,
+/// @pre The second argument of comp should be either T, T& or const T&,
 /// @pre The second argument of err_message should be either T, T& or const T&.
 namespace internal {
 template <template <class, Device> class MatrixType, class T, class ElementGetter, class ComparisonOp,
@@ -86,10 +86,10 @@ void check(ElementGetter expected, MatrixType<T, Device::CPU>& mat, ComparisonOp
 }
 }
 
-/// @brief Checks the elements of the matrix (exact equality).
+/// Checks the elements of the matrix (exact equality).
 ///
 /// The (i, j)-element of the matrix is compared to exp_el({i, j}).
-/// @pre exp_el argument is an index of type const GlobalElementIndex&.
+/// @pre exp_el argument is an index of type const GlobalElementIndex&,
 /// @pre exp_el return type should be T.
 template <template <class, Device> class MatrixType, class T, class ElementGetter>
 void checkEQ(ElementGetter exp_el, MatrixType<T, Device::CPU>& mat, const char* file, const int line) {
@@ -102,10 +102,10 @@ void checkEQ(ElementGetter exp_el, MatrixType<T, Device::CPU>& mat, const char* 
 }
 #define CHECK_MATRIX_EQ(exp_el, mat) ::dlaf::matrix::test::checkEQ(exp_el, mat, __FILE__, __LINE__)
 
-/// @brief Checks the pointers to the elements of the matrix.
+/// Checks the pointers to the elements of the matrix.
 ///
 /// The pointer to (i, j)-element of the matrix is compared to exp_ptr({i, j}).
-/// @pre exp_ptr argument is an index of type const GlobalElementIndex&.
+/// @pre exp_ptr argument is an index of type const GlobalElementIndex&,
 /// @pre exp_ptr return type should be T*.
 template <class T, class PointerGetter>
 void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* file, const int line) {
@@ -119,14 +119,14 @@ void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* fi
 }
 #define CHECK_MATRIX_PTR(exp_ptr, mat) ::dlaf::matrix::test::checkPtr(exp_ptr, mat, __FILE__, __LINE__)
 
-/// @brief Checks the elements of the matrix.
+/// Checks the elements of the matrix.
 ///
 /// The (i, j)-element of the matrix is compared to expected({i, j}).
-/// @pre expected argument is an index of type const GlobalElementIndex&.
-/// @pre expected return type should be T.
-/// @pre rel_err >= 0.
-/// @pre abs_err >= 0.
-/// @pre rel_err > 0 || abs_err > 0
+/// @pre expected argument is an index of type const GlobalElementIndex&,
+/// @pre expected return type should be T,
+/// @pre rel_err >= 0,
+/// @pre abs_err >= 0,
+/// @pre rel_err > 0 || abs_err > 0.
 template <template <class, Device> class MatrixType, class T, class ElementGetter>
 void checkNear(ElementGetter expected, MatrixType<T, Device::CPU>& mat, BaseType<T> rel_err,
                BaseType<T> abs_err, const char* file, const int line) {

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -125,7 +125,7 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlob
 
 /// Returns true if only the first @p futures are ready.
 ///
-/// @pre Future should be a future or shared_future.
+/// @pre Future should be a future or shared_future,
 /// @pre 0 <= ready <= futures.size().
 template <class Future>
 bool checkFuturesStep(size_t ready, const std::vector<Future>& futures) {

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -126,7 +126,7 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlob
 /// Returns true if only the first @p futures are ready.
 ///
 /// @pre Future should be a future or shared_future.
-/// @pre 0 <= ready <= futures.size()
+/// @pre 0 <= ready <= futures.size().
 template <class Future>
 bool checkFuturesStep(size_t ready, const std::vector<Future>& futures) {
   DLAF_ASSERT_HEAVY(ready >= 0, "");
@@ -147,7 +147,7 @@ bool checkFuturesStep(size_t ready, const std::vector<Future>& futures) {
 ///
 /// If get_ready == true it checks if current[i] is ready after previous[i] is used.
 /// If get_ready == false it checks if current[i] is not ready after previous[i] is used.
-/// @pre Future[1,2] should be a future or shared_future
+/// @pre Future[1,2] should be a future or shared_future.
 template <class Future1, class Future2>
 void checkFutures(bool get_ready, const std::vector<Future1>& current, std::vector<Future2>& previous) {
   DLAF_ASSERT_HEAVY(current.size() == previous.size(), "");
@@ -172,7 +172,7 @@ void checkFutures(bool get_ready, const std::vector<Future1>& current, std::vect
 /// where index = LocalTileIndex(i % mat_view.localNrTiles.rows(), i / mat_view.localNrTiles.rows())
 /// If get_ready == true it checks if current[i] is ready after the call to mat_view.done(i).
 /// If get_ready == false it checks if current[i] is not ready after the call to mat_view.done(i).
-/// @pre Future1 should be a future or shared_future
+/// @pre Future1 should be a future or shared_future.
 template <class Future1, class MatrixViewType>
 void checkFuturesDone(bool get_ready, const std::vector<Future1>& current, MatrixViewType& mat_view) {
   using dlaf::util::size_t::mul;

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -102,7 +102,7 @@ void check(ElementGetter expected, const Tile<T, Device::CPU>& tile, ComparisonO
   }
 }
 
-/// Checks the elements of the tile w.r.t. a fixed value
+/// Checks the elements of the tile w.r.t. a fixed value.
 ///
 /// comp(expected, (i, j)-element) is used to compare the elements.
 /// err_message(expected, (i, j)-element) is printed for the first element which does not fulfill

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -25,10 +25,10 @@ namespace matrix {
 namespace test {
 using namespace dlaf;
 
-/// @brief Sets the elements of the tile.
+/// Sets the elements of the tile.
 ///
 /// The (i, j)-element of the tile is set to el({i, j}).
-/// @pre el argument is an index of type const TileElementIndex& or TileElementIndex.
+/// @pre el argument is an index of type const TileElementIndex& or TileElementIndex,
 /// @pre el return type should be T.
 template <class T, class ElementGetter,
           enable_if_signature_t<ElementGetter, T(const TileElementIndex&), int> = 0>
@@ -41,9 +41,9 @@ void set(const Tile<T, Device::CPU>& tile, ElementGetter el) {
   }
 }
 
-/// @brief Sets all the elements of the tile with given value.
+/// Sets all the elements of the tile with given value.
 ///
-/// @pre el is an element of a type U that can be assigned to T
+/// @pre el is an element of a type U that can be assigned to T.
 template <class T, class U, enable_if_convertible_t<U, T, int> = 0>
 void set(const Tile<T, Device::CPU>& tile, U el) {
   for (SizeType j = 0; j < tile.size().cols(); ++j) {
@@ -53,7 +53,7 @@ void set(const Tile<T, Device::CPU>& tile, U el) {
   }
 }
 
-/// @brief Print the elements of the tile.
+/// Print the elements of the tile.
 template <class T>
 void print(const Tile<T, Device::CPU>& tile, int precision = 4, std::ostream& out = std::cout) {
   auto out_precision = out.precision();
@@ -75,16 +75,16 @@ void print(const Tile<T, Device::CPU>& tile, int precision = 4, std::ostream& ou
 }
 
 namespace internal {
-/// @brief Checks the elements of the tile.
+/// Checks the elements of the tile.
 ///
 /// comp(expected({i, j}), (i, j)-element) is used to compare the elements.
 /// err_message(expected({i, j}), (i, j)-element) is printed for the first element which does not fulfill
 /// the comparison.
-/// @pre expected argument is an index of type const TileElementIndex&.
-/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise.
-/// @pre err_message should have two arguments and return a string.
-/// @pre expected return type should be the same as the type of the first argument of comp and of err_message.
-/// @pre The second argument of comp should be either T, T& or const T&.
+/// @pre expected argument is an index of type const TileElementIndex&,
+/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise,
+/// @pre err_message should have two arguments and return a string,
+/// @pre expected return type should be the same as the type of the first argument of comp and of err_message,
+/// @pre The second argument of comp should be either T, T& or const T&,
 /// @pre The second argument of err_message should be either T, T& or const T&.
 template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGetter,
           std::enable_if_t<!std::is_convertible<ElementGetter, T>::value, int> = 0>
@@ -102,16 +102,16 @@ void check(ElementGetter expected, const Tile<T, Device::CPU>& tile, ComparisonO
   }
 }
 
-/// @brief Checks the elements of the tile w.r.t. a fixed value
+/// Checks the elements of the tile w.r.t. a fixed value
 ///
 /// comp(expected, (i, j)-element) is used to compare the elements.
 /// err_message(expected, (i, j)-element) is printed for the first element which does not fulfill
 /// the comparison.
-/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise.
-/// @pre err_message should have two arguments and return a string.
-/// @pre expected type should be the same as the type of the first argument of comp and of err_message.
-/// @pre The second argument of comp should be either T, T& or const T&.
-/// @pre The second argument of err_message should be either T, T& or const T&.
+/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise,
+/// @pre err_message should have two arguments and return a string,
+/// @pre expected type should be the same as the type of the first argument of comp and of err_message,
+/// @pre the second argument of comp should be either T, T& or const T&,
+/// @pre the second argument of err_message should be either T, T& or const T&.
 template <class T, class U, class ComparisonOp, class ErrorMessageGetter,
           enable_if_convertible_t<U, T, int> = 0>
 void check(U expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
@@ -120,10 +120,10 @@ void check(U expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
 }
 }
 
-/// @brief Checks the elements of the tile (exact equality).
+/// Checks the elements of the tile (exact equality).
 ///
 /// The (i, j)-element of the tile is compared to exp_el({i, j}).
-/// @pre exp_el argument is an index of type const TileElementIndex&.
+/// @pre exp_el argument is an index of type const TileElementIndex&,
 /// @pre exp_el return type should be T.
 template <class T, class ElementGetter>
 void checkEQ(ElementGetter exp_el, const Tile<T, Device::CPU>& tile, const char* file, const int line) {
@@ -136,10 +136,10 @@ void checkEQ(ElementGetter exp_el, const Tile<T, Device::CPU>& tile, const char*
 }
 #define CHECK_TILE_EQ(exp_el, tile) ::dlaf::matrix::test::checkEQ(exp_el, tile, __FILE__, __LINE__)
 
-/// @brief Checks the pointers to the elements of the tile.
+/// Checks the pointers to the elements of the tile.
 ///
 /// The pointer to (i, j)-element of the matrix is compared to exp_ptr({i, j}).
-/// @pre exp_ptr argument is an index of type const TileElementIndex&.
+/// @pre exp_ptr argument is an index of type const TileElementIndex&,
 /// @pre exp_ptr return type should be T*.
 template <class T, class PointerGetter>
 void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const char* file,
@@ -154,12 +154,12 @@ void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const cha
 }
 #define CHECK_TILE_PTR(exp_ptr, tile) ::dlaf::matrix::test::checkPtr(exp_ptr, tile, __FILE__, __LINE__)
 
-/// @brief Checks the elements of the tile.
+/// Checks the elements of the tile.
 ///
 /// The (i, j)-element of the tile is compared to expected({i, j}).
-/// @pre expected argument is an index of type const TileElementIndex&.
-/// @pre expected return type should be T.
-/// @pre rel_err > 0.
+/// @pre expected argument is an index of type const TileElementIndex&,
+/// @pre expected return type should be T,
+/// @pre rel_err > 0,
 /// @pre abs_err > 0.
 template <class T, class ElementGetter>
 void checkNear(ElementGetter expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,

--- a/test/include/dlaf_test/matrix/util_tile_blas.h
+++ b/test/include/dlaf_test/matrix/util_tile_blas.h
@@ -23,12 +23,12 @@ namespace matrix {
 namespace test {
 using namespace dlaf_test;
 
-/// @brief Sets the elements of the tile.
+/// Sets the elements of the tile.
 ///
 /// The (i, j)-element of the tile is set to el({i, j}) if op == NoTrans,
 ///                                          el({j, i}) if op == Trans,
 ///                                          conj(el({j, i})) if op == ConjTrans.
-/// @pre el argument is an index of type const TileElementIndex& or TileElementIndex.
+/// @pre el argument is an index of type const TileElementIndex& or TileElementIndex,
 /// @pre el return type should be T.
 template <class T, class Func>
 void set(Tile<T, Device::CPU>& tile, Func el, blas::Op op) {

--- a/test/include/dlaf_test/util_mpi.h
+++ b/test/include/dlaf_test/util_mpi.h
@@ -6,6 +6,7 @@ namespace dlaf_test {
 namespace comm {
 
 /// Compute valid 2D grid dimensions for a given number of ranks.
+///
 /// @return std::array<int, 2> an array with the two dimensions.
 /// @post ret_dims[0] * ret_dims[0] == @p nranks.
 std::array<int, 2> computeGridDims(int nranks);

--- a/test/include/dlaf_test/util_mpi.h
+++ b/test/include/dlaf_test/util_mpi.h
@@ -5,9 +5,9 @@
 namespace dlaf_test {
 namespace comm {
 
-/// @brief Compute valid 2D grid dimensions for a given number of ranks
-/// @return std::array<int, 2> an array with the two dimensions
-/// @post ret_dims[0] * ret_dims[0] == @p nranks
+/// Compute valid 2D grid dimensions for a given number of ranks.
+/// @return std::array<int, 2> an array with the two dimensions.
+/// @post ret_dims[0] * ret_dims[0] == @p nranks.
 std::array<int, 2> computeGridDims(int nranks);
 
 }

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -21,23 +21,24 @@ using MatrixElementTypes = ::testing::Types<float, double, std::complex<float>, 
 
 template <class T>
 struct TypeUtilities {
-  /// @brief Returns r.
+  /// Returns r.
   static constexpr T element(double r, double /* i */) {
     return static_cast<T>(r);
   }
 
-  /// @brief Returns r.
-  /// @pre r > 0
+  /// Returns r.
+  ///
+  /// @pre r > 0.
   static constexpr T polar(double r, double /* theta */) {
     return static_cast<T>(r);
   }
 
-  /// @brief Returns val.
+  /// Returns val.
   static constexpr T conj(T val) {
     return val;
   }
 
-  /// @brief Relative maximum error for a multiplication + addition.
+  /// Relative maximum error for a multiplication + addition.
   static constexpr T error = 2 * std::numeric_limits<T>::epsilon();
 };
 
@@ -46,23 +47,24 @@ constexpr T TypeUtilities<T>::error;
 
 template <class T>
 struct TypeUtilities<std::complex<T>> {
-  /// @brief Returns r + I * i (I is the imaginary unit).
+  /// Returns r + I * i (I is the imaginary unit).
   static constexpr std::complex<T> element(double r, double i) {
     return std::complex<T>(static_cast<T>(r), static_cast<T>(i));
   }
 
-  /// @brief Returns r * (cos(theta) + I * sin(theta)) (I is the imaginary unit).
+  /// Returns r * (cos(theta) + I * sin(theta)) (I is the imaginary unit).
+  ///
   /// @pre r > 0
   static constexpr std::complex<T> polar(double r, double theta) {
     return std::polar<T>(static_cast<T>(r), static_cast<T>(theta));
   }
 
-  /// @brief Returns std::conj(val).
+  /// Returns std::conj(val).
   static constexpr std::complex<T> conj(std::complex<T> val) {
     return std::conj(val);
   }
 
-  /// @brief Relative maximum error for a multiplication + addition.
+  /// Relative maximum error for a multiplication + addition.
   static constexpr T error = 8 * std::numeric_limits<T>::epsilon();
 };
 

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -54,7 +54,7 @@ struct TypeUtilities<std::complex<T>> {
 
   /// Returns r * (cos(theta) + I * sin(theta)) (I is the imaginary unit).
   ///
-  /// @pre r > 0
+  /// @pre r > 0.
   static constexpr std::complex<T> polar(double r, double theta) {
     return std::polar<T>(static_cast<T>(r), static_cast<T>(theta));
   }

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -60,7 +60,7 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
 
   // Note: The tile elements are chosen such that:
   // - op_a(a)_ik = .9 * (i+1) / (k+.5) * exp(I*(2*i-k)),
-  // - op_b(b)_kj = .8 * (k+.5) / (j+2) * exp(I*(k-j)),
+  // - op_b(b)_kj = .8 * (k+.5) / (j+2) * exp(I*(k+j)),
   // - c_ij = 1.2 * i / (j+1) * exp(I*(-i+j)),
   // where I = 0 for real types or I is the complex unit for complex types.
   // Therefore the result should be:


### PR DESCRIPTION
Fixing documentation: added punctuation and removed some `@brief` keyword, forgotten in the previous PR about moving to the new error handling style (#178).

Fixed the equation to obtain the elements of matrix B in test_gemm. 