### PR TITLE
Communication helpers

### DIFF
--- a/include/dlaf/communication/sync/broadcast.h
+++ b/include/dlaf/communication/sync/broadcast.h
@@ -55,59 +55,44 @@ void receive_from(const int broadcaster_rank, Communicator& communicator, DataOu
 }
 }
 
+/// Task for broadcasting (send endpoint) a Tile in a direction over a CommunicatorGrid
 template <class T>
-void send_tile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> task_chain, Coord rc_comm,
+void send_tile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
                hpx::shared_future<matrix::Tile<const T, Device::CPU>> tile) {
-  using ConstTile_t = matrix::Tile<const T, Device::CPU>;
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
 
-  auto send_bcast_f = [rc_comm](hpx::shared_future<ConstTile_t> ftile,
-                                hpx::future<PromiseComm_t> fpcomm) {
-    PromiseComm_t pcomm = fpcomm.get();
-    comm::sync::broadcast::send(pcomm.ref().subCommunicator(rc_comm), ftile.get());
-  };
-
-  send_bcast_f(tile, std::move(task_chain));
+  PromiseComm_t pcomm = mpi_task_chain.get();
+  comm::sync::broadcast::send(pcomm.ref().subCommunicator(rc_comm), tile.get());
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(send_tile);
 
+/// Task for broadcasting (receiving endpoint) a Tile in a direction over a CommunicatorGrid
 template <class T>
 void recv_tile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
                hpx::future<matrix::Tile<T, Device::CPU>> tile, comm::IndexT_MPI rank) {
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
-  using Tile_t = matrix::Tile<T, Device::CPU>;
 
-  auto recv_bcast_f = hpx::util::annotated_function(
-      [rank, rc_comm](hpx::future<PromiseComm_t> fpcomm, hpx::future<Tile_t> ftile) {
-        PromiseComm_t pcomm = fpcomm.get();
-        Tile_t tile = ftile.get();
-        comm::sync::broadcast::receive_from(rank, pcomm.ref().subCommunicator(rc_comm), tile);
-      },
-      "recv_tile");
-  recv_bcast_f(std::move(mpi_task_chain), std::move(tile));
+  PromiseComm_t pcomm = mpi_task_chain.get();
+  comm::sync::broadcast::receive_from(rank, pcomm.ref().subCommunicator(rc_comm), tile.get());
 }
 
+DLAF_MAKE_CALLABLE_OBJECT(recv_tile);
+
+/// Task for broadcasting (receiving endpoint) a Tile ("JIT" allocation) in a direction over a CommunicatorGrid
 template <class T>
 auto recv_tile_with_alloc(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain,
-                          Coord rc_comm, TileElementSize tile_size, int rank) {
+                          Coord rc_comm, TileElementSize tile_size, comm::IndexT_MPI rank) {
   using ConstTile_t = matrix::Tile<const T, Device::CPU>;
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
   using MemView_t = memory::MemoryView<T, Device::CPU>;
   using Tile_t = matrix::Tile<T, Device::CPU>;
 
-  auto recv_bcast_f = hpx::util::annotated_function(
-      [rank, tile_size, rc_comm](hpx::future<PromiseComm_t> fpcomm) -> ConstTile_t {
-        PromiseComm_t pcomm = fpcomm.get();
-        MemView_t mem_view(tile_size.linear_size());
-        Tile_t tile(tile_size, std::move(mem_view), tile_size.rows());
-        comm::sync::broadcast::receive_from(rank, pcomm.ref().subCommunicator(rc_comm), tile);
-        return ConstTile_t(std::move(tile));
-      },
-      "recv_tile");
-  return recv_bcast_f(std::move(mpi_task_chain));
+  PromiseComm_t pcomm = mpi_task_chain.get();
+  MemView_t mem_view(tile_size.linear_size());
+  Tile_t tile(tile_size, std::move(mem_view), tile_size.rows());
+  comm::sync::broadcast::receive_from(rank, pcomm.ref().subCommunicator(rc_comm), tile);
+  return ConstTile_t(std::move(tile));
 }
