### PR TITLE
Add a general tile `copy()`

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -401,11 +401,5 @@ Size2D<IndexT, Tag> operator+(const Size2D<IndexT, Tag>& lhs, const Size2D<Index
   return Size2D<IndexT, Tag>(lhs.rows() + rhs.rows(), lhs.cols() + rhs.cols());
 }
 
-/// Returns true if @param small is within @param big starting at @param idx
-template <class IndexT, class Tag>
-bool isWithin(Size2D<IndexT, Tag> small, Index2D<IndexT, Tag> idx, Size2D<IndexT, Tag> big) {
-  return idx.row() + small.rows() <= big.rows() && idx.col() + small.cols() <= big.cols();
-}
-
 }
 }

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -401,5 +401,11 @@ Size2D<IndexT, Tag> operator+(const Size2D<IndexT, Tag>& lhs, const Size2D<Index
   return Size2D<IndexT, Tag>(lhs.rows() + rhs.rows(), lhs.cols() + rhs.cols());
 }
 
+/// Returns true if @param small is within @param big starting at @param idx
+template <class IndexT, class Tag>
+bool isWithin(Size2D<IndexT, Tag> small, Index2D<IndexT, Tag> idx, Size2D<IndexT, Tag> big) {
+  return idx.row() + small.rows() <= big.rows() && idx.col() + small.cols() <= big.cols();
+}
+
 }
 }

--- a/include/dlaf/lapack_tile.h
+++ b/include/dlaf/lapack_tile.h
@@ -19,6 +19,7 @@
 #undef I
 #endif
 
+#include "dlaf/matrix/index.h"
 #include "dlaf/matrix/tile.h"
 #include "dlaf/types.h"
 
@@ -48,6 +49,15 @@ void hegst(const int itype, const blas::Uplo uplo, const Tile<T, device>& a, con
 /// @pre @param a and @param b must have the same size (number of elements).
 template <class T>
 void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b);
+
+/// Copies a 2D @param region from tile @param in starting at @param in_idx to tile @param out starting
+/// at @param out_idx.
+///
+/// @pre @param region has to fit within @param in and @param out taking into account the starting
+/// indices @param in_idx and @param out_idx.
+template <class T>
+void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, Device::CPU>& in,
+           TileElementIndex out_idx, const Tile<T, Device::CPU>& out);
 
 /// Compute the value of the 1-norm, Frobenius norm, infinity-norm, or the largest absolute value of any
 /// element, of a general rectangular matrix.

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -36,17 +36,11 @@ void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, 
            TileElementIndex out_idx, const Tile<T, Device::CPU>& out) {
   const SizeType m = region.rows();
   const SizeType n = region.cols();
-  const TileElementSize in_sz = in.size();
-  const TileElementSize out_sz = out.size();
 
-  DLAF_ASSERT_MODERATE(m + in_idx.row() <= in_sz.rows(),
-                       "Region goes out of bounds for `in` along rows!", m, in_sz, in_idx);
-  DLAF_ASSERT_MODERATE(m + out_idx.row() <= out_sz.rows(),
-                       "Region goes out of bounds for `out` along rows!", m, out_sz, out_idx);
-  DLAF_ASSERT_MODERATE(n + in_idx.col() <= in_sz.cols(),
-                       "Region goes out of bounds for `in` along columns!", n, in_sz, in_idx);
-  DLAF_ASSERT_MODERATE(n + out_idx.col() <= out_sz.cols(),
-                       "Region goes out of bounds for `out` along columns!", n, out_sz, out_idx);
+  DLAF_ASSERT_MODERATE(isWithin(region, in_idx, in.size()), "Region goes out of bounds for `in`!",
+                       region, in_idx, in);
+  DLAF_ASSERT_MODERATE(isWithin(region, out_idx, out.size()), "Region goes out of bounds for `out`!",
+                       region, out_idx, out);
 
   lapack::lacpy(lapack::MatrixType::General, m, n, in.ptr(in_idx), in.ld(), out.ptr(out_idx), out.ld());
 }

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -34,15 +34,13 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
 template <class T>
 void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, Device::CPU>& in,
            TileElementIndex out_idx, const Tile<T, Device::CPU>& out) {
-  const SizeType m = region.rows();
-  const SizeType n = region.cols();
-
   DLAF_ASSERT_MODERATE(isWithin(region, in_idx, in.size()), "Region goes out of bounds for `in`!",
                        region, in_idx, in);
   DLAF_ASSERT_MODERATE(isWithin(region, out_idx, out.size()), "Region goes out of bounds for `out`!",
                        region, out_idx, out);
 
-  lapack::lacpy(lapack::MatrixType::General, m, n, in.ptr(in_idx), in.ld(), out.ptr(out_idx), out.ld());
+  lapack::lacpy(lapack::MatrixType::General, region.rows(), region.cols(), in.ptr(in_idx), in.ld(),
+                out.ptr(out_idx), out.ld());
 }
 
 template <class T, Device device>

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -31,6 +31,26 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
   lapack::lacpy(lapack::MatrixType::General, m, n, a.ptr(), a.ld(), b.ptr(), b.ld());
 }
 
