### PR TITLE
Add cuBLAS wrappers for tile operations

### DIFF
--- a/include/dlaf/cublas/error.h
+++ b/include/dlaf/cublas/error.h
@@ -1,0 +1,62 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <exception>
+#include <iostream>
+
+#ifdef DLAF_WITH_CUDA
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#endif
+
+#include "dlaf/common/source_location.h"
+
+namespace dlaf {
+namespace internal {
+
+#ifdef DLAF_WITH_CUDA
+
+/// CUBLAS equivalent to `cudaGetErrorString()`
+/// Reference: https://docs.nvidia.com/cuda/cublas/index.html#cublasstatus_t
+inline std::string cublasGetErrorString(cublasStatus_t st) {
+  // clang-format off
+  switch (st) {
+    case CUBLAS_STATUS_SUCCESS:          return "CUBLAS_STATUS_SUCCESS";
+    case CUBLAS_STATUS_NOT_INITIALIZED:  return "CUBLAS_STATUS_NOT_INITIALIZED";
+    case CUBLAS_STATUS_ALLOC_FAILED:     return "CUBLAS_STATUS_ALLOC_FAILED";
+    case CUBLAS_STATUS_INVALID_VALUE:    return "CUBLAS_STATUS_INVALID_VALUE";
+    case CUBLAS_STATUS_ARCH_MISMATCH:    return "CUBLAS_STATUS_ARCH_MISMATCH";
+    case CUBLAS_STATUS_MAPPING_ERROR:    return "CUBLAS_STATUS_MAPPING_ERROR";
+    case CUBLAS_STATUS_EXECUTION_FAILED: return "CUBLAS_STATUS_EXECUTION_FAILED";
+    case CUBLAS_STATUS_INTERNAL_ERROR:   return "CUBLAS_STATUS_INTERNAL_ERROR";
+    case CUBLAS_STATUS_NOT_SUPPORTED:    return "CUBLAS_STATUS_NOT_SUPPORTED";
+    case CUBLAS_STATUS_LICENSE_ERROR:    return "CUBLAS_STATUS_LICENSE_ERROR";
+  }
+  // clang-format on
+  return "UNKNOWN";
+}
+
+inline void cublasCall(cublasStatus_t st, const dlaf::common::internal::source_location& info) noexcept {
+  if (st != CUBLAS_STATUS_SUCCESS) {
+    std::cout << "[CUBLAS ERROR] " << info << std::endl << cublasGetErrorString(st) << std::endl;
+    std::terminate();
+  }
+}
+
+#define DLAF_CUBLAS_CALL(cublas_f) dlaf::internal::cublasCall((cublas_f), SOURCE_LOCATION())
+
+#endif
+
+}
+}

