### PR TITLE
Library initialization/finalization

### DIFF
--- a/include/dlaf/common/callable_object.h
+++ b/include/dlaf/common/callable_object.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2020, ETH Zurich
+// Copyright (c) 2020-2021, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/include/dlaf/common/callable_object.h
+++ b/include/dlaf/common/callable_object.h
@@ -17,11 +17,12 @@
 /// require explicit selection of the overload when passing the function to
 /// higher-order functions. With this wrapper the overload is selected inside
 /// the wrapper's operator().
-#define DLAF_MAKE_CALLABLE_OBJECT(fname)     \
-  constexpr struct fname##_t {               \
-    template <typename... Ts>                \
-    decltype(auto) operator()(Ts&&... ts) {  \
-      return fname(std::forward<Ts>(ts)...); \
-    }                                        \
-  } fname##_o {                              \
+#define DLAF_MAKE_CALLABLE_OBJECT(fname)                                                 \
+  constexpr struct fname##_t {                                                           \
+    template <typename... Ts>                                                            \
+    auto operator()(Ts&&... ts) const noexcept(noexcept(fname(std::forward<Ts>(ts)...))) \
+        -> decltype(fname(std::forward<Ts>(ts)...)) {                                    \
+      return fname(std::forward<Ts>(ts)...);                                             \
+    }                                                                                    \
+  } fname##_o {                                                                          \
   }

--- a/include/dlaf/common/callable_object.h
+++ b/include/dlaf/common/callable_object.h
@@ -1,0 +1,27 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// Given a function name @fname generates a constexpr object with name fname_o
+/// with type fname_t. The generated type has one static operator() which
+/// transparently forwards all arguments to a call to fname. This macro is
+/// useful for creating wrappers of overloaded functions that would otherwise
+/// require explicit selection of the overload when passing the function to
+/// higher-order functions. With this wrapper the overload is selected inside
+/// the wrapper's operator().
+#define DLAF_MAKE_CALLABLE_OBJECT(fname)     \
+  constexpr struct fname##_t {               \
+    template <typename... Ts>                \
+    decltype(auto) operator()(Ts&&... ts) {  \
+      return fname(std::forward<Ts>(ts)...); \
+    }                                        \
+  } fname##_o {                              \
+  }

--- a/include/dlaf/eigensolver/gen_to_std/mc.h
+++ b/include/dlaf/eigensolver/gen_to_std/mc.h
@@ -21,7 +21,7 @@
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/functions_sync.h"
 #include "dlaf/eigensolver/gen_to_std/api.h"
-#include "dlaf/init.h"
+#include "dlaf/executors.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
@@ -53,8 +53,8 @@ void GenToStd<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a
   using hpx::threads::thread_priority;
   using hpx::util::unwrapping;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getHpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   const SizeType m = mat_a.nrTiles().rows();
   const SizeType n = mat_a.nrTiles().cols();

--- a/include/dlaf/eigensolver/gen_to_std/mc.h
+++ b/include/dlaf/eigensolver/gen_to_std/mc.h
@@ -21,6 +21,7 @@
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/functions_sync.h"
 #include "dlaf/eigensolver/gen_to_std/api.h"
+#include "dlaf/init.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
@@ -52,8 +53,8 @@ void GenToStd<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a
   using hpx::threads::thread_priority;
   using hpx::util::unwrapping;
 
-  parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
-  parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
+  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::internal::getHpExecutor<Backend::MC>();
 
   const SizeType m = mat_a.nrTiles().rows();
   const SizeType n = mat_a.nrTiles().cols();
@@ -70,9 +71,9 @@ void GenToStd<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a
       const auto ai_panel = dlaf::common::iterate_range2d(ai_start, ai_end);
 
       for (const auto& ik : ai_panel) {
-        hpx::dataflow(executor_normal, unwrapping(tile::trsm<T, Device::CPU>), Right, Lower, ConjTrans,
+        hpx::dataflow(executor_np, unwrapping(tile::trsm<T, Device::CPU>), Right, Lower, ConjTrans,
                       NonUnit, 1.0, mat_l.read(kk), mat_a(ik));
-        hpx::dataflow(executor_normal, unwrapping(tile::hemm<T, Device::CPU>), Right, Lower, -0.5,
+        hpx::dataflow(executor_np, unwrapping(tile::hemm<T, Device::CPU>), Right, Lower, -0.5,
                       mat_a.read(kk), mat_l.read(ik), 1.0, mat_a(ik));
       }
 
@@ -88,10 +89,10 @@ void GenToStd<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a
                         mat_a.read(jk), mat_l.read(jk), 1.0, mat_a(ij));
         }
         else if (ij.row() > ij.col()) {
-          hpx::dataflow(executor_normal, unwrapping(tile::gemm<T, Device::CPU>), NoTrans, ConjTrans,
-                        -1.0, mat_a.read(ik), mat_l.read(jk), 1.0, mat_a(ij));
-          hpx::dataflow(executor_normal, unwrapping(tile::gemm<T, Device::CPU>), NoTrans, ConjTrans,
-                        -1.0, mat_l.read(ik), mat_a.read(jk), 1.0, mat_a(ij));
+          hpx::dataflow(executor_np, unwrapping(tile::gemm<T, Device::CPU>), NoTrans, ConjTrans, -1.0,
+                        mat_a.read(ik), mat_l.read(jk), 1.0, mat_a(ij));
+          hpx::dataflow(executor_np, unwrapping(tile::gemm<T, Device::CPU>), NoTrans, ConjTrans, -1.0,
+                        mat_l.read(ik), mat_a.read(jk), 1.0, mat_a(ij));
         }
       }
 
@@ -109,7 +110,7 @@ void GenToStd<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a
         for (SizeType i = j + 1; i < m; ++i) {
           const auto ij = LocalTileIndex{i, j};
           const auto ik = LocalTileIndex{i, k};
-          hpx::dataflow(executor_normal, unwrapping(tile::gemm<T, Device::CPU>), NoTrans, NoTrans, -1.0,
+          hpx::dataflow(executor_np, unwrapping(tile::gemm<T, Device::CPU>), NoTrans, NoTrans, -1.0,
                         mat_l.read(ij), mat_a.read(jk), 1.0, mat_a(ik));
         }
       }

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2020, ETH Zurich
+// Copyright (c) 2020-2021, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -1,0 +1,120 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/execution.hpp>
+#include <hpx/thread.hpp>
+
+#ifdef DLAF_WITH_CUDA
+#include <hpx/modules/async_cuda.hpp>
+#endif
+
+#include <dlaf/communication/executor.h>
+#include <dlaf/init.h>
+#include <dlaf/types.h>
+
+#ifdef DLAF_WITH_CUDA
+#include <dlaf/cublas/executor.h>
+#endif
+
+namespace dlaf {
+namespace internal {
+template <Backend B>
+struct GetMPIExecutor {
+  static auto call() {
+    return hpx::execution::parallel_executor(&hpx::resource::get_thread_pool(
+                                                 comm::internal::mpi_pool_exists() ? "mpi" : "default"),
+                                             hpx::threads::thread_priority_high);
+  }
+};
+
+template <Backend B>
+struct GetNpExecutor {
+  static auto call() {
+    return hpx::execution::parallel_executor{hpx::threads::thread_priority::normal};
+  }
+};
+
+#ifdef DLAF_WITH_CUDA
+template <>
+struct GetNpExecutor<Backend::GPU> {
+  static auto call() {
+    return dlaf::cublas::Executor{getNpCudaStreamPool(), getCublasHandlePool()};
+  }
+};
+#endif
+
+template <Backend B>
+struct GetHpExecutor {
+  static auto call() {
+    return hpx::execution::parallel_executor{hpx::threads::thread_priority::high};
+  }
+};
+
+#ifdef DLAF_WITH_CUDA
+template <>
+struct GetHpExecutor<Backend::GPU> {
+  static auto call() {
+    return dlaf::cublas::Executor{getHpCudaStreamPool(), getCublasHandlePool()};
+  }
+};
+#endif
+
+template <Device S, Device D>
+struct GetCopyExecutor {
+  static auto call() {
+    return hpx::execution::parallel_executor{};
+  }
+};
+
+#ifdef DLAF_WITH_CUDA
+template <>
+struct GetCopyExecutor<Device::GPU, Device::CPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{getNpCudaStreamPool()};
+  }
+};
+
+template <>
+struct GetCopyExecutor<Device::CPU, Device::GPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{getNpCudaStreamPool()};
+  }
+};
+
+template <>
+struct GetCopyExecutor<Device::GPU, Device::GPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{getNpCudaStreamPool()};
+  }
+};
+#endif
+}
+
+template <Backend B>
+decltype(auto) getMPIExecutor() {
+  return internal::GetMPIExecutor<B>::call();
+}
+
+template <Backend B>
+decltype(auto) getNpExecutor() {
+  return internal::GetNpExecutor<B>::call();
+}
+
+template <Backend B>
+decltype(auto) getHpExecutor() {
+  return internal::GetHpExecutor<B>::call();
+}
+
+template <Device S, Device D>
+decltype(auto) getCopyExecutor() {
+  return internal::GetCopyExecutor<S, D>::call();
+}
+}

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -28,7 +28,8 @@ namespace internal {
 template <Device S, Device D>
 struct GetCopyExecutor {
   static auto call() {
-    return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default")};
+    return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default"),
+                                             hpx::threads::thread_priority::normal};
   }
 };
 