+template <class T>
+void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, Device::CPU>& in,
+           TileElementIndex out_idx, const Tile<T, Device::CPU>& out) {
+  const SizeType m = region.rows();
+  const SizeType n = region.cols();
+  const TileElementSize in_sz = in.size();
+  const TileElementSize out_sz = out.size();
+
+  DLAF_ASSERT_MODERATE(m + in_idx.row() <= in_sz.rows(),
+                       "Region goes out of bounds for `in` along rows!", m, in_sz, in_idx);
+  DLAF_ASSERT_MODERATE(m + out_idx.row() <= out_sz.rows(),
+                       "Region goes out of bounds for `out` along rows!", m, out_sz, out_idx);
+  DLAF_ASSERT_MODERATE(n + in_idx.col() <= in_sz.cols(),
+                       "Region goes out of bounds for `in` along columns!", n, in_sz, in_idx);
+  DLAF_ASSERT_MODERATE(n + out_idx.col() <= out_sz.cols(),
+                       "Region goes out of bounds for `out` along columns!", n, out_sz, out_idx);
+
+  lapack::lacpy(lapack::MatrixType::General, m, n, in.ptr(in_idx), in.ld(), out.ptr(out_idx), out.ld());
+}
+
 template <class T, Device device>
 dlaf::BaseType<T> lange(const lapack::Norm norm, const Tile<T, device>& a) noexcept {
   return lapack::lange(norm, a.size().rows(), a.size().cols(), a.ptr(), a.ld());

--- a/include/dlaf/lapack_tile.tpp
+++ b/include/dlaf/lapack_tile.tpp
@@ -34,10 +34,10 @@ void lacpy(const Tile<const T, Device::CPU>& a, const Tile<T, Device::CPU>& b) {
 template <class T>
 void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, Device::CPU>& in,
            TileElementIndex out_idx, const Tile<T, Device::CPU>& out) {
-  DLAF_ASSERT_MODERATE(isWithin(region, in_idx, in.size()), "Region goes out of bounds for `in`!",
-                       region, in_idx, in);
-  DLAF_ASSERT_MODERATE(isWithin(region, out_idx, out.size()), "Region goes out of bounds for `out`!",
-                       region, out_idx, out);
+  DLAF_ASSERT_MODERATE(in_idx.isIn(in.size() - region + TileElementSize(1, 1)),
+                       "Region goes out of bounds for `in`!", region, in_idx, in);
+  DLAF_ASSERT_MODERATE(out_idx.isIn(out.size() - region + TileElementSize(1, 1)),
+                       "Region goes out of bounds for `out`!", region, out_idx, out);
 
   lapack::lacpy(lapack::MatrixType::General, region.rows(), region.cols(), in.ptr(in_idx), in.ld(),
                 out.ptr(out_idx), out.ld());

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -35,9 +35,13 @@ void copy(MatrixTypeSrc<const T, device>& source, MatrixTypeDst<T, device>& dest
   const SizeType local_tile_rows = distribution.localNrTiles().rows();
   const SizeType local_tile_cols = distribution.localNrTiles().cols();
 
+  // This prevents a compiler error in `hpx::util::unwrapping()` which is unable to deduce the correct
+  // overload for tile `copy()`.
+  void (&cpy)(const matrix::Tile<const T, Device::CPU>&, const matrix::Tile<T, Device::CPU>&) = copy<T>;
+
   for (SizeType j = 0; j < local_tile_cols; ++j)
     for (SizeType i = 0; i < local_tile_rows; ++i)
-      hpx::dataflow(hpx::util::unwrapping(dlaf::copy<T>), source.read(LocalTileIndex(i, j)),
+      hpx::dataflow(hpx::util::unwrapping(cpy), source.read(LocalTileIndex(i, j)),
                     dest(LocalTileIndex(i, j)));
 }
 

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -22,4 +22,10 @@ void copy(const matrix::Tile<const T, Device::CPU>& source, const matrix::Tile<T
   dlaf::tile::lacpy<T>(source, dest);
 }
 
+template <class T>
+void copy(TileElementSize region, TileElementIndex in_idx, const matrix::Tile<const T, Device::CPU>& in,
+          TileElementIndex out_idx, const matrix::Tile<T, Device::CPU>& out) {
+  dlaf::tile::lacpy<T>(region, in_idx, in, out_idx, out);
+}
+
 }

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -158,3 +158,32 @@ TYPED_TEST(TileOperationsTest, PotrfNonPositiveDefinite) {
     }
   }
 }