--- a/include/dlaf/cublas_tile.h
+++ b/include/dlaf/cublas_tile.h
@@ -1,0 +1,200 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#ifdef DLAF_WITH_CUDA
+
+#include <cublas_v2.h>
+#include <blas.hh>
+
+#include "dlaf/cublas/error.h"
+#include "dlaf/matrix/tile.h"
+#include "dlaf/types.h"
+#include "dlaf/util_cublas.h"
+
+namespace dlaf {
+namespace tile {
+namespace internal {
+template <typename T>
+struct CublasTrsm;
+
+template <>
+struct CublasTrsm<float> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasStrsm(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasTrsm<double> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasDtrsm(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasTrsm<std::complex<float>> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasCtrsm(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasTrsm<std::complex<double>> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasZtrsm(std::forward<Args>(args)...));
+  }
+};
+
+template <typename T>
+struct CublasGemm;
+
+template <>
+struct CublasGemm<float> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasSgemm(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasGemm<double> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasDgemm(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasGemm<std::complex<float>> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasCgemm(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasGemm<std::complex<double>> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasZgemm(std::forward<Args>(args)...));
+  }
+};
+
+template <typename T>
+struct CublasHerk;
+
+template <>
+struct CublasHerk<std::complex<float>> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasCherk(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CublasHerk<std::complex<double>> {
+  template <typename... Args>
+  static void call(Args&&... args) {
+    DLAF_CUBLAS_CALL(cublasZherk(std::forward<Args>(args)...));
+  }
+};
+
+}
+
+template <class T>
+void cublasTrsm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, const blas::Op op,
+                const blas::Diag diag, const T alpha, const matrix::Tile<const T, Device::GPU>& a,
+                const matrix::Tile<T, Device::GPU>& b) {
+  SizeType m = b.size().rows();
+  SizeType n = b.size().cols();
+
+  DLAF_ASSERT(a.size().rows() == a.size().cols(), "`a` is not square!", a);
+
+  auto left_side = (side == blas::Side::Left ? m : n);
+  DLAF_ASSERT(a.size().rows() == left_side, "`a` has an invalid size!", a, left_side);
+
+  internal::CublasTrsm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo),
+                                util::blasToCublas(op), util::blasToCublas(diag), m, n,
+                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                                util::blasToCublasCast(b.ptr()), b.ld());
+}
+
+template <class T>
+void cublasGemm(cublasHandle_t handle, const blas::Op op_a, const blas::Op op_b, const T alpha,
+                const matrix::Tile<const T, Device::GPU>& a, const matrix::Tile<const T, Device::GPU>& b,
+                const T beta, const matrix::Tile<T, Device::GPU>& c) {
+  SizeType m;
+  SizeType k;
+  if (op_a == blas::Op::NoTrans) {
+    m = a.size().rows();
+    k = a.size().cols();
+  }
+  else {
+    m = a.size().cols();
+    k = a.size().rows();
+  }
+  SizeType k2;
+  SizeType n;
+  if (op_b == blas::Op::NoTrans) {
+    k2 = b.size().rows();
+    n = b.size().cols();
+  }
+  else {
+    k2 = b.size().cols();
+    n = b.size().rows();
+  }
+
+  DLAF_ASSERT(m == c.size().rows(), "`m` cannot be determined!", m, c);
+  DLAF_ASSERT(n == c.size().cols(), "`n` cannot be determined!", n, c);
+  DLAF_ASSERT(k == k2, "`k` cannot be determined!", k, k2);
+
+  internal::CublasGemm<T>::call(handle, util::blasToCublas(op_a), util::blasToCublas(op_b), m, n, k,
+                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                                util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
+                                util::blasToCublasCast(c.ptr()), c.ld());
+}
+
+template <class T>
+void cublasHerk(cublasHandle_t handle, const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha,
+                const matrix::Tile<const T, Device::GPU>& a, const BaseType<T> beta,
+                const matrix::Tile<T, Device::GPU>& c) {
+  SizeType n;
+  SizeType k;
+  if (op == blas::Op::NoTrans) {
+    n = a.size().rows();
+    k = a.size().cols();
+  }
+  else {
+    n = a.size().cols();
+    k = a.size().rows();
+  }
+
+  DLAF_ASSERT((!std::is_same<T, ComplexType<T>>::value || op != blas::Op::Trans),
+              "op = Trans is not allowed for Complex values!");
+  DLAF_ASSERT(c.size().rows() == c.size().cols(), "`c` is not square!", c);
+  DLAF_ASSERT(c.size().rows() == n, "`c` has an invalid size!", c, n);
+
+  internal::CublasHerk<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), n, k,
+                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                                util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), c.ld());
+}
+
+}
+}
+
+#endif

