### PR TITLE
Matrix minor changes

### DIFF
--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -56,7 +56,7 @@ public:
          const comm::CommunicatorGrid& comm);
 
   /// Create a matrix distributed according to the distribution @p distribution.
-  Matrix(Distribution&& distribution);
+  Matrix(Distribution distribution);
 
   /// Create a matrix distributed according to the distribution @p distribution,
   /// specifying the layout.
@@ -65,7 +65,7 @@ public:
   ///            of the local part of the matrix will be stored in memory,
   /// @pre distribution.localSize() == layout.size(),
   /// @pre distribution.blockSize() == layout.blockSize().
-  Matrix(Distribution&& distribution, const LayoutInfo& layout) noexcept;
+  Matrix(Distribution distribution, const LayoutInfo& layout) noexcept;
 
   /// Create a non distributed matrix,
   /// which references elements that are already allocated in the memory.
@@ -85,7 +85,7 @@ public:
   /// @pre distribution.localSize() == layout.size(),
   /// @pre distribution.blockSize() == layout.blockSize(),
   /// @pre @p ptr refers to an allocated memory region of at least @c layout.minMemSize() elements.
-  Matrix(Distribution&& distribution, const LayoutInfo& layout, ElementType* ptr) noexcept;
+  Matrix(Distribution distribution, const LayoutInfo& layout, ElementType* ptr) noexcept;
 
   Matrix(const Matrix& rhs) = delete;
   Matrix(Matrix&& rhs) = default;
@@ -130,9 +130,9 @@ public:
   Matrix(const LayoutInfo& layout, const ElementType* ptr)
       : Matrix(layout, const_cast<ElementType*>(ptr)) {}
 
-  Matrix(Distribution&& distribution, const LayoutInfo& layout, ElementType* ptr) noexcept;
+  Matrix(Distribution distribution, const LayoutInfo& layout, ElementType* ptr) noexcept;
 
-  Matrix(Distribution&& distribution, const LayoutInfo& layout, const ElementType* ptr)
+  Matrix(Distribution distribution, const LayoutInfo& layout, const ElementType* ptr)
       : Matrix(std::move(distribution), layout, const_cast<ElementType*>(ptr)) {}
 
   Matrix(const Matrix& rhs) = delete;
@@ -159,8 +159,8 @@ public:
   }
 
 private:
-  Matrix(Distribution&& distribution, std::vector<hpx::future<TileType>>&& tile_futures,
-         std::vector<hpx::shared_future<ConstTileType>>&& tile_shared_futures);
+  Matrix(Distribution distribution, std::vector<hpx::future<TileType>> tile_futures,
+         std::vector<hpx::shared_future<ConstTileType>> tile_shared_futures);
 
   void setUpTiles(const memory::MemoryView<ElementType, device>& mem, const LayoutInfo& layout) noexcept;
 

--- a/include/dlaf/matrix.h
+++ b/include/dlaf/matrix.h
@@ -158,9 +158,8 @@ public:
     return read(distribution().localTileIndex(index));
   }
 
