### PR TITLE
Make sure no yielding happens while handling exceptions

### DIFF
--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -65,13 +65,19 @@ hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex&
   tile_futures_[i] = p.get_future();
   tile_shared_futures_[i] = {};
   return old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileType>&& fut) mutable {
+    std::exception_ptr current_exception_ptr;
+
     try {
       return std::move(fut.get().setPromise(std::move(p)));
     }
     catch (...) {
-      auto current_exception_ptr = std::current_exception();
-      p.set_exception(current_exception_ptr);
-      std::rethrow_exception(current_exception_ptr);
+      current_exception_ptr = std::current_exception();
     }
+
+    // The exception is set outside the catch block since set_exception may
+    // yield. Ending the catch block on a different worker thread than where it
+    // was started may lead to segfaults.
+    p.set_exception(current_exception_ptr);
+    std::rethrow_exception(current_exception_ptr);
   });
 }


### PR DESCRIPTION
See https://github.com/STEllAR-GROUP/hpx/pull/4894 for more details. The short version is that starting a catch block on one worker thread and resuming on another is something that does not work at least with GCC/clang and libstdc++/libc++ (this seems to be handled correctly on Windows). `promise::set_exception` requires a lock which may yield.

Would you like a comment in the code explaining this as well?