### PR TITLE
Fix Compiler ID in CMake (relevant for warnings)

### DIFF
--- a/ci/ctest_to_gitlab.sh
+++ b/ci/ctest_to_gitlab.sh
@@ -30,7 +30,7 @@ allocate:
   extends: .daint_alloc
   variables:
     PULL_IMAGE: 'YES'
-    SLURM_TIMELIMIT: '15:00'
+    SLURM_TIMELIMIT: '20:00'
 
 {{JOBS}}
 
@@ -40,7 +40,7 @@ upload_reports:
   variables:
     PULL_IMAGE: 'NO'
     SLURM_NTASKS: 1
-    SLURM_TIMELIMIT: '15:00'
+    SLURM_TIMELIMIT: '5:00'
     DISABLE_AFTER_SCRIPT: 'YES'
   script: upload_codecov
 
@@ -56,7 +56,7 @@ JOB_TEMPLATE="
   variables:
     SLURM_CPUS_PER_TASK: {{CPUS_PER_TASK}}
     SLURM_NTASKS: {{NTASKS}}
-    SLURM_TIMELIMIT: '15:00'
+    SLURM_TIMELIMIT: '5:00'
     PULL_IMAGE: 'NO'
     USE_MPI: 'YES'
     DISABLE_AFTER_SCRIPT: 'YES'
@@ -104,7 +104,7 @@ JOB_TEMPLATE="
   variables:
     SLURM_CPUS_PER_TASK: {{CPUS_PER_TASK}}
     SLURM_NTASKS: {{NTASKS}}
-    SLURM_TIMELIMIT: '15:00'
+    SLURM_TIMELIMIT: '5:00'
     PULL_IMAGE: 'NO'
     USE_MPI: 'YES'
     DISABLE_AFTER_SCRIPT: 'YES'

--- a/cmake/DLAF_AddTargetWarnings.cmake
+++ b/cmake/DLAF_AddTargetWarnings.cmake
@@ -16,7 +16,7 @@ macro(target_add_warnings target_name)
   endif()
 
   set(IS_COMPILER_CLANG $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
-  set(IS_COMPILER_GCC $<CXX_COMPILER_ID:GCC>)
+  set(IS_COMPILER_GCC $<CXX_COMPILER_ID:GNU>)
 
   target_compile_options(${target_name}
     PRIVATE

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -41,20 +41,24 @@ template <typename T>
 struct CopyTile<T, Device::CPU, Device::GPU> {
   static void call(const matrix::Tile<const T, Device::CPU>& source,
                    const matrix::Tile<T, Device::GPU>& destination) {
-    SizeType m = source.size().rows();
-    SizeType n = source.size().cols();
+    const std::size_t m = to_sizet(source.size().rows());
+    const std::size_t n = to_sizet(source.size().cols());
+    const std::size_t ld_source = to_sizet(source.ld());
+    const std::size_t ld_destination = to_sizet(destination.ld());
 
-    DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
-                                source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
+    DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), ld_destination * sizeof(T), source.ptr(),
+                                ld_source * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
   }
 
   static void call(const matrix::Tile<const T, Device::CPU>& source,
                    const matrix::Tile<T, Device::GPU>& destination, cudaStream_t stream) {
-    SizeType m = source.size().rows();
-    SizeType n = source.size().cols();
+    const std::size_t m = to_sizet(source.size().rows());
+    const std::size_t n = to_sizet(source.size().cols());
+    const std::size_t ld_source = to_sizet(source.ld());
+    const std::size_t ld_destination = to_sizet(destination.ld());
 
-    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
-                                     source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), ld_destination * sizeof(T), source.ptr(),
+                                     ld_source * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
                                      stream));
   }
 };
@@ -63,20 +67,24 @@ template <typename T>
 struct CopyTile<T, Device::GPU, Device::CPU> {
   static void call(const matrix::Tile<const T, Device::GPU>& source,
                    const matrix::Tile<T, Device::CPU>& destination) {
-    SizeType m = source.size().rows();
-    SizeType n = source.size().cols();
+    const std::size_t m = to_sizet(source.size().rows());
+    const std::size_t n = to_sizet(source.size().cols());
+    const std::size_t ld_source = to_sizet(source.ld());
+    const std::size_t ld_destination = to_sizet(destination.ld());
 
-    DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
-                                source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
+    DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), ld_destination * sizeof(T), source.ptr(),
+                                ld_source * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
   }
 
   static void call(const matrix::Tile<const T, Device::GPU>& source,
                    const matrix::Tile<T, Device::CPU>& destination, cudaStream_t stream) {
-    SizeType m = source.size().rows();
-    SizeType n = source.size().cols();
+    const std::size_t m = to_sizet(source.size().rows());
+    const std::size_t n = to_sizet(source.size().cols());
+    const std::size_t ld_source = to_sizet(source.ld());
+    const std::size_t ld_destination = to_sizet(destination.ld());
 
-    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
-                                     source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), ld_destination * sizeof(T), source.ptr(),
+                                     ld_source * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
                                      stream));
   }
 };