@@ -72,7 +73,8 @@ auto getMPIExecutor() {
 /// @tparam B backend with which the executor should be used.
 template <Backend B>
 auto getNpExecutor() {
-  return hpx::execution::parallel_executor{hpx::threads::thread_priority::normal};
+  return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default"),
+                                           hpx::threads::thread_priority::normal};
 }
 
 #ifdef DLAF_WITH_CUDA
@@ -88,7 +90,8 @@ inline auto getNpExecutor<Backend::GPU>() {
 /// @tparam B backend with which the executor should be used.
 template <Backend B>
 auto getHpExecutor() {
-  return hpx::execution::parallel_executor{hpx::threads::thread_priority::high};
+  return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default"),
+                                           hpx::threads::thread_priority::high};
 }
 
 #ifdef DLAF_WITH_CUDA

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -57,7 +57,7 @@ struct GetCopyExecutor<Device::GPU, Device::GPU> {
 #endif
 }
 
-/// Returns an MPI executor approprate for use with the given backend.
+/// Returns an MPI executor appropriate for use with the given backend.
 ///
 /// @tparam B backend with which the executor should be used.
 template <Backend B>
@@ -67,7 +67,7 @@ auto getMPIExecutor() {
                                            hpx::threads::thread_priority::high};
 }
 
-/// Returns a normal priority executor approprate for use with the given
+/// Returns a normal priority executor appropriate for use with the given
 /// backend.
 ///
 /// @tparam B backend with which the executor should be used.
@@ -84,7 +84,7 @@ inline auto getNpExecutor<Backend::GPU>() {
 }
 #endif
 
-/// Returns a high priority executor approprate for use with the given
+/// Returns a high priority executor appropriate for use with the given
 /// backend.
 ///
 /// @tparam B backend with which the executor should be used.

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -98,21 +98,36 @@ struct GetCopyExecutor<Device::GPU, Device::GPU> {
 #endif
 }
 
+/// Returns an MPI executor approprate for use with the given backend.
+///
+/// @tparam B backend with which the executor should be used.
 template <Backend B>
 decltype(auto) getMPIExecutor() {
   return internal::GetMPIExecutor<B>::call();
 }
 
+/// Returns a normal priority executor approprate for use with the given
+/// backend.
+///
+/// @tparam B backend with which the executor should be used.
 template <Backend B>
 decltype(auto) getNpExecutor() {
   return internal::GetNpExecutor<B>::call();
 }
 
+/// Returns a high priority executor approprate for use with the given
+/// backend.
+///
+/// @tparam B backend with which the executor should be used.
 template <Backend B>
 decltype(auto) getHpExecutor() {
   return internal::GetHpExecutor<B>::call();
 }
 
+/// Returns an executor appropriate for copying from @tparam S to @tparam D.
+///
+/// @tparam S source device.
+/// @tparam D destination device.
 template <Device S, Device D>
 decltype(auto) getCopyExecutor() {
   return internal::GetCopyExecutor<S, D>::call();

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -62,10 +62,8 @@ struct GetCopyExecutor<Device::GPU, Device::GPU> {
 template <Backend B>
 auto getMPIExecutor() {
   return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool(
-                                                            hpx::resource::pool_exists("mpi")
-                                                                ? "mpi"
-                                                                : "default"),
-                                                        hpx::threads::thread_priority::high};
+                                               hpx::resource::pool_exists("mpi") ? "mpi" : "default"),
+                                           hpx::threads::thread_priority::high};
 }
 
 /// Returns a normal priority executor approprate for use with the given

--- a/include/dlaf/factorization/cholesky/mc.h
+++ b/include/dlaf/factorization/cholesky/mc.h
@@ -24,8 +24,8 @@
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/functions_sync.h"
+#include "dlaf/executors.h"
 #include "dlaf/factorization/cholesky/api.h"
-#include "dlaf/init.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix/distribution.h"
 
