### PR TITLE
Matrix helper for tests

### DIFF
--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -28,13 +28,15 @@ struct MatrixLocal;
 
 /// MatrixLocal is a local matrix with column-layout, not thread-safe
 ///
-/// It is a useful helper object that allows you to access element directly given their
-/// GlobalElementIndex, or by accessing the tile via its GlobalTileIndex and then the
+/// It is a useful helper object that allows you to access elements directly given their
+/// GlobalElementIndex, or by accessing the tile containing it via its GlobalTileIndex and then the
 /// related LocalTileIndex inside it.
 ///
 /// It uses Index/Size with the Global tag instead of the Local one, because its main task
 /// is to create a local copy of a distributed matrix. So, it is generally easier to think
 /// of it as the global matrix.
+///
+/// About its semantic, it is similar to a std::unique_ptr.
 template <class T>
 struct MatrixLocal<const T> {
   static constexpr auto CPU = Device::CPU;
@@ -52,6 +54,9 @@ struct MatrixLocal<const T> {
                                    layout_.minTileMemSize(tile_index)},
                           layout_.ldTile());
   }
+
+  MatrixLocal(const MatrixLocal&) = delete;
+  MatrixLocal& operator=(const MatrixLocal&) = delete;
 
   MatrixLocal(MatrixLocal&&) = default;
 
