### PR TITLE
Introduce AllReduce wrapper

### DIFF
--- a/include/dlaf/common/data_descriptor.h
+++ b/include/dlaf/common/data_descriptor.h
@@ -158,6 +158,11 @@ struct Buffer : public DataDescriptor<T> {
   /// Internally allocates the memory for @param N contiguous elements.
   Buffer(const std::size_t N) : Buffer(std::make_unique<T[]>(N), N) {}
 
+  /// Return true if it is allocated, false otherwise
+  operator bool() const {
+    return static_cast<bool>(memory_);
+  }
+
 protected:
   std::unique_ptr<T[]> memory_;
 };
@@ -183,10 +188,26 @@ template <class DataIn>
 auto create_temporary_buffer(const DataIn& input) {
   using DataT = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  DLAF_ASSERT_HEAVY(data_count(input) > 0, "");
+  DLAF_ASSERT_HEAVY(data_count(input) > 0, data_count(input));
 
   return common::Buffer<DataT>(data_count(input));
 }
 
+/// Helper function that ensures that the buffer is contiguous, allocating a temporary buffer if needed
+///
+/// @param support_buffer changed just if the @p input buffer is not contiguous
+/// @return the given @p input if it is already contiguous, otherwise returns a newly allocated buffer
+template <class DataIn, class Buffer>
+auto make_contiguous(DataIn input, Buffer& support_buffer) {
+  using DataT = typename common::data_traits<DataIn>::element_t;
+  common::DataDescriptor<DataT>& internal_input = input;
+
+  if (!input.is_contiguous()) {
+    support_buffer = common::create_temporary_buffer(input);
+    internal_input = support_buffer;
+  }
+
+  return internal_input;
+}
 }
 }

--- a/include/dlaf/common/data_descriptor.h
+++ b/include/dlaf/common/data_descriptor.h
@@ -200,14 +200,13 @@ auto create_temporary_buffer(const DataIn& input) {
 template <class DataIn, class Buffer>
 auto make_contiguous(DataIn input, Buffer& support_buffer) {
   using DataT = typename common::data_traits<DataIn>::element_t;
-  common::DataDescriptor<DataT>& internal_input = input;
 
   if (!input.is_contiguous()) {
     support_buffer = common::create_temporary_buffer(input);
-    internal_input = support_buffer;
+    return common::DataDescriptor<DataT>(support_buffer);
   }
 
-  return internal_input;
+  return input;
 }
 }
 }

--- a/include/dlaf/common/data_descriptor.h
+++ b/include/dlaf/common/data_descriptor.h
@@ -193,7 +193,7 @@ auto create_temporary_buffer(const DataIn& input) {
   return common::Buffer<DataT>(data_count(input));
 }
 
-/// Helper function that ensures that the buffer is contiguous, allocating a temporary buffer if needed
+/// Helper function ensuring to work with a contiguous Data, allocating a temporary buffer if needed
 ///
 /// @param support_buffer changed just if the @p input buffer is not contiguous
 /// @return the given @p input if it is already contiguous, otherwise returns a newly allocated buffer

--- a/include/dlaf/communication/functions_sync.h
+++ b/include/dlaf/communication/functions_sync.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "dlaf/communication/sync/all_reduce.h"
 #include "dlaf/communication/sync/basic.h"
 #include "dlaf/communication/sync/broadcast.h"
 #include "dlaf/communication/sync/reduce.h"