@@ -80,8 +80,8 @@ struct Cholesky<Backend::MC, Device::CPU, T> {
 
 template <class T>
 void Cholesky<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a) {
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -120,9 +120,9 @@ void Cholesky<Backend::MC, Device::CPU, T>::call_L(comm::CommunicatorGrid grid,
                                                    Matrix<T, Device::CPU>& mat_a) {
   using ConstTileType = typename Matrix<T, Device::CPU>::ConstTileType;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
-  auto executor_mpi = dlaf::internal::getMPIExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
+  auto executor_mpi = dlaf::getMPIExecutor<Backend::MC>();
 
   // Set up MPI executor
   comm::Index2D this_rank = grid.rank();

--- a/include/dlaf/factorization/cholesky/mc.h
+++ b/include/dlaf/factorization/cholesky/mc.h
@@ -47,18 +47,17 @@ template <class T>
 void trsm_panel_tile(hpx::execution::parallel_executor executor_hp,
                      hpx::shared_future<matrix::Tile<const T, Device::CPU>> kk_tile,
                      hpx::future<matrix::Tile<T, Device::CPU>> matrix_tile) {
-  hpx::dataflow(executor_hp, hpx::util::unwrapping(tile::trsm<T, Device::CPU>),
-                blas::Side::Right, blas::Uplo::Lower, blas::Op::ConjTrans, blas::Diag::NonUnit, 1.0,
-                std::move(kk_tile), std::move(matrix_tile));
+  hpx::dataflow(executor_hp, hpx::util::unwrapping(tile::trsm<T, Device::CPU>), blas::Side::Right,
+                blas::Uplo::Lower, blas::Op::ConjTrans, blas::Diag::NonUnit, 1.0, std::move(kk_tile),
+                std::move(matrix_tile));
 }
 
 template <class T>
 void herk_trailing_diag_tile(hpx::execution::parallel_executor trailing_matrix_executor,
                              hpx::shared_future<matrix::Tile<const T, Device::CPU>> panel_tile,
                              hpx::future<matrix::Tile<T, Device::CPU>> matrix_tile) {
-  hpx::dataflow(trailing_matrix_executor,
-                hpx::util::unwrapping(tile::herk<T, Device::CPU>), blas::Uplo::Lower, blas::Op::NoTrans,
-                -1.0, panel_tile, 1.0, std::move(matrix_tile));
+  hpx::dataflow(trailing_matrix_executor, hpx::util::unwrapping(tile::herk<T, Device::CPU>),
+                blas::Uplo::Lower, blas::Op::NoTrans, -1.0, panel_tile, 1.0, std::move(matrix_tile));
 }
 
 template <class T>
@@ -66,10 +65,9 @@ void gemm_trailing_matrix_tile(hpx::execution::parallel_executor trailing_matrix
                                hpx::shared_future<matrix::Tile<const T, Device::CPU>> panel_tile,
                                hpx::shared_future<matrix::Tile<const T, Device::CPU>> col_panel,
                                hpx::future<matrix::Tile<T, Device::CPU>> matrix_tile) {
-  hpx::dataflow(trailing_matrix_executor,
-                hpx::util::unwrapping(tile::gemm<T, Device::CPU>), blas::Op::NoTrans,
-                blas::Op::ConjTrans, -1.0, std::move(panel_tile), std::move(col_panel), 1.0,
-                std::move(matrix_tile));
+  hpx::dataflow(trailing_matrix_executor, hpx::util::unwrapping(tile::gemm<T, Device::CPU>),
+                blas::Op::NoTrans, blas::Op::ConjTrans, -1.0, std::move(panel_tile),
+                std::move(col_panel), 1.0, std::move(matrix_tile));
 }
 
 template <class T>

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -38,6 +38,7 @@ std::ostream& operator<<(std::ostream& os, configuration const& cfg);
 
 namespace internal {
 bool& initialized();
+configuration& getConfiguration();
 
 template <Backend D>
 struct Init {
@@ -61,7 +62,7 @@ cublas::HandlePool getCublasHandlePool();
 }
 
 /// Returns the DLA-Future command-line options description.
-hpx::program_options::options_description get_options_description();
+hpx::program_options::options_description getOptionsDescription();
 
 /// Initialize DLA-Future.
 ///
@@ -69,7 +70,7 @@ hpx::program_options::options_description get_options_description();
 /// be used when the application is using hpx::program_options for its own
 /// command-line parsing needs. The user is responsible for ensuring that
 /// DLA-Future command-line options are parsed. The DLA-Future options can be
-/// retrieved with dlaf::get_options_description.
+/// retrieved with dlaf::getOptionsDescription.
 ///
 /// @param vm parsed command-line options as provided by the application entry point.
 /// @param user_cfg user-provided default configuration. Takes precedence over
@@ -84,7 +85,7 @@ void initialize(hpx::program_options::variables_map const& vm, configuration con
 /// @param argv as provided by the application entry point.
 /// @param user_cfg user-provided default configuration. Takes precedence over
 /// DLA-Future defaults.
-void initialize(int argc, char** argv, configuration const& user_cfg = {});
+void initialize(int argc, const char* const argv[], configuration const& user_cfg = {});
 
 /// Finalize DLA-Future.
 ///

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2020, ETH Zurich
+// Copyright (c) 2020-2021, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -25,6 +25,10 @@
 #endif
 
 namespace dlaf {
+/// DLA-Future configuration.
+///
+/// Holds configuration values that can be used to customize DLA-Future through
+/// dlaf::initialize.
 struct configuration {
   std::size_t num_np_cuda_streams_per_thread = 3;
   std::size_t num_hp_cuda_streams_per_thread = 3;
@@ -44,48 +48,46 @@ struct Init {
 };
 
 #ifdef DLAF_WITH_CUDA
-void initializeNpCudaStreamPool(int device, std::size_t num_streams_per_thread);
-void finalizeNpCudaStreamPool();
-cuda::StreamPool getNpCudaStreamPool();
-
-void initializeHpCudaStreamPool(int device, std::size_t num_streams_per_thread);
-void finalizeHpCudaStreamPool();
-cuda::StreamPool getHpCudaStreamPool();
-
-void initializeCublasHandlePool();
-void finalizeCublasHandlePool();
-cublas::HandlePool getCublasHandlePool();
-
 template <>
-struct Init<Backend::GPU> {
-  static void initialize(configuration const& cfg) {
-    // TODO: Do we already want to expose this? Not properly supported by
-    // backend (i.e. only one device at a time supported).
-    const int device = 0;
-    initializeNpCudaStreamPool(device, cfg.num_np_cuda_streams_per_thread);
-    initializeHpCudaStreamPool(device, cfg.num_hp_cuda_streams_per_thread);
-    initializeCublasHandlePool();
-    hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool("default"));
-  }
+void Init<Backend::GPU>::initialize(configuration const&);
+template <>
+void Init<Backend::GPU>::finalize();
+extern template struct Init<Backend::GPU>;
 
-  static void finalize() {
-    finalizeNpCudaStreamPool();
-    finalizeHpCudaStreamPool();
-    finalizeCublasHandlePool();
-    hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool("default"));
-  }
-};
+cuda::StreamPool getNpCudaStreamPool();
+cuda::StreamPool getHpCudaStreamPool();
+cublas::HandlePool getCublasHandlePool();
 #endif
-
-template <typename T>
-void update_configuration(hpx::program_options::variables_map const& vm, T& var,
-                          std::string const& cmdline_option, std::string const& env_var);
-configuration get_configuration(hpx::program_options::variables_map const& vm,
-                                configuration const& user_cfg);
 }
 
+/// Returns the DLA-Future command-line options description.
 hpx::program_options::options_description get_options_description();
+
+/// Initialize DLA-Future.
+///
+/// Should be called once before every dlaf::finalize call. This overload can
+/// be used when the application is using hpx::program_options for its own
+/// command-line parsing needs. The user is responsible for ensuring that
+/// DLA-Future command-line options are parsed. The DLA-Future options can be
+/// retrieved with dlaf::get_options_description.
+///
+/// @param vm parsed command-line options as provided by the application entry point.
+/// @param user_cfg user-provided default configuration. Takes precedence over
+/// DLA-Future defaults.
 void initialize(hpx::program_options::variables_map const& vm, configuration const& user_cfg = {});
+
+/// Initialize DLA-Future.
+///
+/// Should be called once before every dlaf::finalize call.
+///
+/// @param argc as provided by the application entry point.
+/// @param argv as provided by the application entry point.
+/// @param user_cfg user-provided default configuration. Takes precedence over
+/// DLA-Future defaults.
 void initialize(int argc, char** argv, configuration const& user_cfg = {});
+
+/// Finalize DLA-Future.
+///
+/// Should be called once after every dlaf::initialize call.
 void finalize();
 }

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -9,9 +9,12 @@
 //
 #pragma once
 
+#include <iostream>
+
 #include <hpx/execution.hpp>
 #include <hpx/functional.hpp>
 #include <hpx/include/resource_partitioner.hpp>
+#include <hpx/program_options.hpp>
 #include <hpx/thread.hpp>
 
 #ifdef DLAF_WITH_CUDA
@@ -25,6 +28,13 @@
 #endif
 
 namespace dlaf {
+struct configuration {
+  std::size_t num_np_cuda_streams_per_thread = 3;
+  std::size_t num_hp_cuda_streams_per_thread = 3;
+};
+
+std::ostream& operator<<(std::ostream& os, configuration const& cfg);
+
 namespace internal {
 bool& initialized();
 
@@ -32,16 +42,16 @@ template <Backend D>
 struct Init {
   // Initialization and finalization does nothing by default. Behaviour can be
   // overridden for backends.
-  static void initialize(int, char**) {}
+  static void initialize(configuration const&) {}
   static void finalize() {}
 };
 
 #ifdef DLAF_WITH_CUDA
-void initializeNpCudaStreamPool();
+void initializeNpCudaStreamPool(int device, std::size_t num_streams_per_thread);
 void finalizeNpCudaStreamPool();
 cuda::StreamPool getNpCudaStreamPool();
 
-void initializeHpCudaStreamPool();
+void initializeHpCudaStreamPool(int device, std::size_t num_streams_per_thread);
 void finalizeHpCudaStreamPool();
 cuda::StreamPool getHpCudaStreamPool();
 
@@ -51,9 +61,12 @@ cublas::HandlePool getCublasHandlePool();
 
 template <>
 struct Init<Backend::GPU> {
-  static void initialize(int, char**) {
-    initializeNpCudaStreamPool();
-    initializeHpCudaStreamPool();
+  static void initialize(configuration const& cfg) {
+    // TODO: Do we already want to expose this? Not properly supported by
+    // backend (i.e. only one device at a time supported).
+    const int device = 0;
+    initializeNpCudaStreamPool(device, cfg.num_np_cuda_streams_per_thread);
+    initializeHpCudaStreamPool(device, cfg.num_hp_cuda_streams_per_thread);
     initializeCublasHandlePool();
     hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
   }
@@ -157,23 +170,16 @@ template <Device S, Device D>
 decltype(auto) getCopyExecutor() {
   return GetCopyExecutor<S, D>::call();
 }
+
+template <typename T>
+void update_configuration(hpx::program_options::variables_map const& vm, T& var,
+                          std::string const& cmdline_option, std::string const& env_var);
+configuration get_configuration(hpx::program_options::variables_map const& vm,
+                                configuration const& user_cfg);
 }
 
-inline void initialize(int argc, char** argv) {
-  DLAF_ASSERT(!internal::initialized(), "");
-  internal::Init<Backend::MC>::initialize(argc, argv);
-#ifdef DLAF_WITH_CUDA
-  internal::Init<Backend::GPU>::initialize(argc, argv);
-#endif
-  internal::initialized() = true;
-}
-
-inline void finalize() {
-  DLAF_ASSERT(internal::initialized(), "");
-  internal::Init<Backend::MC>::finalize();
-#ifdef DLAF_WITH_CUDA
-  internal::Init<Backend::GPU>::finalize();
-#endif
-  internal::initialized() = false;
-}
+hpx::program_options::options_description get_options_description();
+void initialize(hpx::program_options::variables_map const& vm, configuration const& user_cfg = {});
+void initialize(int argc, char** argv, configuration const& user_cfg = {});
+void finalize();
 }

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -1,0 +1,122 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/execution.hpp>
+#include <hpx/functional.hpp>
+#include <hpx/include/resource_partitioner.hpp>
+
+#ifdef DLAF_WITH_CUDA
+#include <hpx/modules/async_cuda.hpp>
+#endif
+
+#include <dlaf/types.h>
+
+#ifdef DLAF_WITH_CUDA
+#include <dlaf/cublas/executor.h>
+#endif
+
+namespace dlaf {
+namespace internal {
+bool& initialized();
+
+template <Backend D>
+struct Init {
+  // Initialization and finalization does nothing by default. Behaviour can be
+  // overridden for backends.
+  static void initialize(int, char**) {}
+  static void finalize() {}
+};
+
+#ifdef DLAF_WITH_CUDA
+void initializeNpCudaStreamPool();
+void finalizeNpCudaStreamPool();
+cuda::StreamPool getNpCudaStreamPool();
+
+void initializeHpCudaStreamPool();
+void finalizeHpCudaStreamPool();
+cuda::StreamPool getHpCudaStreamPool();
+
+void initializeCublasHandlePool();
+void finalizeCublasHandlePool();
+cublas::HandlePool getCublasHandlePool();
+
+template <>
+struct Init<Backend::GPU> {
+  static void initialize(int, char**) {
+    initializeNpCudaStreamPool();
+    initializeHpCudaStreamPool();
+    initializeCublasHandlePool();
+    hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
+  }
+
+  static void finalize() {
+    finalizeNpCudaStreamPool();
+    finalizeHpCudaStreamPool();
+    finalizeCublasHandlePool();
+    hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
+  }
+};
+#endif
+
+template <Device S, Device D>
+struct GetCopyExecutor {
+  static auto call() {
+    return hpx::execution::parallel_executor{};
+  }
+};
+
+#ifdef DLAF_WITH_CUDA
+template <>
+struct GetCopyExecutor<Device::GPU, Device::CPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{getNpCudaStreamPool()};
+  }
+};
+
+template <>
+struct GetCopyExecutor<Device::CPU, Device::GPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{getNpCudaStreamPool()};
+  }
+};
+
+template <>
+struct GetCopyExecutor<Device::GPU, Device::GPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{getNpCudaStreamPool()};
+  }
+};
+#endif
+
+template <Device S, Device D>
+decltype(auto) getCopyExecutor() {
+  return GetCopyExecutor<S, D>::call();
+}
+}
+
+inline void initialize(int argc, char** argv) {
+  DLAF_ASSERT(!internal::initialized(), "");
+  internal::Init<Backend::MC>::initialize(argc, argv);
+#ifdef DLAF_WITH_CUDA
+  internal::Init<Backend::GPU>::initialize(argc, argv);
+#endif
+  internal::initialized() = true;
+}
+
+inline void finalize() {
+  DLAF_ASSERT(internal::initialized(), "");
+  internal::Init<Backend::MC>::finalize();
+#ifdef DLAF_WITH_CUDA
+  internal::Init<Backend::GPU>::finalize();
+#endif
+  internal::initialized() = false;
+}
+}

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -13,7 +13,7 @@
 #include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
 