@@ -85,20 +93,24 @@ template <typename T>
 struct CopyTile<T, Device::GPU, Device::GPU> {
   static void call(const matrix::Tile<const T, Device::GPU>& source,
                    const matrix::Tile<T, Device::GPU>& destination) {
-    SizeType m = source.size().rows();
-    SizeType n = source.size().cols();
+    const std::size_t m = to_sizet(source.size().rows());
+    const std::size_t n = to_sizet(source.size().cols());
+    const std::size_t ld_source = to_sizet(source.ld());
+    const std::size_t ld_destination = to_sizet(destination.ld());
 
-    DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
-                                source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
+    DLAF_CUDA_CALL(cudaMemcpy2D(destination.ptr(), ld_destination * sizeof(T), source.ptr(),
+                                ld_source * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault));
   }
 
   static void call(const matrix::Tile<const T, Device::GPU>& source,
                    const matrix::Tile<T, Device::GPU>& destination, cudaStream_t stream) {
-    SizeType m = source.size().rows();
-    SizeType n = source.size().cols();
+    const std::size_t m = to_sizet(source.size().rows());
+    const std::size_t n = to_sizet(source.size().cols());
+    const std::size_t ld_source = to_sizet(source.ld());
+    const std::size_t ld_destination = to_sizet(destination.ld());
 
-    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), destination.ld() * sizeof(T), source.ptr(),
-                                     source.ld() * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(destination.ptr(), ld_destination * sizeof(T), source.ptr(),
+                                     ld_source * sizeof(T), m * sizeof(T), n, cudaMemcpyDefault,
                                      stream));
   }
 };

--- a/include/dlaf/matrix/matrix.tpp
+++ b/include/dlaf/matrix/matrix.tpp
@@ -59,7 +59,7 @@ Matrix<T, device>::Matrix(const LayoutInfo& layout, ElementType* ptr)
 
 template <class T, Device device>
 hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex& index) noexcept {
-  std::size_t i = tileLinearIndex(index);
+  std::size_t i = to_sizet(tileLinearIndex(index));
   return tile_managers_[i].getRWTileFuture();
 }
 

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -46,7 +46,7 @@ Matrix<const T, device>::~Matrix() {
 template <class T, Device device>
 hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
     const LocalTileIndex& index) noexcept {
-  std::size_t i = tileLinearIndex(index);
+  std::size_t i = to_sizet(tileLinearIndex(index));
   return tile_managers_[i].getReadTileSharedFuture();
 }
 

