### PR TITLE
Add default Device and Backend enumerations

### DIFF
--- a/include/dlaf/types.h
+++ b/include/dlaf/types.h
@@ -26,9 +26,25 @@ static_assert(std::is_signed<SizeType>::value && std::is_integral<SizeType>::val
               "SizeType should be a signed integral type");
 static_assert(sizeof(SizeType) >= 4, "SizeType should be >= 32bit");
 
-enum class Device { CPU, GPU };
+enum class Device {
+  CPU,
+  GPU,
+#ifdef DLAF_WITH_CUDA
+  Default = GPU
+#else
+  Default = CPU
+#endif
+};
 
-enum class Backend { MC, GPU };
+enum class Backend {
+  MC,
+  GPU,
+#ifdef DLAF_WITH_CUDA
+  Default = GPU
+#else
+  Default = MC
+#endif
+};
 
 template <class T>
 struct TypeInfo;


### PR DESCRIPTION
Simply adds `Device::Default` and `Backend::Default` to the `Device` and `Backend` enums, and they are equal to `MC/CPU` when CUDA is disabled and `GPU/GPU` when CUDA is enabled. This helps avoiding ifdefs in user code (i.e. miniapps) to choose the most "capable" backend/device that is available. I wanted to use this in #321 but I think it deserves its own PR.

It's a simple change so I may be overthinking the implications of it, but given that those enums are quite fundamental I'd be curious to hear if you think there might be another way to do this.