### PR TITLE
Minor improvements for Index2D/Size2D

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -60,12 +60,9 @@ public:
   /// Return a copy of the row or the col index as specified by @p rc.
   template <Coord rc>
   IndexT get() const noexcept {
-    switch (rc) {
-      case Coord::Row:
-        return row_;
-      case Coord::Col:
-        return col_;
-    }
+    if (rc == Coord::Row)
+      return row_;
+    return col_;
   }
 
   /// Check if it is a valid position (no upper bound check).

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -43,6 +43,8 @@ public:
   static_assert(std::is_integral<IndexT>::value && std::is_signed<IndexT>::value,
                 "basic_coords just works with signed integers types");
 
+  using IndexType = IndexT;
+
   /// Create a position with given coordinates.
   ///
   /// @param row index of the row (0-based),
@@ -138,10 +140,6 @@ public:
   bool operator!=(const Size2D& rhs) const noexcept {
     return BaseT::operator!=(rhs);
   }
-
-  friend std::ostream& operator<<(std::ostream& out, const Size2D& index) {
-    return out << static_cast<BaseT>(index);
-  }
 };
 
 /// A strong-type for 2D coordinates.
@@ -154,8 +152,6 @@ class Index2D : public internal::basic_coords<IndexT> {
 
 public:
   using BaseT::basic_coords;
-
-  using IndexType = IndexT;
 
   /// Create an invalid 2D coordinate.
   Index2D() noexcept : BaseT(-1, -1) {}
@@ -221,6 +217,13 @@ struct is_coord<Size2D<T, Tag>> {
   constexpr static bool value = true;
 };
 
+}
+
+/// Basic print utility for coordinate types
+template <class Coords2DType, std::enable_if_t<internal::is_coord<Coords2DType>::value, int> = 0>
+std::ostream& operator<<(std::ostream& out, const Coords2DType& index) {
+  using IndexT = typename Coords2DType::IndexType;
+  return out << static_cast<internal::basic_coords<IndexT>>(index);
 }
 
 /// Given a Coordinate type, being it an Index2D or a Size2D, it returns its transpose

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -294,8 +294,6 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
       return computeCoordsRowMajor(index, dims);
     case Ordering::ColumnMajor:
       return computeCoordsColMajor(index, dims);
-    default:
-      return {};
   }
 }
 
@@ -362,8 +360,6 @@ LinearIndexT computeLinearIndex(Ordering ordering, const Index2D<IndexT, Tag>& i
       return computeLinearIndexRowMajor<LinearIndexT>(index, dims);
     case Ordering::ColumnMajor:
       return computeLinearIndexColMajor<LinearIndexT>(index, dims);
-    default:
-      return {};
   }
 }
 

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -75,19 +75,13 @@ public:
     std::swap(row_, col_);
   }
 
-  /// Given a coordinate, returns its transposed with the same type.
-  template <class Coords2DType>
-  friend Coords2DType transposed(const Coords2DType& coords);
-
   /// Adds "(<row_>, <col_>)" to out.
   friend std::ostream& operator<<(std::ostream& out, const basic_coords& index) {
-    if (std::is_same<IndexT, signed char>::value || std::is_same<IndexT, char>::value) {
+    if (std::is_same<IndexT, signed char>::value || std::is_same<IndexT, char>::value)
       return out << "(" << static_cast<int>(index.row_) << ", " << static_cast<int>(index.col_) << ")";
-    }
     return out << "(" << index.row_ << ", " << index.col_ << ")";
   }
 
-protected:
   /// @return true if `this` and `rhs` have the same row and column.
   bool operator==(const basic_coords& rhs) const noexcept {
     return row_ == rhs.row_ && col_ == rhs.col_;
@@ -98,14 +92,10 @@ protected:
     return !operator==(rhs);
   }
 
+protected:
   IndexT row_;
   IndexT col_;
 };
-
-template <class Coords2DType>
-Coords2DType transposed(const Coords2DType& coords) {
-  return {coords.col_, coords.row_};
-}
 
 }
 
@@ -150,11 +140,6 @@ public:
     return out << static_cast<BaseT>(index);
   }
 };
-
-template <class T, class Tag>
-std::ostream& operator<<(std::ostream& os, const Size2D<T, Tag>& size) {
-  return os << static_cast<internal::basic_coords<T>>(size);
-}
 
 /// A strong-type for 2D coordinates.
 ///