--- a/test/unit/common/test_data_descriptor.cpp
+++ b/test/unit/common/test_data_descriptor.cpp
@@ -124,8 +124,8 @@ TYPED_TEST(DataDescriptorTest, MakeFromPointerConst) {
 }
 
 TYPED_TEST(DataDescriptorTest, MakeFromCArray) {
-  const int N = 13;
-  TypeParam value_array[N]{};
+  const SizeType N = 13;
+  TypeParam value_array[static_cast<std::size_t>(N)]{};
 
   auto data = common::make_data(value_array, N);
 
@@ -142,8 +142,8 @@ TYPED_TEST(DataDescriptorTest, MakeFromCArray) {
 }
 
 TYPED_TEST(DataDescriptorTest, MakeFromCArrayConst) {
-  const int N = 13;
-  const TypeParam value_array[N]{};
+  const SizeType N = 13;
+  const TypeParam value_array[static_cast<std::size_t>(N)]{};
 
   auto data = common::make_data(value_array, N);
 
@@ -319,8 +319,8 @@ TYPED_TEST(DataDescriptorTest, CtorFromPointerConst) {
 }
 
 TYPED_TEST(DataDescriptorTest, CtorFromCArray) {
-  const int N = 13;
-  TypeParam value_array[N]{};
+  const SizeType N = 13;
+  TypeParam value_array[static_cast<std::size_t>(N)]{};
 
   auto data = common::DataDescriptor<decltype(value_array)>{value_array};
 
@@ -337,8 +337,8 @@ TYPED_TEST(DataDescriptorTest, CtorFromCArray) {
 }
 
 TYPED_TEST(DataDescriptorTest, CtorFromCArrayConst) {
-  const int N = 13;
-  const TypeParam value_array[N]{};
+  const SizeType N = 13;
+  const TypeParam value_array[static_cast<std::size_t>(N)]{};
 
   auto data = common::DataDescriptor<decltype(value_array)>{value_array};
 
@@ -502,13 +502,13 @@ TYPED_TEST(DataDescriptorTest, CopyCtorFromPointer) {
 }
 
 TYPED_TEST(DataDescriptorTest, CopyCtorFromCArray) {
-  const int N = 13;
-  TypeParam value_array[N]{};
+  const SizeType N = 13;
+  TypeParam value_array[static_cast<std::size_t>(N)]{};
 
   auto data = common::make_data(value_array, N);
   check_copy_ctor<TypeParam>(data);
 
-  const TypeParam value_array_const[N]{};
+  const TypeParam value_array_const[static_cast<std::size_t>(N)]{};
   auto data_const = common::make_data(value_array_const, N);
   check_copy_ctor<const TypeParam>(data_const);
 }
@@ -603,14 +603,14 @@ TYPED_TEST(DataDescriptorTest, CreateTemporaryFromPointer) {
 }
 
 TYPED_TEST(DataDescriptorTest, CreateTemporaryFromCArray) {
-  const int N = 13;
-  TypeParam value_array[N]{};
+  const SizeType N = 13;
+  TypeParam value_array[static_cast<std::size_t>(N)]{};
 
   auto data = common::make_data(value_array, N);
   EXPECT_TRUE(checkCreateTemporaryBuffer((data)));
   EXPECT_TRUE(checkMakeContiguous(data));
 
-  const TypeParam value_array_const[N]{};
+  const TypeParam value_array_const[static_cast<std::size_t>(N)]{};
   auto data_const = common::make_data(value_array_const, N);
   EXPECT_TRUE(checkCreateTemporaryBuffer((data_const)));
   EXPECT_TRUE(checkMakeContiguous(data_const));
@@ -667,9 +667,9 @@ auto create_const_data_from_memory(memory_data<T>& memory) {
 }
 
 TYPED_TEST(DataDescriptorTest, CopyDataCArrays) {
-  const int N = 13;
-  TypeParam memory_src[N];
-  TypeParam memory_dst[N];
+  const SizeType N = 13;
+  TypeParam memory_src[static_cast<std::size_t>(N)];
+  TypeParam memory_dst[static_cast<std::size_t>(N)];
 
   for (int i = 0; i < N; ++i)
     memory_src[i] = TypeUtilities<TypeParam>::element(i, 0);
@@ -720,7 +720,7 @@ TYPED_TEST(DataDescriptorTest, CopyDataHeterogeneous) {
 
   // CArray as source
   for (auto& memory_dest : memory_types) {
-    TypeParam memory_array[N];
+    TypeParam memory_array[static_cast<std::size_t>(N)];
     for (SizeType i = 0; i < N; ++i)
       memory_array[i] = TypeUtilities<TypeParam>::element(i, 0);
 
@@ -738,7 +738,7 @@ TYPED_TEST(DataDescriptorTest, CopyDataHeterogeneous) {
 
   // CArray as destination
   for (auto& memory_src : memory_types) {
-    TypeParam memory_array[N];
+    TypeParam memory_array[static_cast<std::size_t>(N)];
     for (SizeType i = 0; i < N; ++i)
       memory_array[i] = 0;
 

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -177,7 +177,7 @@ TYPED_TEST(ComputeTFactorDistributedTest, Correctness) {
 
         const TypeParam* data_ptr = v.ptr({j, j});
         const auto norm = blas::nrm2(reflector_size, data_ptr, 1);
-        const TypeParam tau = 2 / std::pow(norm, 2);
+        const TypeParam tau = 2 / std::pow(norm, static_cast<decltype(norm)>(2));
 
         taus.push_back(tau);
 

--- a/test/unit/test_cublas_tile/test_gemm.h
+++ b/test/unit/test_cublas_tile/test_gemm.h
@@ -32,8 +32,6 @@ using namespace dlaf::matrix::test;
 using namespace dlaf::tile;
 using namespace testing;
 
-using dlaf::util::size_t::mul;
-
 template <class T, class CT = const T>
 void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, SizeType extra_lda,
               SizeType extra_ldb, SizeType extra_ldc) {
@@ -92,9 +90,9 @@ void testGemm(blas::Op op_a, blas::Op op_b, SizeType m, SizeType n, SizeType k, 
   auto b = createTile<CT>(el_op_b, size_b, ldb, op_b);
   auto c = createTile<T>(el_c, size_c, ldc);
 
-  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(mul(lda, size_a.cols())), lda);
-  Tile<T, Device::GPU> b0d(size_b, memory::MemoryView<T, Device::GPU>(mul(ldb, size_b.cols())), ldb);
-  Tile<T, Device::GPU> cd(size_c, memory::MemoryView<T, Device::GPU>(mul(ldc, size_c.cols())), ldc);
+  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(lda * size_a.cols()), lda);
+  Tile<T, Device::GPU> b0d(size_b, memory::MemoryView<T, Device::GPU>(ldb * size_b.cols()), ldb);
+  Tile<T, Device::GPU> cd(size_c, memory::MemoryView<T, Device::GPU>(ldc * size_c.cols()), ldc);
 
   copy(a, a0d);
   copy(b, b0d);

--- a/test/unit/test_cublas_tile/test_herk.h
+++ b/test/unit/test_cublas_tile/test_herk.h
@@ -30,8 +30,6 @@ using namespace dlaf::matrix::test;
 using namespace dlaf::tile;
 using namespace testing;
 
-using dlaf::util::size_t::mul;
-
 template <class T, class CT = const T>
 void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType extra_lda,
               SizeType extra_ldc) {
@@ -85,8 +83,8 @@ void testHerk(blas::Uplo uplo, blas::Op op_a, SizeType n, SizeType k, SizeType e
   auto a = createTile<CT>(el_op_a, size_a, lda, op_a);
   auto c = createTile<T>(el_c, size_c, ldc);
 
-  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(mul(lda, size_a.cols())), lda);
-  Tile<T, Device::GPU> cd(size_c, memory::MemoryView<T, Device::GPU>(mul(ldc, size_c.cols())), ldc);
+  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(lda * size_a.cols()), lda);
+  Tile<T, Device::GPU> cd(size_c, memory::MemoryView<T, Device::GPU>(ldc * size_c.cols()), ldc);
 
   copy(a, a0d);
   copy(c, cd);

--- a/test/unit/test_cublas_tile/test_trsm.h
+++ b/test/unit/test_cublas_tile/test_trsm.h
@@ -34,8 +34,6 @@ using namespace dlaf::matrix::test;
 using namespace dlaf::tile;
 using namespace testing;
 
-using dlaf::util::size_t::mul;
-
 template <class ElementIndex, class T, class CT = const T>
 void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, SizeType m, SizeType n,
               SizeType extra_lda, SizeType extra_ldb) {
@@ -63,8 +61,8 @@ void testTrsm(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, Si
   auto a = createTile<CT>(el_op_a, size_a, lda, op);
   auto b = createTile<T>(el_b, size_b, ldb);
 
-  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(mul(lda, size_a.cols())), lda);
-  Tile<T, Device::GPU> bd(size_b, memory::MemoryView<T, Device::GPU>(mul(ldb, size_b.cols())), ldb);
+  Tile<T, Device::GPU> a0d(size_a, memory::MemoryView<T, Device::GPU>(lda * size_a.cols()), lda);
+  Tile<T, Device::GPU> bd(size_b, memory::MemoryView<T, Device::GPU>(ldb * size_b.cols()), ldb);
 
   copy(a, a0d);
   copy(b, bd);

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -83,7 +83,7 @@ void test_lange(const lapack::Norm norm, const Tile<T, Device::CPU>& a, NormT<T>
 
   SCOPED_TRACE(::testing::Message() << "LANGE: " << norm << ", " << a.size() << ", ld = " << a.ld());
 
-  EXPECT_FLOAT_EQ(norm_expected, lange(norm, a));
+  EXPECT_NEAR(norm_expected, lange(norm, a), norm_expected * TypeUtilities<T>::error);
 }
 
 template <class T>
@@ -104,7 +104,8 @@ void run(const lapack::Norm norm, const Tile<T, Device::CPU>& a) {
       norm_expected = size != TileElementSize{1, 1} ? 4 : 2;
       break;
     case lapack::Norm::Fro:
-      norm_expected = size != TileElementSize{1, 1} ? std::sqrt(17) : std::sqrt(4);
+      norm_expected =
+          static_cast<NormT<T>>(size != TileElementSize{1, 1} ? std::sqrt(17) : std::sqrt(4));
       break;
     case lapack::Norm::Two:
       FAIL() << "norm " << norm << " is not supported by lange";

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -109,7 +109,7 @@ void test_lantr(const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag
   SCOPED_TRACE(::testing::Message() << "LANTR: " << norm << ", " << a.size() << ", ld = " << a.ld()
                                     << " uplo = " << uplo << " diag = " << diag);
 
-  EXPECT_FLOAT_EQ(norm_expected, lantr(norm, uplo, diag, a));
+  EXPECT_NEAR(norm_expected, lantr(norm, uplo, diag, a), norm_expected * TypeUtilities<T>::error);
 }
 
 template <class T>
@@ -145,12 +145,14 @@ void run(const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
     case lapack::Norm::Fro:
       switch (diag) {
         case blas::Diag::Unit:
-          norm_expected = size != TileElementSize{1, 1}
-                              ? std::sqrt(std::pow(3 * value, 2) + std::min(size.rows(), size.cols()))
-                              : 1;
+          norm_expected = static_cast<NormT<T>>(
+              size != TileElementSize{1, 1}
+                  ? std::sqrt(std::pow(3 * value, 2) + std::min(size.rows(), size.cols()))
+                  : 1);
           break;
         case blas::Diag::NonUnit:
-          norm_expected = size != TileElementSize{1, 1} ? std::sqrt(17) * value : std::sqrt(4) * value;
+          norm_expected = static_cast<NormT<T>>(size != TileElementSize{1, 1} ? std::sqrt(17) * value
+                                                                              : std::sqrt(4) * value);
           break;
       }
       break;

--- a/test/unit/test_types.cpp
+++ b/test/unit/test_types.cpp
@@ -23,11 +23,11 @@ using dlaf::common::internal::source_location;
 
 const char* ERROR_MESSAGE = "\\[ERROR\\]";
 
-template <class T>
-const auto LOWER_BOUND = std::numeric_limits<T>::min;
+template <class T, class C = T>
+const auto LOWER_BOUND = []() { return static_cast<C>(std::numeric_limits<T>::min()); };
 
-template <class T>
-const auto UPPER_BOUND = std::numeric_limits<T>::max;
+template <class T, class C = T>
+const auto UPPER_BOUND = []() { return static_cast<C>(std::numeric_limits<T>::max()); };
 
 /// Check that no alteration happens during cast From -> To with @param cast_func and dlaf::integral_cast.
 ///
@@ -73,7 +73,7 @@ TEST(ToSigned, FromUnsigned) {
   // |-----|-----|
   DLAF_TEST_CAST(uint16_t, To, to_signed, 13);
   DLAF_TEST_CAST(uint16_t, To, to_signed, LOWER_BOUND<uint16_t>());
-  DLAF_TEST_CAST(uint16_t, To, to_signed, UPPER_BOUND<To>());
+  DLAF_TEST_CAST(uint16_t, To, to_signed, UPPER_BOUND<To, uint16_t>());
   DLAF_TEST_CAST_FAIL(uint16_t, To, to_signed, UPPER_BOUND<uint16_t>());
 
   // DOWN CAST
@@ -81,7 +81,7 @@ TEST(ToSigned, FromUnsigned) {
   // |-----|-----|
   DLAF_TEST_CAST(uint32_t, To, to_signed, 13);
   DLAF_TEST_CAST(uint32_t, To, to_signed, LOWER_BOUND<uint32_t>());
-  DLAF_TEST_CAST(uint32_t, To, to_signed, UPPER_BOUND<To>());
+  DLAF_TEST_CAST(uint32_t, To, to_signed, UPPER_BOUND<To, uint32_t>());
   DLAF_TEST_CAST_FAIL(uint32_t, To, to_signed, UPPER_BOUND<uint32_t>());
 }
 
@@ -127,7 +127,7 @@ TEST(ToUnsigned, FromSigned) {
   // |-----|-----|
   //       |-----------|
   DLAF_TEST_CAST(int16_t, To, to_unsigned, 13);
-  DLAF_TEST_CAST(int16_t, To, to_unsigned, LOWER_BOUND<To>());
+  DLAF_TEST_CAST(int16_t, To, to_unsigned, LOWER_BOUND<To, int16_t>());
   DLAF_TEST_CAST_FAIL(int16_t, To, to_unsigned, LOWER_BOUND<int16_t>());
   DLAF_TEST_CAST(int16_t, To, to_unsigned, UPPER_BOUND<int16_t>());
 


### PR DESCRIPTION
I just realized that I used the wrong compiler ID as a trigger for a couple of warnings...