### PR TITLE
Fixing preconditions in checkNear (Tile)

### DIFF
--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -159,8 +159,9 @@ void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const cha
 /// The (i, j)-element of the tile is compared to expected({i, j}).
 /// @pre expected argument is an index of type const TileElementIndex&,
 /// @pre expected return type should be T,
-/// @pre rel_err > 0,
-/// @pre abs_err > 0.
+/// @pre rel_err >= 0,
+/// @pre abs_err >= 0,
+/// @pre rel_err > 0 || abs_err > 0.
 template <class T, class ElementGetter>
 void checkNear(ElementGetter expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,
                BaseType<T> abs_err, const char* file, const int line) {

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -164,8 +164,9 @@ void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const cha
 template <class T, class ElementGetter>
 void checkNear(ElementGetter expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,
                BaseType<T> abs_err, const char* file, const int line) {
-  ASSERT_GT(rel_err, 0);
-  ASSERT_GT(abs_err, 0);
+  ASSERT_GE(rel_err, 0);
+  ASSERT_GE(abs_err, 0);
+  ASSERT_TRUE(rel_err > 0 || abs_err > 0);
 
   auto comp = [rel_err, abs_err](T expected, T value) {
     auto diff = std::abs(expected - value);


### PR DESCRIPTION
Fixing preconditions in `checkNear`, used for `Tile`, to allow checking only relative or absolute error (instead of forcing both checks), as implemented for `Matrix`. 

This solves issue #285.