@@ -214,9 +199,28 @@ public:
   }
 };
 
+// Traits
+/// This traits has a true value if T is an Index2D or a Size2D (with any index type and any tag)
+template <class T>
+struct is_coord {
+  constexpr static bool value = false;
+};
+
 template <class T, class Tag>
-std::ostream& operator<<(std::ostream& os, const Index2D<T, Tag>& size) {
-  return os << static_cast<internal::basic_coords<T>>(size);
+struct is_coord<Index2D<T, Tag>> {
+  constexpr static bool value = true;
+};
+
+template <class T, class Tag>
+struct is_coord<Size2D<T, Tag>> {
+  constexpr static bool value = true;
+};
+
+/// Given a Coordinate type, being it an Index2D or a Size2D, it returns its transpose
+template <class Coords2DType, std::enable_if_t<is_coord<Coords2DType>::value, int> = 0>
+Coords2DType transposed(Coords2DType coords) {
+  coords.transpose();
+  return coords;
 }
 
 /// Compute coords of the @p index -th cell in a row-major ordered 2D grid with size @p dims.

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -162,7 +162,15 @@ public:
   /// @param coords where coords[0] is the row index and coords[1] is the column index,
   /// @pre coords[0] >= 0,
   /// @pre coords[1] >= 0.
-  Index2D(const std::array<IndexT, 2>& coords) : Index2D(coords[0], coords[1]) {}
+  Index2D(const std::array<IndexT, 2>& coords) noexcept : Index2D(coords[0], coords[1]) {}
+
+  IndexT row() const noexcept {
+    return BaseT::row_;
+  }
+
+  IndexT col() const noexcept {
+    return BaseT::col_;
+  }
 
   /// Check if it is a valid position inside the grid size specified by @p boundary.
   ///
@@ -183,18 +191,6 @@ public:
   /// @return true if `this` and `rhs` have different row or column.
   bool operator!=(const Index2D& rhs) const noexcept {
     return BaseT::operator!=(rhs);
-  }
-
-  IndexT row() const noexcept {
-    return BaseT::row_;
-  }
-
-  IndexT col() const noexcept {
-    return BaseT::col_;
-  }
-
-  friend std::ostream& operator<<(std::ostream& out, const Index2D& index) {
-    return out << static_cast<BaseT>(index);
   }
 };
 

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -199,6 +199,8 @@ public:
   }
 };
 
+namespace internal {
+
 // Traits
 /// This traits has a true value if T is an Index2D or a Size2D (with any index type and any tag)
 template <class T>
@@ -216,8 +218,10 @@ struct is_coord<Size2D<T, Tag>> {
   constexpr static bool value = true;
 };
 
+}
+
 /// Given a Coordinate type, being it an Index2D or a Size2D, it returns its transpose
-template <class Coords2DType, std::enable_if_t<is_coord<Coords2DType>::value, int> = 0>
+template <class Coords2DType, std::enable_if_t<internal::is_coord<Coords2DType>::value, int> = 0>
 Coords2DType transposed(Coords2DType coords) {
   coords.transpose();
   return coords;

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -294,6 +294,8 @@ Index2D<IndexT, Tag> computeCoords(Ordering ordering, std::ptrdiff_t index,
       return computeCoordsRowMajor(index, dims);
     case Ordering::ColumnMajor:
       return computeCoordsColMajor(index, dims);
+    default:
+      return {};
   }
 }
 
@@ -360,6 +362,8 @@ LinearIndexT computeLinearIndex(Ordering ordering, const Index2D<IndexT, Tag>& i
       return computeLinearIndexRowMajor<LinearIndexT>(index, dims);
     case Ordering::ColumnMajor:
       return computeLinearIndexColMajor<LinearIndexT>(index, dims);
+    default:
+      return {};
   }
 }
 

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -86,7 +86,7 @@ public:
 
 protected:
   // NOTE: operator== and operator! are protected otherwise it would be possible to compare Index2D and