-#include "dlaf/init.h"
+#include "dlaf/executors.h"
 #include "dlaf/matrix/copy_tile.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
@@ -38,7 +38,7 @@ void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
 
   for (SizeType j = 0; j < local_tile_cols; ++j)
     for (SizeType i = 0; i < local_tile_rows; ++i)
-      hpx::dataflow(dlaf::internal::getCopyExecutor<Source, Destination>(), unwrapExtendTiles(copy_o),
+      hpx::dataflow(dlaf::getCopyExecutor<Source, Destination>(), unwrapExtendTiles(copy_o),
                     source.read(LocalTileIndex(i, j)), dest(LocalTileIndex(i, j)));
 }
 }

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -13,6 +13,7 @@
 #include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
 
+#include "dlaf/init.h"
 #include "dlaf/matrix/copy_tile.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
@@ -35,14 +36,10 @@ void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
   const SizeType local_tile_rows = distribution.localNrTiles().rows();
   const SizeType local_tile_cols = distribution.localNrTiles().cols();
 
-  // This prevents a compiler error in `hpx::util::unwrapping()` which is unable to deduce the correct
-  // overload for tile `copy()`.
-  void (&cpy)(const matrix::Tile<const T, Source>&, const matrix::Tile<T, Destination>&) = copy<T>;
-
   for (SizeType j = 0; j < local_tile_cols; ++j)
     for (SizeType i = 0; i < local_tile_rows; ++i)
-      hpx::dataflow(hpx::util::unwrapping(cpy), source.read(LocalTileIndex(i, j)),
-                    dest(LocalTileIndex(i, j)));
+      hpx::dataflow(dlaf::internal::getCopyExecutor<Source, Destination>(), unwrapExtendTiles(copy_o),
+                    source.read(LocalTileIndex(i, j)), dest(LocalTileIndex(i, j)));
 }
 }
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -18,6 +18,7 @@
 #include "dlaf/cuda/error.h"
 #endif
 
+#include "dlaf/common/callable_object.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix/tile.h"
 
@@ -46,6 +47,16 @@ struct CopyTile<T, Device::CPU, Device::GPU> {
     DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
                                 source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
   }
+
+  static void call(const matrix::Tile<const T, Device::CPU>& source,
+                   const matrix::Tile<T, Device::GPU>& destination, cudaStream_t stream) {
+    SizeType m = source.size().rows();
+    SizeType n = source.size().cols();
+
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
+                                     source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
+                                     stream));
+  }
 };
 
 template <typename T>
@@ -57,6 +68,16 @@ struct CopyTile<T, Device::GPU, Device::CPU> {
 
     DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
                                 source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
+  }
+
+  static void call(const matrix::Tile<const T, Device::GPU>& source,
+                   const matrix::Tile<T, Device::CPU>& destination, cudaStream_t stream) {
+    SizeType m = source.size().rows();
+    SizeType n = source.size().cols();
+
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
+                                     source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
+                                     stream));
   }
 };
 
@@ -70,17 +91,27 @@ struct CopyTile<T, Device::GPU, Device::GPU> {
     DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
                                 source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
   }
+
+  static void call(const matrix::Tile<const T, Device::GPU>& source,
+                   const matrix::Tile<T, Device::GPU>& destination, cudaStream_t stream) {
+    SizeType m = source.size().rows();
+    SizeType n = source.size().cols();
+
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
+                                     source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
+                                     stream));
+  }
 };
 #endif
 }
 
-template <typename T, Device Source, Device Destination>
-void copy(const Tile<const T, Source>& source, const Tile<T, Destination>& destination) {
+template <typename T, Device Source, Device Destination, typename... Ts>
+void copy(const Tile<const T, Source>& source, const Tile<T, Destination>& destination, Ts&&... ts) {
   DLAF_ASSERT_HEAVY(source.size().rows() == destination.size().rows(),
                     "number of rows in source and destination tiles must be equal for tile copy");
   DLAF_ASSERT_HEAVY(source.size().cols() == destination.size().cols(),
                     "number of columns in source and destination tiles must be equal for tile copy");
-  internal::CopyTile<T, Source, Destination>::call(source, destination);
+  internal::CopyTile<T, Source, Destination>::call(source, destination, std::forward<Ts>(ts)...);
 }
 
 template <class T>
@@ -89,5 +120,6 @@ void copy(TileElementSize region, TileElementIndex in_idx, const matrix::Tile<co
   dlaf::tile::lacpy<T>(region, in_idx, in, out_idx, out);
 }
 
+DLAF_MAKE_CALLABLE_OBJECT(copy);
 }
 }

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -241,15 +241,16 @@ struct UnwrapExtendTiles {
 };
 }
 
