### PR TITLE
Extend API for in-place MPI reduction

### DIFF
--- a/include/dlaf/common/data_descriptor.h
+++ b/include/dlaf/common/data_descriptor.h
@@ -123,8 +123,8 @@ struct DataDescriptor {
   }
 
   bool operator==(const DataDescriptor& rhs) const noexcept {
-    return (this == &rhs) && this->data_ == rhs.data_ && this->nblocks_ == rhs.nblocks_ &&
-           this->blocksize_ == rhs.blocksize_ && this->stride_ == rhs.stride_;
+    return this == &rhs || (this->data_ == rhs.data_ && this->nblocks_ == rhs.nblocks_ &&
+                            this->blocksize_ == rhs.blocksize_ && this->stride_ == rhs.stride_);
   }
 
   bool operator!=(const DataDescriptor& rhs) const noexcept {

--- a/include/dlaf/common/data_descriptor.h
+++ b/include/dlaf/common/data_descriptor.h
@@ -122,6 +122,15 @@ struct DataDescriptor {
     return nblocks_ == 1 || stride_ == blocksize_;
   }
 
+  bool operator==(const DataDescriptor& rhs) const noexcept {
+    return (this == &rhs) && this->data_ == rhs.data_ && this->nblocks_ == rhs.nblocks_ &&
+           this->blocksize_ == rhs.blocksize_ && this->stride_ == rhs.stride_;
+  }
+
+  bool operator!=(const DataDescriptor& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+
 protected:
   T* data_;
   SizeType nblocks_;

--- a/include/dlaf/communication/communicator.h
+++ b/include/dlaf/communication/communicator.h
@@ -16,6 +16,9 @@
 namespace dlaf {
 namespace comm {
 
+/// Type used for indexes in MPI API.
+using IndexT_MPI = int;
+
 class CommunicatorImpl;
 
 /// MPI-compatible wrapper for the MPI_Comm.
@@ -57,9 +60,9 @@ public:
   const MPI_Comm* operator&() const noexcept;
 
   /// Return the rank of the current process in the Communicator.
-  int rank() const noexcept;
+  IndexT_MPI rank() const noexcept;
   /// Return the number of ranks in the Communicator.
-  int size() const noexcept;
+  IndexT_MPI size() const noexcept;
 
 private:
   /// Tag to give to constructor in order to give MPI_Comm ownership to Communicator.

--- a/include/dlaf/communication/communicator_grid.h
+++ b/include/dlaf/communication/communicator_grid.h
@@ -23,9 +23,6 @@ namespace comm {
 /// TAG for strong-typing basic_coords.
 struct TAG_MPI;
 
-/// Type used for indexes in MPI API.
-using IndexT_MPI = int;
-
 /// 2D index strong-typed for MPI.
 using Index2D = common::Index2D<IndexT_MPI, TAG_MPI>;
 /// 2D size strong-typed for MPI.

--- a/include/dlaf/communication/sync/all_reduce.h
+++ b/include/dlaf/communication/sync/all_reduce.h
@@ -35,7 +35,7 @@ void all_reduce(Communicator& communicator, MPI_Op reduce_operation, const DataI
 
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-pace)");
+  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-place)");
 
   // Wayout for single rank communicator, just copy data
   if (communicator.size() == 1) {

--- a/include/dlaf/communication/sync/all_reduce.h
+++ b/include/dlaf/communication/sync/all_reduce.h
@@ -34,6 +34,8 @@ void all_reduce(Communicator& communicator, MPI_Op reduce_operation, const DataI
 
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
+  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-pace)");
+
   // Wayout for single rank communicator, just copy data
   if (communicator.size() == 1) {
     common::copy(input, output);

--- a/include/dlaf/communication/sync/all_reduce.h
+++ b/include/dlaf/communication/sync/all_reduce.h
@@ -17,7 +17,6 @@
 #include "dlaf/common/data_descriptor.h"
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/message.h"
-#include "dlaf/communication/sync/broadcast.h"
 #include "dlaf/communication/sync/reduce.h"
 
 namespace dlaf {

--- a/include/dlaf/communication/sync/all_reduce.h
+++ b/include/dlaf/communication/sync/all_reduce.h
@@ -35,10 +35,9 @@ void allReduce(Communicator& communicator, MPI_Op reduce_operation, const DataIn
 
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-place)");
-
   // Wayout for single rank communicator, just copy data
   if (communicator.size() == 1) {
+    DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-place)");
     common::copy(input, output);
     return;
   }
@@ -48,6 +47,9 @@ void allReduce(Communicator& communicator, MPI_Op reduce_operation, const DataIn
 
   auto message_input = comm::make_message(make_contiguous(input, buffer_in));
   auto message_output = comm::make_message(make_contiguous(output, buffer_out));
+
+  DLAF_ASSERT_MODERATE((buffer_in || buffer_out) || (input != output),
+                       "input and output should not equal (use in-place)");
 
   // if the input buffer has been used, initialize it with input values
   if (buffer_in)

--- a/include/dlaf/communication/sync/all_reduce.h
+++ b/include/dlaf/communication/sync/all_reduce.h
@@ -29,8 +29,8 @@ namespace sync {
 /// MPI AllReduce(see MPI documentation for additional info).
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator,
 template <class DataIn, class DataOut>
-void all_reduce(Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
-                const DataOut output) {
+void allReduce(Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
+               const DataOut output) {
   using common::make_contiguous;
 
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
@@ -66,7 +66,7 @@ void all_reduce(Communicator& communicator, MPI_Op reduce_operation, const DataI
 /// MPI AllReduce(see MPI documentation for additional info).
 /// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator,
 template <class DataInOut>
-void all_reduce(Communicator& communicator, MPI_Op reduce_operation, const DataInOut inout) {
+void allReduceInPlace(Communicator& communicator, MPI_Op reduce_operation, const DataInOut inout) {
   using common::make_contiguous;
 
   using T = std::remove_const_t<typename common::data_traits<DataInOut>::element_t>;

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -25,13 +25,12 @@ namespace sync {
 namespace internal {
 namespace reduce {
 
-/// MPI_Reduce wrapper (sender side).
+/// MPI_Reduce wrapper (collector side, i.e. send and receive).
 ///
 /// MPI Reduce(see MPI documentation for additional info).
-/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator.
+/// @param reduce_op MPI_Op to perform on @p input data coming from ranks in @p communicator.
 template <class DataIn, class DataOut>
-void collector(Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
-               const DataOut output) {
+void collector(Communicator& communicator, MPI_Op reduce_op, const DataIn input, const DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
   // Wayout for single rank communicator, just copy data
@@ -51,22 +50,20 @@ void collector(Communicator& communicator, MPI_Op reduce_operation, const DataIn
     common::copy(input, buffer_in);
 
   DLAF_MPI_CALL(MPI_Reduce(message_input.data(), message_output.data(), message_input.count(),
-                           message_input.mpi_type(), reduce_operation, communicator.rank(),
-                           communicator));
+                           message_input.mpi_type(), reduce_op, communicator.rank(), communicator));
 
   // if the output buffer has been used, copy-back output values
   if (buffer_out)
     common::copy(buffer_out, output);
 }
 
-/// MPI_Reduce wrapper (receiver side).
+/// MPI_Reduce wrapper (sender side).
 ///
 /// MPI Reduce(see MPI documentation for additional info).
 /// @param rank_root  the rank that will collect the result in output,
-/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator.
+/// @param reduce_op MPI_Op to perform on @p input data coming from ranks in @p communicator.
 template <class DataIn>
-void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operation,
-                 const DataIn input) {
+void participant(IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op, const DataIn input) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
   // Buffers not allocated, just placeholders in case we need to allocate them
@@ -79,28 +76,79 @@ void participant(int rank_root, Communicator& communicator, MPI_Op reduce_operat
     common::copy(input, buffer_in);
 
   DLAF_MPI_CALL(MPI_Reduce(message_input.data(), nullptr, message_input.count(),
-                           message_input.mpi_type(), reduce_operation, rank_root, communicator));
+                           message_input.mpi_type(), reduce_op, rank_root, communicator));
 }
 }
 }
 
-/// MPI_Reduce wrapper.
+/// MPI_Reduce wrapper (both sides).
 ///
 /// MPI Reduce(see MPI documentation for additional info).
 /// @param rank_root the rank that will collect the result in output,
-/// @param reduce_operation MPI_Op to perform on @p input data coming from ranks in @p communicator,
+/// @param reduce_op MPI_Op to perform on @p input data coming from ranks in @p communicator,
 /// @pre @p rank_root < @p communicator.size(),
 /// @pre @p rank_root != MPI_UNDEFINED.
 template <class DataIn, class DataOut>
-void reduce(const int rank_root, Communicator& communicator, MPI_Op reduce_operation, const DataIn input,
+void reduce(const IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op, const DataIn input,
             const DataOut output) {
   DLAF_ASSERT(rank_root < communicator.size() && rank_root != MPI_UNDEFINED, rank_root,
               communicator.size());
 
   if (rank_root == communicator.rank())
-    internal::reduce::collector(communicator, reduce_operation, input, output);
+    internal::reduce::collector(communicator, reduce_op, input, output);
   else
-    internal::reduce::participant(rank_root, communicator, reduce_operation, input);
+    internal::reduce::participant(rank_root, communicator, reduce_op, input);
+}
+
+/// MPI_Reduce wrapper (collector-side, in-place).
+///
+/// MPI Reduce(see MPI documentation for additional info).
+/// It uses the MPI_IN_PLACE option, so the result of the reduce is stored in the same buffer
+/// used for the input, i.e. @p inout
+///
+/// It must be highlighted that if the buffer is not contiguous, it will get copied to a support
+/// buffer, and then copied back. From the user perspective it is still in-place, but in that specific
+/// case there will be internal memory copies.
+///
+/// @param reduce_op MPI_Op to perform on @p inout data coming from ranks in @p communicator,
+/// @pre @p rank_root < @p communicator.size(),
+template <class DataInOut>
+void reduce(Communicator& communicator, MPI_Op reduce_op, const DataInOut inout) {
+  using T = std::remove_const_t<typename common::data_traits<DataInOut>::element_t>;
+
+  // Wayout for single rank communicator, just copy data
+  if (communicator.size() == 1) {
+    return;
+  }
+
+  // Buffers not allocated, just placeholders in case we need to allocate them
+  common::Buffer<T> buffer_inout;
+
+  auto message_inout = comm::make_message(make_contiguous(inout, buffer_inout));
+
+  // if the input buffer has been used, initialize it with input values
+  if (buffer_inout)
+    common::copy(inout, buffer_inout);
+
+  DLAF_MPI_CALL(MPI_Reduce(MPI_IN_PLACE, message_inout.data(), message_inout.count(),
+                           message_inout.mpi_type(), reduce_op, communicator.rank(), communicator));
+
+  // if the output buffer has been used, copy-back output values
+  if (buffer_inout)
+    common::copy(buffer_inout, inout);
+}
+
+/// MPI_Reduce wrapper (sender side).
+///
+/// MPI Reduce(see MPI documentation for additional info).
+///
+/// This is an helper function for the sender side, with just needed arguments (i.e. output parameter
+/// is meaningful just on the sender side).
+/// @param rank_root  the rank that will collect the result in output,
+/// @param reduce_op MPI_Op to perform on @p input data coming from ranks in @p communicator.
+template <class DataIn>
+void reduce(IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op, const DataIn input) {
+  internal::reduce::participant(rank_root, communicator, reduce_op, input);
 }
 }
 }

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -123,12 +123,12 @@ void reduce(IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op, 
 /// MPI Reduce(see MPI documentation for additional info).
 /// @param rank_root the rank that will collect the result in output,
 /// @param reduce_op MPI_Op to perform on @p input data coming from ranks in @p communicator,
-/// @pre @p rank_root < @p communicator.size(),
+/// @pre @p 0 <= rank_root < @p communicator.size(),
 /// @pre @p rank_root != MPI_UNDEFINED.
 template <class DataIn, class DataOut>
 void reduce(const IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op, const DataIn input,
             const DataOut output) {
-  DLAF_ASSERT(rank_root < communicator.size() && rank_root != MPI_UNDEFINED, rank_root,
+  DLAF_ASSERT(0 <= rank_root && rank_root < communicator.size() && rank_root != MPI_UNDEFINED, rank_root,
               communicator.size());
 
   if (rank_root == communicator.rank())

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -30,6 +30,8 @@ template <class DataIn, class DataOut>
 void reduce(Communicator& communicator, MPI_Op reduce_op, const DataIn input, const DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
+  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal");
+
   // Wayout for single rank communicator, just copy data
   if (communicator.size() == 1) {
     common::copy(input, output);
@@ -134,7 +136,6 @@ void reduce(const IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduc
   else
     reduce(rank_root, communicator, reduce_op, input);
 }
-
 }
 }
 }

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -30,7 +30,7 @@ template <class DataIn, class DataOut>
 void reduce(Communicator& communicator, MPI_Op reduce_op, const DataIn input, const DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal");
+  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-place)");
 
   // Wayout for single rank communicator, just copy data
   if (communicator.size() == 1) {

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -63,7 +63,8 @@ void collector(Communicator& communicator, MPI_Op reduce_op, const DataIn input,
 /// @param rank_root  the rank that will collect the result in output,
 /// @param reduce_op MPI_Op to perform on @p input data coming from ranks in @p communicator.
 template <class DataIn>
-void participant(IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op, const DataIn input) {
+void participant(IndexT_MPI rank_root, Communicator& communicator, MPI_Op reduce_op,
+                 const DataIn input) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
   // Buffers not allocated, just placeholders in case we need to allocate them
@@ -121,19 +122,19 @@ void reduce(Communicator& communicator, MPI_Op reduce_op, const DataInOut inout)
     return;
   }
 
-  // Buffers not allocated, just placeholders in case we need to allocate them
+  // Buffer not allocated, just a placeholder in case we need to allocate it
   common::Buffer<T> buffer_inout;
 
   auto message_inout = comm::make_message(make_contiguous(inout, buffer_inout));
 
-  // if the input buffer has been used, initialize it with input values
+  // if the buffer has been used, initialize it with input values
   if (buffer_inout)
     common::copy(inout, buffer_inout);
 
   DLAF_MPI_CALL(MPI_Reduce(MPI_IN_PLACE, message_inout.data(), message_inout.count(),
                            message_inout.mpi_type(), reduce_op, communicator.rank(), communicator));
 
-  // if the output buffer has been used, copy-back output values
+  // if the buffer has been used, copy-back output values
   if (buffer_inout)
     common::copy(buffer_inout, inout);
 }

--- a/include/dlaf/communication/sync/reduce.h
+++ b/include/dlaf/communication/sync/reduce.h
@@ -30,10 +30,9 @@ template <class DataIn, class DataOut>
 void reduceRecv(Communicator& communicator, MPI_Op reduce_op, const DataIn input, const DataOut output) {
   using T = std::remove_const_t<typename common::data_traits<DataIn>::element_t>;
 
-  DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-place)");
-
   // Wayout for single rank communicator, just copy data
   if (communicator.size() == 1) {
+    DLAF_ASSERT_MODERATE(input != output, "input and output should not equal (use in-place)");
     common::copy(input, output);
     return;
   }
@@ -43,6 +42,9 @@ void reduceRecv(Communicator& communicator, MPI_Op reduce_op, const DataIn input
 
   auto message_input = comm::make_message(make_contiguous(input, buffer_in));
   auto message_output = comm::make_message(make_contiguous(output, buffer_out));
+
+  DLAF_ASSERT_MODERATE((buffer_in || buffer_out) || (input != output),
+                       "input and output should not equal (use in-place)");
 
   // if the input buffer has been used, initialize it with input values
   if (buffer_in)

--- a/include/dlaf/factorization/qr/t_factor_mc.h
+++ b/include/dlaf/factorization/qr/t_factor_mc.h
@@ -187,8 +187,7 @@ void QR_Tfactor<Backend::MC, Device::CPU, T>::call(
   // so, let's reduce the results (on all ranks, so that everyone can independently compute T factor)
   if (true) {  // TODO if the column communicator has more than 1 tile...but I just have the pipeline
     auto reduce_t_func = unwrapping([=](auto&& tile_t, auto&& comm_wrapper) {
-      auto&& input_t = make_data(tile_t);
-      all_reduce(comm_wrapper.ref().colCommunicator(), MPI_SUM, input_t, input_t);
+      allReduceInPlace(comm_wrapper.ref().colCommunicator(), MPI_SUM, make_data(tile_t));
       return std::move(tile_t);
     });
 

--- a/test/unit/communication/test_all_reduce.cpp
+++ b/test/unit/communication/test_all_reduce.cpp
@@ -24,6 +24,7 @@ using namespace dlaf::comm::test;
 using namespace dlaf::test;
 
 using AllReduceTest = SplittedCommunicatorsTest;
+using AllReduceInPlaceTest = SplittedCommunicatorsTest;
 
 using TypeParam = std::complex<double>;
 
@@ -188,4 +189,111 @@ TEST_F(AllReduceTest, ContiguousToStrided) {
       EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_strided[mem_pos]),
                 NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
     }
+}
+
+TEST_F(AllReduceInPlaceTest, ValueOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = value;
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::allReduceInPlace(alone_world, MPI_SUM, common::make_data(&result, 1));
+
+  EXPECT_LE(std::abs(value - result), TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceInPlaceTest, CArrayOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr SizeType N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+  std::copy(input, input + N, reduced);
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::allReduceInPlace(alone_world, MPI_SUM, common::make_data(reduced, N));
+
+  for (SizeType index = 0; index < N; ++index)
+    EXPECT_LE(std::abs(input[index] - reduced[index]), TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceInPlaceTest, Value) {
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = value;
+
+  sync::allReduceInPlace(world, MPI_SUM, common::make_data(&result, 1));
+
+  EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
+            NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceInPlaceTest, CArray) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  constexpr SizeType N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+  std::copy(input, input + N, reduced);
+
+  sync::allReduceInPlace(world, MPI_SUM, common::make_data(reduced, N));
+
+  for (SizeType index = 0; index < N; ++index)
+    EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(AllReduceInPlaceTest, WithStrided) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr SizeType nblocks = 3;
+  constexpr SizeType block_size = 2;
+  constexpr SizeType block_distance = 5;
+
+  constexpr SizeType memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (SizeType i_block = 0; i_block < nblocks; ++i_block) {
+    for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = value;
+    }
+  }
+
+  auto message_inout = common::make_data(data_strided, nblocks, block_size, block_distance);
+
+  sync::allReduceInPlace(world, MPI_SUM, std::move(message_inout));
+
+  const TypeParam expected_result = value * static_cast<TypeParam>(NUM_MPI_RANKS);
+
+  for (SizeType i_block = 0; i_block < nblocks; ++i_block) {
+    for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      EXPECT_LE(std::abs(expected_result - data_strided[mem_pos]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+    }
+  }
 }

--- a/test/unit/communication/test_all_reduce.cpp
+++ b/test/unit/communication/test_all_reduce.cpp
@@ -42,7 +42,7 @@ TEST_F(AllReduceTest, ValueOnSingleRank) {
 
   ASSERT_EQ(alone_world.rank(), root);
 
-  sync::all_reduce(alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
+  sync::allReduce(alone_world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
   EXPECT_LE(std::abs(value - result), TypeUtilities<TypeParam>::error);
 }
@@ -65,7 +65,7 @@ TEST_F(AllReduceTest, CArrayOnSingleRank) {
 
   ASSERT_EQ(alone_world.rank(), root);
 
-  sync::all_reduce(alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
+  sync::allReduce(alone_world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (SizeType index = 0; index < N; ++index)
     EXPECT_LE(std::abs(input[index] - reduced[index]), TypeUtilities<TypeParam>::error);
@@ -75,7 +75,7 @@ TEST_F(AllReduceTest, Value) {
   constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
   TypeParam result = 0;
 
-  sync::all_reduce(world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
+  sync::allReduce(world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
 
   EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
             NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
@@ -90,7 +90,7 @@ TEST_F(AllReduceTest, CArray) {
                                   TypeUtilities<TypeParam>::element(2, 3)};
   TypeParam reduced[N];
 
-  sync::all_reduce(world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
+  sync::allReduce(world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
 
   for (SizeType index = 0; index < N; ++index)
     EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
@@ -114,7 +114,7 @@ TEST_F(AllReduceTest, ContiguousToContiguous) {
   auto&& message_output = common::make_data(data_B, N);
   MPI_Op op = MPI_SUM;
 
-  sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
+  sync::allReduce(communicator, op, std::move(message_input), std::move(message_output));
 
   for (auto i = 0; i < N; ++i)
     EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_B[i]),
@@ -149,7 +149,7 @@ TEST_F(AllReduceTest, StridedToContiguous) {
 
   auto& communicator = world;
   MPI_Op op = MPI_SUM;
-  sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
+  sync::allReduce(communicator, op, std::move(message_input), std::move(message_output));
 
   for (auto i = 0; i < N; ++i)
     EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_contiguous[i]),
@@ -180,7 +180,7 @@ TEST_F(AllReduceTest, ContiguousToStrided) {
 
   auto& communicator = world;
   MPI_Op op = MPI_SUM;
-  sync::all_reduce(communicator, op, std::move(message_input), std::move(message_output));
+  sync::allReduce(communicator, op, std::move(message_input), std::move(message_output));
 
   for (SizeType i_block = 0; i_block < nblocks; ++i_block)
     for (SizeType i_element = 0; i_element < block_size; ++i_element) {

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -23,6 +23,7 @@ using namespace dlaf::test;
 using namespace dlaf::comm;
 
 using ReduceTest = dlaf::comm::test::SplittedCommunicatorsTest;
+using ReduceInPlaceTest = dlaf::comm::test::SplittedCommunicatorsTest;
 
 using TypeParam = std::complex<double>;
 
@@ -201,5 +202,121 @@ TEST_F(ReduceTest, ContiguousToStrided) {
         EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_strided[mem_pos]),
                   NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
       }
+  }
+}
+
+TEST_F(ReduceInPlaceTest, ValueOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = value;
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::reduceInPlace(root, alone_world, MPI_SUM, common::make_data(&result, 1));
+
+  EXPECT_LE(std::abs(value - result), TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(ReduceInPlaceTest, CArrayOnSingleRank) {
+  CommunicatorGrid alone_grid(world, 1, 1, common::Ordering::RowMajor);
+
+  Communicator alone_world = alone_grid.rowCommunicator();
+
+  // just the master rank has to reduce
+  if (alone_world == MPI_COMM_NULL)
+    return;
+
+  constexpr int root = 0;
+  constexpr SizeType N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+  std::copy(input, input + N, reduced);
+
+  ASSERT_EQ(alone_world.rank(), root);
+
+  sync::reduceInPlace(root, alone_world, MPI_SUM, common::make_data(reduced, N));
+
+  for (SizeType index = 0; index < N; ++index)
+    EXPECT_LE(std::abs(input[index] - reduced[index]), TypeUtilities<TypeParam>::error);
+}
+
+TEST_F(ReduceInPlaceTest, Value) {
+  const int root = 0;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = value;
+
+  sync::reduceInPlace(root, world, MPI_SUM, common::make_data(&result, 1));
+
+  if (world.rank() == root) {
+    EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+}
+
+TEST_F(ReduceInPlaceTest, CArray) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+  int root = 1;
+
+  constexpr SizeType N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+  std::copy(input, input + N, reduced);
+
+  sync::reduceInPlace(root, world, MPI_SUM, common::make_data(reduced, N));
+
+  if (world.rank() == root) {
+    for (SizeType index = 0; index < N; ++index)
+      EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+}
+
+TEST_F(ReduceInPlaceTest, Strided) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr SizeType nblocks = 3;
+  constexpr SizeType block_size = 2;
+  constexpr SizeType block_distance = 5;
+
+  constexpr SizeType memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (SizeType i_block = 0; i_block < nblocks; ++i_block)
+    for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = value;
+    }
+
+  auto&& message_inout = common::make_data(data_strided, nblocks, block_size, block_distance);
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
+  sync::reduceInPlace(root, communicator, op, std::move(message_inout));
+
+  if (root == world.rank()) {
+    const TypeParam expected_result = value * static_cast<TypeParam>(NUM_MPI_RANKS);
+    for (SizeType i_block = 0; i_block < nblocks; ++i_block) {
+      for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+        auto mem_pos = i_block * block_distance + i_element;
+        EXPECT_LE(std::abs(expected_result - data_strided[mem_pos]),
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      }
+    }
   }
 }

--- a/test/unit/communication/test_reduce.cpp
+++ b/test/unit/communication/test_reduce.cpp
@@ -24,6 +24,8 @@ using namespace dlaf::comm;
 
 using ReduceTest = dlaf::comm::test::SplittedCommunicatorsTest;
 using ReduceInPlaceTest = dlaf::comm::test::SplittedCommunicatorsTest;
+using ReduceSplitAPITest = dlaf::comm::test::SplittedCommunicatorsTest;
+using ReduceInPlaceSplitAPITest = dlaf::comm::test::SplittedCommunicatorsTest;
 
 using TypeParam = std::complex<double>;
 
@@ -84,6 +86,21 @@ TEST_F(ReduceTest, Value) {
   }
 }
 
+TEST_F(ReduceSplitAPITest, Value) {
+  const int root = 0;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = 0;
+
+  if (world.rank() == root) {
+    sync::reduceRecv(world, MPI_SUM, common::make_data(&value, 1), common::make_data(&result, 1));
+    EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+  else {
+    sync::reduceSend(root, world, MPI_SUM, common::make_data(&value, 1));
+  }
+}
+
 TEST_F(ReduceTest, CArray) {
   static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
   int root = 1;
@@ -100,6 +117,28 @@ TEST_F(ReduceTest, CArray) {
     for (SizeType index = 0; index < N; ++index)
       EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
                 NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+}
+
+TEST_F(ReduceSplitAPITest, CArray) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+  int root = 1;
+
+  constexpr SizeType N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+
+  if (world.rank() == root) {
+    sync::reduceRecv(world, MPI_SUM, common::make_data(input, N), common::make_data(reduced, N));
+
+    for (SizeType index = 0; index < N; ++index)
+      EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+  else {
+    sync::reduceSend(root, world, MPI_SUM, common::make_data(input, N));
   }
 }
 
@@ -127,6 +166,36 @@ TEST_F(ReduceTest, ContiguousToContiguous) {
     for (auto i = 0; i < N; ++i)
       EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_B[i]),
                 NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+}
+
+TEST_F(ReduceSplitAPITest, ContiguousToContiguous) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  constexpr int N = 10;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+
+  TypeParam data_A[N];
+  TypeParam data_B[N];
+
+  for (auto i = 0; i < N; ++i)
+    data_A[i] = value;
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_A), N);
+  auto&& message_output = common::make_data(data_B, N);
+  MPI_Op op = MPI_SUM;
+
+  if (root == world.rank()) {
+    sync::reduceRecv(communicator, op, std::move(message_input), std::move(message_output));
+
+    for (auto i = 0; i < N; ++i)
+      EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_B[i]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+  else {
+    sync::reduceSend(root, communicator, op, std::move(message_input));
   }
 }
 
@@ -168,6 +237,47 @@ TEST_F(ReduceTest, StridedToContiguous) {
   }
 }
 
+TEST_F(ReduceSplitAPITest, StridedToContiguous) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr SizeType nblocks = 3;
+  constexpr SizeType block_size = 2;
+  constexpr SizeType block_distance = 5;
+
+  constexpr SizeType memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (SizeType i_block = 0; i_block < nblocks; ++i_block)
+    for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = value;
+    }
+
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_strided), nblocks,
+                                           block_size, block_distance);
+  auto&& message_output = common::make_data(data_contiguous, N);
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
+
+  if (root == world.rank()) {
+    sync::reduceRecv(communicator, op, std::move(message_input), std::move(message_output));
+    for (auto i = 0; i < N; ++i)
+      EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_contiguous[i]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+  else {
+    sync::reduceSend(root, communicator, op, std::move(message_input));
+  }
+}
+
 TEST_F(ReduceTest, ContiguousToStrided) {
   static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
 
@@ -202,6 +312,46 @@ TEST_F(ReduceTest, ContiguousToStrided) {
         EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_strided[mem_pos]),
                   NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
       }
+  }
+}
+
+TEST_F(ReduceSplitAPITest, ContiguousToStrided) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr SizeType nblocks = 3;
+  constexpr SizeType block_size = 2;
+  constexpr SizeType block_distance = 5;
+
+  constexpr SizeType memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr int N = nblocks * block_size;
+  TypeParam data_contiguous[N];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (auto i = 0; i < N; ++i)
+    data_contiguous[i] = value;
+
+  auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_contiguous), N);
+  auto&& message_output = common::make_data(data_strided, nblocks, block_size, block_distance);
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
+
+  if (world.rank() == root) {
+    sync::reduceRecv(communicator, op, std::move(message_input), std::move(message_output));
+    for (SizeType i_block = 0; i_block < nblocks; ++i_block)
+      for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+        auto mem_pos = i_block * block_distance + i_element;
+        EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - data_strided[mem_pos]),
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      }
+  }
+  else {
+    sync::reduceSend(root, communicator, op, std::move(message_input));
   }
 }
 
@@ -263,6 +413,21 @@ TEST_F(ReduceInPlaceTest, Value) {
   }
 }
 
+TEST_F(ReduceInPlaceSplitAPITest, Value) {
+  const int root = 0;
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  TypeParam result = value;
+
+  if (world.rank() == root) {
+    sync::reduceRecvInPlace(world, MPI_SUM, common::make_data(&result, 1));
+    EXPECT_LE(std::abs(value * static_cast<TypeParam>(NUM_MPI_RANKS) - result),
+              NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+  else {
+    sync::reduceSend(root, world, MPI_SUM, common::make_data(&value, 1));
+  }
+}
+
 TEST_F(ReduceInPlaceTest, CArray) {
   static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
   int root = 1;
@@ -280,6 +445,28 @@ TEST_F(ReduceInPlaceTest, CArray) {
     for (SizeType index = 0; index < N; ++index)
       EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
                 NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+}
+
+TEST_F(ReduceInPlaceSplitAPITest, CArray) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+  int root = 1;
+
+  constexpr SizeType N = 3;
+  constexpr TypeParam input[N] = {TypeUtilities<TypeParam>::element(0, 1),
+                                  TypeUtilities<TypeParam>::element(1, 2),
+                                  TypeUtilities<TypeParam>::element(2, 3)};
+  TypeParam reduced[N];
+  std::copy(input, input + N, reduced);
+
+  if (world.rank() == root) {
+    sync::reduceRecvInPlace(world, MPI_SUM, common::make_data(reduced, N));
+    for (SizeType index = 0; index < N; ++index)
+      EXPECT_LE(std::abs(input[index] * static_cast<TypeParam>(NUM_MPI_RANKS) - reduced[index]),
+                NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+  }
+  else {
+    sync::reduceSend(root, world, MPI_SUM, common::make_data(input, N));
   }
 }
 
@@ -318,5 +505,48 @@ TEST_F(ReduceInPlaceTest, Strided) {
                   NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
       }
     }
+  }
+}
+
+TEST_F(ReduceInPlaceSplitAPITest, Strided) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires at least two ranks");
+
+  // 3 blocks, 2 elements each, with a distance of 5 elements between start of each block
+  // E E - - - E E - - - E E    (without padding at the end)
+  constexpr SizeType nblocks = 3;
+  constexpr SizeType block_size = 2;
+  constexpr SizeType block_distance = 5;
+
+  constexpr SizeType memory_footprint = (nblocks - 1) * block_distance + block_size;
+  TypeParam data_strided[memory_footprint];
+
+  constexpr TypeParam value = TypeUtilities<TypeParam>::element(13, 26);
+  for (SizeType i_block = 0; i_block < nblocks; ++i_block)
+    for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+      auto mem_pos = i_block * block_distance + i_element;
+      data_strided[mem_pos] = value;
+    }
+
+  constexpr int root = 0;
+  auto& communicator = world;
+  MPI_Op op = MPI_SUM;
+
+  if (root == world.rank()) {
+    auto&& message_inout = common::make_data(data_strided, nblocks, block_size, block_distance);
+    sync::reduceRecvInPlace(communicator, op, std::move(message_inout));
+
+    const TypeParam expected_result = value * static_cast<TypeParam>(NUM_MPI_RANKS);
+    for (SizeType i_block = 0; i_block < nblocks; ++i_block) {
+      for (SizeType i_element = 0; i_element < block_size; ++i_element) {
+        auto mem_pos = i_block * block_distance + i_element;
+        EXPECT_LE(std::abs(expected_result - data_strided[mem_pos]),
+                  NUM_MPI_RANKS * TypeUtilities<TypeParam>::error);
+      }
+    }
+  }
+  else {
+    auto&& message_input = common::make_data(static_cast<const TypeParam*>(data_strided), nblocks,
+                                             block_size, block_distance);
+    sync::reduceSend(root, communicator, op, std::move(message_input));
   }
 }


### PR DESCRIPTION
This PR extends a bit the MPI reduce API.

In particular, before this, there was just the "single access" signature, valid for both endpoints, resembling `MPI_Reduce` (apart from the order, arguments are the same).
```cpp
reduce(
  const IndexT_MPI rank_root,
  Communicator& communicator,
  MPI_Op reduce_op,
  const DataIn input,
  const DataOut output)
```

This has a couple of downsides:
- On the sender side, you have to specify a "fake" `DataOut`, even if it is not needed at all;
- On the receiver side, you have to specify the `rank_root`

With this PR, three functions are going to be added:
- sender endpoint: it won't be needed anymore to specify the `output` argument
`reduce(rank_root, comm, op, input)`
- receiver endpoint:
  - the classic version, but implying that if you call this function, the calling rank is the one that collects results
  `reduce(comm, op, in, out)`
  - an alternative version, similar to previous one, but it uses internally `MPI_IN_PLACE`, allowing to use the same memory for input and output
  `reduce(comm, op, inout)`

The main point of this PR is being able to reduce in-place.

In addition, a minor thing: move `IndexT_MPI` to communicator.