### PR TITLE
computeTFactor: API change

### DIFF
--- a/include/dlaf/factorization/qr.h
+++ b/include/dlaf/factorization/qr.h
@@ -25,9 +25,10 @@ namespace internal {
 // SIAM Journal on Scientific and Statistical Computing. 10. 10.1137/0910005.
 template <Backend backend, Device device, class T>
 void computeTFactor(const SizeType k, Matrix<const T, device>& v, const GlobalTileIndex v_start,
-                    hpx::shared_future<common::internal::vector<T>> taus, Matrix<T, device>& t,
+                    hpx::shared_future<common::internal::vector<T>> taus,
+                    hpx::future<matrix::Tile<T, device>> t,
                     common::Pipeline<comm::CommunicatorGrid>& serial_comm) {
-  QR_Tfactor<backend, device, T>::call(k, v, v_start, taus, t, serial_comm);
+  QR_Tfactor<backend, device, T>::call(k, v, v_start, taus, std::move(t), serial_comm);
 }
 }
 

--- a/include/dlaf/factorization/qr.h
+++ b/include/dlaf/factorization/qr.h
@@ -25,11 +25,10 @@ namespace internal {
 // SIAM Journal on Scientific and Statistical Computing. 10. 10.1137/0910005.
 template <Backend backend, Device device, class T>
 void computeTFactor(const SizeType k, Matrix<const T, device>& v, const GlobalTileIndex v_start,
-                    common::internal::vector<hpx::shared_future<T>> taus, Matrix<T, device>& t,
+                    hpx::shared_future<common::internal::vector<T>> taus, Matrix<T, device>& t,
                     common::Pipeline<comm::CommunicatorGrid>& serial_comm) {
   QR_Tfactor<backend, device, T>::call(k, v, v_start, taus, t, serial_comm);
 }
-
 }
 
 }