-  // Size2D or same type but mixing IndexType and/or Tag. Which is something not desired.
+  // Size2D or same type but mixing Tag. Which is something not desired.
 
   /// @return true if `this` and `rhs` have the same row and column.
   bool operator==(const basic_coords& rhs) const noexcept {

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -222,7 +222,7 @@ std::ostream& operator<<(std::ostream& out, const Coords2DType& index) {
   return out << static_cast<internal::basic_coords<IndexT>>(index);
 }
 
-/// Given a Coordinate type, being it an Index2D or a Size2D, it returns its transpose
+/// Given a coordinate type, it returns its transpose
 template <class Coords2DType, std::enable_if_t<internal::is_coord<Coords2DType>::value, int> = 0>
 Coords2DType transposed(Coords2DType coords) {
   coords.transpose();

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -84,6 +84,10 @@ public:
     return out << "(" << index.row_ << ", " << index.col_ << ")";
   }
 
+protected:
+  // NOTE: operator== and operator! are protected otherwise it would be possible to compare Index2D and
+  // Size2D or same type but mixing IndexType and/or Tag. Which is something not desired.
+
   /// @return true if `this` and `rhs` have the same row and column.
   bool operator==(const basic_coords& rhs) const noexcept {
     return row_ == rhs.row_ && col_ == rhs.col_;
@@ -94,7 +98,6 @@ public:
     return !operator==(rhs);
   }
 
-protected:
   IndexT row_;
   IndexT col_;
 };

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -58,9 +58,12 @@ public:
   /// Return a copy of the row or the col index as specified by @p rc.
   template <Coord rc>
   IndexT get() const noexcept {
-    if (rc == Coord::Row)
-      return row_;
-    return col_;
+    switch (rc) {
+      case Coord::Row:
+        return row_;
+      case Coord::Col:
+        return col_;
+    }
   }
 
   /// Check if it is a valid position (no upper bound check).

--- a/test/src/gtest_hpx_main.cpp
+++ b/test/src/gtest_hpx_main.cpp
@@ -42,7 +42,7 @@
 #include <gtest/gtest.h>
 #include <hpx/init.hpp>
 
