### PR TITLE
Fix deploy of CMake configuration files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
+option(DLAF_WITH_MKL "Enable MKL as provider for LAPACK" OFF)
 option(DLAF_WITH_CUDA "Enable CUDA support" OFF)
 option(DLAF_BUILD_MINIAPPS "Build miniapps" ON)
 option(DLAF_BUILD_TESTING "Build tests" ON)
@@ -53,7 +54,6 @@ find_package(MPI REQUIRED)
 
 # ----- LAPACK/SCALAPACK
 set(LAPACK_TARGET "")
-set(DLAF_WITH_MKL OFF CACHE BOOL "Enable MKL as provider for LAPACK")
 if (DLAF_WITH_MKL)
   set(MKL_CUSTOM_THREADING "Sequential")
   find_package(MKL REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,7 +142,7 @@ install(DIRECTORY ../include/
 
 # install custom FindModules
 install(DIRECTORY ../cmake/
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
   FILES_MATCHING PATTERN "Find*.cmake"
   PATTERN "template" EXCLUDE
 )
@@ -158,17 +158,17 @@ include(CMakePackageConfigHelpers)
 install(EXPORT
   DLAF-Targets
   NAMESPACE DLAF::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )
 
 # Config-file preparation and install
 configure_package_config_file(
   ${CMAKE_CURRENT_LIST_DIR}/../cmake/template/DLAFConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )


### PR DESCRIPTION
According to CMake documentation, `find_package` automatically looks for library configuration files in [specific places](https://cmake.org/cmake/help/latest/command/find_package.html?highlight=find_package#search-procedure).

Currently used one is not one of them, so it requires to manually specify with `DLAF_DIR` to the folder containing the `DLAFConfig.cmake`. With this change, it would be enough setting the root where the library is installed, which is quite helpful in case the library is installed in a common root (e.g. spack environment view, `/usr/local`).