--- a/include/dlaf/factorization/qr/t_factor_mc.h
+++ b/include/dlaf/factorization/qr/t_factor_mc.h
@@ -56,14 +56,14 @@ struct QR_Tfactor<Backend::MC, Device::CPU, T> {
   /// column of the reflectors
   /// @param serial_comm where internal communications are issued
   static void call(const SizeType k, Matrix<const T, Device::CPU>& v, const GlobalTileIndex v_start,
-                   common::internal::vector<hpx::shared_future<T>> taus, Matrix<T, Device::CPU>& t,
+                   hpx::shared_future<common::internal::vector<T>> taus, Matrix<T, Device::CPU>& t,
                    common::Pipeline<comm::CommunicatorGrid>& serial_comm);
 };
 
 template <class T>
 void QR_Tfactor<Backend::MC, Device::CPU, T>::call(
     const SizeType k, Matrix<const T, Device::CPU>& v, const GlobalTileIndex v_start,
-    common::internal::vector<hpx::shared_future<T>> taus, Matrix<T, Device::CPU>& t,
+    hpx::shared_future<common::internal::vector<T>> taus, Matrix<T, Device::CPU>& t,
     common::Pipeline<comm::CommunicatorGrid>& serial_comm) {
   using hpx::util::unwrapping;
   using common::make_data;
@@ -76,7 +76,6 @@ void QR_Tfactor<Backend::MC, Device::CPU, T>::call(
   const auto panel_width = v.tileSize(v_start).cols();
 
   DLAF_ASSERT(k <= panel_width, k, panel_width);
-  DLAF_ASSERT(taus.size() == k, taus.size(), k);
 
   const GlobalTileIndex t_idx(0, 0);
   const auto t_size = t.tileSize(t_idx);
@@ -121,6 +120,7 @@ void QR_Tfactor<Backend::MC, Device::CPU, T>::call(
     const bool is_v0 = (v_i == v_start.row());
 
     auto gemv_func = unwrapping([=](const auto& tile_v, const auto& taus, auto&& tile_t) {
+      DLAF_ASSERT(taus.size() == k, taus.size(), k);
       for (SizeType j = 0; j < k; ++j) {
         const T tau = taus[j];
         // this is the x0 element of the reflector j

--- a/include/dlaf/factorization/qr/t_factor_mc.h
+++ b/include/dlaf/factorization/qr/t_factor_mc.h
@@ -52,9 +52,10 @@ struct QR_Tfactor<Backend::MC, Device::CPU, T> {
   /// @param v where the elementary reflectors are stored
   /// @param v_start tile in @p v where the column of reflectors starts
   /// @param taus array of taus, associated with the related elementary reflector
-  /// @param t a matrix where the triangular factor will be stored (in tile {0, 0}) for all ranks in the
-  /// column of the reflectors
+  /// @param t tile where the resulting T factor will be stored
   /// @param serial_comm where internal communications are issued
+  ///
+  /// @pre k <= t.get().size().rows && k <= t.get().size().cols()
   static void call(const SizeType k, Matrix<const T, Device::CPU>& v, const GlobalTileIndex v_start,
                    hpx::shared_future<common::internal::vector<T>> taus,
                    hpx::future<matrix::Tile<T, Device::CPU>> t,

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -215,10 +215,12 @@ TYPED_TEST(ComputeTFactorDistributedTest, Correctness) {
       is_orthogonal(h_expected);
 
       common::Pipeline<comm::CommunicatorGrid> serial_comm(comm_grid);
-      Matrix<TypeParam, Device::CPU> t_output(LocalElementSize{k, k}, block_size);
+
+      Matrix<TypeParam, Device::CPU> t_output({k, k}, block_size);
+      const LocalTileIndex t_idx(0, 0);
 
       dlaf::factorization::internal::computeTFactor<Backend::MC>(k, v_input, v_start, taus_input,
-                                                                 t_output, serial_comm);
+                                                                 t_output(t_idx), serial_comm);
 
       const auto column_involved = dist_v.rankGlobalTile(v_start).col();
       if (dist_v.rankIndex().col() != column_involved)
@@ -234,7 +236,7 @@ TYPED_TEST(ComputeTFactorDistributedTest, Correctness) {
       //
       // is computed and compared to the one previously obtained by applying reflectors sequentially
 
-      const auto& t = t_output.read(LocalTileIndex{0, 0}).get();
+      const auto& t = t_output.read(t_idx).get();
 
       // TV* = (VT*)* = W
       MatrixLocal<TypeParam> w({m, k}, block_size);

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 #include <blas.hh>
+#include <hpx/futures/future.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator_grid.h"
@@ -165,8 +166,8 @@ TYPED_TEST(ComputeTFactorDistributedTest, Correctness) {
       const SizeType m = v.size().rows();
 
       // compute taus and H_exp
-      common::internal::vector<hpx::shared_future<TypeParam>> taus_input;
-      taus_input.reserve(k);
+      common::internal::vector<TypeParam> taus;
+      taus.reserve(k);
 
       MatrixLocal<TypeParam> h_expected({m, m}, block_size);
       set(h_expected, preset_eye<TypeParam>);
@@ -178,7 +179,7 @@ TYPED_TEST(ComputeTFactorDistributedTest, Correctness) {
         const auto norm = blas::nrm2(reflector_size, data_ptr, 1);
         const TypeParam tau = 2 / std::pow(norm, 2);
 
-        taus_input.push_back(hpx::make_ready_future<TypeParam>(tau));
+        taus.push_back(tau);
 
         MatrixLocal<TypeParam> h_i({reflector_size, reflector_size}, block_size);
         set(h_i, preset_eye<TypeParam>);
@@ -209,6 +210,7 @@ TYPED_TEST(ComputeTFactorDistributedTest, Correctness) {
         std::copy(workspace.ptr(), workspace.ptr() + workspace.size().linear_size(),
                   h_expected.ptr(h_offset));
       }
+      hpx::shared_future<decltype(taus)> taus_input = hpx::make_ready_future(taus);
 
       is_orthogonal(h_expected);
 


### PR DESCRIPTION
After a discussion with @rasolca, this PR proposes two major API changes:
- `taus` are passed as `shared_future<vector<T>>` and not as `vector<shared_future<T>>`;
- pass a `future<Tile>` instead of a `Matrix` as storage for the output

The former suggests better the idea that all the `taus` for this panel are considered together instead as a results of single columns. This reduces the atomicity of the operation, but the granularity at column level is not interesting because it leads to numerous "microtasks" (not advisable due to overhead and management by the scheduling).

The latter allows to use any Tile (of the right size) from whatever Matrix and in the preferred position (not strictly the top-left one). Since there is no more the Matrix that manages the "pipelining" of the accesses to the tile, it required to do it inside the algorithm (keeping/returning the future<Tile> from tasks).