--- a/include/dlaf/util_cublas.h
+++ b/include/dlaf/util_cublas.h
@@ -1,0 +1,105 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#ifdef DLAF_WITH_CUDA
+
+#include <cublas_v2.h>
+#include <blas.hh>
+
+namespace dlaf {
+namespace util {
+namespace internal {
+
+template <typename T>
+struct BlasToCublasType {
+  using type = T;
+};
+
+template <>
+struct BlasToCublasType<std::complex<float>> {
+  using type = cuComplex;
+};
+
+template <>
+struct BlasToCublasType<std::complex<double>> {
+  using type = cuDoubleComplex;
+};
+
+template <typename T>
+struct BlasToCublasType<const T> {
+  using type = const typename BlasToCublasType<T>::type;
+};
+
+template <typename T>
+struct BlasToCublasType<T*> {
+  using type = typename BlasToCublasType<T>::type*;
+};
+
+}
+
+template <typename T>
+constexpr typename internal::BlasToCublasType<T>::type blasToCublasCast(T p) {
+  return reinterpret_cast<typename internal::BlasToCublasType<T>::type>(p);
+}
+
+inline constexpr cublasSideMode_t blasToCublas(const blas::Side side) {
+  switch (side) {
+    case blas::Side::Left:
+      return CUBLAS_SIDE_LEFT;
+    case blas::Side::Right:
+      return CUBLAS_SIDE_RIGHT;
+    default:
+      return {};
+  }
+}
+
+inline constexpr cublasFillMode_t blasToCublas(const blas::Uplo uplo) {
+  switch (uplo) {
+    case blas::Uplo::Lower:
+      return CUBLAS_FILL_MODE_LOWER;
+    case blas::Uplo::Upper:
+      return CUBLAS_FILL_MODE_UPPER;
+    case blas::Uplo::General:
+      return CUBLAS_FILL_MODE_FULL;
+    default:
+      return {};
+  }
+}
+
+inline constexpr cublasOperation_t blasToCublas(const blas::Op op) {
+  switch (op) {
+    case blas::Op::NoTrans:
+      return CUBLAS_OP_N;
+    case blas::Op::Trans:
+      return CUBLAS_OP_T;
+    case blas::Op::ConjTrans:
+      return CUBLAS_OP_C;
+    default:
+      return {};
+  }
+}
+
+inline constexpr cublasDiagType_t blasToCublas(const blas::Diag diag) {
+  switch (diag) {
+    case blas::Diag::Unit:
+      return CUBLAS_DIAG_UNIT;
+    case blas::Diag::NonUnit:
+      return CUBLAS_DIAG_NON_UNIT;
+    default:
+      return {};
+  }
+}
+
+}
+}
+
+#endif

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -32,6 +32,14 @@ DLAF_addTest(test_lapack_tile
   USE_MAIN HPX
 )
 
+if(DLAF_WITH_CUDA)
+  DLAF_addTest(test_cublas_tile
+    SOURCES test_cublas_tile.cpp
+    LIBRARIES dlaf.core
+    USE_MAIN HPX
+  )
+endif()
+
 # Generic libraries
 add_subdirectory(common)
 add_subdirectory(communication)