-/// Custom version of hpx::util::unwrapping, which unwraps and forwards all
-/// arguments to the function f, but also returns all arguments as they are with
-/// the exception of future<Tile> arguments. future<Tile> arguments are returned
-/// unwrapped (as getting the value from the future leaves the future empty).
-/// The return value of f is ignored. This wrapper is useful for extending the
-/// lifetimes of tiles with custom executors such as the CUDA/cuBLAS executors,
-/// where f returns immediately, but the tiles must be kept alive until the
-/// completion of the operation. The wrapper can be used with "normal" blocking
-/// host-side operations as well.
+/// Custom version of hpx::util::unwrapping for tile lifetime management.
+///
+/// Unwraps and forwards all arguments to the function f, but also returns all
+/// arguments as they are with the exception of future<Tile> arguments.
+/// future<Tile> arguments are returned unwrapped (as getting the value from the
+/// future leaves the future empty).  The return value of f is ignored. This
+/// wrapper is useful for extending the lifetimes of tiles with custom executors
+/// such as the CUDA/cuBLAS executors, where f returns immediately, but the
+/// tiles must be kept alive until the completion of the operation. The wrapper
+/// can be used with "normal" blocking host-side operations as well.
 template <typename F>
 auto unwrapExtendTiles(F&& f) {
   return internal::UnwrapExtendTiles<std::decay_t<F>>{std::forward<F>(f)};

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -13,7 +13,9 @@
 #include <exception>
 #include <ostream>
 
+#include <hpx/functional.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/tuple.hpp>
 
 #include "dlaf/common/data_descriptor.h"
 #include "dlaf/matrix/index.h"
@@ -197,6 +199,60 @@ private:
 template <class T, Device device>
 auto create_data(const Tile<T, device>& tile) {
   return common::DataDescriptor<T>(tile.ptr({0, 0}), tile.size().cols(), tile.size().rows(), tile.ld());
+}
+
+namespace internal {
+/// Gets the value from future<Tile>, and forwards all other types unchanged.
+template <typename T>
+struct UnwrapFuture {
+  template <typename U>
+  static decltype(auto) call(U&& u) {
+    return std::forward<U>(u);
+  }
+};
+
+template <typename T, Device D>
+struct UnwrapFuture<hpx::future<Tile<T, D>>> {
+  template <typename U>
+  static auto call(U&& u) {
+    auto t = u.get();
+    return t;
+  }
+};
+
+/// Callable object used for the unwrapExtendTiles function below.
+template <typename F>
+struct UnwrapExtendTiles {
+  F f;
+
+  template <typename... Ts>
+  auto operator()(Ts&&... ts) {
+    // Extract values from futures (not shared_futures).
+    auto t = hpx::make_tuple<>(UnwrapFuture<std::decay_t<Ts>>::call(std::forward<Ts>(ts))...);
+
+    // Call f with all futures (not just future<Tile>) unwrapped.
+    hpx::invoke_fused(hpx::util::unwrapping(f), t);
+
+    // Finally, we extend the lifetime of read-write tiles directly and
+    // read-only tiles wrapped in shared_futures by returning them here in a
+    // tuple.
+    return t;
+  }
+};
+}
+
+/// Custom version of hpx::util::unwrapping, which unwraps and forwards all
+/// arguments to the function f, but also returns all arguments as they are with
+/// the exception of future<Tile> arguments. future<Tile> arguments are returned
+/// unwrapped (as getting the value from the future leaves the future empty).
+/// The return value of f is ignored. This wrapper is useful for extending the
+/// lifetimes of tiles with custom executors such as the CUDA/cuBLAS executors,
+/// where f returns immediately, but the tiles must be kept alive until the
+/// completion of the operation. The wrapper can be used with "normal" blocking
+/// host-side operations as well.
+template <typename F>
+auto unwrapExtendTiles(F&& f) {
+  return internal::UnwrapExtendTiles<std::decay_t<F>>{std::forward<F>(f)};
 }
 
 /// ---- ETI

--- a/include/dlaf/solver/triangular/mc.h
+++ b/include/dlaf/solver/triangular/mc.h
@@ -114,16 +114,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLT(blas::Op op, blas::Diag d
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -160,16 +153,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LUN(blas::Diag diag, T alpha,
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -206,16 +192,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LUT(blas::Op op, blas::Diag d
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -253,16 +232,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RLN(blas::Diag diag, T alpha,
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -300,16 +272,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RLT(blas::Op op, blas::Diag d
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -347,16 +312,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RUN(blas::Diag diag, T alpha,
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -394,16 +352,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RUT(blas::Op op, blas::Diag d
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
-=======
-  using hpx::threads::executors::pool_executor;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
->>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -437,7 +388,6 @@ template <class T>
 void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid grid, blas::Diag diag,
                                                        T alpha, Matrix<const T, Device::CPU>& mat_a,
                                                        Matrix<T, Device::CPU>& mat_b) {
-<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::resource::pool_exists;
@@ -447,18 +397,6 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
-=======
-  using hpx::threads::executors::pool_executor;
-  using comm::internal::mpi_pool_exists;
-  using common::internal::vector;
-  using ConstTileType = typename Matrix<T, Device::CPU>::ConstTileType;
-
-  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
-  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
-
-  pool_executor executor_hp("default", thread_priority_high);
-  pool_executor executor_normal("default", thread_priority_default);
->>>>>>> e298edf7... thread priority changes
 
   // Set up MPI
   auto executor_mpi = (pool_exists("mpi"))

--- a/include/dlaf/solver/triangular/mc.h
+++ b/include/dlaf/solver/triangular/mc.h
@@ -59,8 +59,8 @@ template <class T>
 void trsm_B_panel_tile(hpx::execution::parallel_executor ex, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, Device::CPU>> in_tile,
                        hpx::future<matrix::Tile<T, Device::CPU>> out_tile) {
-  hpx::dataflow(ex, hpx::util::unwrapping(tile::trsm<T, Device::CPU>),
-                blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
+  hpx::dataflow(ex, hpx::util::unwrapping(tile::trsm<T, Device::CPU>), blas::Side::Left,
+                blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
                 std::move(out_tile));
 }
 
@@ -69,9 +69,8 @@ void gemm_trailing_matrix_tile(hpx::execution::parallel_executor ex, T beta,
                                hpx::shared_future<matrix::Tile<const T, Device::CPU>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, Device::CPU>> b_tile,
                                hpx::future<matrix::Tile<T, Device::CPU>> c_tile) {
-  hpx::dataflow(ex, hpx::util::unwrapping(tile::gemm<T, Device::CPU>),
-                blas::Op::NoTrans, blas::Op::NoTrans, beta, std::move(a_tile), std::move(b_tile), 1.0,
-                std::move(c_tile));
+  hpx::dataflow(ex, hpx::util::unwrapping(tile::gemm<T, Device::CPU>), blas::Op::NoTrans,
+                blas::Op::NoTrans, beta, std::move(a_tile), std::move(b_tile), 1.0, std::move(c_tile));
 }
 }
 

--- a/include/dlaf/solver/triangular/mc.h
+++ b/include/dlaf/solver/triangular/mc.h
@@ -21,7 +21,7 @@
 #include "dlaf/common/vector.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/functions_sync.h"
-#include "dlaf/init.h"
+#include "dlaf/executors.h"
 #include "dlaf/lapack_tile.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
@@ -79,8 +79,8 @@ template <class T>
 void Triangular<Backend::MC, Device::CPU, T>::call_LLN(blas::Diag diag, T alpha,
                                                        Matrix<const T, Device::CPU>& mat_a,
                                                        Matrix<T, Device::CPU>& mat_b) {
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -112,8 +112,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLT(blas::Op op, blas::Diag d
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -147,8 +147,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LUN(blas::Diag diag, T alpha,
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -182,8 +182,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LUT(blas::Op op, blas::Diag d
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -218,8 +218,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RLN(blas::Diag diag, T alpha,
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -254,8 +254,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RLT(blas::Op op, blas::Diag d
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -290,8 +290,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RUN(blas::Diag diag, T alpha,
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -326,8 +326,8 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RUT(blas::Op op, blas::Diag d
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -361,9 +361,9 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
   using common::internal::vector;
   using ConstTileType = typename Matrix<T, Device::CPU>::ConstTileType;
 
-  auto executor_hp = dlaf::internal::getHpExecutor<Backend::MC>();
-  auto executor_np = dlaf::internal::getNpExecutor<Backend::MC>();
-  auto executor_mpi = dlaf::internal::getMPIExecutor<Backend::MC>();
+  auto executor_hp = dlaf::getHpExecutor<Backend::MC>();
+  auto executor_np = dlaf::getNpExecutor<Backend::MC>();
+  auto executor_mpi = dlaf::getMPIExecutor<Backend::MC>();
 
   common::Pipeline<comm::CommunicatorGrid> serial_comm(std::move(grid));
 

--- a/include/dlaf/solver/triangular/mc.h
+++ b/include/dlaf/solver/triangular/mc.h
@@ -114,9 +114,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLT(blas::Op op, blas::Diag d
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -153,9 +160,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LUN(blas::Diag diag, T alpha,
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -192,9 +206,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LUT(blas::Op op, blas::Diag d
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -232,9 +253,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RLN(blas::Diag diag, T alpha,
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -272,9 +300,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RLT(blas::Op op, blas::Diag d
   constexpr auto Lower = blas::Uplo::Lower;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -312,9 +347,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RUN(blas::Diag diag, T alpha,
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -352,9 +394,16 @@ void Triangular<Backend::MC, Device::CPU, T>::call_RUT(blas::Op op, blas::Diag d
   constexpr auto Upper = blas::Uplo::Upper;
   constexpr auto NoTrans = blas::Op::NoTrans;
 
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::threads::thread_priority;
+=======
+  using hpx::threads::executors::pool_executor;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+>>>>>>> e298edf7... thread priority changes
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
@@ -388,6 +437,7 @@ template <class T>
 void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid grid, blas::Diag diag,
                                                        T alpha, Matrix<const T, Device::CPU>& mat_a,
                                                        Matrix<T, Device::CPU>& mat_b) {
+<<<<<<< HEAD
   using hpx::execution::parallel_executor;
   using hpx::resource::get_thread_pool;
   using hpx::resource::pool_exists;
@@ -397,6 +447,18 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
 
   parallel_executor executor_hp(&get_thread_pool("default"), thread_priority::high);
   parallel_executor executor_normal(&get_thread_pool("default"), thread_priority::default_);
+=======
+  using hpx::threads::executors::pool_executor;
+  using comm::internal::mpi_pool_exists;
+  using common::internal::vector;
+  using ConstTileType = typename Matrix<T, Device::CPU>::ConstTileType;
+
+  constexpr auto thread_priority_high = hpx::threads::thread_priority::high;
+  constexpr auto thread_priority_default = hpx::threads::thread_priority::default_;
+
+  pool_executor executor_hp("default", thread_priority_high);
+  pool_executor executor_normal("default", thread_priority_default);
+>>>>>>> e298edf7... thread priority changes
 
   // Set up MPI
   auto executor_mpi = (pool_exists("mpi"))

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -174,6 +174,8 @@ int main(int argc, char** argv) {
   ;
   // clang-format on
 
+  desc_commandline.add(dlaf::getOptionsDescription());
+
   hpx::init_params p;
   p.desc_cmdline = desc_commandline;
   p.rp_callback = [](auto& rp, auto) {

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -18,6 +18,7 @@
 #include "dlaf/communication/error.h"
 #include "dlaf/communication/init.h"
 #include "dlaf/factorization/cholesky.h"
+#include "dlaf/init.h"
 #include "dlaf/matrix/copy.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
@@ -74,6 +75,8 @@ options_t check_options(hpx::program_options::variables_map& vm);
 }
 
 int hpx_main(hpx::program_options::variables_map& vm) {
+  dlaf::initialize(vm);
+
   options_t opts = check_options(vm);
 
   Communicator world(MPI_COMM_WORLD);
@@ -146,6 +149,8 @@ int hpx_main(hpx::program_options::variables_map& vm) {
       check_cholesky(original, matrix, comm_grid);
     }
   }
+
+  dlaf::finalize();
 
   return hpx::finalize();
 }

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -21,17 +21,13 @@
 #include <hpx/thread.hpp>
 
 #include "dlaf/cublas/executor.h"
+#include "dlaf/init.h"
 
-int hpx_main() {
-  constexpr int device = 0;
-  constexpr std::size_t num_streams_per_worker_thread = 10;
+int hpx_main(int argc, char* argv[]) {
+  dlaf::initialize(argc, argv);
 
-  dlaf::cuda::StreamPool stream_pool{device, num_streams_per_worker_thread,
-                                     hpx::threads::thread_priority::high};
-  dlaf::cublas::HandlePool handle_pool{device, CUBLAS_POINTER_MODE_HOST};
-  dlaf::cublas::Executor cublas_exec{stream_pool, handle_pool};
-
-  hpx::cuda::experimental::enable_user_polling p;
+  dlaf::cublas::Executor cublas_exec{dlaf::internal::getHpCudaStreamPool(),
+                                     dlaf::internal::getCublasHandlePool()};
 
   constexpr int n = 10000;
   constexpr int incx = 1;
@@ -68,7 +64,10 @@ int hpx_main() {
 
   f2.get();
 
-  return hpx::finalize();
+  dlaf::finalize();
+  hpx::finalize();
+
+  return 0;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -20,14 +20,13 @@
 #include <hpx/modules/async_cuda.hpp>
 #include <hpx/thread.hpp>
 
-#include "dlaf/cublas/executor.h"
+#include "dlaf/executors.h"
 #include "dlaf/init.h"
 
 int hpx_main(int argc, char* argv[]) {
   dlaf::initialize(argc, argv);
 
-  dlaf::cublas::Executor cublas_exec{dlaf::internal::getHpCudaStreamPool(),
-                                     dlaf::internal::getCublasHandlePool()};
+  auto exec = dlaf::getHpExecutor<dlaf::Backend::GPU>();
 
   constexpr int n = 10000;
   constexpr int incx = 1;
@@ -46,8 +45,8 @@ int hpx_main(int argc, char* argv[]) {
     return &alpha;
   });
 
-  hpx::future<cublasStatus_t> f1 = hpx::dataflow(cublas_exec, hpx::util::unwrapping(cublasDaxpy), n,
-                                                 alpha_f, x.data().get(), incx, y.data().get(), incy);
+  hpx::future<cublasStatus_t> f1 = hpx::dataflow(exec, hpx::util::unwrapping(cublasDaxpy), n, alpha_f,
+                                                 x.data().get(), incx, y.data().get(), incy);
 
   hpx::future<void> f2 = f1.then([&y](hpx::future<cublasStatus_t> s) {
     DLAF_CUBLAS_CALL(s.get());

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -65,6 +65,8 @@ linear_system_t sampleLeftTr(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 }
 
 int hpx_main(hpx::program_options::variables_map& vm) {
+  dlaf::initialize(vm);
+
   options_t opts = check_options(vm);
 
   Communicator world(MPI_COMM_WORLD);
@@ -134,6 +136,8 @@ int hpx_main(hpx::program_options::variables_map& vm) {
     }
   }
 
+  dlaf::finalize();
+
   return hpx::finalize();
 }
 
@@ -160,6 +164,8 @@ int main(int argc, char** argv) {
     ("check-result",  bool_switch()    ->default_value(false), "Check the triangular system solution (for each run)")
   ;
   // clang-format on
+
+  desc_commandline.add(dlaf::get_options_description());
 
   hpx::init_params p;
   p.desc_cmdline = desc_commandline;

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -20,6 +20,7 @@
 #include "dlaf/common/timer.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/init.h"
+#include "dlaf/init.h"
 #include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/solver/triangular.h"

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv) {
   ;
   // clang-format on
 
-  desc_commandline.add(dlaf::get_options_description());
+  desc_commandline.add(dlaf::getOptionsDescription());
 
   hpx::init_params p;
   p.desc_cmdline = desc_commandline;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(dlaf.core
     communication/communicator.cpp
     communication/communicator_grid.cpp
     communication/datatypes.cpp
+    init.cpp
     matrix/distribution.cpp
     matrix/layout_info.cpp
     matrix/tile.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2020, ETH Zurich
+// Copyright (c) 2020-2021, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,0 +1,81 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <dlaf/common/assert.h>
+#include <dlaf/init.h>
+
+#ifdef DLAF_WITH_CUDA
+#include <dlaf/cublas/executor.h>
+#include <dlaf/cuda/executor.h>
+#endif
+
+#include <memory>
+
+namespace dlaf {
+namespace internal {
+bool& initialized() {
+  static bool i = false;
+  return i;
+}
+
+#ifdef DLAF_WITH_CUDA
+static std::unique_ptr<cuda::StreamPool> np_stream_pool{nullptr};
+
+void initializeNpCudaStreamPool() {
+  DLAF_ASSERT(!np_stream_pool, "");
+  np_stream_pool = std::make_unique<cuda::StreamPool>(0, 3, hpx::threads::thread_priority::normal);
+}
+
+void finalizeNpCudaStreamPool() {
+  DLAF_ASSERT(bool(np_stream_pool), "");
+  np_stream_pool.reset();
+}
+
+cuda::StreamPool getNpCudaStreamPool() {
+  DLAF_ASSERT(bool(np_stream_pool), "");
+  return *np_stream_pool;
+}
+
+static std::unique_ptr<cuda::StreamPool> hp_stream_pool{nullptr};
+
+void initializeHpCudaStreamPool() {
+  DLAF_ASSERT(!hp_stream_pool, "");
+  hp_stream_pool = std::make_unique<cuda::StreamPool>(0, 3, hpx::threads::thread_priority::high);
+}
+
+void finalizeHpCudaStreamPool() {
+  DLAF_ASSERT(bool(hp_stream_pool), "");
+  hp_stream_pool.reset();
+}
+
+cuda::StreamPool getHpCudaStreamPool() {
+  DLAF_ASSERT(bool(hp_stream_pool), "");
+  return *hp_stream_pool;
+}
+
+static std::unique_ptr<cublas::HandlePool> handle_pool{nullptr};
+
+void initializeCublasHandlePool() {
+  DLAF_ASSERT(!handle_pool, "");
+  handle_pool = std::make_unique<cublas::HandlePool>(0, CUBLAS_POINTER_MODE_HOST);
+}
+
+void finalizeCublasHandlePool() {
+  DLAF_ASSERT(bool(handle_pool), "");
+  handle_pool.reset();
+}
+
+cublas::HandlePool getCublasHandlePool() {
+  DLAF_ASSERT(bool(handle_pool), "");
+  return *handle_pool;
+}
+#endif
+}
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -106,7 +106,7 @@ void Init<Backend::GPU>::finalize() {
 
 template <typename T>
 void updateConfigurationValue(hpx::program_options::variables_map const& vm, T& var,
-                              std::string const& cmdline_option, std::string const& env_var);
+                              std::string const& env_var, std::string const& cmdline_option);
 
 template <>
 void updateConfigurationValue(hpx::program_options::variables_map const& vm, std::size_t& var,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,12 +16,13 @@
 #include <dlaf/cuda/executor.h>
 #endif
 
+#include <cstdlib>
 #include <memory>
 
 namespace dlaf {
 std::ostream& operator<<(std::ostream& os, configuration const& cfg) {
-  os << "num_np_cuda_streams_per_thread = " << cfg.num_np_cuda_streams_per_thread << std::endl;
-  os << "num_hp_cuda_streams_per_thread = " << cfg.num_hp_cuda_streams_per_thread;
+  os << "  num_np_cuda_streams_per_thread = " << cfg.num_np_cuda_streams_per_thread << std::endl;
+  os << "  num_hp_cuda_streams_per_thread = " << cfg.num_hp_cuda_streams_per_thread;
 
   return os;
 }
@@ -150,7 +151,9 @@ hpx::program_options::options_description getOptionsDescription() {
 }
 
 void initialize(hpx::program_options::variables_map const& vm, configuration const& user_cfg) {
+  bool should_exit = false;
   if (vm.count("dlaf:help") > 0) {
+    should_exit = true;
     std::cout << getOptionsDescription() << std::endl;
   }
 
@@ -159,7 +162,13 @@ void initialize(hpx::program_options::variables_map const& vm, configuration con
   internal::getConfiguration() = cfg;
 
   if (vm.count("dlaf:print-config") > 0) {
+    std::cout << "DLA-Future configuration options:" << std::endl;
     std::cout << cfg << std::endl;
+    std::cout << std::endl;
+  }
+
+  if (should_exit) {
+    std::exit(0);
   }
 
   DLAF_ASSERT(!internal::initialized(), "");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -85,7 +85,28 @@ cublas::HandlePool getCublasHandlePool() {
   DLAF_ASSERT(bool(handle_pool), "");
   return *handle_pool;
 }
+
+template <>
+void Init<Backend::GPU>::initialize(configuration const& cfg) {
+  const int device = 0;
+  initializeNpCudaStreamPool(device, cfg.num_np_cuda_streams_per_thread);
+  initializeHpCudaStreamPool(device, cfg.num_hp_cuda_streams_per_thread);
+  initializeCublasHandlePool();
+  hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool("default"));
+}
+
+template <>
+void Init<Backend::GPU>::finalize() {
+  finalizeNpCudaStreamPool();
+  finalizeHpCudaStreamPool();
+  finalizeCublasHandlePool();
+  hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool("default"));
+}
 #endif
+
+template <typename T>
+void update_configuration(hpx::program_options::variables_map const& vm, T& var,
+                          std::string const& cmdline_option, std::string const& env_var);
 
 template <>
 inline void update_configuration(hpx::program_options::variables_map const& vm, std::size_t& var,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -19,6 +19,13 @@
 #include <memory>
 
 namespace dlaf {
+std::ostream& operator<<(std::ostream& os, configuration const& cfg) {
+  os << "num_np_cuda_streams_per_thread = " << cfg.num_np_cuda_streams_per_thread << std::endl;
+  os << "num_hp_cuda_streams_per_thread = " << cfg.num_hp_cuda_streams_per_thread;
+
+  return os;
+}
+
 namespace internal {
 bool& initialized() {
   static bool i = false;
@@ -28,9 +35,10 @@ bool& initialized() {
 #ifdef DLAF_WITH_CUDA
 static std::unique_ptr<cuda::StreamPool> np_stream_pool{nullptr};
 
-void initializeNpCudaStreamPool() {
+void initializeNpCudaStreamPool(int device, std::size_t num_streams_per_thread) {
   DLAF_ASSERT(!np_stream_pool, "");
-  np_stream_pool = std::make_unique<cuda::StreamPool>(0, 3, hpx::threads::thread_priority::normal);
+  np_stream_pool = std::make_unique<cuda::StreamPool>(device, num_streams_per_thread,
+                                                      hpx::threads::thread_priority::normal);
 }
 
 void finalizeNpCudaStreamPool() {
@@ -45,9 +53,10 @@ cuda::StreamPool getNpCudaStreamPool() {
 
 static std::unique_ptr<cuda::StreamPool> hp_stream_pool{nullptr};
 
-void initializeHpCudaStreamPool() {
+void initializeHpCudaStreamPool(int device, std::size_t num_streams_per_thread) {
   DLAF_ASSERT(!hp_stream_pool, "");
-  hp_stream_pool = std::make_unique<cuda::StreamPool>(0, 3, hpx::threads::thread_priority::high);
+  hp_stream_pool = std::make_unique<cuda::StreamPool>(device, num_streams_per_thread,
+                                                      hpx::threads::thread_priority::high);
 }
 
 void finalizeHpCudaStreamPool() {
@@ -77,5 +86,83 @@ cublas::HandlePool getCublasHandlePool() {
   return *handle_pool;
 }
 #endif
+
+template <>
+inline void update_configuration(hpx::program_options::variables_map const& vm, std::size_t& var,
+                                 std::string const& env_var, std::string const& cmdline_option) {
+  const std::string dlaf_env_var = "DLAF_" + env_var;
+  char* env_var_value = std::getenv(dlaf_env_var.c_str());
+  if (env_var_value) {
+    var = std::stoul(env_var_value);
+  }
+
+  const std::string dlaf_cmdline_option = "dlaf:" + cmdline_option;
+  if (vm.count(dlaf_cmdline_option)) {
+    var = vm[dlaf_cmdline_option].as<std::size_t>();
+  }
+}
+
+configuration get_configuration(hpx::program_options::variables_map const& vm,
+                                configuration const& user_cfg) {
+  configuration cfg = user_cfg;
+
+  update_configuration(vm, cfg.num_np_cuda_streams_per_thread, "NUM_NP_CUDA_STREAMS_PER_THREAD",
+                       "num-np-cuda-streams-per-thread");
+  update_configuration(vm, cfg.num_hp_cuda_streams_per_thread, "NUM_HP_CUDA_STREAMS_PER_THREAD",
+                       "num-hp-cuda-streams-per-thread");
+
+  return cfg;
+}
+}
+
+hpx::program_options::options_description get_options_description() {
+  hpx::program_options::options_description desc("DLA-Future options");
+
+  desc.add_options()("dlaf:help", "Print help message");
+  desc.add_options()("dlaf:print-config", "Print the DLA-Future configuration");
+  desc.add_options()("dlaf:num-np-cuda-streams-per-thread", hpx::program_options::value<std::size_t>(),
+                     "Number of normal priority CUDA streams per worker thread");
+  desc.add_options()("dlaf:num-hp-cuda-streams-per-thread", hpx::program_options::value<std::size_t>(),
+                     "Number of high priority CUDA streams per worker thread");
+
+  return desc;
+}
+
+void initialize(hpx::program_options::variables_map const& vm, configuration const& user_cfg) {
+  if (vm.count("dlaf:help") > 0) {
+    std::cout << get_options_description() << std::endl;
+  }
+
+  auto cfg = internal::get_configuration(vm, user_cfg);
+
+  if (vm.count("dlaf:print-config") > 0) {
+    std::cout << cfg << std::endl;
+  }
+
+  DLAF_ASSERT(!internal::initialized(), "");
+  internal::Init<Backend::MC>::initialize(cfg);
+#ifdef DLAF_WITH_CUDA
+  internal::Init<Backend::GPU>::initialize(cfg);
+#endif
+  internal::initialized() = true;
+}
+
+void initialize(int argc, char** argv, configuration const& user_cfg) {
+  auto desc = get_options_description();
+
+  hpx::program_options::variables_map vm;
+  hpx::program_options::store(hpx::program_options::parse_command_line(argc, argv, desc), vm);
+  hpx::program_options::notify(vm);
+
+  initialize(vm, user_cfg);
+}
+
+void finalize() {
+  DLAF_ASSERT(internal::initialized(), "");
+  internal::Init<Backend::MC>::finalize();
+#ifdef DLAF_WITH_CUDA
+  internal::Init<Backend::GPU>::finalize();
+#endif
+  internal::initialized() = false;
 }
 }

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(DLAF_gtest_hpx_main
   PUBLIC
     gtest
   PRIVATE
+    DLAF
     HPX::hpx
 )
 
@@ -29,6 +30,7 @@ target_link_libraries(DLAF_gtest_mpihpx_main
   PUBLIC
     gtest
   PRIVATE
+    DLAF
     MPI::MPI_CXX
     HPX::hpx
 )

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(DLAF_gtest_hpx_main
   PUBLIC
     gtest
   PRIVATE
-    DLAF
+    dlaf.core
     HPX::hpx
 )
 
@@ -30,7 +30,7 @@ target_link_libraries(DLAF_gtest_mpihpx_main
   PUBLIC
     gtest
   PRIVATE
-    DLAF
+    dlaf.core
     MPI::MPI_CXX
     HPX::hpx
 )

--- a/test/src/gtest_hpx_main.cpp
+++ b/test/src/gtest_hpx_main.cpp
@@ -42,9 +42,13 @@
 #include <gtest/gtest.h>
 #include <hpx/init.hpp>
 
-GTEST_API_ int test_main(int, char**) {
+#include <dlaf/init.h>
+
+GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_hpx_main.cpp\n");
+  dlaf::initialize(argc, argv);
   auto ret = RUN_ALL_TESTS();
+  dlaf::finalize();
   hpx::finalize();
   return ret;
 }

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -42,11 +42,15 @@
 #include <gtest/gtest.h>
 #include <hpx/init.hpp>
 
+#include <dlaf/init.h>
+
 #include "gtest_mpi_listener.h"
 
-GTEST_API_ int test_main(int, char**) {
+GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_mpihpx_main.cpp\n");
+  dlaf::initialize(argc, argv);
   auto ret = RUN_ALL_TESTS();
+  dlaf::finalize();
   hpx::finalize();
   return ret;
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 add_subdirectory(common)
 add_subdirectory(communication)
 add_subdirectory(eigensolver)
+add_subdirectory(init)
 add_subdirectory(matrix)
 add_subdirectory(memory)
 

--- a/test/unit/init/CMakeLists.txt
+++ b/test/unit/init/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2020, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+DLAF_addTest(test_init
+  SOURCES test_init.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)

--- a/test/unit/init/CMakeLists.txt
+++ b/test/unit/init/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Distributed Linear Algebra with Future (DLAF)
 #
-# Copyright (c) 2020, ETH Zurich
+# Copyright (c) 2020-2021, ETH Zurich
 # All rights reserved.
 #
 # Please, refer to the LICENSE file in the root directory.

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2020, ETH Zurich
+// Copyright (c) 2020-2021, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -8,13 +8,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include "dlaf/init.h"
+
 #include <cstdlib>
 
 #include <gtest/gtest.h>
 
 #include <hpx/init.hpp>
-
-#include "dlaf/init.h"
 
 static const char* binary_name = "init_test";
 static const char* env_var_name = "DLAF_NUM_HP_CUDA_STREAMS_PER_THREAD";

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -162,12 +162,6 @@ int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
 }
 
 TEST(Init, VariablesMapNoCommandLineOption) {
-  hpx::program_options::options_description options("options");
-  options.add(dlaf::getOptionsDescription());
-
-  hpx::init_params p;
-  p.desc_cmdline = options;
-
   // The const_cast is currently necessary for hpx::init. HPX should be updated
   // to take const argc/argv.
   hpx::init(vm_no_command_line_option_main, argc_without_option,

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -1,0 +1,223 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+#include <hpx/init.hpp>
+
+#include "dlaf/init.h"
+
+static const char* binary_name = "init_test";
+static const char* env_var_name = "DLAF_NUM_HP_CUDA_STREAMS_PER_THREAD";
+static const char* command_line_option_name = "--dlaf:num-hp-cuda-streams-per-thread";
+
+static int argc_without_option = 1;
+static const char* argv_without_option[] = {binary_name};
+
+int precedence_main(int, char*[]) {
+  const dlaf::configuration default_cfg;
+  const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
+  // Note that this test doesn't mean that the default value has to be 3. It is
+  // included to help catch unexpected changes in the configuration handling.
+  EXPECT_EQ(default_val, 3);
+
+  // Make sure environment is clean for the test.
+  unsetenv(env_var_name);
+
+  // Default configuration.
+  {
+    dlaf::initialize(argc_without_option, argv_without_option);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(default_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  // User configuration should take precedence over default configuration.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+
+    dlaf::initialize(argc_without_option, argv_without_option, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(user_cfg.num_hp_cuda_streams_per_thread, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  // Environment variables should take precedence over user configuration.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_hp_cuda_streams_per_thread + 1;
+    const std::string env_var_val_str = std::to_string(env_var_val);
+    setenv(env_var_name, env_var_val_str.c_str(), 1);
+
+    dlaf::initialize(argc_without_option, argv_without_option, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(env_var_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  // Command-line options should take precedence over environment variables.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_hp_cuda_streams_per_thread + 1;
+    const std::string env_var_val_str = std::to_string(env_var_val);
+    setenv(env_var_name, env_var_val_str.c_str(), 1);
+    const std::size_t command_line_option_val = env_var_val + 1;
+    const std::string command_line_option_val_str = std::to_string(command_line_option_val);
+    const std::string command_line_option_str =
+        command_line_option_name + std::string("=") + command_line_option_val_str;
+    const int argc_with_option = 2;
+    const char* argv_with_option[] = {binary_name, command_line_option_str.c_str()};
+
+    dlaf::initialize(argc_with_option, argv_with_option, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  return hpx::finalize();
+}
+
+TEST(Init, Precedence) {
+  // The const_cast is currently necessary for hpx::init. HPX should be updated
+  // to take const argc/argv.
+  hpx::init(precedence_main, argc_without_option, const_cast<char**>(argv_without_option));
+}
+
+int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
+  const dlaf::configuration default_cfg;
+  const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
+  // Note that this test doesn't mean that the default value has to be 3. It is
+  // included to help catch unexpected changes in the configuration handling.
+  EXPECT_EQ(default_val, 3);
+
+  // Make sure environment is clean for the test.
+  unsetenv(env_var_name);
+
+  // Default configuration.
+  {
+    dlaf::initialize(vm);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(default_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  // User configuration should take precedence over default configuration.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+
+    dlaf::initialize(vm, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(user_cfg.num_hp_cuda_streams_per_thread, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  // Environment variables should take precedence over user configuration.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_hp_cuda_streams_per_thread + 1;
+    const std::string env_var_val_str = std::to_string(env_var_val);
+    setenv(env_var_name, env_var_val_str.c_str(), 1);
+
+    dlaf::initialize(vm, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(env_var_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  // Command-line options should take precedence over environment variables.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_hp_cuda_streams_per_thread + 1;
+    const std::string env_var_val_str = std::to_string(env_var_val);
+    setenv(env_var_name, env_var_val_str.c_str(), 1);
+    const std::size_t command_line_option_val = env_var_val + 1;
+    const std::string command_line_option_val_str = std::to_string(command_line_option_val);
+    const std::string command_line_option_str =
+        command_line_option_name + std::string("=") + command_line_option_val_str;
+    const int argc_with_option = 2;
+    const char* argv_with_option[] = {binary_name, command_line_option_str.c_str()};
+
+    dlaf::initialize(argc_with_option, argv_with_option, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  return hpx::finalize();
+}
+
+TEST(Init, VariablesMapNoCommandLineOption) {
+  hpx::program_options::options_description options("options");
+  options.add(dlaf::getOptionsDescription());
+
+  hpx::init_params p;
+  p.desc_cmdline = options;
+
+  // The const_cast is currently necessary for hpx::init. HPX should be updated
+  // to take const argc/argv.
+  hpx::init(vm_no_command_line_option_main, argc_without_option,
+            const_cast<char**>(argv_without_option));
+}
+
+int vm_command_line_option_main(hpx::program_options::variables_map& vm) {
+  dlaf::configuration default_cfg;
+  const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
+
+  // Command-line options should take precedence over everything else.
+  {
+    dlaf::configuration user_cfg = default_cfg;
+    user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_hp_cuda_streams_per_thread + 1;
+    const std::string env_var_val_str = std::to_string(env_var_val);
+    setenv(env_var_name, env_var_val_str.c_str(), 1);
+    const std::size_t command_line_option_val = env_var_val + 1;
+
+    dlaf::initialize(vm, user_cfg);
+    dlaf::configuration cfg = dlaf::internal::getConfiguration();
+    EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
+    dlaf::finalize();
+  }
+
+  return hpx::finalize();
+}
+
+TEST(Init, VariablesMapCommandLineOption) {
+  hpx::program_options::options_description options("options");
+  options.add(dlaf::getOptionsDescription());
+
+  hpx::init_params p;
+  p.desc_cmdline = options;
+
+  dlaf::configuration default_cfg;
+  const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
+  // Note that this test doesn't mean that the default value has to be 3. It is
+  // included to help catch unexpected changes in the configuration handling.
+  EXPECT_EQ(default_val, 3);
+
+  std::size_t command_line_option_val = default_val + 3;
+  std::string command_line_option_val_str = std::to_string(command_line_option_val);
+  std::string command_line_option_str =
+      command_line_option_name + std::string("=") + command_line_option_val_str;
+  int argc_with_option = 2;
+  // The const_cast is currently necessary for hpx::init. HPX should be updated
+  // to take const argc/argv.
+  char* argv_with_option[] = {const_cast<char*>(binary_name),
+                              const_cast<char*>(command_line_option_str.c_str())};
+
+  hpx::init(vm_command_line_option_main, argc_with_option, argv_with_option, p);
+}


### PR DESCRIPTION
Note that this builds on #234, and thus the diff looks a bit larger than it really is. I've squashed the current changes into the last commit.

This addresses #100/#306.

This is a draft for a couple things:
1. `dlaf::initialize/finalize` for (at this point) initializing static CUDA stream/cuBLAS handle pools, but this could be useful for other things as well.
2. A way to generically use functionality for different backends (with different executors) (not really new, but just applied to a new thing: copy).

As a bonus, it also demonstrates the way I've used so far for extending tile lifetimes generically. I can eventually split this out into a separate PR, but it's related as it makes use of the possibility to get executors for different backends.

To expand on what this includes right now:
1. `dlaf::initialize` currently takes `argc/argv` but does nothing with them. It initializes the static pools for the GPU backend. I could see DLAF eventually getting some command line options for controlling e.g. the number of streams per worker thread. Do we want to do that now? If yes, with `hpx::program_options`? With something else?
2. Currently the only thing I've added is `getCopyExecutor` which returns different types of executors for CPU and GPU (note that the only reason why it's specifically *copy*, not e.g. normal priority, is because I don't have the cuBLAS executor forward to the superclass `async_execute` at the moment. I'm looking into making this work.) For this to actually be generic I've added some helper functionality.

The first helper is a macro for creating callable objects for a particular function name. This simplifies (i.e. avoids) having to do things like this: https://github.com/eth-cscs/DLA-Future/blob/4d66c894389ff99c974ed9f69383cc48cc2088fe/include/dlaf/matrix/copy.h#L39-L41. The callable object simply passes through any and all arguments it gets and dispatches to the actual function. This doesn't have to be done with a macro, but I think in many cases it simplifies having to create the wrapper manually.

The second helper is `unwrapExtendTiles` (name needs some bikeshedding). This is essentially a custom version of `hpx::util::unwrapping` which does the unwrapping, but also returns a tuple of the arguments to extend the lifetimes of the tiles. Currently it simply returns a tuple of *all* the arguments, but this could perhaps be made to return only the tile arguments. I'm not sure yet how to do that.

Note that I've made no attempt to put things in appropriate places yet. I'd appreciate feedback on the functionality. I realize some of this significantly adds complexity, but I think at least some of it is justified. Here I've only done the copy operation (the CUDA versions are now asynchronous!), but I think this would allow having a single implementation of *any* algorithm.