-
-DLAF_MAKE_CALLABLE_OBJECT(recv_tile);
 }
 }

--- a/include/dlaf/communication/sync/broadcast.h
+++ b/include/dlaf/communication/sync/broadcast.h
@@ -81,7 +81,7 @@ DLAF_MAKE_CALLABLE_OBJECT(recv_tile);
 
 /// Task for broadcasting (receiving endpoint) a Tile ("JIT" allocation) in a direction over a CommunicatorGrid
 template <class T>
-auto recv_tile_with_alloc(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain,
+matrix::Tile<const T, Device::CPU> recv_tile_with_alloc(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain,
                           Coord rc_comm, TileElementSize tile_size, comm::IndexT_MPI rank) {
   using ConstTile_t = matrix::Tile<const T, Device::CPU>;
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;

--- a/include/dlaf/communication/sync/broadcast.h
+++ b/include/dlaf/communication/sync/broadcast.h
@@ -81,8 +81,9 @@ DLAF_MAKE_CALLABLE_OBJECT(recv_tile);
 
 /// Task for broadcasting (receiving endpoint) a Tile ("JIT" allocation) in a direction over a CommunicatorGrid
 template <class T>
-matrix::Tile<const T, Device::CPU> recv_tile_with_alloc(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain,
-                          Coord rc_comm, TileElementSize tile_size, comm::IndexT_MPI rank) {
+matrix::Tile<const T, Device::CPU> recv_tile_with_alloc(
+    hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
+    TileElementSize tile_size, comm::IndexT_MPI rank) {
   using ConstTile_t = matrix::Tile<const T, Device::CPU>;
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
   using MemView_t = memory::MemoryView<T, Device::CPU>;

--- a/include/dlaf/communication/sync/broadcast.h
+++ b/include/dlaf/communication/sync/broadcast.h
@@ -86,9 +86,8 @@ void send_tile(hpx::threads::executors::pool_executor ex,
 }
 
 template <class T>
-void recv_tile(
-    common::Pipeline<comm::CommunicatorGrid>& mpi_task_chain,
-    Coord rc_comm, hpx::future<matrix::Tile<T, Device::CPU>>, int rank) {
+void recv_tile(common::Pipeline<comm::CommunicatorGrid>& mpi_task_chain, Coord rc_comm,
+               hpx::future<matrix::Tile<T, Device::CPU>> tile, int rank) {
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
   using Tile_t = matrix::Tile<T, Device::CPU>;
 
@@ -99,7 +98,7 @@ void recv_tile(
         comm::sync::broadcast::receive_from(rank, pcomm.ref().subCommunicator(rc_comm), tile);
       },
       "recv_tile");
-  return hpx::dataflow(std::move(recv_bcast_f), mpi_task_chain());
+  hpx::dataflow(std::move(recv_bcast_f), mpi_task_chain(), std::move(tile));
 }
 
 template <class T>

--- a/include/dlaf/communication/sync/broadcast.h
+++ b/include/dlaf/communication/sync/broadcast.h
@@ -57,31 +57,31 @@ void receive_from(const int broadcaster_rank, Communicator& communicator, DataOu
 
 /// Task for broadcasting (send endpoint) a Tile in a direction over a CommunicatorGrid
 template <class T>
-void send_tile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
-               hpx::shared_future<matrix::Tile<const T, Device::CPU>> tile) {
+void sendTile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
+              hpx::shared_future<matrix::Tile<const T, Device::CPU>> tile) {
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
 
   PromiseComm_t pcomm = mpi_task_chain.get();
   comm::sync::broadcast::send(pcomm.ref().subCommunicator(rc_comm), tile.get());
 }
 
-DLAF_MAKE_CALLABLE_OBJECT(send_tile);
+DLAF_MAKE_CALLABLE_OBJECT(sendTile);
 
 /// Task for broadcasting (receiving endpoint) a Tile in a direction over a CommunicatorGrid
 template <class T>
-void recv_tile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
-               hpx::future<matrix::Tile<T, Device::CPU>> tile, comm::IndexT_MPI rank) {
+void recvTile(hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
+              hpx::future<matrix::Tile<T, Device::CPU>> tile, comm::IndexT_MPI rank) {
   using PromiseComm_t = common::PromiseGuard<comm::CommunicatorGrid>;
 
   PromiseComm_t pcomm = mpi_task_chain.get();
   comm::sync::broadcast::receive_from(rank, pcomm.ref().subCommunicator(rc_comm), tile.get());
 }
 
-DLAF_MAKE_CALLABLE_OBJECT(recv_tile);
+DLAF_MAKE_CALLABLE_OBJECT(recvTile);
 
 /// Task for broadcasting (receiving endpoint) a Tile ("JIT" allocation) in a direction over a CommunicatorGrid
 template <class T>
-matrix::Tile<const T, Device::CPU> recv_tile_with_alloc(
+matrix::Tile<const T, Device::CPU> recvAllocTile(
     hpx::future<common::PromiseGuard<comm::CommunicatorGrid>> mpi_task_chain, Coord rc_comm,
     TileElementSize tile_size, comm::IndexT_MPI rank) {
   using ConstTile_t = matrix::Tile<const T, Device::CPU>;

--- a/include/dlaf/factorization/cholesky/mc.h
+++ b/include/dlaf/factorization/cholesky/mc.h
@@ -113,7 +113,6 @@ void Cholesky<Backend::MC, Device::CPU, T>::call_L(Matrix<T, Device::CPU>& mat_a
 }
 
 template <class T>
-
 void Cholesky<Backend::MC, Device::CPU, T>::call_L(comm::CommunicatorGrid grid,
                                                    Matrix<T, Device::CPU>& mat_a) {
   using ConstTileType = typename Matrix<T, Device::CPU>::ConstTileType;

--- a/include/dlaf/factorization/cholesky/mc.h
+++ b/include/dlaf/factorization/cholesky/mc.h
@@ -140,11 +140,11 @@ void Cholesky<Backend::MC, Device::CPU, T>::call_L(comm::CommunicatorGrid grid,
       potrf_diag_tile(executor_hp, mat_a(kk_idx));
       panel[k] = mat_a.read(kk_idx);
       if (k != nrtile - 1)
-        dataflow(executor_mpi, comm::send_tile_o, mpi_task_chain(), Coord::Col, panel[k]);
+        dataflow(executor_mpi, comm::sendTile_o, mpi_task_chain(), Coord::Col, panel[k]);
     }
     else if (this_rank.col() == kk_rank.col()) {
       if (k != nrtile - 1)
-        panel[k] = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, mpi_task_chain(), Coord::Col,
+        panel[k] = dataflow(executor_mpi, comm::recvAllocTile<T>, mpi_task_chain(), Coord::Col,
                             mat_a.tileSize(kk_idx), kk_rank.row());
     }
 
@@ -156,10 +156,10 @@ void Cholesky<Backend::MC, Device::CPU, T>::call_L(comm::CommunicatorGrid grid,
       if (this_rank == ik_rank) {
         trsm_panel_tile(executor_hp, panel[k], mat_a(ik_idx));
         panel[i] = mat_a.read(ik_idx);
-        dataflow(executor_mpi, comm::send_tile_o, mpi_task_chain(), Coord::Row, panel[i]);
+        dataflow(executor_mpi, comm::sendTile_o, mpi_task_chain(), Coord::Row, panel[i]);
       }
       else if (this_rank.row() == ik_rank.row()) {
-        panel[i] = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, mpi_task_chain(), Coord::Row,
+        panel[i] = dataflow(executor_mpi, comm::recvAllocTile<T>, mpi_task_chain(), Coord::Row,
                             mat_a.tileSize(ik_idx), ik_rank.col());
       }
     }
@@ -177,12 +177,12 @@ void Cholesky<Backend::MC, Device::CPU, T>::call_L(comm::CommunicatorGrid grid,
         auto& trailing_matrix_executor = (j == k + 1) ? executor_hp : executor_np;
         herk_trailing_diag_tile(trailing_matrix_executor, panel[j], mat_a(jj_idx));
         if (j != nrtile - 1)
-          dataflow(executor_mpi, comm::send_tile_o, mpi_task_chain(), Coord::Col, panel[j]);
+          dataflow(executor_mpi, comm::sendTile_o, mpi_task_chain(), Coord::Col, panel[j]);
       }
       else {
         GlobalTileIndex jk_idx(j, k);
         if (j != nrtile - 1)
-          panel[j] = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, mpi_task_chain(), Coord::Col,
+          panel[j] = dataflow(executor_mpi, comm::recvAllocTile<T>, mpi_task_chain(), Coord::Col,
                               mat_a.tileSize(jk_idx), jj_rank.row());
       }
 

--- a/include/dlaf/solver/triangular/mc.h
+++ b/include/dlaf/solver/triangular/mc.h
@@ -390,10 +390,10 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
         auto kk = LocalTileIndex{k_local_row, k_local_col};
 
         kk_tile = mat_a.read(kk);
-        dataflow(executor_mpi, comm::send_tile_o, serial_comm(), Coord::Row, mat_a.read(kk));
+        dataflow(executor_mpi, comm::sendTile_o, serial_comm(), Coord::Row, mat_a.read(kk));
       }
       else {
-        kk_tile = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, serial_comm(), Coord::Row,
+        kk_tile = dataflow(executor_mpi, comm::recvAllocTile<T>, serial_comm(), Coord::Row,
                            mat_a.tileSize(GlobalTileIndex(k, k)), k_rank_col);
       }
     }
@@ -408,13 +408,13 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
         lln::trsm_B_panel_tile(executor_hp, diag, alpha, kk_tile, mat_b(kj));
         panel[j_local] = mat_b.read(kj);
         if (k != (mat_b.nrTiles().rows() - 1)) {
-          dataflow(executor_mpi, comm::send_tile_o, serial_comm(), Coord::Col, panel[j_local]);
+          dataflow(executor_mpi, comm::sendTile_o, serial_comm(), Coord::Col, panel[j_local]);
         }
       }
       else {
         if (k != (mat_b.nrTiles().rows() - 1)) {
-          panel[j_local] = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, serial_comm(),
-                                    Coord::Col, mat_b.tileSize(GlobalTileIndex(k, j)), k_rank_row);
+          panel[j_local] = dataflow(executor_mpi, comm::recvAllocTile<T>, serial_comm(), Coord::Col,
+                                    mat_b.tileSize(GlobalTileIndex(k, j)), k_rank_row);
         }
       }
     }
@@ -434,10 +434,10 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
         auto ik = LocalTileIndex{i_local, k_local_col};
 
         ik_tile = mat_a.read(ik);
-        dataflow(executor_mpi, comm::send_tile_o, serial_comm(), Coord::Row, mat_a.read(ik));
+        dataflow(executor_mpi, comm::sendTile_o, serial_comm(), Coord::Row, mat_a.read(ik));
       }
       else {
-        ik_tile = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, serial_comm(), Coord::Row,
+        ik_tile = dataflow(executor_mpi, comm::recvAllocTile<T>, serial_comm(), Coord::Row,
                            mat_a.tileSize(GlobalTileIndex(i, k)), k_rank_col);
       }
 

--- a/include/dlaf/solver/triangular/mc.h
+++ b/include/dlaf/solver/triangular/mc.h
@@ -390,11 +390,11 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
         auto kk = LocalTileIndex{k_local_row, k_local_col};
 
         kk_tile = mat_a.read(kk);
-        comm::send_tile(executor_mpi, serial_comm, Coord::Row, mat_a.read(kk));
+        dataflow(executor_mpi, comm::send_tile_o, serial_comm(), Coord::Row, mat_a.read(kk));
       }
       else {
-        kk_tile = comm::recv_tile<T>(executor_mpi, serial_comm, Coord::Row,
-                                     mat_a.tileSize(GlobalTileIndex(k, k)), k_rank_col);
+        kk_tile = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, serial_comm(), Coord::Row,
+                           mat_a.tileSize(GlobalTileIndex(k, k)), k_rank_col);
       }
     }
 