-GTEST_API_ int test_main(int argc, char** argv) {
+GTEST_API_ int test_main(int, char**) {
   std::printf("Running main() from gtest_hpx_main.cpp\n");
   auto ret = RUN_ALL_TESTS();
   hpx::finalize();

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -64,7 +64,7 @@ void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_re
 }
 
 void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
-  auto print_partial_results = [this](int rank, int total_results,
+  auto print_partial_results = [](int rank, int total_results,
                                       std::function<std::string(int)> get_result) {
     if (total_results <= 0)
       return;

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -21,7 +21,7 @@ void mpi_send_string(const std::string& message, int to_rank);
 std::string mpi_receive_string(int from_rank);
 }
 
-MPIListener::MPIListener(int argc, char** argv, ::testing::TestEventListener* other)
+MPIListener::MPIListener(int, char**, ::testing::TestEventListener* other)
     : listener_(std::move(other)) {
   MPI_Comm_size(MPI_COMM_WORLD, &world_size_);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank_);

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -65,7 +65,7 @@ void MPIListener::OnTestPartResult(const ::testing::TestPartResult& test_part_re
 
 void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
   auto print_partial_results = [](int rank, int total_results,
-                                      std::function<std::string(int)> get_result) {
+                                  std::function<std::string(int)> get_result) {
     if (total_results <= 0)
       return;
 

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -44,7 +44,7 @@
 
 #include "gtest_mpi_listener.h"
 
-GTEST_API_ int test_main(int argc, char** argv) {
+GTEST_API_ int test_main(int, char**) {
   std::printf("Running main() from gtest_mpihpx_main.cpp\n");
   auto ret = RUN_ALL_TESTS();
   hpx::finalize();

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -113,19 +113,20 @@ TYPED_TEST(Index2DTest, Comparison) {
 }
 
 TYPED_TEST(Index2DTest, Transpose) {
-  Index2D<TypeParam> index1(7, 13);
-  std::array<TypeParam, 2> coords{9, 6};
-  Index2D<TypeParam> index2(coords);
+  const Index2D<TypeParam> size_original(7, 13);
+  Index2D<TypeParam> size = size_original;
 
-  index1.transpose();
-  EXPECT_EQ(Index2D<TypeParam>(13, 7), index1);
-  index1.transpose();
-  EXPECT_EQ(Index2D<TypeParam>(7, 13), index1);
+  // tranpose it (with member function)
+  size.transpose();
+  EXPECT_EQ(Index2D<TypeParam>(13, 7), size);
 
-  index2.transpose();
-  EXPECT_EQ(Index2D<TypeParam>(6, 9), index2);
+  // get its tranpose, without changing it (with free function)
+  const auto size_transposed = transposed(size);
+  // check that tranpose is self-inverse
+  EXPECT_EQ(size_original, size_transposed);
+  // check the source has not been changed
+  EXPECT_EQ(Index2D<TypeParam>(13, 7), size);
 }
-
 TYPED_TEST(Index2DTest, Print) {
   Index2D<TypeParam> index1(7, 13);
   std::array<TypeParam, 2> coords{9, 6};

--- a/test/unit/common/test_index2d.cpp
+++ b/test/unit/common/test_index2d.cpp
@@ -113,20 +113,21 @@ TYPED_TEST(Index2DTest, Comparison) {
 }
 
 TYPED_TEST(Index2DTest, Transpose) {
-  const Index2D<TypeParam> size_original(7, 13);
-  Index2D<TypeParam> size = size_original;
+  const Index2D<TypeParam> index_original(7, 13);
+  Index2D<TypeParam> index = index_original;
 
   // tranpose it (with member function)
-  size.transpose();
-  EXPECT_EQ(Index2D<TypeParam>(13, 7), size);
+  index.transpose();
+  EXPECT_EQ(Index2D<TypeParam>(13, 7), index);
 
   // get its tranpose, without changing it (with free function)
-  const auto size_transposed = transposed(size);
+  const auto index_transposed = transposed(index);
   // check that tranpose is self-inverse
-  EXPECT_EQ(size_original, size_transposed);
+  EXPECT_EQ(index_original, index_transposed);
   // check the source has not been changed
-  EXPECT_EQ(Index2D<TypeParam>(13, 7), size);
+  EXPECT_EQ(Index2D<TypeParam>(13, 7), index);
 }
+
 TYPED_TEST(Index2DTest, Print) {
   Index2D<TypeParam> index1(7, 13);
   std::array<TypeParam, 2> coords{9, 6};

--- a/test/unit/common/test_size2d.cpp
+++ b/test/unit/common/test_size2d.cpp
@@ -71,17 +71,19 @@ TYPED_TEST(Size2DTest, Comparison) {
 }
 
 TYPED_TEST(Size2DTest, Transpose) {
-  Size2D<TypeParam> size1(7, 13);
-  std::array<TypeParam, 2> coords{9, 6};
-  Size2D<TypeParam> size2(coords);
+  const Size2D<TypeParam> size_original(7, 13);
+  Size2D<TypeParam> size = size_original;
 
-  size1.transpose();
-  EXPECT_EQ(Size2D<TypeParam>(13, 7), size1);
-  size1.transpose();
-  EXPECT_EQ(Size2D<TypeParam>(7, 13), size1);
+  // tranpose it (with member function)
+  size.transpose();
+  EXPECT_EQ(Size2D<TypeParam>(13, 7), size);
 
-  size2.transpose();
-  EXPECT_EQ(Size2D<TypeParam>(6, 9), size2);
+  // get its tranpose, without changing it (with free function)
+  const auto size_transposed = transposed(size);
+  // check that tranpose is self-inverse
+  EXPECT_EQ(size_original, size_transposed);
+  // check the source has not been changed
+  EXPECT_EQ(Size2D<TypeParam>(13, 7), size);
 }
 
 TYPED_TEST(Size2DTest, Print) {

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -123,7 +123,7 @@ void check_is_hermitian(dlaf::Matrix<const T, Device::CPU>& matrix,
       if (current_rank == owner_original) {
         const auto& tile_original = matrix.read(index_tile_original).get();
         hpx::shared_future<dlaf::Tile<const T, Device::CPU>> tile_transposed;
-        auto size_tile_transposed = transposed(tile_original.size());
+        const auto size_tile_transposed = transposed(tile_original.size());
 
         if (current_rank == owner_transposed) {
           tile_transposed = matrix.read(index_tile_transposed);


### PR DESCRIPTION
- introduce `internal::is_coords` traits
- define `operator<<` just in one place;
- improve test for `Index2D` and `Size2D`, where free function `dlaf::common::transposed` was not tested
- add implementation note about why `operator==`/`operator!=`for `internal::basic_coords` are protected
- minor changes: removing warnings for unused parameters