### PR TITLE
[spack] Enforce same build type

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -30,6 +30,10 @@ class DlaFuture(CMakePackage):
     depends_on('hpx@1.4.0:1.4.1 cxxstd=14 networking=none')
     depends_on('cuda', when='+cuda')
 
+    depends_on('hpx build_type=Debug', when='build_type=Debug')
+    depends_on('hpx build_type=Release', when='build_type=Release')
+    depends_on('hpx build_type=RelWithDebInfo', when='build_type=RelWithDebInfo')
+
     def cmake_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Related to #84 . In particular, this from HPX :

> We currently don’t guarantee ABI compatibility between Debug and Release builds. Please make sure that applications built against HPX use the same build type as you used to build HPX. For CMake builds, this means that the CMAKE_BUILD_TYPE variables have to match and for projects not using CMake, the HPX_DEBUG macro has to be set in debug mode.