@@ -408,13 +408,13 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
         lln::trsm_B_panel_tile(executor_hp, diag, alpha, kk_tile, mat_b(kj));
         panel[j_local] = mat_b.read(kj);
         if (k != (mat_b.nrTiles().rows() - 1)) {
-          comm::send_tile(executor_mpi, serial_comm, Coord::Col, panel[j_local]);
+          dataflow(executor_mpi, comm::send_tile_o, serial_comm(), Coord::Col, panel[j_local]);
         }
       }
       else {
         if (k != (mat_b.nrTiles().rows() - 1)) {
-          panel[j_local] = comm::recv_tile<T>(executor_mpi, serial_comm, Coord::Col,
-                                              mat_b.tileSize(GlobalTileIndex(k, j)), k_rank_row);
+          panel[j_local] = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, serial_comm(),
+                                    Coord::Col, mat_b.tileSize(GlobalTileIndex(k, j)), k_rank_row);
         }
       }
     }
@@ -434,11 +434,11 @@ void Triangular<Backend::MC, Device::CPU, T>::call_LLN(comm::CommunicatorGrid gr
         auto ik = LocalTileIndex{i_local, k_local_col};
 
         ik_tile = mat_a.read(ik);
-        comm::send_tile(executor_mpi, serial_comm, Coord::Row, mat_a.read(ik));
+        dataflow(executor_mpi, comm::send_tile_o, serial_comm(), Coord::Row, mat_a.read(ik));
       }
       else {
-        ik_tile = comm::recv_tile<T>(executor_mpi, serial_comm, Coord::Row,
-                                     mat_a.tileSize(GlobalTileIndex(i, k)), k_rank_col);
+        ik_tile = dataflow(executor_mpi, comm::recv_tile_with_alloc<T>, serial_comm(), Coord::Row,
+                           mat_a.tileSize(GlobalTileIndex(i, k)), k_rank_col);
       }
 
       // Update trailing matrix