--- a/include/dlaf/communication/sync/all_reduce.h
+++ b/include/dlaf/communication/sync/all_reduce.h
@@ -1,0 +1,82 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <mpi.h>
+#include "dlaf/common/assert.h"
+#include "dlaf/common/data_descriptor.h"
+#include "dlaf/communication/communicator.h"
+#include "dlaf/communication/message.h"
+#include "dlaf/communication/sync/broadcast.h"
+#include "dlaf/communication/sync/reduce.h"
+
+namespace dlaf {
+namespace comm {
+namespace sync {
+
+/// MPI_AllReduce wrapper.
+///
+/// MPI AllReduce(see MPI documentation for additional info).
+/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator,
+template <class DataIn, class DataOut>
+void all_reduce(Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
+                const DataOut output) {
+  using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
+
+  // Wayout for single rank communicator, just copy data
+  if (communicator.size() == 1) {
+    common::copy(input, output);
+    return;
+  }
+
+  // Data descriptors used internally, initialized with Data given as parameters,
+  // but they may be replaced internally by contiguous Buffers in case of need
+  common::DataDescriptor<const T> internal_input = input;
+  common::DataDescriptor<T> internal_output = output;
+
+  // Buffers not allocated, just placeholders in case we need to allocate them
+  common::Buffer<T> temporary_buffer_in;
+  common::Buffer<T> temporary_buffer_out;
+
+  // if input is not contiguous, copy it in a contiguous temporary buffer
+  if (!input.is_contiguous()) {
+    // allocate the temporary buffer
+    temporary_buffer_in = common::create_temporary_buffer(internal_input);
+    // set it as internal intermediate input
+    internal_input = temporary_buffer_in;
+    // copy the data to the internal intermediate buffer
+    common::copy(input, temporary_buffer_in);
+  }
+
+  // if output is not contiguous, create an intermediate buffer
+  if (!output.is_contiguous()) {
+    // allocate the temporary buffer
+    temporary_buffer_out = common::create_temporary_buffer(internal_output);
+    // and set it as internal intermediate output
+    internal_output = temporary_buffer_out;
+  }
+
+  auto message_input = comm::make_message(std::move(internal_input));
+  auto message_output = comm::make_message(DataOut(internal_output));
+
+  MPI_Allreduce(message_input.data(), message_output.data(), message_input.count(),
+                message_input.mpi_type(), reduce_operation, communicator);
+
+  // if output was not contiguous, copy it back!
+  if (!output.is_contiguous())
+    common::copy(internal_output, output);
+}
+
+}
+}
+}

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -43,6 +43,13 @@ DLAF_addTest(test_reduce
   USE_MAIN MPI
 )
 