+
+TYPED_TEST(TileOperationsTest, Lacpy) {
+  using Scalar = TypeParam;
+  using Tile_t = Tile<Scalar, Device::CPU>;
+  using ConstTile_t = Tile<const Scalar, Device::CPU>;
+
+  TileElementSize region(3, 3);
+  TileElementIndex in_idx(1, 2);
+  ConstTile_t in_tile = createTile<Scalar>([](TileElementIndex idx) { return idx.row() + idx.col(); },
+                                           TileElementSize(5, 5), 5);
+  TileElementIndex out_idx(2, 3);
+  Tile_t out_tile = createTile<Scalar>([](TileElementIndex) { return 2; }, TileElementSize(7, 7), 7);
+
+  tile::lacpy(region, in_idx, in_tile, out_idx, out_tile);
+
+  double eps = std::numeric_limits<double>::epsilon();
+
+  ASSERT_TRUE(std::abs(Scalar(1 + 2) - out_tile(TileElementIndex(2, 3))) < eps);
+  ASSERT_TRUE(std::abs(Scalar(2 + 2) - out_tile(TileElementIndex(3, 3))) < eps);
+  ASSERT_TRUE(std::abs(Scalar(3 + 2) - out_tile(TileElementIndex(4, 3))) < eps);
+
+  ASSERT_TRUE(std::abs(Scalar(1 + 3) - out_tile(TileElementIndex(2, 4))) < eps);
+  ASSERT_TRUE(std::abs(Scalar(2 + 3) - out_tile(TileElementIndex(3, 4))) < eps);
+  ASSERT_TRUE(std::abs(Scalar(3 + 3) - out_tile(TileElementIndex(4, 4))) < eps);
+
+  ASSERT_TRUE(std::abs(Scalar(1 + 4) - out_tile(TileElementIndex(2, 5))) < eps);
+  ASSERT_TRUE(std::abs(Scalar(2 + 4) - out_tile(TileElementIndex(3, 5))) < eps);
+  ASSERT_TRUE(std::abs(Scalar(3 + 4) - out_tile(TileElementIndex(4, 5))) < eps);
+}


### PR DESCRIPTION
- Generalize `copy()`: copy a 2D sub-region from an input tile to an output
  tile. The operation is needed when batching multiple times or
  splitting a tile (separate PRs for these are coming).