--- a/test/unit/test_cublas_tile.cpp
+++ b/test/unit/test_cublas_tile.cpp
@@ -1,0 +1,127 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/cublas_tile.h"
+
+#include "gtest/gtest.h"
+#include "dlaf_test/util_types.h"
+
+#include "test_cublas_tile/test_gemm.h"
+#include "test_cublas_tile/test_herk.h"
+#include "test_cublas_tile/test_trsm.h"
+
+using namespace dlaf;
+using namespace dlaf::test;
+using namespace testing;
+
+const std::vector<blas::Diag> blas_diags({blas::Diag::Unit, blas::Diag::NonUnit});
+const std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
+const std::vector<blas::Side> blas_sides({blas::Side::Left, blas::Side::Right});
+const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper});
+
+template <typename Type>
+class TileOperationsTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE(TileOperationsTest, MatrixElementTypes);
+
+TYPED_TEST(TileOperationsTest, Gemm) {
+  using Type = TypeParam;
+
+  SizeType m, n, k, extra_lda, extra_ldb, extra_ldc;
+
+  std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, SizeType>> sizes = {
+      {0, 0, 0, 0, 0, 0},                                               // all 0 sizes
+      {7, 0, 0, 3, 1, 0},  {0, 5, 0, 0, 0, 1},    {0, 0, 11, 1, 1, 2},  // two 0 sizes
+      {0, 5, 13, 1, 0, 1}, {7, 0, 4, 1, 2, 0},    {3, 11, 0, 0, 1, 0},  // one 0 size
+      {1, 1, 1, 0, 3, 0},  {1, 12, 1, 1, 0, 7},   {17, 12, 16, 1, 3, 0}, {11, 23, 8, 0, 3, 4},
+      {6, 9, 12, 1, 1, 1}, {32, 32, 32, 0, 0, 0}, {32, 32, 32, 4, 5, 7},
+  };
+
+  for (const auto op_a : blas_ops) {
+    for (const auto op_b : blas_ops) {
+      for (const auto& size : sizes) {
+        std::tie(m, n, k, extra_lda, extra_ldb, extra_ldc) = size;
+
+        // Test a and b const Tiles.
+        testGemm<Type>(op_a, op_b, m, n, k, extra_lda, extra_ldb, extra_ldc);
+
+        // Test a and b non const Tiles.
+        testGemm<Type, Type>(op_a, op_b, m, n, k, extra_lda, extra_ldb, extra_ldc);
+      }
+    }
+  }
+}
+
+template <typename Type>
+class HerkTileOperationsTest : public ::testing::Test {};
+
+using HerkMatrixElementTypes = ::testing::Types<std::complex<float>, std::complex<double>>;
+
+TYPED_TEST_SUITE(HerkTileOperationsTest, HerkMatrixElementTypes);
+
+TYPED_TEST(HerkTileOperationsTest, Herk) {
+  using Type = TypeParam;
+
+  auto herk_blas_ops = blas_ops;
+  // [c,z]herk do not allow op = Trans
+  if (std::is_same<Type, ComplexType<Type>>::value)
+    herk_blas_ops = {blas::Op::NoTrans, blas::Op::ConjTrans};
+  SizeType n, k, extra_lda, extra_ldc;
+
+  std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> sizes =
+      {{0, 0, 0, 0},                 // all 0 sizes
+       {0, 5, 1, 0},  {7, 0, 1, 2},  // one 0 size
+       {1, 1, 0, 3},  {1, 12, 1, 0},  {17, 12, 1, 3}, {11, 23, 0, 3},
+       {9, 12, 1, 1}, {32, 32, 0, 0}, {32, 32, 4, 7}};
+
+  for (const auto uplo : blas_uplos) {
+    for (const auto op : herk_blas_ops) {
+      for (const auto& size : sizes) {
+        std::tie(n, k, extra_lda, extra_ldc) = size;
+
+        // Test a const Tile.
+        testHerk<Type>(uplo, op, n, k, extra_lda, extra_ldc);
+
+        // Test a non const Tile.
+        testHerk<Type, Type>(uplo, op, n, k, extra_lda, extra_ldc);
+      }
+    }
+  }
+}
+
+TYPED_TEST(TileOperationsTest, Trsm) {
+  using Type = TypeParam;
+
+  SizeType m, n, extra_lda, extra_ldb;
+
+  std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> sizes =
+      {{0, 0, 0, 0},                 // all 0 sizes
+       {0, 5, 1, 0},  {7, 0, 1, 2},  // one 0 size
+       {1, 1, 0, 3},  {1, 12, 1, 0},  {17, 12, 1, 3}, {11, 23, 0, 3},
+       {9, 12, 1, 1}, {32, 32, 0, 0}, {32, 32, 4, 7}};
+
+  for (const auto side : blas_sides) {
+    for (const auto uplo : blas_uplos) {
+      for (const auto op : blas_ops) {
+        for (const auto diag : blas_diags) {
+          for (const auto& size : sizes) {
+            std::tie(m, n, extra_lda, extra_ldb) = size;
+
+            // Test a const Tile.
+            testTrsm<TileElementIndex, Type>(side, uplo, op, diag, m, n, extra_lda, extra_ldb);
+
+            // Test a non const Tile.
+            testTrsm<TileElementIndex, Type, Type>(side, uplo, op, diag, m, n, extra_lda, extra_ldb);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/unit/test_cublas_tile/test_gemm.h
+++ b/test/unit/test_cublas_tile/test_gemm.h
@@ -1,0 +1,119 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <sstream>
+#include "gtest/gtest.h"
+#include "dlaf/blas/enum_output.h"
+#include "dlaf/cublas/error.h"
+#include "dlaf/cublas_tile.h"
+#include "dlaf/matrix/copy_tile.h"
+#include "dlaf/matrix/tile.h"
+#include "dlaf/memory/memory_view.h"
+#include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/matrix/util_tile_blas.h"
+#include "dlaf_test/util_types.h"
+
+namespace dlaf {
+namespace test {
+
+using namespace dlaf;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf::tile;
+using namespace testing;
+
+using dlaf::util::size_t::mul;
+
+template <class T, class CT = const T>
+void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, SizeType extra_lda,
+              SizeType extra_ldb, SizeType extra_ldc) {
+  const TileElementSize size_a =
+      (op_a == blas::Op::NoTrans) ? TileElementSize(m, k) : TileElementSize(k, m);
+  const TileElementSize size_b =
+      (op_b == blas::Op::NoTrans) ? TileElementSize(k, n) : TileElementSize(n, k);
+  const TileElementSize size_c(m, n);
+
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
+  const SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
+
+  std::stringstream s;
+  s << "GEMM: " << op_a << ", " << op_a;
+  s << ", m = " << m << ", n = " << n << ", k = " << k;
+  s << ", lda = " << lda << ", ldb = " << ldb << ", ldc = " << ldc;
+  SCOPED_TRACE(s.str());
+
+  // Note: The tile elements are chosen such that:
+  // - op_a(a)_ik = .9 * (i+1) / (k+.5) * exp(I*(2*i-k)),
+  // - op_b(b)_kj = .8 * (k+.5) / (j+2) * exp(I*(k+j)),
+  // - c_ij = 1.2 * i / (j+1) * exp(I*(-i+j)),
+  // where I = 0 for real types or I is the complex unit for complex types.
+  // Therefore the result should be:
+  // res_ij = beta * c_ij + Sum_k(alpha * op_a(a)_ik * op_b(b)_kj)
+  //        = beta * c_ij + gamma * (i+1) / (j+2) * exp(I*(2*i+j)),
+  // where gamma = .72 * k * alpha.
+  auto el_op_a = [](const TileElementIndex& index) {
+    double i = index.row();
+    double k = index.col();
+    return TypeUtilities<T>::polar(.9 * (i + 1) / (k + .5), 2 * i - k);
+  };
+  auto el_op_b = [](const TileElementIndex& index) {
+    double k = index.row();
+    double j = index.col();
+    return TypeUtilities<T>::polar(.8 * (k + .5) / (j + 2), k + j);
+  };
+  auto el_c = [](const TileElementIndex& index) {
+    double i = index.row();
+    double j = index.col();
+    return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
+  };
+
+  T alpha = TypeUtilities<T>::element(-1.2, .7);
+  T beta = TypeUtilities<T>::element(1.1, .4);
+
+  T gamma = TypeUtilities<T>::element(.72 * k, 0) * alpha;
+  auto res_c = [beta, el_c, gamma](const TileElementIndex& index) {
+    double i = index.row();
+    double j = index.col();
+    return beta * el_c(index) + gamma * TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
+  };
+
+  auto a = createTile<CT>(el_op_a, size_a, lda, op_a);
+  auto b = createTile<CT>(el_op_b, size_b, ldb, op_b);
+  auto c = createTile<T>(el_c, size_c, ldc);
+
+  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(mul(lda, size_a.cols())), lda);
+  Tile<T, Device::GPU> b0d(size_b, memory::MemoryView<T, Device::GPU>(mul(ldb, size_b.cols())), ldb);
+  Tile<T, Device::GPU> cd(size_c, memory::MemoryView<T, Device::GPU>(mul(ldc, size_c.cols())), ldc);
+
+  copy(a, a0d);
+  copy(b, b0d);
+  copy(c, cd);
+
+  Tile<CT, Device::GPU> ad(std::move(a0d));
+  Tile<CT, Device::GPU> bd(std::move(b0d));
+
+  cublasHandle_t handle;
+  DLAF_CUBLAS_CALL(cublasCreate(&handle));
+  cublasGemm(handle, op_a, op_b, alpha, ad, bd, beta, cd);
+  DLAF_CUDA_CALL(cudaDeviceSynchronize());
+  DLAF_CUBLAS_CALL(cublasDestroy(handle));
+
+  copy(cd, c);
+
+  // Check result against analytical result.
+  CHECK_TILE_NEAR(res_c, c, 2 * (k + 1) * TypeUtilities<T>::error,
+                  2 * (k + 1) * TypeUtilities<T>::error);
+}
+}
+}

--- a/test/unit/test_cublas_tile/test_herk.h
+++ b/test/unit/test_cublas_tile/test_herk.h
@@ -1,0 +1,108 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <sstream>
+#include "gtest/gtest.h"
+#include "dlaf/blas/enum_output.h"
+#include "dlaf/cublas_tile.h"
+#include "dlaf/matrix/copy_tile.h"
+#include "dlaf/matrix/tile.h"
+#include "dlaf/memory/memory_view.h"
+#include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/matrix/util_tile_blas.h"
+#include "dlaf_test/util_types.h"
+
+namespace dlaf {
+namespace test {
+
+using namespace dlaf;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf::tile;
+using namespace testing;
+
+using dlaf::util::size_t::mul;
+
+template <class T, class CT = const T>
+void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType extra_lda,
+              SizeType extra_ldc) {
+  const TileElementSize size_a =
+      (op_a == blas::Op::NoTrans) ? TileElementSize(n, k) : TileElementSize(k, n);
+  const TileElementSize size_c(n, n);
+
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const SizeType ldc = std::max<SizeType>(1, size_c.rows()) + extra_ldc;
+
+  std::stringstream s;
+  s << "HERK: " << uplo << ", " << op_a;
+  s << ", n = " << n << ", k = " << k;
+  s << ", lda = " << lda << ", ldc = " << ldc;
+  SCOPED_TRACE(s.str());
+
+  // Returns op_a(a)_ik
+  auto el_op_a = [](const TileElementIndex& index) {
+    double i = index.row();
+    double k = index.col();
+    return TypeUtilities<T>::polar(.9 * (i + 1) / (k + .5), i - k);
+  };
+  auto el_c = [uplo](const TileElementIndex& index) {
+    // Return -1 for elements not referenced
+    if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
+        (uplo == blas::Uplo::Upper && index.row() > index.col()))
+      return TypeUtilities<T>::element(-1, 0);
+
+    double i = index.row();
+    double j = index.col();
+    return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
+  };
+
+  BaseType<T> alpha = -1.2f;
+  BaseType<T> beta = 1.1f;
+
+  auto res_c = [uplo, k, alpha, el_op_a, beta, el_c](const TileElementIndex& index) {
+    // Return el_c(index) for elements not referenced
+    if ((uplo == blas::Uplo::Lower && index.row() < index.col()) ||
+        (uplo == blas::Uplo::Upper && index.row() > index.col()))
+      return el_c(index);
+
+    T tmp = TypeUtilities<T>::element(0, 0);
+    // Compute result of cij
+    for (SizeType kk = 0; kk < k; ++kk) {
+      tmp += el_op_a({index.row(), kk}) * TypeUtilities<T>::conj(el_op_a({index.col(), kk}));
+    }
+    return beta * el_c(index) + alpha * tmp;
+  };
+
+  auto a = createTile<CT>(el_op_a, size_a, lda, op_a);
+  auto c = createTile<T>(el_c, size_c, ldc);
+
+  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(mul(lda, size_a.cols())), lda);
+  Tile<T, Device::GPU> cd(size_c, memory::MemoryView<T, Device::GPU>(mul(ldc, size_c.cols())), ldc);
+
+  copy(a, a0d);
+  copy(c, cd);
+
+  Tile<CT, Device::GPU> ad(std::move(a0d));
+
+  cublasHandle_t handle;
+  DLAF_CUBLAS_CALL(cublasCreate(&handle));
+  cublasHerk(handle, uplo, op_a, alpha, ad, beta, cd);
+  DLAF_CUDA_CALL(cudaDeviceSynchronize());
+  DLAF_CUBLAS_CALL(cublasDestroy(handle));
+
+  copy(cd, c);
+
+  CHECK_TILE_NEAR(res_c, c, (k + 1) * TypeUtilities<T>::error, (k + 1) * TypeUtilities<T>::error);
+}
+
+}
+}

--- a/test/unit/test_cublas_tile/test_trsm.h
+++ b/test/unit/test_cublas_tile/test_trsm.h
@@ -1,0 +1,87 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2019, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <functional>
+#include <sstream>
+#include <tuple>
+#include "gtest/gtest.h"
+#include "dlaf/blas/enum_output.h"
+#include "dlaf/cublas/error.h"
+#include "dlaf/cublas_tile.h"
+#include "dlaf/matrix/copy_tile.h"
+#include "dlaf/matrix/tile.h"
+#include "dlaf/memory/memory_view.h"
+#include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/matrix/util_tile_blas.h"
+#include "dlaf_test/util_types.h"
+
+namespace dlaf {
+namespace test {
+
+using namespace dlaf;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf::tile;
+using namespace testing;
+
+using dlaf::util::size_t::mul;
+
+template <class ElementIndex, class T, class CT = const T>
+void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, SizeType m, SizeType n,
+              SizeType extra_lda, SizeType extra_ldb) {
+  const TileElementSize size_a =
+      side == blas::Side::Left ? TileElementSize(m, m) : TileElementSize(n, n);
+  const TileElementSize size_b(m, n);
+
+  const SizeType lda = std::max<SizeType>(1, size_a.rows()) + extra_lda;
+  const SizeType ldb = std::max<SizeType>(1, size_b.rows()) + extra_ldb;
+
+  std::stringstream s;
+  s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n
+    << ", lda = " << lda << ", ldb = " << ldb;
+  SCOPED_TRACE(s.str());
+
+  const T alpha = TypeUtilities<T>::element(-1.2, .7);
+
+  std::function<T(const TileElementIndex&)> el_op_a, el_b, res_b;
+
+  if (side == blas::Side::Left)
+    std::tie(el_op_a, el_b, res_b) = getLeftTriangularSystem<ElementIndex, T>(uplo, op, diag, alpha, m);
+  else
+    std::tie(el_op_a, el_b, res_b) = getRightTriangularSystem<ElementIndex, T>(uplo, op, diag, alpha, n);
+
+  auto a = createTile<CT>(el_op_a, size_a, lda, op);
+  auto b = createTile<T>(el_b, size_b, ldb);
+
+  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(mul(lda, size_a.cols())), lda);
+  Tile<T, Device::GPU> bd(size_b, memory::MemoryView<T, Device::GPU>(mul(ldb, size_b.cols())), ldb);
+
+  copy(a, a0d);
+  copy(b, bd);
+
+  Tile<CT, Device::GPU> ad(std::move(a0d));
+
+  cublasHandle_t handle;
+  DLAF_CUBLAS_CALL(cublasCreate(&handle));
+  cublasTrsm(handle, side, uplo, op, diag, alpha, ad, bd);
+  DLAF_CUDA_CALL(cudaDeviceSynchronize());
+  DLAF_CUBLAS_CALL(cublasDestroy(handle));
+
+  copy(bd, b);
+
+  CHECK_TILE_NEAR(res_b, b, 10 * (m + 1) * TypeUtilities<T>::error,
+                  10 * (m + 1) * TypeUtilities<T>::error);
+}
+
+}
+}


### PR DESCRIPTION
This adds the basic wrappers that do argument conversion (blaspp enums to cuBLAS enums, `std::complex` to `cuComplex`/`cuDoubleComplex`), and tests.

Questions:
- Namespaces and names? The blaspp wrappers are in `dlaf::tile`. The signatures won't be the same since the cuBLAS wrappers will take a cuBLAS handle. Is this functionality meant to be public? I've currently prefixed the wrappers with `cublas_`.
- Do you rely only on `-Wswitch-enum` to cover all cases in a switch statement? I currently added a false assertion on the default case, but I see that you haven't done that elsewhere.

Includes #289.