+DLAF_addTest(test_all_reduce
+  SOURCES test_all_reduce.cpp
+  LIBRARIES dlaf.core
+  MPIRANKS 4
+  USE_MAIN MPI
+)
+
 DLAF_addTest(test_broadcast_tile
   SOURCES test_broadcast_tile.cpp
   LIBRARIES dlaf.core

--- a/test/unit/communication/test_all_reduce.cpp
+++ b/test/unit/communication/test_all_reduce.cpp
@@ -24,16 +24,6 @@ using namespace dlaf::comm;
 
 using AllReduceTest = SplittedCommunicatorsTest;
 
-template <class T, class = std::enable_if_t<std::is_arithmetic<T>::value>>
-void DLAF_EXPECT_NEAR(const T a, const T b, const T abs_err) {
-  EXPECT_NEAR(a, b, abs_err);
-}
-
-template <class T>
-void DLAF_EXPECT_NEAR(const std::complex<T>& a, const std::complex<T>& b, const T abs_err) {
-  EXPECT_NEAR(std::abs(a - b), 0, abs_err);
-}
-
 using TypeParam = std::complex<double>;
 
 TEST_F(AllReduceTest, ValueOnSingleRank) {
@@ -53,7 +43,7 @@ TEST_F(AllReduceTest, ValueOnSingleRank) {
 
   sync::all_reduce(alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  DLAF_EXPECT_NEAR(value, result, TypeUtilities<TypeParam>::error);
+  EXPECT_LE(std::abs(value - result), TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, CArrayOnSingleRank) {
@@ -77,7 +67,7 @@ TEST_F(AllReduceTest, CArrayOnSingleRank) {
   sync::all_reduce(alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (std::size_t index = 0; index < N; ++index)
-    DLAF_EXPECT_NEAR(input[index], reduced[index], TypeUtilities<TypeParam>::error);
+    EXPECT_LE(std::abs(input[index] - reduced[index]), TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, Value) {
@@ -86,8 +76,8 @@ TEST_F(AllReduceTest, Value) {
 
   sync::all_reduce(world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), result,
-                   NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
+            NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, CArray) {
@@ -102,8 +92,8 @@ TEST_F(AllReduceTest, CArray) {
   sync::all_reduce(world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (std::size_t index = 0; index < N; ++index)
-    DLAF_EXPECT_NEAR(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index],
-                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, ContiguousToContiguous) {
@@ -126,8 +116,8 @@ TEST_F(AllReduceTest, ContiguousToContiguous) {
   sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
 
   for (auto i = 0; i < N; ++i)
-    DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i],
-                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_B[i]),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, StridedToContiguous) {
@@ -161,8 +151,8 @@ TEST_F(AllReduceTest, StridedToContiguous) {
   sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
 
   for (auto i = 0; i < N; ++i)
-    DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
-                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_contiguous[i]),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, ContiguousToStrided) {
@@ -194,7 +184,7 @@ TEST_F(AllReduceTest, ContiguousToStrided) {
   for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
     for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
       auto mem_pos = i_block * block_distance + i_element;
-      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
-                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_strided[mem_pos]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
     }
 }

--- a/test/unit/communication/test_all_reduce.cpp
+++ b/test/unit/communication/test_all_reduce.cpp
@@ -1,0 +1,206 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/communication/sync/all_reduce.h"
+
+#include <gtest/gtest.h>
+
+#include "dlaf/common/data_descriptor.h"
+#include "dlaf/communication/communicator_grid.h"
+
+#include "dlaf_test/helper_communicators.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf_test;
+using namespace dlaf::comm;
+
+using AllReduceTest = SplittedCommunicatorsTest;
+
+template <class T, class = std::enable_if_t<std::is_arithmetic<T>::value>>
+void DLAF_EXPECT_NEAR(const T a, const T b, const T abs_err) {
+  EXPECT_NEAR(a, b, abs_err);
+}
+
+template <class T>
+void DLAF_EXPECT_NEAR(const std::complex<T>& a, const std::complex<T>& b, const T abs_err) {
+  EXPECT_NEAR(std::abs(a - b), 0, abs_err);
+}
+
+using TypeParam = std::complex<double>;
+
+TEST_F(AllReduceTest, ValueOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = 0;
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::all_reduce(alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
+
+  DLAF_EXPECT_NEAR(value, result, TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceTest, CArrayOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr std::size_t N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::all_reduce(alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
+
+  for (std::size_t index = 0; index < N; ++index)
+    DLAF_EXPECT_NEAR(input[index], reduced[index], TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceTest, Value) {
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = 0;
+
+  sync::all_reduce(world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
+
+  DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), result,
+                   NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceTest, CArray) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  constexpr std::size_t N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+
+  sync::all_reduce(world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
+
+  for (std::size_t index = 0; index < N; ++index)
+    DLAF_EXPECT_NEAR(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index],
+                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceTest, ContiguousToContiguous) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  constexpr int N = 10;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+
+  TypeParam data_A[N];
+  TypeParam data_B[N];
+
+  for (auto i = 0; i < N; ++i)
+    data_A[i] = value;
+
+  auto& communicator = world;
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_A), N);
+  auto&& message_output = common::make_data(data_B, N);
+  MPI_Op op = MPI_SUM;
+
+  sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
+
+  for (auto i = 0; i < N; ++i)
+    DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i],
+                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceTest, StridedToContiguous) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr std::size_t nblocks = 3;
+  constexpr std::size_t block_size = 2;
+  constexpr std::size_t block_distance = 5;
+
+  constexpr std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+    for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = value;
+    }
+
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_strided), nblocks,
+                                           block_size, block_distance);
+  auto&& message_output = common::make_data(data_contiguous, N);
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
+  sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
+
+  if (root == world.rank()) {
+    for (auto i = 0; i < N; ++i)
+      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
+                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+}
+
+TEST_F(AllReduceTest, ContiguousToStrided) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr std::size_t nblocks = 3;
+  constexpr std::size_t block_size = 2;
+  constexpr std::size_t block_distance = 5;
+
+  constexpr std::size_t memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (auto i = 0; i < N; ++i)
+    data_contiguous[i] = value;
+
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_contiguous), N);
+  auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
+  sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
+
+  if (world.rank() == root) {
+    for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+      for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
+        auto mem_pos = i_block * block_distance + i_element;
+        DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
+                         NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      }
+  }
+}

--- a/test/unit/communication/test_all_reduce.cpp
+++ b/test/unit/communication/test_all_reduce.cpp
@@ -156,16 +156,13 @@ TEST_F(AllReduceTest, StridedToContiguous) {
                                            block_size, block_distance);
   auto&& message_output = common::make_data(data_contiguous, N);
 
-  constexpr int root = 0;
   auto& communicator = world;
   MPI_Op op = MPI_SUM;
   sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
 
-  if (root == world.rank()) {
-    for (auto i = 0; i < N; ++i)
-      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
-                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
-  }
+  for (auto i = 0; i < N; ++i)
+    DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
+                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(AllReduceTest, ContiguousToStrided) {
@@ -190,17 +187,14 @@ TEST_F(AllReduceTest, ContiguousToStrided) {
   auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_contiguous), N);
   auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
 
-  constexpr int root = 0;
   auto& communicator = world;
   MPI_Op op = MPI_SUM;
   sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
 
-  if (world.rank() == root) {
-    for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
-      for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
-        auto mem_pos = i_block * block_distance + i_element;
-        DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
-                         NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
-      }
-  }
+  for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
+    for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
+                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    }
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -24,16 +24,6 @@ using namespace dlaf::comm;
 
 using ReduceTest = SplittedCommunicatorsTest;
 