### PR DESCRIPTION
This PR for discussing about communication helpers and extend the set of available ones.

IMHO their main purpose is hiding all the needed boilerplate for communicating using a specific (sub-)`Communicator` wrapped+embedded in `PromiseGuard<CommunicatorGrid>`.

About design decisions, following what it has been already implemented:
1. Manage variants with or without the executor as first parameter
2. Helpers are task schedulers and not task functions (i.e. they are not the thing to be passed to `hpx::dataflow` but the thing that internally calls `hpx::dataflow`)
3. The available `recv_tile` helper also manage the allocation of the destination tile and returns it

About 3, I think we should improve separation of concerns: IMHO currently it seems more a "need" of the code where it is used, but for them I can see a use case for the #309 or something very similar.

Last thing, I played a bit with templates for a possible alternative/complementary option ((see [alby/proposal/comm_helpers_template](https://github.com/eth-cscs/DLA-Future/pull/new/alby/proposal/comm_helpers_template)). It is mainly about `unwrap_guards` and `selector` that acts as "extensions" of `hpx::unwrapping`: former one unwraps the `PromiseGuards<T>` and the latter one selects the specified sub-`Communicator` in a `CommunicatorGrid`, allowing something like `hpx::dataflow(unwrap_guards(selector<Coord::Row>(broadcast::send))), ...)`