### PR TITLE
Allow empty range2d

### DIFF
--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -84,8 +84,8 @@ public:
   IterableRange2D(index2d_t begin_idx, index2d_t end_idx)
       : begin_idx_(begin_idx), ld_(end_idx.row() - begin_idx.row()),
         i_max_(ld_ * (end_idx.col() - begin_idx_.col())) {
-    DLAF_ASSERT(begin_idx.row() < end_idx.row(), begin_idx, end_idx);
-    DLAF_ASSERT(begin_idx.col() < end_idx.col(), begin_idx, end_idx);
+    DLAF_ASSERT(begin_idx.row() <= end_idx.row(), begin_idx, end_idx);
+    DLAF_ASSERT(begin_idx.col() <= end_idx.col(), begin_idx, end_idx);
   }
 
   iter2d_t begin() const noexcept {


### PR DESCRIPTION
I don't know if it was intended or not, but I think that empty ranges are quite useful.

Currently, my use case is a distributed matrix where a rank may or may not have local elements, so it would be nice that, once local range boundaries are computed, the `for (auto local : iterate_range2d)` would just skip without any additional check.

For the moment, I would propose just to remove strictness in the condition, leaving any major implementation changes to the iterator design for future improvements (just if needed).