@@ -116,6 +121,9 @@ struct MatrixLocal : public MatrixLocal<const T> {
 
   MatrixLocal(GlobalElementSize size, TileElementSize blocksize) noexcept
       : MatrixLocal<const T>(size, blocksize) {}
+
+  MatrixLocal(const MatrixLocal&) = delete;
+  MatrixLocal& operator=(const MatrixLocal&) = delete;
 
   MatrixLocal(MatrixLocal&&) = default;
 

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -88,19 +88,6 @@ struct MatrixLocal<const T> {
     return GlobalTileSize{layout_.nrTiles().rows(), layout_.nrTiles().cols()};
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const MatrixLocal& matrix) {
-    using dlaf::util::size_t::mul;
-    using dlaf::util::size_t::sum;
-
-    os << matrix.size() << matrix.ld() << std::endl;
-    for (const auto& index : iterate_range2d(matrix.size())) {
-      auto linear_index = dlaf::to_sizet(sum(mul(index.col(), matrix.ld()), index.row()));
-      os << "[" << index.row() << ", " << index.col() << "]" << '=' << *matrix.memory_(linear_index)
-         << "\n";
-    }
-    return os;
-  }
-
 protected:
   SizeType elementLinearIndex(const GlobalElementIndex& index) const noexcept {
     using dlaf::util::size_t::mul;

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -57,16 +57,17 @@ struct MatrixLocal<const T> {
                       tiles_.size());
   }
 
-  /// Access directly elements
+  /// Access elements
   const T* ptr(const GlobalElementIndex& index = {0, 0}) const noexcept {
     return memory_(elementLinearIndex(index));
   }
 
+  /// Access elements
   const T& operator()(const GlobalElementIndex& index) const noexcept {
     return *ptr(index);
   }
 
-  /// Access a tile
+  /// Access tiles
   const ConstTileT& read_tile(const GlobalTileIndex& index) const noexcept {
     return tiles_[tileLinearIndex(index)];
   }
@@ -135,16 +136,17 @@ struct MatrixLocal : public MatrixLocal<const T> {
   MatrixLocal(GlobalElementSize size, TileElementSize blocksize) noexcept
       : MatrixLocal<const T>(size, blocksize) {}
 
-  /// Access an element
+  /// Access elements
   T* ptr(const GlobalElementIndex& index = {0, 0}) const noexcept {
     return memory_(elementLinearIndex(index));
   }
 
+  /// Access elements
   T& operator()(const GlobalElementIndex& index) const noexcept {
     return *ptr(index);
   }
 
-  /// Access a tile
+  /// Access tiles
   const TileT& readwrite_tile(const GlobalTileIndex& index) const noexcept {
     return tiles_[tileLinearIndex(index)];
   }

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -21,6 +21,7 @@
 #include "dlaf/util_math.h"
 
 namespace dlaf {
+namespace matrix {
 namespace test {
 
 template <class T>
@@ -148,5 +149,6 @@ protected:
   using MatrixLocal<const T>::tiles_;
 };
 
+}
 }
 }

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -16,7 +16,7 @@
 #include "dlaf/common/vector.h"
 #include "dlaf/matrix/layout_info.h"
 #include "dlaf/memory/memory_view.h"
-#include "dlaf/tile.h"
+#include "dlaf/matrix/tile.h"
 #include "dlaf/types.h"
 #include "dlaf/util_math.h"
 

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -1,0 +1,152 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <type_traits>
+
+#include "dlaf/common/range2d.h"
+#include "dlaf/common/vector.h"
+#include "dlaf/matrix/layout_info.h"
+#include "dlaf/memory/memory_view.h"
+#include "dlaf/tile.h"
+#include "dlaf/types.h"
+#include "dlaf/util_math.h"
+
+namespace dlaf {
+namespace test {
+
+template <class T>
+struct MatrixLocal;
+
+/// MatrixLocal is a local matrix with column-layout, not thread-safe
+///
+/// It is a useful helper object that allows you to access element directly given their
+/// GlobalElementIndex, or by accessing the tile via its GlobalTileIndex and then the
+/// related LocalTileIndex inside it.
+///
+/// It uses Index/Size with the Global tag instead of the Local one, because its main task
+/// is to create a local copy of a distributed matrix. So, it is generally easier to think
+/// of it as the global matrix.
+template <class T>
+struct MatrixLocal<const T> {
+  using ConstTileT = Tile<const T, Device::CPU>;
+
+  MatrixLocal(GlobalElementSize sz, TileElementSize blocksize) noexcept
+      : layout_(colMajorLayout({sz.rows(), sz.cols()}, blocksize, sz.rows())), memory_{
+                                                                                   layout_.minMemSize()} {
+    using dlaf::util::size_t::mul;
+
+    for (const auto& tile_index : iterate_range2d(layout_.nrTiles())) {
+      memory::MemoryView<T, Device::CPU> tile_memory{memory_, layout_.tileOffset(tile_index),
+                                                     layout_.minTileMemSize(tile_index)};
+      tiles_.emplace_back(layout_.tileSize(tile_index), std::move(tile_memory), layout_.ldTile());
+    }
+
+    DLAF_ASSERT_HEAVY(ld() == sz.rows(), ld(), sz.rows());
+    DLAF_ASSERT_HEAVY(size() == sz, size(), sz);
+    DLAF_ASSERT_HEAVY(tiles_.size() == mul(layout_.nrTiles().rows(), layout_.nrTiles().cols()),
+                      tiles_.size());
+  }
+
+  /// Access directly elements
+  const T* ptr(const GlobalElementIndex& index = {0, 0}) const noexcept {
+    return memory_(elementLinearIndex(index));
+  }
+
+  /// Access a tile
+  const ConstTileT& operator()(const GlobalTileIndex& index) const noexcept {
+    return tiles_[tileLinearIndex(index)];
+  }
+
+  SizeType ld() const noexcept {
+    return layout_.size().rows();
+  }
+
+  GlobalElementSize size() const noexcept {
+    return GlobalElementSize{layout_.size().rows(), layout_.size().cols()};
+  }
+
+  TileElementSize blockSize() const noexcept {
+    return layout_.blockSize();
+  }
+
+  GlobalTileSize nrTiles() const noexcept {
+    return GlobalTileSize{layout_.nrTiles().rows(), layout_.nrTiles().cols()};
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const MatrixLocal& matrix) {
+    using dlaf::util::size_t::mul;
+    using dlaf::util::size_t::sum;
+
+    os << matrix.size() << matrix.ld() << std::endl;
+    for (const auto& index : iterate_range2d(matrix.size())) {
+      auto linear_index = dlaf::to_sizet(sum(mul(index.col(), matrix.ld()), index.row()));
+      os << "[" << index.row() << ", " << index.col() << "]" << '=' << *matrix.memory_(linear_index)
+         << "\n";
+    }
+    return os;
+  }
+
+protected:
+  std::size_t elementLinearIndex(const GlobalElementIndex& index) const noexcept {
+    using dlaf::util::size_t::mul;
+    using dlaf::util::size_t::sum;
+
+    DLAF_ASSERT(GlobalElementIndex(index.row(), index.col()).isIn(size()), index, size());
+
+    return sum(mul(index.col(), layout_.ldTile()), index.row());
+  }
+
+  SizeType tileLinearIndex(const GlobalTileIndex& index) const noexcept {
+    using dlaf::util::size_t::mul;
+    using dlaf::util::size_t::sum;
+
+    DLAF_ASSERT(LocalTileIndex(index.row(), index.col()).isIn(layout_.nrTiles()), index,
+                layout_.nrTiles());
+
+    return dlaf::to_SizeType(sum(mul(index.col(), layout_.nrTiles().rows()), index.row()));
+  }
+
+  const dlaf::matrix::LayoutInfo layout_;
+  memory::MemoryView<T, Device::CPU> memory_;
+  common::internal::vector<Tile<T, Device::CPU>> tiles_;
+};
+
+// Note:
+// this is the same workaround used for dlaf::matrix::Matrix in order to be able
+// assigning a non-const to a const matrix.
+template <class T>
+struct MatrixLocal : public MatrixLocal<const T> {
+  using TileT = Tile<T, Device::CPU>;
+
+  MatrixLocal(GlobalElementSize size, TileElementSize blocksize) noexcept
+      : MatrixLocal<const T>(size, blocksize) {}
+
+  /// Access an element
+  T* ptr(const GlobalElementIndex& index = {0, 0}) const noexcept {
+    return memory_(elementLinearIndex(index));
+  }
+
+  /// Access a tile
+  const TileT& operator()(const GlobalTileIndex& index) const noexcept {
+    return tiles_[tileLinearIndex(index)];
+  }
+
+protected:
+  using MatrixLocal<const T>::elementLinearIndex;
+  using MatrixLocal<const T>::tileLinearIndex;
+  using MatrixLocal<const T>::layout_;
+  using MatrixLocal<const T>::memory_;
+  using MatrixLocal<const T>::tiles_;
+};
+
+}
+}

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -15,8 +15,8 @@
 #include "dlaf/common/range2d.h"
 #include "dlaf/common/vector.h"
 #include "dlaf/matrix/layout_info.h"
-#include "dlaf/memory/memory_view.h"
 #include "dlaf/matrix/tile.h"
+#include "dlaf/memory/memory_view.h"
 #include "dlaf/types.h"
 #include "dlaf/util_math.h"
 

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -154,11 +154,12 @@ struct MatrixLocal : public MatrixLocal<const T> {
   }
 
 protected:
-  using MatrixLocal<const T>::elementLinearIndex;
-  using MatrixLocal<const T>::tileLinearIndex;
-  using MatrixLocal<const T>::layout_;
-  using MatrixLocal<const T>::memory_;
-  using MatrixLocal<const T>::tiles_;
+  using BaseT = MatrixLocal<const T>;
+  using BaseT::elementLinearIndex;
+  using BaseT::tileLinearIndex;
+  using BaseT::layout_;
+  using BaseT::memory_;
+  using BaseT::tiles_;
 };
 
 }

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -62,8 +62,12 @@ struct MatrixLocal<const T> {
     return memory_(elementLinearIndex(index));
   }
 
