### PR TITLE
Select a range of tiles (for creating a barrier)

### DIFF
--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -74,11 +74,10 @@ protected:
 template <typename IndexT, class Tag>
 class IterableRange2D {
   using size2d_t = Size2D<IndexT, Tag>;
+  using index2d_t = Index2D<IndexT, Tag>;
   using iter2d_t = IteratorRange2D<IndexT, Tag>;
 
 public:
-  using index2d_t = Index2D<IndexT, Tag>;
-
   IterableRange2D(index2d_t begin_idx, size2d_t sz)
       : begin_idx_(begin_idx), ld_(sz.rows()), i_max_(sz.rows() * sz.cols()) {}
 

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -74,10 +74,11 @@ protected:
 template <typename IndexT, class Tag>
 class IterableRange2D {
   using size2d_t = Size2D<IndexT, Tag>;
-  using index2d_t = Index2D<IndexT, Tag>;
   using iter2d_t = IteratorRange2D<IndexT, Tag>;
 
 public:
+  using index2d_t = Index2D<IndexT, Tag>;
+
   IterableRange2D(index2d_t begin_idx, size2d_t sz)
       : begin_idx_(begin_idx), ld_(sz.rows()), i_max_(sz.rows() * sz.cols()) {}
 

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -36,6 +36,7 @@
 /// ```
 
 #include <cstddef>
+#include <iterator>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
@@ -45,29 +46,113 @@ namespace common {
 
 /// An Iterator returning indices in column-major order.
 template <typename IndexT, class Tag>
-class IteratorRange2D {
-  using index2d_t = Index2D<IndexT, Tag>;
+struct IteratorRange2D {
+  using iterator_category = std::random_access_iterator_tag;
+  using difference_type = SizeType;
+  using value_type = Index2D<IndexT, Tag>;
+  using reference = const Index2D<IndexT, Tag>&;
+  using pointer = const Index2D<IndexT, Tag>*;
 
-public:
-  IteratorRange2D(index2d_t begin, IndexT ld, SizeType i) : begin_(begin), ld_(ld), i_(i) {}
+  IteratorRange2D() = default;
 
-  void operator++() noexcept {
-    ++i_;
+  IteratorRange2D(const IteratorRange2D&) = default;
+  IteratorRange2D& operator=(const IteratorRange2D&) = default;
+
+  IteratorRange2D(value_type begin, IndexT ld, SizeType i) : begin_(begin), i_(i), ld_(ld) {
+    current_ = computeIndex2D(i_);
   }
 
-  bool operator!=(const IteratorRange2D& o) const noexcept {
-    return i_ != o.i_;
+  reference operator*() const noexcept {
+    return current_;
   }
 
-  index2d_t operator*() const noexcept {
-    return index2d_t(begin_.row() + static_cast<IndexT>(i_ % ld_),
-                     begin_.col() + static_cast<IndexT>(i_ / ld_));
+  pointer operator->() const noexcept {
+    return &current_;
+  }
+
+  reference operator[](difference_type n) const noexcept {
+    return computeIndex2D(n);
+  }
+
+  IteratorRange2D& operator++() noexcept {
+    current_ = (++i_, computeIndex2D(i_));
+    return *this;
+  }
+
+  IteratorRange2D& operator++(int) noexcept {
+    auto tmp = *this;
+    operator++();
+    return tmp;
+  }
+
+  IteratorRange2D& operator--() noexcept {
+    current_ = (--i_, computeIndex2D(i_));
+    return *this;
+  }
+
+  IteratorRange2D& operator--(int) noexcept {
+    auto tmp = *this;
+    operator--();
+    return tmp;
+  }
+
+  IteratorRange2D& operator+=(difference_type n) noexcept {
+    return i_ += n, *this;
+  }
+
+  IteratorRange2D& operator-=(difference_type n) noexcept {
+    return i_ -= n, *this;
+  }
+
+  friend IteratorRange2D operator+(IteratorRange2D a, difference_type n) noexcept {
+    return a += n;
+  }
+
+  friend IteratorRange2D operator+(difference_type n, const IteratorRange2D& a) noexcept {
+    return a + n;
+  }
+
+  friend IteratorRange2D operator-(IteratorRange2D i, difference_type n) noexcept {
+    return i -= n;
+  }
+
+  friend difference_type operator-(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return a.i_ - b.i_;
+  }
+
+  friend bool operator==(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return a.i_ == b.i_;
+  }
+
+  friend bool operator!=(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return !(a == b);
+  }
+
+  friend bool operator<(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return a.i_ < b.i_;
+  }
+
+  friend bool operator<=(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return a.i_ <= b.i_;
+  }
+
+  friend bool operator>(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return a.i_ > b.i_;
+  }
+
+  friend bool operator>=(const IteratorRange2D& a, const IteratorRange2D& b) noexcept {
+    return a.i_ >= b.i_;
   }
 
 protected:
-  index2d_t begin_;
-  IndexT ld_;
+  value_type computeIndex2D(difference_type n) {
+    return {begin_.row() + static_cast<IndexT>(n % ld_), begin_.col() + static_cast<IndexT>(n / ld_)};
+  }
+
+  value_type current_;
+  value_type begin_;
   SizeType i_;
+  SizeType ld_;
 };
 
 /// An Iterable representing a 2D range.

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -58,7 +58,8 @@ struct IteratorRange2D {
   IteratorRange2D(const IteratorRange2D&) = default;
   IteratorRange2D& operator=(const IteratorRange2D&) = default;
 
-  IteratorRange2D(value_type begin, IndexT ld, SizeType i) : begin_(begin), i_(i), ld_(ld) {
+  IteratorRange2D(value_type begin, IndexT ld, SizeType i)
+      : begin_(begin), i_(i), ld_(std::max(ld, IndexT(1))) {
     current_ = computeIndex2D(i_);
   }
 

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -38,6 +38,7 @@ auto selectGeneric(Func&& f, common::IterableRange2D<SizeType, LocalTile_TAG> ra
   using RetT = decltype(f(LocalTileIndex{}));
 
   std::vector<RetT> tiles;
+  tiles.reserve(to_sizet(std::distance(range.begin(), range.end())));
   std::transform(range.begin(), range.end(), std::back_inserter(tiles),
                  [&](auto idx) { return f(idx); });
   return tiles;

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -355,18 +355,18 @@ Matrix<T, device> createMatrixFromTile(const GlobalElementSize& size, const Tile
 /// Returns a container grouping all the tiles retrieved using Matrix::read
 ///
 /// @pre @p range must be a valid range for @p matrix
-template <class T, dlaf::Device d>
-std::vector<hpx::shared_future<dlaf::matrix::Tile<const T, d>>> selectRead(
-    Matrix<T, d>& matrix, common::IterableRange2D<SizeType, LocalTile_TAG> range) {
+template <class MatrixLike>
+std::vector<hpx::shared_future<typename MatrixLike::ConstTileType>> selectRead(
+    MatrixLike& matrix, common::IterableRange2D<SizeType, LocalTile_TAG> range) {
   return internal::selectGeneric([&](auto index) { return matrix.read(index); }, range);
 }
 
 /// Returns a container grouping all the tiles retrieved using Matrix::operator()
 ///
 /// @pre @p range must be a valid range for @p matrix
-template <class T, dlaf::Device d>
-std::vector<hpx::future<dlaf::matrix::Tile<T, d>>> select(
-    Matrix<T, d>& matrix, common::IterableRange2D<SizeType, LocalTile_TAG> range) {
+template <class MatrixLike>
+std::vector<hpx::future<typename MatrixLike::TileType>> select(
+    MatrixLike& matrix, common::IterableRange2D<SizeType, LocalTile_TAG> range) {
   return internal::selectGeneric([&](auto index) { return matrix(index); }, range);
 }
 

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -38,7 +38,8 @@ auto selectGeneric(Func&& f, common::IterableRange2D<SizeType, LocalTile_TAG> ra
   using RetT = decltype(f(LocalTileIndex{}));
 
   std::vector<RetT> tiles;
-  std::transform(range.begin(), range.end(), std::back_inserter(tiles), [&](auto idx) { return f(idx); });
+  std::transform(range.begin(), range.end(), std::back_inserter(tiles),
+                 [&](auto idx) { return f(idx); });
   return tiles;
 }
 }

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -118,21 +118,24 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlob
   return result;
 }
 
-/// Returns true if only the first @p futures are ready.
+/// Returns true if only the @p first_n futures are ready (or the opposite).
+///
+/// @param invert if set to true it checks that all futures are ready except the first_n
 ///
 /// @pre Future should be a future or shared_future,
 /// @pre 0 <= ready <= futures.size().
 template <class Future>
-bool checkFuturesStep(size_t ready, const std::vector<Future>& futures) {
-  DLAF_ASSERT_HEAVY(ready >= 0, ready);
-  DLAF_ASSERT_HEAVY(ready <= futures.size(), ready, futures.size());
+bool checkFuturesStep(size_t first_n, const std::vector<Future>& futures, bool invert = false) {
+  DLAF_ASSERT_HEAVY(first_n <= futures.size(), first_n, futures.size());
 
-  for (std::size_t index = 0; index < ready; ++index) {
-    if (!futures[index].is_ready())
+  const bool first_n_status = !invert;
+
+  for (std::size_t index = 0; index < first_n; ++index) {
+    if (futures[index].is_ready() != first_n_status)
       return false;
   }
-  for (std::size_t index = ready; index < futures.size(); ++index) {
-    if (futures[index].is_ready())
+  for (std::size_t index = first_n; index < futures.size(); ++index) {
+    if (futures[index].is_ready() == first_n_status)
       return false;
   }
   return true;

--- a/test/unit/common/test_range2d.cpp
+++ b/test/unit/common/test_range2d.cpp
@@ -25,6 +25,7 @@ using dlaf::common::iterate_range2d;
 template <typename TypeParam>
 void test_single_arg() {
   TypeParam sz(7, 2);
+  const auto range = iterate_range2d(sz);
 
   std::vector<Index> exp_values = {
       Index(0, 0), Index(1, 0), Index(2, 0), Index(3, 0), Index(4, 0), Index(5, 0), Index(6, 0),
@@ -33,28 +34,34 @@ void test_single_arg() {
 
   std::vector<Index> act_values;
   act_values.reserve(exp_values.size());
-  for (Index i : iterate_range2d(sz)) {
+  for (Index i : range) {
     act_values.push_back(i);
   }
 
-  ASSERT_TRUE(act_values == exp_values);
+  EXPECT_EQ(exp_values.size(), std::distance(range.begin(), range.end()));
+  EXPECT_EQ(act_values, exp_values);
 }
 
 // `end` is either `Index(7, 4)` or `Size(4, 2)`
 template <typename TypeParam>
 void test_double_arg(TypeParam end) {
   Index begin(3, 2);
+  const auto range = iterate_range2d(begin, end);
+
+  EXPECT_EQ(3, range.begin()->row());
+  EXPECT_EQ(2, range.begin()->col());
 
   std::vector<Index> exp_values = {Index(3, 2), Index(4, 2), Index(5, 2), Index(6, 2),
                                    Index(3, 3), Index(4, 3), Index(5, 3), Index(6, 3)};
 
   std::vector<Index> act_values;
   act_values.reserve(exp_values.size());
-  for (Index i : iterate_range2d(begin, end)) {
+  for (Index i : range) {
     act_values.push_back(i);
   }
 
-  ASSERT_TRUE(act_values == exp_values);
+  EXPECT_EQ(exp_values.size(), std::distance(range.begin(), range.end()));
+  EXPECT_EQ(act_values, exp_values);
 }
 
 }

--- a/test/unit/common/test_range2d.cpp
+++ b/test/unit/common/test_range2d.cpp
@@ -81,3 +81,35 @@ TEST(DoubleArgRange2D, Index2D) {
 TEST(DoubleArgRange2D, Size2D) {
   ::test_double_arg(Size(4, 2));
 }
+
+template <class TypeParam>
+void test_single_arg_empty() {
+  TypeParam sz(0, 0);
+  const auto range = iterate_range2d(sz);
+
+  EXPECT_EQ(range.begin(), range.end());
+}
+
+template <class TypeParam>
+void test_double_arg_empty(TypeParam end) {
+  const ::Index begin(3, 2);
+  const auto range = iterate_range2d(begin, end);
+
+  EXPECT_EQ(range.begin(), range.end());
+}
+
+TEST(SingleArgEmptyRange2D, Size2D) {
+  ::test_single_arg_empty<::Size>();
+}
+
+TEST(SingleArgEmptyRange2D, Index2D) {
+  ::test_single_arg_empty<::Index>();
+}
+
+TEST(DoubleArgEmptyRange2D, Index2D) {
+  ::test_double_arg_empty(Index(3, 2));
+}
+
+TEST(DoubleArgEmptyRange2D, Size2D) {
+  ::test_double_arg_empty(Size(0, 0));
+}


### PR DESCRIPTION
This is a proposal for adding a way to get a set of tiles from a Matrix, in readwrite or readonly mode.

In particular, two functions are proposed, `select` and `select_read`, which return a vector of futures or shared_futures of Tile respectively.

With the return vector, it would be possible to do something like

```cpp
Matrix m;

// create a barrier
hpx::when_all(select_read(m, iterate_range2d(m.nrTiles())).get();

// select a range of tiles, e.g. a panel, and then operate on them
hpx::dataflow(do_something_on_panel, select(m, iterate_range2d({1, 1}, {2, 3}));
```

These extension to the API could represent an interesting building block for #332, but it can play an important role in algorithms in order to avoid problems like micro-tasking.

Just for giving a bit of context about latter case with an example, in `redutionToBand` algorithm it is necessary to work with a single matrix column spread across multiple tiles (and the next column has to wait for the first column result). The micro-tasking problem arises due to code like this

```cpp
for (auto index : panel_range) {
 ...
 hpx::dataflow(work_on_single_column, matrix(index));
}
```

while we can "reverse-out" that part of the algorithm with

```cpp
hpx::dataflow([](std::vector<hpx::future<Tile>> tiles){
  for (auto& tile : tile)
    work_on_single_column(tile);
}, select(matrix, panel_range));
```

Getting a single HPX task that internally has a for-loop that groups a set of small operations, instead of having a moltitude of micro-tasks which may overload the scheduler and on which the overhead may easily become unsustainable.

Clearly, this is not possible everywhere because it creates a barrier and it "locks/unlocks" dependencies all at once, but if there is anyway an implicit dependency, it helps improving the performances.

Just one last comment, I still have some concerns about the API, in particular about keeping the "index" of the `Tile` inside the for-loop, because with the current proposal we loose the information of the tile position in the matrix, and we have it just like an ordered linear sequence of tiles.