-template <class T, class = std::enable_if_t<std::is_arithmetic<T>::value>>
-void DLAF_EXPECT_NEAR(const T a, const T b, const T abs_err) {
-  EXPECT_NEAR(a, b, abs_err);
-}
-
-template <class T>
-void DLAF_EXPECT_NEAR(const std::complex<T>& a, const std::complex<T>& b, const T abs_err) {
-  EXPECT_NEAR(std::abs(a - b), 0, abs_err);
-}
-
 using TypeParam = std::complex<double>;
 
 TEST_F(ReduceTest, ValueOnSingleRank) {
@@ -53,7 +43,7 @@ TEST_F(ReduceTest, ValueOnSingleRank) {
 
   sync::reduce(root, alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  DLAF_EXPECT_NEAR(value, result, TypeUtilities<TypeParam>::error);
+  EXPECT_LE(std::abs(value - result), TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, CArrayOnSingleRank) {
@@ -77,7 +67,7 @@ TEST_F(ReduceTest, CArrayOnSingleRank) {
   sync::reduce(root, alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (std::size_t index = 0; index < N; ++index)
-    DLAF_EXPECT_NEAR(input[index], reduced[index], TypeUtilities<TypeParam>::error);
+    EXPECT_LE(std::abs(input[index] - reduced[index]), TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, Value) {
@@ -88,8 +78,8 @@ TEST_F(ReduceTest, Value) {
   sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
   if (world.rank() == root)
-    DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), result,
-                     NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
 }
 
 TEST_F(ReduceTest, CArray) {
@@ -106,8 +96,8 @@ TEST_F(ReduceTest, CArray) {
 
   if (world.rank() == root) {
     for (std::size_t index = 0; index < N; ++index)
-      DLAF_EXPECT_NEAR(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS), reduced[index],
-                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -133,8 +123,8 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
 
   if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
-      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_B[i],
-                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_B[i]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -171,8 +161,8 @@ TEST_F(ReduceTest, StridedToContiguous) {
 
   if (root == world.rank()) {
     for (auto i = 0; i < N; ++i)
-      DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_contiguous[i],
-                       NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_contiguous[i]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
   }
 }
 
@@ -207,8 +197,8 @@ TEST_F(ReduceTest, ContiguousToStrided) {
     for (std::size_t i_block = 0; i_block < nblocks; ++i_block)
       for (std::size_t i_element = 0; i_element < block_size; ++i_element) {
         auto mem_pos = i_block * block_distance + i_element;
-        DLAF_EXPECT_NEAR(value * static_cast<TypeParam>(NUM_MPI_RANKS), data_strided[mem_pos],
-                         NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+        EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_strided[mem_pos]),
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
       }
   }
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -77,9 +77,10 @@ TEST_F(ReduceTest, Value) {
 
   sync::reduce(root, world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
-  if (world.rank() == root)
+  if (world.rank() == root) {
     EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
               NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
 }
 
 TEST_F(ReduceTest, CArray) {


### PR DESCRIPTION
This PR introduces the DLAF `all_reduce` wrapper for the `MPI_AllReduce` function.

Tests are clones of the `reduce` ones, just slightly changed for checking that results are available on all ranks involved.

Even for this implementation, I used the workaround from #177 for the problem #148, about the incompatibility between pre-defined `MPI_Op` and custom type (used for non-contiguous memory). The logic has been refactored.

I'm going to integrate test for new functions (i.e. `Buffer::operator bool`, `make_contiguous).