-private:
-  Matrix(Distribution distribution, std::vector<hpx::future<TileType>> tile_futures,
-         std::vector<hpx::shared_future<ConstTileType>> tile_shared_futures);
+protected:
+  Matrix(Distribution distribution) : internal::MatrixBase{std::move(distribution)} {}
 
   void setUpTiles(const memory::MemoryView<ElementType, device>& mem, const LayoutInfo& layout) noexcept;
 

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -22,7 +22,7 @@ Matrix<T, device>::Matrix(const GlobalElementSize& size, const TileElementSize& 
 
 template <class T, Device device>
 Matrix<T, device>::Matrix(Distribution distribution)
-    : Matrix<const T, device>(std::move(distribution), {}, {}) {
+    : Matrix<const T, device>(std::move(distribution)) {
   const SizeType alignment = 64;
   const SizeType ld =
       std::max<SizeType>(1,
@@ -38,7 +38,7 @@ Matrix<T, device>::Matrix(Distribution distribution)
 
 template <class T, Device device>
 Matrix<T, device>::Matrix(Distribution distribution, const LayoutInfo& layout) noexcept
-    : Matrix<const T, device>(std::move(distribution), {}, {}) {
+    : Matrix<const T, device>(std::move(distribution)) {
   DLAF_ASSERT(this->distribution().localSize() == layout.size(),
               "Size of distribution does not match layout size!", distribution.localSize(),
               layout.size());

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -21,7 +21,7 @@ Matrix<T, device>::Matrix(const GlobalElementSize& size, const TileElementSize& 
     : Matrix<T, device>(Distribution(size, block_size, comm.size(), comm.rank(), {0, 0})) {}
 
 template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution&& distribution)
+Matrix<T, device>::Matrix(Distribution distribution)
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
   const SizeType alignment = 64;
   const SizeType ld =
@@ -37,7 +37,7 @@ Matrix<T, device>::Matrix(Distribution&& distribution)
 }
 
 template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution&& distribution, const LayoutInfo& layout) noexcept
+Matrix<T, device>::Matrix(Distribution distribution, const LayoutInfo& layout) noexcept
     : Matrix<const T, device>(std::move(distribution), {}, {}) {
   DLAF_ASSERT(this->distribution().localSize() == layout.size(),
               "Size of distribution does not match layout size!", distribution.localSize(),
@@ -52,8 +52,7 @@ Matrix<T, device>::Matrix(Distribution&& distribution, const LayoutInfo& layout)
 }
 
 template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution&& distribution, const LayoutInfo& layout,
-                          ElementType* ptr) noexcept
+Matrix<T, device>::Matrix(Distribution distribution, const LayoutInfo& layout, ElementType* ptr) noexcept
     : Matrix<const T, device>(std::move(distribution), layout, ptr) {}
 
 template <class T, Device device>

--- a/include/dlaf/matrix.tpp
+++ b/include/dlaf/matrix.tpp
@@ -21,8 +21,7 @@ Matrix<T, device>::Matrix(const GlobalElementSize& size, const TileElementSize& 
     : Matrix<T, device>(Distribution(size, block_size, comm.size(), comm.rank(), {0, 0})) {}
 
 template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution distribution)
-    : Matrix<const T, device>(std::move(distribution)) {
+Matrix<T, device>::Matrix(Distribution distribution) : Matrix<const T, device>(std::move(distribution)) {
   const SizeType alignment = 64;
   const SizeType ld =
       std::max<SizeType>(1,

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -18,6 +18,7 @@
 #include "dlaf/util_matrix.h"
 
 namespace dlaf {
+namespace matrix {
 
 /// Copy values from another matrix.
 ///
@@ -37,8 +38,9 @@ void copy(MatrixTypeSrc<const T, device>& source, MatrixTypeDst<T, device>& dest
 
   for (SizeType j = 0; j < local_tile_cols; ++j)
     for (SizeType i = 0; i < local_tile_rows; ++i)
-      hpx::dataflow(hpx::util::unwrapping(dlaf::copy<T>), source.read(LocalTileIndex(i, j)),
+      hpx::dataflow(hpx::util::unwrapping(copy<T>), source.read(LocalTileIndex(i, j)),
                     dest(LocalTileIndex(i, j)));
 }
 
+}
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -16,10 +16,12 @@
 #include "dlaf/matrix/tile.h"
 
 namespace dlaf {
+namespace matrix {
 
 template <class T>
-void copy(const matrix::Tile<const T, Device::CPU>& source, const matrix::Tile<T, Device::CPU>& dest) {
+void copy(const Tile<const T, Device::CPU>& source, const Tile<T, Device::CPU>& dest) {
   dlaf::tile::lacpy<T>(source, dest);
 }
 
+}
 }

--- a/include/dlaf/matrix/distribution.h
+++ b/include/dlaf/matrix/distribution.h
@@ -227,7 +227,8 @@ public:
   /// @pre 0 <= local_tile < localNrTiles().get<rc>().
   template <Coord rc>
   SizeType globalTileFromLocalTile(SizeType local_tile) const noexcept {
-    DLAF_ASSERT_HEAVY(0 <= local_tile && local_tile < local_nr_tiles_.get<rc>(), "");
+    DLAF_ASSERT_HEAVY(0 <= local_tile && local_tile < local_nr_tiles_.get<rc>(), local_tile,
+                      local_nr_tiles_.get<rc>());
     return util::matrix::globalTileFromLocalTile(local_tile, grid_size_.get<rc>(), rank_index_.get<rc>(),
                                                  source_rank_index_.get<rc>());
   }

--- a/include/dlaf/matrix/layout_info.h
+++ b/include/dlaf/matrix/layout_info.h
@@ -39,11 +39,10 @@ public:
   ///   @pre tile_offset_col >= 1;
   /// - if !size.isEmpty():
   ///   @pre tile_ld >= max(size.rows(), block_size.rows()),
-  ///   @pre tile_row_offset >= block_size.rows(),
-  ///   @pre tile_col_offset >= size of the memory (in elements, padding included)
+  ///   @pre tile_offset_row >= block_size.rows(),
+  ///   @pre tile_offset_col >= size of the memory (in elements, padding included)
   ///      to store a column of tiles;
   ///   @pre the tiles should not overlap (combinations of @p tile_ld, @p tile_row_offset).
-
   LayoutInfo(const LocalElementSize& size, const TileElementSize& block_size, SizeType tile_ld,
              SizeType tile_offset_row, SizeType tile_offset_col);
 
@@ -64,7 +63,7 @@ public:
   ///
   /// @pre index.isIn(nr_tiles_).
   SizeType tileOffset(const LocalTileIndex& index) const noexcept {
-    DLAF_ASSERT_HEAVY(index.isIn(nr_tiles_), "");
+    DLAF_ASSERT_HEAVY(index.isIn(nr_tiles_), index, nr_tiles_);
     return index.row() * tile_offset_row_ + index.col() * tile_offset_col_;
   }
 

--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -21,7 +21,7 @@ namespace internal {
 
 class MatrixBase {
 public:
-  MatrixBase(Distribution&& distribution)
+  MatrixBase(Distribution distribution)
       : distribution_(std::make_shared<Distribution>(std::move(distribution))) {}
 
   MatrixBase(const MatrixBase& rhs) = default;

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -98,7 +98,7 @@ public:
   ///
   /// @pre index.isIn(size()).
   const T* ptr(const TileElementIndex& index) const noexcept {
-    DLAF_ASSERT_HEAVY(index.isIn(size_), "");
+    DLAF_ASSERT_HEAVY(index.isIn(size_), index, size_);
     return memory_view_(index.row() + static_cast<SizeType>(ld_) * index.col());
   }
 
@@ -173,7 +173,7 @@ public:
   ///
   /// @pre index.isIn(size()).
   T* ptr(const TileElementIndex& index) const noexcept {
-    DLAF_ASSERT_HEAVY(index.isIn(size_), "");
+    DLAF_ASSERT_HEAVY(index.isIn(size_), index, size_);
     return memory_view_(index.row() + ld_ * index.col());
   }
 

--- a/include/dlaf/matrix_const.tpp
+++ b/include/dlaf/matrix_const.tpp
@@ -77,13 +77,6 @@ hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
 }
 
 template <class T, Device device>
-Matrix<const T, device>::Matrix(Distribution distribution,
-                                std::vector<hpx::future<TileType>> tile_futures,
-                                std::vector<hpx::shared_future<ConstTileType>> tile_shared_futures)
-    : MatrixBase(std::move(distribution)), tile_futures_(std::move(tile_futures)),
-      tile_shared_futures_(std::move(tile_shared_futures)) {}
-
-template <class T, Device device>
 void Matrix<const T, device>::setUpTiles(const memory::MemoryView<ElementType, device>& mem,
                                          const LayoutInfo& layout) noexcept {
   const auto& nr_tiles = layout.nrTiles();

--- a/include/dlaf/matrix_const.tpp
+++ b/include/dlaf/matrix_const.tpp
@@ -19,7 +19,7 @@ Matrix<const T, device>::Matrix(const LayoutInfo& layout, ElementType* ptr)
 }
 
 template <class T, Device device>
-Matrix<const T, device>::Matrix(Distribution&& distribution, const matrix::LayoutInfo& layout,
+Matrix<const T, device>::Matrix(Distribution distribution, const matrix::LayoutInfo& layout,
                                 ElementType* ptr) noexcept
     : MatrixBase(std::move(distribution)) {
   DLAF_ASSERT(this->distribution().localSize() == layout.size(),
@@ -77,9 +77,9 @@ hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
 }
 
 template <class T, Device device>
-Matrix<const T, device>::Matrix(Distribution&& distribution,
-                                std::vector<hpx::future<TileType>>&& tile_futures,
-                                std::vector<hpx::shared_future<ConstTileType>>&& tile_shared_futures)
+Matrix<const T, device>::Matrix(Distribution distribution,
+                                std::vector<hpx::future<TileType>> tile_futures,
+                                std::vector<hpx::shared_future<ConstTileType>> tile_shared_futures)
     : MatrixBase(std::move(distribution)), tile_futures_(std::move(tile_futures)),
       tile_shared_futures_(std::move(tile_shared_futures)) {}
 

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -68,6 +68,7 @@ public:
     rhs.size_ = 0;
     rhs.offset_ = 0;
   }
+
   template <class U = T,
             class = typename std::enable_if_t<std::is_const<U>::value && std::is_same<T, U>::value>>
   MemoryView(MemoryView<ElementType, device>&& rhs)

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -97,7 +97,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
       std::cout << "[" << run_index << "]" << std::endl;
 
     MatrixType matrix(matrix_size, block_size, comm_grid);
-    dlaf::copy(matrix_ref, matrix);
+    copy(matrix_ref, matrix);
 
     // wait all setup tasks before starting benchmark
     {
@@ -140,7 +140,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
         continue;
 
       MatrixType original(matrix_size, block_size, comm_grid);
-      dlaf::copy(matrix_ref, original);
+      copy(matrix_ref, original);
       check_cholesky(original, matrix, comm_grid);
     }
   }

--- a/src/matrix/layout_info.cpp
+++ b/src/matrix/layout_info.cpp
@@ -60,8 +60,8 @@ SizeType LayoutInfo::minMemSize() const noexcept {
 }
 
 SizeType LayoutInfo::minTileMemSize(const TileElementSize& tile_size) const noexcept {
-  DLAF_ASSERT_HEAVY(tile_size.rows() <= block_size_.rows(), "");
-  DLAF_ASSERT_HEAVY(tile_size.cols() <= block_size_.cols(), "");
+  DLAF_ASSERT_HEAVY(tile_size.rows() <= block_size_.rows(), tile_size.rows(), block_size_.rows());
+  DLAF_ASSERT_HEAVY(tile_size.cols() <= block_size_.cols(), tile_size.cols(), block_size_.cols());
 
   if (tile_size.isEmpty()) {
     return 0;

--- a/src/matrix/layout_info.cpp
+++ b/src/matrix/layout_info.cpp
@@ -60,8 +60,8 @@ SizeType LayoutInfo::minMemSize() const noexcept {
 }
 
 SizeType LayoutInfo::minTileMemSize(const TileElementSize& tile_size) const noexcept {
-  DLAF_ASSERT_HEAVY(tile_size.rows() <= block_size_.rows(), tile_size.rows(), block_size_.rows());
-  DLAF_ASSERT_HEAVY(tile_size.cols() <= block_size_.cols(), tile_size.cols(), block_size_.cols());
+  DLAF_ASSERT_HEAVY(tile_size.rows() <= block_size_.rows(), tile_size, block_size_);
+  DLAF_ASSERT_HEAVY(tile_size.cols() <= block_size_.cols(), tile_size, block_size_);
 
   if (tile_size.isEmpty()) {
     return 0;


### PR DESCRIPTION
This PR:
- slightly improves the `Matrix` API not forcing to pass the `Distribution` as an `rvalue`.
- moves the `copy` free functions for both `Matrix` and `Tile` to the `dlaf::matrix` namespace.
- simplifies a constructor

It takes the chance to improve some assertion messages.