### PR TITLE
Making arguments "const" in Lapack and Blas wrappers

### DIFF
--- a/include/dlaf/blas_tile.h
+++ b/include/dlaf/blas_tile.h
@@ -24,8 +24,8 @@ using matrix::Tile;
 
 /// Computes general matrix matrix multiplication.
 template <class T, Device device>
-void gemm(blas::Op op_a, blas::Op op_b, T alpha, const Tile<const T, device>& a,
-          const Tile<const T, device>& b, T beta, const Tile<T, device>& c) noexcept;
+void gemm(const blas::Op op_a, const blas::Op op_b, const T alpha, const Tile<const T, device>& a,
+          const Tile<const T, device>& b, const T beta, const Tile<T, device>& c) noexcept;
 
 /// Computes matrix matrix multiplication where matrix @p a is hermitian (symmetric if T is real).
 template <class T, Device device>
@@ -39,13 +39,13 @@ void her2k(const blas::Uplo uplo, const blas::Op op, const T alpha, const Tile<c
 
 /// Performs a rank k update of hermitian (symmetric if T is real) tile @p a.
 template <class T, Device device>
-void herk(blas::Uplo uplo, blas::Op op, BaseType<T> alpha, const Tile<const T, device>& a,
-          BaseType<T> beta, const Tile<T, device>& c) noexcept;
+void herk(const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha,
+          const Tile<const T, device>& a, const BaseType<T> beta, const Tile<T, device>& c) noexcept;
 
 /// Performs a triangular solve.
 template <class T, Device device>
-void trsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha,
-          const Tile<const T, device>& a, const Tile<T, device>& b) noexcept;
+void trsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const blas::Diag diag,
+          const T alpha, const Tile<const T, device>& a, const Tile<T, device>& b) noexcept;
 
 #include "dlaf/blas_tile.tpp"
 }

--- a/include/dlaf/blas_tile.tpp
+++ b/include/dlaf/blas_tile.tpp
@@ -9,8 +9,8 @@
 //
 
 template <class T, Device device>
