### PR TITLE
HPX version compatibility in spack package

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -26,7 +26,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     depends_on("blaspp")
     depends_on("lapackpp")
     depends_on("hpx cxxstd=14 networking=none")
-    depends_on("hpx@1.5.0", when="~cuda")
+    depends_on("hpx@1.5.0:1.5.99", when="~cuda")
     depends_on("hpx@master +cuda", when="+cuda")
 
     depends_on("hpx build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -26,7 +26,10 @@ class DlaFuture(CMakePackage, CudaPackage):
     depends_on("blaspp")
     depends_on("lapackpp")
     depends_on("hpx cxxstd=14 networking=none")
-    depends_on("hpx@1.5", when="~cuda")
+    # it would have been "more correct" specifying @1.5 as constraint but, if clingo
+    # solver works as expected, the default solver has problems with that.
+    # Eventually, we opted for specifying the range more explicitly, so it works with both
+    depends_on("hpx@1.5.0:1.5.1", when="~cuda")
     depends_on("hpx@master +cuda", when="+cuda")
 
     depends_on("hpx build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -29,7 +29,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     # it would have been "more correct" specifying @1.5 as constraint but, if clingo
     # solver works as expected, the default solver has problems with that.
     # Eventually, we opted for specifying the range more explicitly, so it works with both
-    depends_on("hpx@1.5.0:1.5.1", when="~cuda")
+    depends_on("hpx@1.5.0:1.5.999", when="~cuda")
     depends_on("hpx@master +cuda", when="+cuda")
 
     depends_on("hpx build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -26,7 +26,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     depends_on("blaspp")
     depends_on("lapackpp")
     depends_on("hpx cxxstd=14 networking=none")
-    depends_on("hpx@1.5.0:1.5.99", when="~cuda")
+    depends_on("hpx@1.5", when="~cuda")
     depends_on("hpx@master +cuda", when="+cuda")
 
     depends_on("hpx build_type=Debug", when="build_type=Debug")


### PR DESCRIPTION
I realized this just now that I started using our spack package for DLAF.

It may be a bit late for this, since we are close to HPX 1.6.0, iirc. I'm going to add a similar thing to #315.