### PR TITLE
Fix FindMKL on mac + minor improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,15 @@ find_package(MPI REQUIRED)
 # ----- LAPACK/SCALAPACK
 set(LAPACK_TARGET "")
 if (DLAF_WITH_MKL)
+  set(MKL_CUSTOM_THREADING "Sequential")
   find_package(MKL REQUIRED)
   set(LAPACK_TARGET "mkl::mkl_intel_32bit_seq_dyn")
   if (NOT TARGET ${LAPACK_TARGET})
     message(FATAL_ERROR "MKL target ${LAPACK_TARGET} has not been found")
   endif()
-  add_library(LAPACK::LAPACK ALIAS ${LAPACK_TARGET})
 else()
+  set(LAPACK_TARGET "lapack::lapack")
   find_package(LAPACK REQUIRED)
-  add_library(LAPACK::LAPACK ALIAS lapack::lapack)
 endif()
 
 # ----- HPX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if (DLAF_WITH_MKL)
   add_library(LAPACK::LAPACK ALIAS ${LAPACK_TARGET})
 else()
   find_package(LAPACK REQUIRED)
-  add_library(LAPACK::LAPACK ALIAS ${LAPACK_TARGET})
+  add_library(LAPACK::LAPACK ALIAS lapack::lapack)
 endif()
 
 # ----- HPX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,15 @@ find_package(MPI REQUIRED)
 # ----- LAPACK/SCALAPACK
 set(LAPACK_TARGET "")
 if (DLAF_WITH_MKL)
-  set(MKL_CUSTOM_THREADING "Sequential")
   find_package(MKL REQUIRED)
   set(LAPACK_TARGET "mkl::mkl_intel_32bit_seq_dyn")
+  if (NOT TARGET ${LAPACK_TARGET})
+    message(FATAL_ERROR "MKL target ${LAPACK_TARGET} has not been found")
+  endif()
+  add_library(LAPACK::LAPACK ALIAS ${LAPACK_TARGET})
 else()
-  set(LAPACK_TARGET "lapack::lapack")
   find_package(LAPACK REQUIRED)
+  add_library(LAPACK::LAPACK ALIAS ${LAPACK_TARGET})
 endif()
 
 # ----- HPX

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -5,7 +5,7 @@
 # Copyright (c) 2018-2019, ETH Zurich
 # BSD 3-Clause License. All rights reserved.
 #
-# Author: Teodor Nikolov (teodor.nikolov22@gmail.com)
+# Author: Teodor Nikolov (tnikolov@cscs.ch)
 #
 #[=======================================================================[.rst:
 FindMKL
@@ -81,7 +81,7 @@ ScaLAPACK targets:
 
   mkl::scalapack_[mpich|ompi]_[gf|intel]_[32bit|64bit]_[seq|omp|tbb]_[st|dyn] e.g.
 
-  mkl::scalapack_intel_mpich_64bit_omp_dyn
+  mkl::scalapack_mpich_intel_64bit_omp_dyn
 
 Result variables
 ^^^^^^^^^^^^^^^^
@@ -142,6 +142,7 @@ else() # LINUX
     set(_mkl_static_lib ".a")
 endif()
 set(_mkl_search_paths "${MKL_ROOT}"
+                      "${MKL_ROOT}/lib"
                       "${MKL_ROOT}/mkl"
                       "${MKL_ROOT}/compiler")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,8 +64,8 @@ target_include_directories(dlaf.prop
 target_link_libraries(dlaf.prop
   INTERFACE
     MPI::MPI_CXX
+    LAPACK::LAPACK
     HPX::hpx
-    ${LAPACK_TARGET}
     lapackpp
     blaspp
     $<TARGET_NAME_IF_EXISTS:dlaf::cublas>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ target_include_directories(dlaf.prop
 target_link_libraries(dlaf.prop
   INTERFACE
     MPI::MPI_CXX
-    LAPACK::LAPACK
+    ${LAPACK_TARGET}
     HPX::hpx
     lapackpp
     blaspp


### PR DESCRIPTION
- Use updated version of FindMKL from external repository `cmake-recipes`
- Add check about MKL target existing
- ~Use alias target `LAPACK::LAPACK` (mirroring the target from standard cmake FindLAPACK)~

Opened it in draft mode, waiting for PR approval of the updated version of FindMKL