-void gemm(blas::Op op_a, blas::Op op_b, T alpha, const Tile<const T, device>& a,
-          const Tile<const T, device>& b, T beta, const Tile<T, device>& c) noexcept {
+void gemm(const blas::Op op_a, const blas::Op op_b, const T alpha, const Tile<const T, device>& a,
+          const Tile<const T, device>& b, const T beta, const Tile<T, device>& c) noexcept {
   SizeType m;
   SizeType k;
   if (op_a == blas::Op::NoTrans) {
@@ -79,8 +79,8 @@ void her2k(const blas::Uplo uplo, const blas::Op op, const T alpha, const Tile<c
 }
 
 template <class T, Device device>
-void herk(blas::Uplo uplo, blas::Op op, BaseType<T> alpha, const Tile<const T, device>& a,
-          BaseType<T> beta, const Tile<T, device>& c) noexcept {
+void herk(const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha,
+          const Tile<const T, device>& a, const BaseType<T> beta, const Tile<T, device>& c) noexcept {
   SizeType n;
   SizeType k;
   if (op == blas::Op::NoTrans) {
@@ -101,8 +101,8 @@ void herk(blas::Uplo uplo, blas::Op op, BaseType<T> alpha, const Tile<const T, d
 }
 
 template <class T, Device device>
-void trsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha,
-          const Tile<const T, device>& a, const Tile<T, device>& b) noexcept {
+void trsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const blas::Diag diag,
+          const T alpha, const Tile<const T, device>& a, const Tile<T, device>& b) noexcept {
   SizeType m = b.size().rows();
   SizeType n = b.size().cols();
 

--- a/include/dlaf/blas_tile.tpp
+++ b/include/dlaf/blas_tile.tpp
@@ -103,12 +103,12 @@ void herk(const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha,
 template <class T, Device device>
 void trsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const blas::Diag diag,
           const T alpha, const Tile<const T, device>& a, const Tile<T, device>& b) noexcept {
-  SizeType m = b.size().rows();
-  SizeType n = b.size().cols();
+  const SizeType m = b.size().rows();
+  const SizeType n = b.size().cols();
 
   DLAF_ASSERT(a.size().rows() == a.size().cols(), "`a` is not square!", a);
 
-  auto left_side = (side == blas::Side::Left ? m : n);
+  const auto left_side = (side == blas::Side::Left ? m : n);
   DLAF_ASSERT(a.size().rows() == left_side, "`a` has an invalid size!", a, left_side);
 
   blas::trsm(blas::Layout::ColMajor, side, uplo, op, diag, m, n, alpha, a.ptr(), a.ld(), b.ptr(),

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -54,7 +54,7 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b);
 ///
 /// @pre a.size().isValid().
 template <class T, Device device>
-dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept;
+dlaf::BaseType<T> lange(const lapack::Norm norm, const Tile<T, device>& a) noexcept;
 
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a triangular matrix.
@@ -64,7 +64,7 @@ dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept;
 /// @pre a.size().rows() >= a.size().cols() if uplo == blas::Uplo::Lower,
 /// @pre a.size().rows() <= a.size().cols() if uplo == blas::Uplo::Upper.
 template <class T, Device device>
-dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
+dlaf::BaseType<T> lantr(const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
                         const Tile<T, device>& a) noexcept;
 
 /// Compute the cholesky decomposition of a.
@@ -73,14 +73,14 @@ dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
 /// @pre matrix @p a is square,
 /// @pre matrix @p a is positive definite.
 template <class T, Device device>
-void potrf(blas::Uplo uplo, const Tile<T, device>& a) noexcept;
+void potrf(const blas::Uplo uplo, const Tile<T, device>& a) noexcept;
 
 /// Compute the cholesky decomposition of a (with return code).
 ///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @returns info = 0 on success or info > 0 if the tile is not positive definite.
 template <class T, Device device>
-long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a);
+long long potrfInfo(const blas::Uplo uplo, const Tile<T, device>& a);
 
 #include "dlaf/lapack_tile.tpp"
 

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -32,12 +32,12 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
 }
 
 template <class T, Device device>
-dlaf::BaseType<T> lange(lapack::Norm norm, const Tile<T, device>& a) noexcept {
+dlaf::BaseType<T> lange(const lapack::Norm norm, const Tile<T, device>& a) noexcept {
   return lapack::lange(norm, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 
 template <class T, Device device>
-dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
+dlaf::BaseType<T> lantr(const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
                         const Tile<T, device>& a) noexcept {
   switch (uplo) {
     case blas::Uplo::Lower:
@@ -54,14 +54,14 @@ dlaf::BaseType<T> lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag,
 }
 
 template <class T, Device device>
-void potrf(blas::Uplo uplo, const Tile<T, device>& a) noexcept {
+void potrf(const blas::Uplo uplo, const Tile<T, device>& a) noexcept {
   auto info = potrfInfo(uplo, a);
 
   DLAF_ASSERT(info == 0, "a is not positive definite");
 }
 
 template <class T, Device device>
-long long potrfInfo(blas::Uplo uplo, const Tile<T, device>& a) {
+long long potrfInfo(const blas::Uplo uplo, const Tile<T, device>& a) {
   DLAF_ASSERT(a.size().rows() == a.size().cols(), "POTRF: `a` is not square!", a);
 
   auto info = lapack::potrf(uplo, a.size().rows(), a.ptr(), a.ld());

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -25,8 +25,8 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
   DLAF_ASSERT_MODERATE(a.size() == b.size(), "Source and destination tile must have the same size!", a,
                        b);
 
-  SizeType m = a.size().rows();
-  SizeType n = a.size().cols();
+  const SizeType m = a.size().rows();
+  const SizeType n = a.size().cols();
 
   lapack::lacpy(lapack::MatrixType::General, m, n, a.ptr(), a.ld(), b.ptr(), b.ld());
 }

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -50,25 +50,25 @@ using namespace dlaf_test;
 ///
 template <class ElementIndex, class T>
 auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType m) {
-  bool op_a_lower = false;
-  if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
-      (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
-    op_a_lower = true;
+  const bool op_a_lower = ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
+                           (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
+                              ? true
+                              : false;
 
   std::function<T(const ElementIndex&)> el_op_a = [op_a_lower, diag](const ElementIndex& index) {
     if ((op_a_lower && index.row() < index.col()) || (!op_a_lower && index.row() > index.col()) ||
         (diag == blas::Diag::Unit && index.row() == index.col()))
       return TypeUtilities<T>::element(-9.9, 0);
 
-    double i = index.row();
-    double k = index.col();
+    const double i = index.row();
+    const double k = index.col();
 
     return TypeUtilities<T>::polar((i + 1) / (k + .5), 2 * i - k);
   };
 
   std::function<T(const ElementIndex&)> el_x = [](const ElementIndex& index) {
-    double k = index.row();
-    double j = index.col();
+    const double k = index.row();
+    const double j = index.col();
 
     return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
   };
@@ -77,9 +77,9 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
                                                 el_x](const ElementIndex& index) {
     BaseType<T> kk = op_a_lower ? index.row() + 1 : m - index.row();
 
-    double i = index.row();
-    double j = index.col();
-    T gamma = TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
+    const double i = index.row();
+    const double j = index.col();
+    const T gamma = TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
     if (diag == blas::Diag::Unit)
       return ((kk - 1) * gamma + el_x(index)) / alpha;
     else
@@ -114,14 +114,14 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 ///
 template <class ElementIndex, class T>
 auto getRightTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType n) {
-  bool op_a_lower = false;
-  if ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
-      (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
-    op_a_lower = true;
+  const bool op_a_lower = ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
+                           (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
+                              ? true
+                              : false;
 
   auto el_x = [](const ElementIndex& index) {
-    double i = index.row();
-    double k = index.col();
+    const double i = index.row();
+    const double k = index.col();
 
     return TypeUtilities<T>::polar((k + .5) / (i + 2), i + k);
   };
@@ -131,8 +131,8 @@ auto getRightTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T a
         (diag == blas::Diag::Unit && index.row() == index.col()))
       return TypeUtilities<T>::element(-9.9, 0);
 
-    double k = index.row();
-    double j = index.col();
+    const double k = index.row();
+    const double j = index.col();
 
     return TypeUtilities<T>::polar((j + 1) / (k + .5), 2 * j - k);
   };
@@ -140,9 +140,9 @@ auto getRightTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T a
   auto el_b = [n, alpha, diag, op_a_lower, el_x](const ElementIndex& index) {
     BaseType<T> kk = op_a_lower ? n - index.col() : index.col() + 1;
 
-    double i = index.row();
-    double j = index.col();
-    T gamma = TypeUtilities<T>::polar((j + 1) / (i + 2), i + 2 * j);
+    const double i = index.row();
+    const double j = index.col();
+    const T gamma = TypeUtilities<T>::polar((j + 1) / (i + 2), i + 2 * j);
     if (diag == blas::Diag::Unit)
       return ((kk - 1) * gamma + el_x(index)) / alpha;
     else

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -51,9 +51,7 @@ using namespace dlaf_test;
 template <class ElementIndex, class T>
 auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType m) {
   const bool op_a_lower = ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
-                           (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
-                              ? true
-                              : false;
+                           (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans));
 
   std::function<T(const ElementIndex&)> el_op_a = [op_a_lower, diag](const ElementIndex& index) {
     if ((op_a_lower && index.row() < index.col()) || (!op_a_lower && index.row() > index.col()) ||
@@ -115,9 +113,7 @@ auto getLeftTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 template <class ElementIndex, class T>
 auto getRightTriangularSystem(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType n) {
   const bool op_a_lower = ((uplo == blas::Uplo::Lower && op == blas::Op::NoTrans) ||
-                           (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans))
-                              ? true
-                              : false;
+                           (uplo == blas::Uplo::Upper && op != blas::Op::NoTrans));
 
   auto el_x = [](const ElementIndex& index) {
     const double i = index.row();

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -67,18 +67,18 @@ void testGemm(const blas::Op op_a, const blas::Op op_b, const SizeType m, const 
   //        = beta * c_ij + gamma * (i+1) / (j+2) * exp(I*(2*i+j)),
   // where gamma = .72 * k * alpha.
   auto el_op_a = [](const TileElementIndex& index) {
-    double i = index.row();
-    double k = index.col();
+    const double i = index.row();
+    const double k = index.col();
     return TypeUtilities<T>::polar(.9 * (i + 1) / (k + .5), 2 * i - k);
   };
   auto el_op_b = [](const TileElementIndex& index) {
-    double k = index.row();
-    double j = index.col();
+    const double k = index.row();
+    const double j = index.col();
     return TypeUtilities<T>::polar(.8 * (k + .5) / (j + 2), k + j);
   };
   auto el_c = [](const TileElementIndex& index) {
-    double i = index.row();
-    double j = index.col();
+    const double i = index.row();
+    const double j = index.col();
     return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
   };
 
@@ -87,8 +87,8 @@ void testGemm(const blas::Op op_a, const blas::Op op_b, const SizeType m, const 
 
   const T gamma = TypeUtilities<T>::element(.72 * k, 0) * alpha;
   auto res_c = [beta, el_c, gamma](const TileElementIndex& index) {
-    double i = index.row();
-    double j = index.col();
+    const double i = index.row();
+    const double j = index.col();
     return beta * el_c(index) + gamma * TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
   };
 

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -29,8 +29,8 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class T, class CT = const T>
-void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, SizeType extra_lda,
-              SizeType extra_ldb, SizeType extra_ldc) {
+void testGemm(const blas::Op op_a, const blas::Op op_b, SizeType m, SizeType n, SizeType k,
+              SizeType extra_lda, SizeType extra_ldb, SizeType extra_ldc) {
   TileElementSize size_a(m, k);
   if (op_a != blas::Op::NoTrans)
     size_a.transpose();
@@ -83,10 +83,10 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
     return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
   };
 
-  T alpha = TypeUtilities<T>::element(-1.2, .7);
-  T beta = TypeUtilities<T>::element(1.1, .4);
+  const T alpha = TypeUtilities<T>::element(-1.2, .7);
+  const T beta = TypeUtilities<T>::element(1.1, .4);
 
-  T gamma = TypeUtilities<T>::element(.72 * k, 0) * alpha;
+  const T gamma = TypeUtilities<T>::element(.72 * k, 0) * alpha;
   auto res_c = [beta, el_c, gamma](const TileElementIndex& index) {
     double i = index.row();
     double j = index.col();

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -37,11 +37,11 @@ void testGemm(const blas::Op op_a, const blas::Op op_b, SizeType m, SizeType n, 
   TileElementSize size_b(k, n);
   if (op_b != blas::Op::NoTrans)
     size_b.transpose();
-  TileElementSize size_c(m, n);
+  const TileElementSize size_c(m, n);
 
-  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
-  SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
+  const SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "GEMM: " << op_a << ", " << op_a;

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -29,14 +29,13 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class T, class CT = const T>
-void testGemm(const blas::Op op_a, const blas::Op op_b, SizeType m, SizeType n, SizeType k,
-              SizeType extra_lda, SizeType extra_ldb, SizeType extra_ldc) {
-  TileElementSize size_a(m, k);
-  if (op_a != blas::Op::NoTrans)
-    size_a.transpose();
-  TileElementSize size_b(k, n);
-  if (op_b != blas::Op::NoTrans)
-    size_b.transpose();
+void testGemm(const blas::Op op_a, const blas::Op op_b, const SizeType m, const SizeType n,
+              const SizeType k, const SizeType extra_lda, const SizeType extra_ldb,
+              const SizeType extra_ldc) {
+  const TileElementSize size_a =
+      (op_a == blas::Op::NoTrans) ? TileElementSize(m, k) : TileElementSize(k, m);
+  const TileElementSize size_b =
+      (op_b == blas::Op::NoTrans) ? TileElementSize(k, n) : TileElementSize(n, k);
   const TileElementSize size_c(m, n);
 
   const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -34,10 +34,10 @@ void testHerk(const blas::Uplo uplo, const blas::Op op_a, SizeType n, SizeType k
   TileElementSize size_a(n, k);
   if (op_a != blas::Op::NoTrans)
     size_a.transpose();
-  TileElementSize size_c(n, n);
+  const TileElementSize size_c(n, n);
 
-  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
-  SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
 
   std::stringstream s;
   s << "HERK: " << uplo << ", " << op_a;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -29,11 +29,10 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class T, class CT = const T>
-void testHerk(const blas::Uplo uplo, const blas::Op op_a, SizeType n, SizeType k, SizeType extra_lda,
-              SizeType extra_ldc) {
-  TileElementSize size_a(n, k);
-  if (op_a != blas::Op::NoTrans)
-    size_a.transpose();
+void testHerk(const blas::Uplo uplo, const blas::Op op_a, const SizeType n, const SizeType k,
+              const SizeType extra_lda, const SizeType extra_ldc) {
+  const TileElementSize size_a =
+      (op_a == blas::Op::NoTrans) ? TileElementSize(n, k) : TileElementSize(k, n);
   const TileElementSize size_c(n, n);
 
   const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -52,8 +52,8 @@ void testHerk(const blas::Uplo uplo, const blas::Op op_a, const SizeType n, cons
 
   // Returns op_a(a)_ik
   auto el_op_a = [](const TileElementIndex& index) {
-    double i = index.row();
-    double k = index.col();
+    const double i = index.row();
+    const double k = index.col();
     return TypeUtilities<T>::polar(.9 * (i + 1) / (k + .5), i - k);
   };
   auto el_c = [uplo](const TileElementIndex& index) {
@@ -62,8 +62,8 @@ void testHerk(const blas::Uplo uplo, const blas::Op op_a, const SizeType n, cons
         (uplo == blas::Uplo::Upper && index.row() > index.col()))
       return TypeUtilities<T>::element(-1, 0);
 
-    double i = index.row();
-    double j = index.col();
+    const double i = index.row();
+    const double j = index.col();
     return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
   };
 

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -29,7 +29,7 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class T, class CT = const T>
-void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType extra_lda,
+void testHerk(const blas::Uplo uplo, const blas::Op op_a, SizeType n, SizeType k, SizeType extra_lda,
               SizeType extra_ldc) {
   TileElementSize size_a(n, k);
   if (op_a != blas::Op::NoTrans)
@@ -68,8 +68,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
     return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
   };
 
-  BaseType<T> alpha = -1.2f;
-  BaseType<T> beta = 1.1f;
+  const BaseType<T> alpha = -1.2f;
+  const BaseType<T> beta = 1.1f;
 
   auto res_c = [uplo, k, alpha, el_op_a, beta, el_c](const TileElementIndex& index) {
     // Return el_c(index) for elements not referenced

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -32,7 +32,7 @@ using dlaf::util::size_t::mul;
 
 template <class ElementIndex, class T, class CT = const T>
 void testTrsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const blas::Diag diag,
-              SizeType m, SizeType n, SizeType extra_lda, SizeType extra_ldb) {
+              const SizeType m, const SizeType n, const SizeType extra_lda, const SizeType extra_ldb) {
   const TileElementSize size_a =
       side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
   const TileElementSize size_b(m, n);

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -33,11 +33,12 @@ using dlaf::util::size_t::mul;
 template <class ElementIndex, class T, class CT = const T>
 void testTrsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const blas::Diag diag,
               SizeType m, SizeType n, SizeType extra_lda, SizeType extra_ldb) {
-  TileElementSize size_a = side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
-  TileElementSize size_b(m, n);
+  const TileElementSize size_a =
+      side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
+  const TileElementSize size_b(m, n);
 
-  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
-  SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -31,8 +31,8 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class ElementIndex, class T, class CT = const T>
-void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, SizeType m, SizeType n,
-              SizeType extra_lda, SizeType extra_ldb) {
+void testTrsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const blas::Diag diag,
+              SizeType m, SizeType n, SizeType extra_lda, SizeType extra_ldb) {
   TileElementSize size_a = side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
   TileElementSize size_b(m, n);
 
@@ -50,7 +50,7 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
   Tile<T, Device::CPU> a0(size_a, std::move(mem_a), lda);
   Tile<T, Device::CPU> b(size_b, std::move(mem_b), ldb);
 
-  T alpha = TypeUtilities<T>::element(-1.2, .7);
+  const T alpha = TypeUtilities<T>::element(-1.2, .7);
 
   std::function<T(const TileElementIndex&)> el_op_a, el_b, res_b;
 

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -79,7 +79,7 @@ template <class T>
 const T TileSetter<T>::value = dlaf_test::TypeUtilities<T>::element(13, -13);
 
 template <class T>
-void test_lange(lapack::Norm norm, const Tile<T, Device::CPU>& a, NormT<T> norm_expected) {
+void test_lange(const lapack::Norm norm, const Tile<T, Device::CPU>& a, NormT<T> norm_expected) {
   set(a, TileSetter<T>{a.size()});
 
   SCOPED_TRACE(::testing::Message() << "LANGE: " << norm << ", " << a.size() << ", ld = " << a.ld());
@@ -88,7 +88,7 @@ void test_lange(lapack::Norm norm, const Tile<T, Device::CPU>& a, NormT<T> norm_
 }
 
 template <class T>
-void run(lapack::Norm norm, const Tile<T, Device::CPU>& a) {
+void run(const lapack::Norm norm, const Tile<T, Device::CPU>& a) {
   const TileElementSize size = a.size();
 
   NormT<T> value = std::abs(TileSetter<T>::value);

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -63,7 +63,7 @@ template <class T>
 struct TileSetter {
   static const T value;
 
-  TileSetter(TileElementSize size, blas::Uplo uplo) : size_(size), uplo_(uplo) {}
+  TileSetter(const TileElementSize size, const blas::Uplo uplo) : size_(size), uplo_(uplo) {}
 
   T operator()(const TileElementIndex& index) const {
     const auto tr_size = std::min(size_.rows(), size_.cols());
@@ -103,8 +103,8 @@ template <class T>
 const T TileSetter<T>::value = dlaf_test::TypeUtilities<T>::element(13, -13);
 
 template <class T>
-void test_lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, Device::CPU>& a,
-                NormT<T> norm_expected) {
+void test_lantr(const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
+                const Tile<T, Device::CPU>& a, const NormT<T> norm_expected) {
   set(a, TileSetter<T>{a.size(), uplo});
 
   SCOPED_TRACE(::testing::Message() << "LANTR: " << norm << ", " << a.size() << ", ld = " << a.ld()
@@ -114,10 +114,11 @@ void test_lantr(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<
 }
 
 template <class T>
-void run(lapack::Norm norm, blas::Uplo uplo, blas::Diag diag, const Tile<T, Device::CPU>& a) {
+void run(const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
+         const Tile<T, Device::CPU>& a) {
   const TileElementSize size = a.size();
 
-  NormT<T> value = std::abs(TileSetter<T>::value);
+  const NormT<T> value = std::abs(TileSetter<T>::value);
   NormT<T> norm_expected = -1;
 
   switch (norm) {

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -28,7 +28,7 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class T, bool return_info>
-void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
+void testPotrf(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
   SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
@@ -91,7 +91,7 @@ void testPotrf(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
 }
 
 template <class T, bool return_info>
-void testPotrfNonPosDef(blas::Uplo uplo, SizeType n, SizeType extra_lda) {
+void testPotrfNonPosDef(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
   TileElementSize size_a = TileElementSize(n, n);
 
   SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -56,8 +56,8 @@ void testPotrf(const blas::Uplo uplo, const SizeType n, const SizeType extra_lda
         (uplo == blas::Uplo::Upper && index.row() > index.col()))
       return TypeUtilities<T>::element(-9.9, 0);
 
-    double i = index.row();
-    double j = index.col();
+    const double i = index.row();
+    const double j = index.col();
 
     return TypeUtilities<T>::polar(std::exp2(-(i + j)) / 3 * (std::exp2(2 * (std::min(i, j) + 1)) - 1),
                                    -i + j);
@@ -68,8 +68,8 @@ void testPotrf(const blas::Uplo uplo, const SizeType n, const SizeType extra_lda
         (uplo == blas::Uplo::Upper && index.row() > index.col()))
       return TypeUtilities<T>::element(-9.9, 0);
 
-    double i = index.row();
-    double j = index.col();
+    const double i = index.row();
+    const double j = index.col();
 
     return TypeUtilities<T>::polar(std::exp2(-std::abs(i - j)), -i + j);
   };

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -28,7 +28,7 @@ using namespace testing;
 using dlaf::util::size_t::mul;
 
 template <class T, bool return_info>
-void testPotrf(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
+void testPotrf(const blas::Uplo uplo, const SizeType n, const SizeType extra_lda) {
   const TileElementSize size_a = TileElementSize(n, n);
   const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
 

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -29,9 +29,8 @@ using dlaf::util::size_t::mul;
 
 template <class T, bool return_info>
 void testPotrf(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
-  TileElementSize size_a = TileElementSize(n, n);
-
-  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const TileElementSize size_a = TileElementSize(n, n);
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF: " << uplo;
@@ -92,9 +91,8 @@ void testPotrf(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
 
 template <class T, bool return_info>
 void testPotrfNonPosDef(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
-  TileElementSize size_a = TileElementSize(n, n);
-
-  SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const TileElementSize size_a = TileElementSize(n, n);
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
 
   std::stringstream s;
   s << "POTRF Non Positive Definite: " << uplo;


### PR DESCRIPTION
Added `const` declaration to Lapack and Blas functions arguments (`blas::Uplo`, `blas::Side`, ...) to avoid erroneous modifications.

Ref. comment by @albestro in https://github.com/eth-cscs/DLA-Future/pull/261#discussion_r506315003