+  const T& operator()(const GlobalElementIndex& index) const noexcept {
+    return *ptr(index);
+  }
+
   /// Access a tile
-  const ConstTileT& operator()(const GlobalTileIndex& index) const noexcept {
+  const ConstTileT& read_tile(const GlobalTileIndex& index) const noexcept {
     return tiles_[tileLinearIndex(index)];
   }
 
@@ -136,8 +140,12 @@ struct MatrixLocal : public MatrixLocal<const T> {
     return memory_(elementLinearIndex(index));
   }
 
+  T& operator()(const GlobalElementIndex& index) const noexcept {
+    return *ptr(index);
+  }
+
   /// Access a tile
-  const TileT& operator()(const GlobalTileIndex& index) const noexcept {
+  const TileT& readwrite_tile(const GlobalTileIndex& index) const noexcept {
     return tiles_[tileLinearIndex(index)];
   }
 

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -102,13 +102,13 @@ struct MatrixLocal<const T> {
   }
 
 protected:
-  std::size_t elementLinearIndex(const GlobalElementIndex& index) const noexcept {
+  SizeType elementLinearIndex(const GlobalElementIndex& index) const noexcept {
     using dlaf::util::size_t::mul;
     using dlaf::util::size_t::sum;
 
     DLAF_ASSERT(GlobalElementIndex(index.row(), index.col()).isIn(size()), index, size());
 
-    return sum(mul(index.col(), layout_.ldTile()), index.row());
+    return index.row() + index.col() * layout_.ldTile();
   }
 
   SizeType tileLinearIndex(const GlobalTileIndex& index) const noexcept {

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -26,7 +26,7 @@ namespace test {
 template <class T>
 struct MatrixLocal;
 
-/// MatrixLocal is a local matrix with column-layout, not thread-safe
+/// MatrixLocal is a local matrix with column-layout, not thread-safe.
 ///
 /// It is a useful helper object that allows you to access elements directly given their
 /// GlobalElementIndex, or by accessing the tile containing it via its GlobalTileIndex and then the
@@ -42,8 +42,14 @@ struct MatrixLocal<const T> {
   using MemoryT = memory::MemoryView<T, Device::CPU>;
   using ConstTileT = Tile<const T, Device::CPU>;
 
+  /// Create a matrix with given size and blocksize
+  //
+  /// @pre !sz.isEmpty()
+  /// @pre !blocksize.isEmpty()
   MatrixLocal(GlobalElementSize sz, TileElementSize blocksize) noexcept
       : layout_{colMajorLayout({sz.rows(), sz.cols()}, blocksize, sz.rows())} {
+    DLAF_ASSERT(!sz.isEmpty(), sz);
+    DLAF_ASSERT(!blocksize.isEmpty(), blocksize);
     memory_ = MemoryT{layout_.minMemSize()};
 
     for (const auto& tile_index : iterate_range2d(layout_.nrTiles()))

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -56,6 +56,8 @@ struct MatrixLocal<const T> {
                           layout_.ldTile());
   }
 
+  MatrixLocal(MatrixLocal&&) = default;
+
   /// Access elements
   const T* ptr(const GlobalElementIndex& index = {0, 0}) const noexcept {
     return memory_(elementLinearIndex(index));
@@ -89,22 +91,16 @@ struct MatrixLocal<const T> {
 
 protected:
   SizeType elementLinearIndex(const GlobalElementIndex& index) const noexcept {
-    using dlaf::util::size_t::mul;
-    using dlaf::util::size_t::sum;
-
     DLAF_ASSERT(GlobalElementIndex(index.row(), index.col()).isIn(size()), index, size());
 
     return index.row() + index.col() * layout_.ldTile();
   }
 
   SizeType tileLinearIndex(const GlobalTileIndex& index) const noexcept {
-    using dlaf::util::size_t::mul;
-    using dlaf::util::size_t::sum;
-
     DLAF_ASSERT(LocalTileIndex(index.row(), index.col()).isIn(layout_.nrTiles()), index,
                 layout_.nrTiles());
 
-    return dlaf::to_SizeType(sum(mul(index.col(), layout_.nrTiles().rows()), index.row()));
+    return index.row() + index.col() * layout_.nrTiles().rows();
   }
 
   dlaf::matrix::LayoutInfo layout_;
@@ -121,6 +117,8 @@ struct MatrixLocal : public MatrixLocal<const T> {
 
   MatrixLocal(GlobalElementSize size, TileElementSize blocksize) noexcept
       : MatrixLocal<const T>(size, blocksize) {}
+
+  MatrixLocal(MatrixLocal&&) = default;
 
   /// Access elements
   T* ptr(const GlobalElementIndex& index = {0, 0}) const noexcept {

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -26,11 +26,18 @@ namespace test {
 template <class T>
 struct MatrixLocal;
 
-/// MatrixLocal is a local matrix with column-layout, not thread-safe.
+/// MatrixLocal is a column-major local matrix, not thread-safe.
 ///
 /// It is a useful helper object that allows you to access elements directly given their
 /// GlobalElementIndex, or by accessing the tile containing it via its GlobalTileIndex and then the
 /// related LocalTileIndex inside it.
+///
+/// Thanks to operator()(GlobalTileIndex) it can be used as a function, which turns out to be useful for
+/// comparisons with CHECK macros.
+///
+/// The column-major layout allow to use it with BLAS/LAPACK routines.
+///
+/// It is neither thread-safe nor async-ready (see dlaf::Matrix for that).
 ///
 /// It uses Index/Size with the Global tag instead of the Local one, because its main task
 /// is to create a local copy of a distributed matrix. So, it is generally easier to think

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -15,15 +15,18 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include <gtest/gtest.h>
 
+#include "dlaf/common/range2d.h"
 #include "dlaf/matrix.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/layout_info.h"
 #include "dlaf/util_math.h"
 #include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/matrix/matrix_local.h"
 
 namespace dlaf {
 namespace matrix {
@@ -51,6 +54,8 @@ void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
   }
 }
 
+namespace internal {
+
 /// Checks the elements of the matrix.
 ///
 /// comp(expected({i, j}), (i, j)-element) is used to compare the elements.
@@ -62,7 +67,6 @@ void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
 /// @pre expected return type should be the same as the type of the first argument of comp and of err_message,
 /// @pre The second argument of comp should be either T, T& or const T&,
 /// @pre The second argument of err_message should be either T, T& or const T&.
-namespace internal {
 template <template <class, Device> class MatrixType, class T, class ElementGetter, class ComparisonOp,
           class ErrorMessageGetter>
 void check(ElementGetter expected, MatrixType<T, Device::CPU>& mat, ComparisonOp comp,
@@ -86,6 +90,30 @@ void check(ElementGetter expected, MatrixType<T, Device::CPU>& mat, ComparisonOp
     }
   }
 }
+
+/// Checks the elements of the matrix.
+///
+/// comp(expected({i, j}), (i, j)-element) is used to compare the elements.
+/// err_message(expected({i, j}), (i, j)-element) is printed for the first element
+/// that does not fulfill the comparison.
+/// @pre expected argument is an index of type const GlobalElementIndex&,
+/// @pre comp should have two arguments and return true if the comparison is fulfilled and false otherwise,
+/// @pre err_message should have two arguments and return a string,
+/// @pre expected return type should be the same as the type of the first argument of comp and of err_message,
+/// @pre The second argument of comp should be either T, T& or const T&,
+/// @pre The second argument of err_message should be either T, T& or const T&.
+template <class T, class ElementGetter, class ComparisonOp,
+          class ErrorMessageGetter>
+void check(ElementGetter expected, MatrixLocal<const T>& mat, ComparisonOp comp,
+           ErrorMessageGetter err_message, const char* file, const int line) {
+  for (const auto& index : dlaf::common::iterate_range2d(mat.size())) {
+    if (!comp(expected(index), mat(index))) {
+      ADD_FAILURE_AT(file, line)
+        << "Error at index (" << index
+        << "): " << err_message(expected(index), mat(index)) << std::endl;
+      return;
+    }}
+}
 }
 
 /// Checks the elements of the matrix (exact equality).
@@ -93,8 +121,9 @@ void check(ElementGetter expected, MatrixType<T, Device::CPU>& mat, ComparisonOp
 /// The (i, j)-element of the matrix is compared to exp_el({i, j}).
 /// @pre exp_el argument is an index of type const GlobalElementIndex&,
 /// @pre exp_el return type should be T.
-template <template <class, Device> class MatrixType, class T, class ElementGetter>
-void checkEQ(ElementGetter exp_el, MatrixType<T, Device::CPU>& mat, const char* file, const int line) {
+template <class MatrixType, class ElementGetter>
+void checkEQ(ElementGetter exp_el, MatrixType& mat, const char* file, const int line) {
+  using T = decltype(exp_el({}));
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
@@ -109,8 +138,9 @@ void checkEQ(ElementGetter exp_el, MatrixType<T, Device::CPU>& mat, const char* 
 /// The pointer to (i, j)-element of the matrix is compared to exp_ptr({i, j}).
 /// @pre exp_ptr argument is an index of type const GlobalElementIndex&,
 /// @pre exp_ptr return type should be T*.
-template <class T, class PointerGetter>
-void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* file, const int line) {
+template <class MatrixType, class PointerGetter>
+void checkPtr(PointerGetter exp_ptr, MatrixType& mat, const char* file, const int line) {
+  using T = typename std::pointer_traits<decltype(exp_ptr({}))>::element_type;
   auto comp = [](T* ptr, const T& value) { return ptr == &value; };
   auto err_message = [](T* expected, const T& value) {
     std::stringstream s;
@@ -129,9 +159,10 @@ void checkPtr(PointerGetter exp_ptr, Matrix<T, Device::CPU>& mat, const char* fi
 /// @pre rel_err >= 0,
 /// @pre abs_err >= 0,
 /// @pre rel_err > 0 || abs_err > 0.
-template <template <class, Device> class MatrixType, class T, class ElementGetter>
-void checkNear(ElementGetter expected, MatrixType<T, Device::CPU>& mat, BaseType<T> rel_err,
-               BaseType<T> abs_err, const char* file, const int line) {
+template <class MatrixType, class ElementGetter>
+void checkNear(ElementGetter expected, MatrixType& mat, BaseType<decltype(expected({}))> rel_err,
+               BaseType<decltype(expected({}))> abs_err, const char* file, const int line) {
+  using T = decltype(expected({}));
   ASSERT_GE(rel_err, 0);
   ASSERT_GE(abs_err, 0);
   ASSERT_TRUE(rel_err > 0 || abs_err > 0);

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -16,7 +16,9 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+
 #include "dlaf/matrix.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/layout_info.h"

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -38,12 +38,12 @@ struct matrix_traits;
 
 template <template <class, Device> class MatrixLike, class T, Device device>
 struct matrix_traits<MatrixLike<T, device>> {
-  using Element_t = std::remove_cv_t<T>;
+  using ElementT = std::remove_cv_t<T>;
 };
 
 template <class T>
 struct matrix_traits<MatrixLocal<T>> {
-  using Element_t = std::remove_cv_t<T>;
+  using ElementT = std::remove_cv_t<T>;
 };
 
 /// Sets the elements of the matrix.
@@ -83,7 +83,7 @@ namespace internal {
 /// @pre The second argument of err_message should be either T, T& or const T&.
 template <template <class, Device> class MatrixType, class T, class ElementGetter, class ComparisonOp,
           class ErrorMessageGetter>
-void check(ElementGetter expected, MatrixType<T, Device::CPU>& mat, ComparisonOp comp,
+void check(ElementGetter expected, MatrixType<const T, Device::CPU>& mat, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   const matrix::Distribution& dist = mat.distribution();
   for (SizeType tile_j = 0; tile_j < dist.localNrTiles().cols(); ++tile_j) {
@@ -136,7 +136,7 @@ void check(ElementGetter&& expected, MatrixLocal<const T>& mat, ComparisonOp com
 /// @pre exp_el return type should be T.
 template <class MatrixType, class ElementGetter>
 void checkEQ(ElementGetter&& exp_el, MatrixType& mat, const char* file, const int line) {
-  using T = typename matrix_traits<MatrixType>::Element_t;
+  using T = typename matrix_traits<MatrixType>::ElementT;
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
@@ -174,10 +174,10 @@ void checkPtr(PointerGetter exp_ptr, MatrixType& mat, const char* file, const in
 /// @pre rel_err > 0 || abs_err > 0.
 template <class MatrixType, class ElementGetter>
 void checkNear(ElementGetter&& expected, MatrixType& mat,
-               BaseType<typename matrix_traits<MatrixType>::Element_t> rel_err,
-               BaseType<typename matrix_traits<MatrixType>::Element_t> abs_err, const char* file,
+               BaseType<typename matrix_traits<MatrixType>::ElementT> rel_err,
+               BaseType<typename matrix_traits<MatrixType>::ElementT> abs_err, const char* file,
                const int line) {
-  using T = typename matrix_traits<MatrixType>::Element_t;
+  using T = typename matrix_traits<MatrixType>::ElementT;
   ASSERT_GE(rel_err, 0);
   ASSERT_GE(abs_err, 0);
   ASSERT_TRUE(rel_err > 0 || abs_err > 0);

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -44,7 +44,9 @@ void set(const MatrixLocal<T>& matrix, ElementGetter el) {
 template <class T>
 void copy(const MatrixLocal<const T>& source, MatrixLocal<T>& dest) {
   DLAF_ASSERT(source.size() == dest.size(), source.size(), dest.size());
+
   const auto linear_size = static_cast<std::size_t>(source.size().rows() * source.size().cols());
+
   std::copy(source.ptr(), source.ptr() + linear_size, dest.ptr());
 }
 

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -70,8 +70,8 @@ void all_gather(Matrix<const T, Device::CPU>& source, MatrixLocal<T>& dest,
 }
 
 template <class T>
-void checkNear(const MatrixLocal<const T>& expected, const MatrixLocal<const T>& mat, BaseType<T> rel_err,
-               BaseType<T> abs_err, const char* file, const int line) {
+void checkNear(const MatrixLocal<const T>& expected, const MatrixLocal<const T>& mat,
+               BaseType<T> rel_err, BaseType<T> abs_err, const char* file, const int line) {
   ASSERT_GE(rel_err, 0);
   ASSERT_GE(abs_err, 0);
   ASSERT_TRUE(rel_err > 0 || abs_err > 0);
@@ -94,12 +94,12 @@ void checkNear(const MatrixLocal<const T>& expected, const MatrixLocal<const T>&
     return s.str();
   };
 
-  //internal::check(expected, mat, comp, err_message, file, line);
+  // internal::check(expected, mat, comp, err_message, file, line);
   for (const auto& index : iterate_range2d(expected.size())) {
     if (!comp(*expected.ptr(index), *mat.ptr(index))) {
-      ADD_FAILURE_AT(file, line)
-        << "Error at index " << index
-        << "): " << err_message(*expected.ptr(index), *mat.ptr(index)) << std::endl;
+      ADD_FAILURE_AT(file, line) << "Error at index " << index
+                                 << "): " << err_message(*expected.ptr(index), *mat.ptr(index))
+                                 << std::endl;
       return;
     }
   }

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -1,0 +1,65 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <functional>
+
+#include <gtest/gtest.h>
+
+#include "dlaf/common/range2d.h"
+#include "dlaf/communication/communicator_grid.h"
+#include "dlaf/communication/functions_sync.h"
+#include "dlaf/matrix/matrix.h"
+
+#include "dlaf_test/matrix/matrix_local.h"
+
+namespace dlaf {
+namespace matrix {
+namespace test {
+
+/// Sets the elements of the matrix.
+///
+/// The (i, j)-element of the matrix is set to el({i, j}).
+/// @pre el argument is an index of type const GlobalElementIndex& or GlobalElementIndex,
+/// @pre el return type should be T.
+template <class T, class ElementGetter>
+void set(MatrixLocal<T>& matrix, ElementGetter el) {
+  using dlaf::common::iterate_range2d;
+
+  for (const auto& tile_index : iterate_range2d(matrix.size()))
+    *matrix.ptr(*index) = el(index);
+}
+
+template <class T>  // TODO add tile_selector predicate
+void all_gather(Matrix<const T, Device::CPU>& source, MatrixLocal<T>& dest, comm::CommunicatorGrid comm_grid) {
+  using namespace dlaf;
+  const auto& dist_source = source.distribution();
+  const auto rank = dist_source.rankIndex();
+  for (const auto& ij_tile : iterate_range2d(dist_source.nrTiles())) {
+    const auto owner = dist_source.rankGlobalTile(ij_tile);
+    auto& dest_tile = dest(ij_tile);
+    if (owner == rank) {
+      const auto& source_tile = source.read(ij_tile).get();
+      comm::sync::broadcast::send(comm_grid.fullCommunicator(), source_tile);
+      copy(source_tile, dest_tile);
+    }
+    else {
+      comm::sync::broadcast::receive_from(comm_grid.rankFullCommunicator(owner),
+                                          comm_grid.fullCommunicator(), dest_tile);
+    }
+  }
+}
+
+}
+}
+}

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -41,7 +41,8 @@ void set(MatrixLocal<T>& matrix, ElementGetter el) {
 }
 
 template <class T>  // TODO add tile_selector predicate
-void all_gather(Matrix<const T, Device::CPU>& source, MatrixLocal<T>& dest, comm::CommunicatorGrid comm_grid) {
+void all_gather(Matrix<const T, Device::CPU>& source, MatrixLocal<T>& dest,
+                comm::CommunicatorGrid comm_grid) {
   using namespace dlaf;
   const auto& dist_source = source.distribution();
   const auto rank = dist_source.rankIndex();

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -19,7 +19,7 @@
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/functions_sync.h"
-#include "dlaf/matrix/matrix.h"
+#include "dlaf/matrix.h"
 
 #include "dlaf_test/matrix/matrix_local.h"
 
@@ -36,8 +36,8 @@ template <class T, class ElementGetter>
 void set(MatrixLocal<T>& matrix, ElementGetter el) {
   using dlaf::common::iterate_range2d;
 
-  for (const auto& tile_index : iterate_range2d(matrix.size()))
-    *matrix.ptr(*index) = el(index);
+  for (const auto& index : iterate_range2d(matrix.size()))
+    *matrix.ptr(index) = el(index);
 }
 
 template <class T>  // TODO add tile_selector predicate

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -69,42 +69,6 @@ void all_gather(Matrix<const T, Device::CPU>& source, MatrixLocal<T>& dest,
   }
 }
 
-template <class T>
-void checkNear(const MatrixLocal<const T>& expected, const MatrixLocal<const T>& mat,
-               BaseType<T> rel_err, BaseType<T> abs_err, const char* file, const int line) {
-  ASSERT_GE(rel_err, 0);
-  ASSERT_GE(abs_err, 0);
-  ASSERT_TRUE(rel_err > 0 || abs_err > 0);
-
-  DLAF_ASSERT(expected.size() == mat.size(), expected.size(), mat.size());
-
-  auto comp = [rel_err, abs_err](T expected, T value) {
-    auto diff = std::abs(expected - value);
-    auto abs_max = std::max(std::abs(expected), std::abs(value));
-
-    return (diff < abs_err) || (diff / abs_max < rel_err);
-  };
-  auto err_message = [rel_err, abs_err](T expected, T value) {
-    auto diff = std::abs(expected - value);
-    auto abs_max = std::max(std::abs(expected), std::abs(value));
-
-    std::stringstream s;
-    s << "expected " << expected << " == " << value << " (Relative diff: " << diff / abs_max << " > "
-      << rel_err << ", Absolute diff: " << diff << " > " << abs_err << ")";
-    return s.str();
-  };
-
-  // internal::check(expected, mat, comp, err_message, file, line);
-  for (const auto& index : iterate_range2d(expected.size())) {
-    if (!comp(*expected.ptr(index), *mat.ptr(index))) {
-      ADD_FAILURE_AT(file, line) << "Error at index " << index
-                                 << "): " << err_message(*expected.ptr(index), *mat.ptr(index))
-                                 << std::endl;
-      return;
-    }
-  }
-}
-
 }
 }
 }

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -111,7 +111,7 @@ namespace internal {
 /// @pre The second argument of err_message should be either T, T& or const T&.
 template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGetter,
           std::enable_if_t<!std::is_convertible<ElementGetter, T>::value, int> = 0>
-void check(ElementGetter expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
+void check(ElementGetter&& expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   for (SizeType j = 0; j < tile.size().cols(); ++j) {
     for (SizeType i = 0; i < tile.size().rows(); ++i) {
@@ -186,7 +186,7 @@ void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const cha
 /// @pre abs_err >= 0,
 /// @pre rel_err > 0 || abs_err > 0.
 template <class T, class ElementGetter>
-void checkNear(ElementGetter expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,
+void checkNear(ElementGetter&& expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,
                BaseType<T> abs_err, const char* file, const int line) {
   ASSERT_GE(rel_err, 0);
   ASSERT_GE(abs_err, 0);

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -111,7 +111,7 @@ namespace internal {
 /// @pre The second argument of err_message should be either T, T& or const T&.
 template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGetter,
           std::enable_if_t<!std::is_convertible<ElementGetter, T>::value, int> = 0>
-void check(ElementGetter&& expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
+void check(ElementGetter&& expected, const Tile<const T, Device::CPU>& tile, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   for (SizeType j = 0; j < tile.size().cols(); ++j) {
     for (SizeType i = 0; i < tile.size().rows(); ++i) {
@@ -137,7 +137,7 @@ void check(ElementGetter&& expected, const Tile<T, Device::CPU>& tile, Compariso
 /// @pre the second argument of err_message should be either T, T& or const T&.
 template <class T, class U, class ComparisonOp, class ErrorMessageGetter,
           enable_if_convertible_t<U, T, int> = 0>
-void check(U expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
+void check(U expected, const Tile<const T, Device::CPU>& tile, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   check([expected](TileElementIndex) { return expected; }, tile, comp, err_message, file, line);
 }
@@ -149,7 +149,7 @@ void check(U expected, const Tile<T, Device::CPU>& tile, ComparisonOp comp,
 /// @pre exp_el argument is an index of type const TileElementIndex&,
 /// @pre exp_el return type should be T.
 template <class T, class ElementGetter>
-void checkEQ(ElementGetter exp_el, const Tile<T, Device::CPU>& tile, const char* file, const int line) {
+void checkEQ(ElementGetter&& exp_el, const Tile<const T, Device::CPU>& tile, const char* file, const int line) {
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;
@@ -165,7 +165,7 @@ void checkEQ(ElementGetter exp_el, const Tile<T, Device::CPU>& tile, const char*
 /// @pre exp_ptr argument is an index of type const TileElementIndex&,
 /// @pre exp_ptr return type should be T*.
 template <class T, class PointerGetter>
-void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const char* file,
+void checkPtr(PointerGetter exp_ptr, const Tile<const T, Device::CPU>& tile, const char* file,
               const int line) {
   auto comp = [](T* ptr, const T& value) { return ptr == &value; };
   auto err_message = [](T* expected, const T& value) {
@@ -186,7 +186,7 @@ void checkPtr(PointerGetter exp_ptr, const Tile<T, Device::CPU>& tile, const cha
 /// @pre abs_err >= 0,
 /// @pre rel_err > 0 || abs_err > 0.
 template <class T, class ElementGetter>
-void checkNear(ElementGetter&& expected, const Tile<T, Device::CPU>& tile, BaseType<T> rel_err,
+void checkNear(ElementGetter&& expected, const Tile<const T, Device::CPU>& tile, BaseType<T> rel_err,
                BaseType<T> abs_err, const char* file, const int line) {
   ASSERT_GE(rel_err, 0);
   ASSERT_GE(abs_err, 0);

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -149,7 +149,8 @@ void check(U expected, const Tile<const T, Device::CPU>& tile, ComparisonOp comp
 /// @pre exp_el argument is an index of type const TileElementIndex&,
 /// @pre exp_el return type should be T.
 template <class T, class ElementGetter>
-void checkEQ(ElementGetter&& exp_el, const Tile<const T, Device::CPU>& tile, const char* file, const int line) {
+void checkEQ(ElementGetter&& exp_el, const Tile<const T, Device::CPU>& tile, const char* file,
+             const int line) {
   auto err_message = [](T expected, T value) {
     std::stringstream s;
     s << "expected " << expected << " == " << value;

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -39,6 +39,13 @@ DLAF_addTest(test_matrix
   MPIRANKS 6
 )
 
+DLAF_addTest(test_matrix_local
+  SOURCES test_matrix_local.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN MPIHPX
+  MPIRANKS 6
+)
+
 DLAF_addTest(test_matrix_view
   SOURCES test_matrix_view.cpp
   LIBRARIES dlaf.core

--- a/test/unit/matrix/test_matrix_local.cpp
+++ b/test/unit/matrix/test_matrix_local.cpp
@@ -29,11 +29,11 @@ using namespace dlaf::test;
 using namespace testing;
 
 template <class T>
-auto value_preset(const GlobalElementIndex& index) {
+T value_preset(const GlobalElementIndex& index) {
   const auto i = index.row();
   const auto j = index.col();
   return TypeUtilities<T>::element(i + j / 1024., j - i / 128.);
-};
+}
 
 struct TestSizes {
   GlobalElementSize size;

--- a/test/unit/matrix/test_matrix_local.cpp
+++ b/test/unit/matrix/test_matrix_local.cpp
@@ -15,8 +15,9 @@
 
 #include <gtest/gtest.h>
 
-#include "dlaf_test/util_types.h"
+#include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/matrix/util_matrix_local.h"
+#include "dlaf_test/util_types.h"
 
 using namespace dlaf;
 using namespace dlaf::matrix;
@@ -24,6 +25,13 @@ using namespace dlaf::matrix::test;
 using namespace dlaf::comm;
 using namespace dlaf::test;
 using namespace testing;
+
+template <class T>
+auto el(const GlobalElementIndex& index) {
+  const auto i = index.row();
+  const auto j = index.col();
+  return TypeUtilities<T>::element(i + j / 1024., j - i / 128.);
+};
 
 template <typename Type>
 class MatrixLocalTest : public ::testing::Test {};
@@ -37,7 +45,7 @@ struct TestSizes {
 
 const std::vector<TestSizes> sizes_tests({
     //{{0, 0}, {11, 13}},
-    {{3, 0}, {1, 2}},
+    //{{3, 0}, {1, 2}},
     //{{0, 1}, {7, 32}},
     {{15, 18}, {5, 9}},
     {{6, 6}, {2, 2}},
@@ -48,8 +56,8 @@ const std::vector<TestSizes> sizes_tests({
 TYPED_TEST(MatrixLocalTest, ConstructorAndShape) {
   for (const auto& test : sizes_tests) {
     const GlobalTileSize nrTiles{
-      dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
-      dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
+        dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
+        dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
     };
 
     const MatrixLocal<const TypeParam> mat(test.size, test.block_size);
@@ -63,24 +71,28 @@ TYPED_TEST(MatrixLocalTest, ConstructorAndShape) {
   }
 }
 
-TYPED_TEST(MatrixLocalTest, Set) {
-  auto el = [](const GlobalElementIndex& index) {
-    const auto i = index.row();
-    const auto j = index.col();
-    return TypeUtilities<TypeParam>::element(i + j / 1024., j - i / 128.);
-  };
+TYPED_TEST(MatrixLocalTest, Copy) {
+  for (const auto& config : sizes_tests) {
+    MatrixLocal<const TypeParam> source = [&config]() {
+      MatrixLocal<TypeParam> source(config.size, config.block_size);
+      set(source, el<TypeParam>);
+      return source;
+    }();
 
-  for (const auto& test : sizes_tests) {
-    const GlobalTileSize nrTiles{
-      dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
-      dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
-    };
+    MatrixLocal<TypeParam> dest(config.size, config.block_size);
 
-    MatrixLocal<TypeParam> mat(test.size, test.block_size);
+    copy(source, dest);
 
-    set(mat, el);
-
-    CHECK_MATRIX_NEAR(el, mat, 1e-3, 1e-3);
+    CHECK_MATRIX_NEAR(source, dest, 1e-3, 1e-3);
   }
 }
 
+TYPED_TEST(MatrixLocalTest, Set) {
+  for (const auto& test : sizes_tests) {
+    MatrixLocal<TypeParam> mat(test.size, test.block_size);
+
+    set(mat, el<TypeParam>);
+
+    CHECK_MATRIX_NEAR(el<TypeParam>, mat, 1e-3, 1e-3);
+  }
+}

--- a/test/unit/matrix/test_matrix_local.cpp
+++ b/test/unit/matrix/test_matrix_local.cpp
@@ -41,9 +41,6 @@ struct TestSizes {
 };
 
 const std::vector<TestSizes> sizes_tests({
-    //{{0, 0}, {11, 13}},
-    //{{3, 0}, {1, 2}},
-    //{{0, 1}, {7, 32}},
     {{15, 18}, {5, 9}},
     {{6, 6}, {2, 2}},
     {{3, 4}, {24, 15}},
@@ -57,16 +54,15 @@ TYPED_TEST_SUITE(MatrixLocalTest, MatrixElementTypes);
 
 TYPED_TEST(MatrixLocalTest, ConstructorAndShape) {
   for (const auto& test : sizes_tests) {
-    const GlobalTileSize nrTiles{
-        dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
-        dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
-    };
-
     const MatrixLocal<const TypeParam> mat(test.size, test.block_size);
 
     EXPECT_EQ(test.size, mat.size());
     EXPECT_EQ(test.block_size, mat.blockSize());
 
+    const GlobalTileSize nrTiles{
+        dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
+        dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
+    };
     EXPECT_EQ(nrTiles, mat.nrTiles());
 
     EXPECT_EQ(test.size.rows(), mat.ld());

--- a/test/unit/matrix/test_matrix_local.cpp
+++ b/test/unit/matrix/test_matrix_local.cpp
@@ -1,0 +1,86 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/util_math.h"
+#include "dlaf_test/matrix/matrix_local.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dlaf_test/util_types.h"
+#include "dlaf_test/matrix/util_matrix_local.h"
+
+using namespace dlaf;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf::comm;
+using namespace dlaf::test;
+using namespace testing;
+
+template <typename Type>
+class MatrixLocalTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE(MatrixLocalTest, MatrixElementTypes);
+
+struct TestSizes {
+  GlobalElementSize size;
+  TileElementSize block_size;
+};
+
+const std::vector<TestSizes> sizes_tests({
+    //{{0, 0}, {11, 13}},
+    {{3, 0}, {1, 2}},
+    //{{0, 1}, {7, 32}},
+    {{15, 18}, {5, 9}},
+    {{6, 6}, {2, 2}},
+    {{3, 4}, {24, 15}},
+    {{16, 24}, {3, 5}},
+});
+
+TYPED_TEST(MatrixLocalTest, ConstructorAndShape) {
+  for (const auto& test : sizes_tests) {
+    const GlobalTileSize nrTiles{
+      dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
+      dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
+    };
+
+    const MatrixLocal<const TypeParam> mat(test.size, test.block_size);
+
+    EXPECT_EQ(test.size, mat.size());
+    EXPECT_EQ(test.block_size, mat.blockSize());
+
+    EXPECT_EQ(nrTiles, mat.nrTiles());
+
+    EXPECT_EQ(test.size.rows(), mat.ld());
+  }
+}
+
+TYPED_TEST(MatrixLocalTest, Set) {
+  auto el = [](const GlobalElementIndex& index) {
+    const auto i = index.row();
+    const auto j = index.col();
+    return TypeUtilities<TypeParam>::element(i + j / 1024., j - i / 128.);
+  };
+
+  for (const auto& test : sizes_tests) {
+    const GlobalTileSize nrTiles{
+      dlaf::util::ceilDiv(test.size.rows(), test.block_size.rows()),
+      dlaf::util::ceilDiv(test.size.cols(), test.block_size.cols()),
+    };
+
+    MatrixLocal<TypeParam> mat(test.size, test.block_size);
+
+    set(mat, el);
+
+    CHECK_MATRIX_NEAR(el, mat, 1e-3, 1e-3);
+  }
+}
+


### PR DESCRIPTION
The aim of this PR is introducing a simple data-structure for a Matrix, useful during tests writing.

For this reason I would go for keeping it in the `dlaf::test` namespace, not making it part of our library.

The main idea is to have a `MatrixLocal` that has these main properties:

- it is not async, so it does not have to deal with futures;
- it is not thread-safe;
- it is fully locally stored;
- it should be possible to work with it in terms of tiles or directly elements: this double-abstraction over it allows to keep a direct connection with a distributed matrix (if it has been "gathered" from it) but at the same time it is easy to access (address) of elements for inter-operability with BLAS/LAPACK;

At the moment I wouldn't mind about having it device portable (e.g. stored on GPU or CPU). The philosophy can be, as soon as we need it, we can improve it.

I already have some helper functions that I'm going to add soon. Some examples:
- `set`, similar to what it is already available for `dlaf::matrix::Matrix`
- `all_gather` that allows to collect locally a distributed `dlaf::matrix::Matrix`