### PR TITLE
Remove implicit synchronization in Matrix d'tor

### DIFF
--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -160,10 +160,11 @@ protected:
 template <typename IndexT, class Tag>
 class IterableRange2D {
   using size2d_t = Size2D<IndexT, Tag>;
-  using index2d_t = Index2D<IndexT, Tag>;
   using iter2d_t = IteratorRange2D<IndexT, Tag>;
 
 public:
+  using index2d_t = Index2D<IndexT, Tag>;
+
   IterableRange2D(index2d_t begin_idx, size2d_t sz)
       : begin_idx_(begin_idx), ld_(sz.rows()), i_max_(sz.rows() * sz.cols()) {}
 

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -160,11 +160,10 @@ protected:
 template <typename IndexT, class Tag>
 class IterableRange2D {
   using size2d_t = Size2D<IndexT, Tag>;
+  using index2d_t = Index2D<IndexT, Tag>;
   using iter2d_t = IteratorRange2D<IndexT, Tag>;
 
 public:
-  using index2d_t = Index2D<IndexT, Tag>;
-
   IterableRange2D(index2d_t begin_idx, size2d_t sz)
       : begin_idx_(begin_idx), ld_(sz.rows()), i_max_(sz.rows() * sz.cols()) {}
 

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -176,7 +176,7 @@ public:
   }
 
   /// Synchronization barrier for all local tiles in the matrix
-  void syncAll() noexcept;
+  void waitLocalTiles() noexcept;
 
 protected:
   Matrix(Distribution distribution) : internal::MatrixBase{std::move(distribution)} {}

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -175,21 +175,8 @@ public:
     return read(distribution().localTileIndex(index));
   }
 
-  /// Synchronization barrier for all tiles in the matrix
-  void syncAll() noexcept {
-    // Note:
-    // Using a readwrite access to the tile ensures that the access is exclusive and not shared
-    // among multiple tasks.
-
-    auto readwrite_f = [this](const LocalTileIndex& index) {
-      const auto i = tileLinearIndex(index);
-      return this->tile_managers_[i].getRWTileFuture();
-    };
-
-    const auto range_local = common::iterate_range2d(distribution().localNrTiles());
-    auto all_local_tiles_rw = internal::selectGeneric(readwrite_f, range_local);
-    hpx::when_all(std::move(all_local_tiles_rw)).get();
-  }
+  /// Synchronization barrier for all local tiles in the matrix
+  void syncAll() noexcept;
 
 protected:
   Matrix(Distribution distribution) : internal::MatrixBase{std::move(distribution)} {}

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -157,8 +157,6 @@ public:
   Matrix(const Matrix& rhs) = delete;
   Matrix(Matrix&& rhs) = default;
 
-  virtual ~Matrix();
-
   Matrix& operator=(const Matrix& rhs) = delete;
   Matrix& operator=(Matrix&& rhs) = default;
 

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -182,7 +182,7 @@ public:
     // among multiple tasks.
 
     auto readwrite_f = [this](const LocalTileIndex& index) {
-      std::size_t i = tileLinearIndex(index);
+      const auto i = tileLinearIndex(index);
       return this->tile_managers_[i].getRWTileFuture();
     };
 

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -176,6 +176,9 @@ public:
   }
 
   /// Synchronization barrier for all local tiles in the matrix
+  ///
+  /// This blocking call does not return until all operations, i.e. both RO and RW,
+  /// involving any of the locally available tiles are completed.
   void waitLocalTiles() noexcept;
 
 protected:

--- a/include/dlaf/matrix/matrix.tpp
+++ b/include/dlaf/matrix/matrix.tpp
@@ -59,7 +59,7 @@ Matrix<T, device>::Matrix(const LayoutInfo& layout, ElementType* ptr)
 
 template <class T, Device device>
 hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex& index) noexcept {
-  std::size_t i = to_sizet(tileLinearIndex(index));
+  const auto i = tileLinearIndex(index);
   return tile_managers_[i].getRWTileFuture();
 }
 

--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -86,7 +86,8 @@ protected:
   ///
   /// @pre index.isIn(localNrTiles()).
   std::size_t tileLinearIndex(const LocalTileIndex& index) const noexcept {
-    return to_sizet(index.row() + distribution_->localNrTiles().rows() * static_cast<SizeType>(index.col()));
+    return to_sizet(index.row() +
+                    distribution_->localNrTiles().rows() * static_cast<SizeType>(index.col()));
   }
 
   /// Prints information about the matrix.

--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -86,8 +86,7 @@ protected:
   ///
   /// @pre index.isIn(localNrTiles()).
   std::size_t tileLinearIndex(const LocalTileIndex& index) const noexcept {
-    return to_sizet(index.row() +
-                    distribution_->localNrTiles().rows() * static_cast<SizeType>(index.col()));
+    return to_sizet(index.row() + distribution_->localNrTiles().rows() * index.col());
   }
 
   /// Prints information about the matrix.

--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -85,8 +85,8 @@ protected:
   /// Returns the position in the vector of the index Tile.
   ///
   /// @pre index.isIn(localNrTiles()).
-  SizeType tileLinearIndex(const LocalTileIndex& index) const noexcept {
-    return index.row() + distribution_->localNrTiles().rows() * static_cast<SizeType>(index.col());
+  std::size_t tileLinearIndex(const LocalTileIndex& index) const noexcept {
+    return to_sizet(index.row() + distribution_->localNrTiles().rows() * static_cast<SizeType>(index.col()));
   }
 
   /// Prints information about the matrix.

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -39,7 +39,7 @@ hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
 }
 
 template <class T, Device device>
-void Matrix<const T, device>::syncAll() noexcept {
+void Matrix<const T, device>::waitLocalTiles() noexcept {
   // Note:
   // Using a readwrite access to the tile ensures that the access is exclusive and not shared
   // among multiple tasks.

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -38,6 +38,7 @@ hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
   return tile_managers_[i].getReadTileSharedFuture();
 }
 
+template <class T, Device device>
 void Matrix<const T, device>::syncAll() noexcept {
   // Note:
   // Using a readwrite access to the tile ensures that the access is exclusive and not shared
@@ -50,7 +51,7 @@ void Matrix<const T, device>::syncAll() noexcept {
 
   const auto range_local = common::iterate_range2d(distribution().localNrTiles());
   auto all_local_tiles_rw = internal::selectGeneric(readwrite_f, range_local);
-  hpx::when_all(std::move(all_local_tiles_rw)).get();
+  hpx::wait_all(std::move(all_local_tiles_rw));
 }
 
 template <class T, Device device>

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -50,8 +50,7 @@ void Matrix<const T, device>::waitLocalTiles() noexcept {
   };
 
   const auto range_local = common::iterate_range2d(distribution().localNrTiles());
-  auto all_local_tiles_rw = internal::selectGeneric(readwrite_f, range_local);
-  hpx::wait_all(std::move(all_local_tiles_rw));
+  hpx::wait_all(internal::selectGeneric(readwrite_f, range_local));
 }
 
 template <class T, Device device>

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -32,18 +32,6 @@ Matrix<const T, device>::Matrix(Distribution distribution, const matrix::LayoutI
 }
 
 template <class T, Device device>
-Matrix<const T, device>::~Matrix() {
-  for (auto&& tile_manager : tile_managers_) {
-    try {
-      tile_manager.clearSync();
-    }
-    catch (...) {
-      // TODO WARNING
-    }
-  }
-}
-
-template <class T, Device device>
 hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
     const LocalTileIndex& index) noexcept {
   std::size_t i = to_sizet(tileLinearIndex(index));

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -34,7 +34,7 @@ Matrix<const T, device>::Matrix(Distribution distribution, const matrix::LayoutI
 template <class T, Device device>
 hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
     const LocalTileIndex& index) noexcept {
-  std::size_t i = to_sizet(tileLinearIndex(index));
+  const auto i = tileLinearIndex(index);
   return tile_managers_[i].getReadTileSharedFuture();
 }
 

--- a/include/dlaf/matrix/matrix_view_const.tpp
+++ b/include/dlaf/matrix/matrix_view_const.tpp
@@ -26,13 +26,13 @@ MatrixView<const T, device>::MatrixView(blas::Uplo uplo, MatrixType<T2, device>&
 template <class T, Device device>
 hpx::shared_future<Tile<const T, device>> MatrixView<const T, device>::read(
     const LocalTileIndex& index) noexcept {
-  std::size_t i = static_cast<std::size_t>(tileLinearIndex(index));
+  const auto i = tileLinearIndex(index);
   return tile_shared_futures_[i];
 }
 
 template <class T, Device device>
 void MatrixView<const T, device>::done(const LocalTileIndex& index) noexcept {
-  std::size_t i = static_cast<std::size_t>(tileLinearIndex(index));
+  const auto i = tileLinearIndex(index);
   tile_shared_futures_[i] = {};
 }
 

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -110,7 +110,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
     copy(matrix_ref, matrix);
 
     // wait all setup tasks before starting benchmark
-    matrix.syncAll();
+    matrix.waitLocalTiles();
     DLAF_MPI_CALL(MPI_Barrier(world));
 
     dlaf::common::Timer<> timeit;

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -110,11 +110,8 @@ int hpx_main(hpx::program_options::variables_map& vm) {
     copy(matrix_ref, matrix);
 
     // wait all setup tasks before starting benchmark
-    {
-      for (const auto tile_idx : dlaf::common::iterate_range2d(distribution.localNrTiles()))
-        matrix(tile_idx).get();
-      DLAF_MPI_CALL(MPI_Barrier(world));
-    }
+    matrix.syncAll();
+    DLAF_MPI_CALL(MPI_Barrier(world));
 
     dlaf::common::Timer<> timeit;
     dlaf::factorization::cholesky<Backend::MC, Device::CPU, T>(comm_grid, blas::Uplo::Lower, matrix);

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -83,8 +83,8 @@ int hpx_main(hpx::program_options::variables_map& vm) {
   dlaf::matrix::MatrixMirror<T, Device::Default, Device::CPU> b(bh);
 
   auto sync_barrier = [&]() {
-    a.syncAll();
-    b.syncAll();
+    a.waitLocalTiles();
+    b.waitLocalTiles();
     DLAF_MPI_CALL(MPI_Barrier(world));
   };
 

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -61,9 +61,6 @@ struct options_t {
 
 options_t check_options(hpx::program_options::variables_map& vm);
 
-template <typename T, Device D>
-void waitall_tiles(dlaf::Matrix<T, D>& matrix);
-
 using matrix_values_t = std::function<T(const GlobalElementIndex&)>;
 using linear_system_t = std::tuple<matrix_values_t, matrix_values_t, matrix_values_t>;  // A, B, X
 linear_system_t sampleLeftTr(blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha, SizeType m);
@@ -86,8 +83,8 @@ int hpx_main(hpx::program_options::variables_map& vm) {
   dlaf::matrix::MatrixMirror<T, Device::Default, Device::CPU> b(bh);
 
   auto sync_barrier = [&]() {
-    ::waitall_tiles(a.get());
-    ::waitall_tiles(b.get());
+    a.syncAll();
+    b.syncAll();
     DLAF_MPI_CALL(MPI_Barrier(world));
   };
 
@@ -209,13 +206,6 @@ options_t check_options(hpx::program_options::variables_map& vm) {
   DLAF_ASSERT(opts.nwarmups >= 0, opts.nwarmups);
 
   return opts;
-}
-
-template <typename T, Device D>
-void waitall_tiles(dlaf::Matrix<T, D>& matrix) {
-  using dlaf::common::iterate_range2d;
-  for (const auto tile_idx : iterate_range2d(matrix.distribution().localNrTiles()))
-    matrix(tile_idx).get();
 }
 
 /// Returns a tuple of element generators of three matrices A(m x m), B (m x n), X (m x n), for which it

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -83,8 +83,8 @@ int hpx_main(hpx::program_options::variables_map& vm) {
   dlaf::matrix::MatrixMirror<T, Device::Default, Device::CPU> b(bh);
 
   auto sync_barrier = [&]() {
-    a.waitLocalTiles();
-    b.waitLocalTiles();
+    a.get().waitLocalTiles();
+    b.get().waitLocalTiles();
     DLAF_MPI_CALL(MPI_Barrier(world));
   };
 

--- a/test/include/dlaf_test/matrix/matrix_local.h
+++ b/test/include/dlaf_test/matrix/matrix_local.h
@@ -83,7 +83,7 @@ struct MatrixLocal<const T> {
 
   /// Access tiles
   const ConstTileT& tile_read(const GlobalTileIndex& index) const noexcept {
-    return tiles_[static_cast<size_t>(tileLinearIndex(index))];
+    return tiles_[tileLinearIndex(index)];
   }
 
   SizeType ld() const noexcept {
@@ -109,11 +109,11 @@ protected:
     return index.row() + index.col() * layout_.ldTile();
   }
 
-  SizeType tileLinearIndex(const GlobalTileIndex& index) const noexcept {
+  std::size_t tileLinearIndex(const GlobalTileIndex& index) const noexcept {
     DLAF_ASSERT(LocalTileIndex(index.row(), index.col()).isIn(layout_.nrTiles()), index,
                 layout_.nrTiles());
 
-    return index.row() + index.col() * layout_.nrTiles().rows();
+    return to_sizet(index.row() + index.col() * layout_.nrTiles().rows());
   }
 
   dlaf::matrix::LayoutInfo layout_;
@@ -150,7 +150,7 @@ struct MatrixLocal : public MatrixLocal<const T> {
 
   /// Access tiles
   const TileT& tile(const GlobalTileIndex& index) const noexcept {
-    return tiles_[static_cast<size_t>(tileLinearIndex(index))];
+    return tiles_[tileLinearIndex(index)];
   }
 
 protected:

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -1371,9 +1371,8 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
 
       const auto local_size = distribution.localNrTiles();
       const LocalTileIndex tile_tl(0, 0);
-      const LocalTileIndex tile_br(
-          std::max(SizeType(0), local_size.rows() - 1),
-          std::max(SizeType(0), local_size.cols() - 1));
+      const LocalTileIndex tile_br(std::max(SizeType(0), local_size.rows() - 1),
+                                   std::max(SizeType(0), local_size.cols() - 1));
 
       const bool has_local = !local_size.isEmpty();
 

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -12,6 +12,7 @@
 #include "dlaf/matrix/matrix.h"
 
 #include <atomic>
+#include <chrono>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -24,6 +25,8 @@
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/matrix/util_matrix_futures.h"
 #include "dlaf_test/util_types.h"
+
+using namespace std::chrono_literals;
 
 using namespace dlaf;
 using namespace dlaf::matrix;
@@ -1243,7 +1246,7 @@ using TypeParam = std::complex<float>;  // randomly chosen element type for matr
 
 // wait for guard to become true
 auto try_waiting_guard = [](auto& guard) {
-  const auto wait_guard = std::chrono::milliseconds(20);
+  const auto wait_guard = 20ms;
 
   for (int i = 0; i < 100 && !guard; ++i)
     hpx::this_thread::sleep_for(wait_guard);
@@ -1393,7 +1396,7 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
       // start a task (if it has at least a local part...otherwise there is no tile to work on)
       if (has_local)
         matrix.read(tile_tl).then(hpx::launch::async, [&guard](auto&&) {
-          hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+          hpx::this_thread::sleep_for(100ms);
           guard = true;
         });
 

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -1228,7 +1228,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadwrite) {
 // already finished (and in case of failure it may not be presented correctly)
 //
 // Note 2:
-// WAIT_GUARD is the time to wait in the launched task for assuring that Matrix d'tor has been called
+// wait_guard is the time to wait in the launched task for assuring that Matrix d'tor has been called
 // after going out-of-scope. This duration must be kept as low as possible in order to not waste time
 // during tests, but at the same time it must be enough to let the "main" to arrive to the end of the
 // scope.
@@ -1238,7 +1238,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadwrite) {
 // usage, but they are just meant to test that the Matrix does not wait on destruction for any left
 // task on one of its tiles.
 
-const auto WAIT_GUARD = std::chrono::milliseconds(10);
+const auto wait_guard = std::chrono::milliseconds(100);
 const auto device = dlaf::Device::CPU;
 using TypeParam = std::complex<float>;  // randomly chosen element type for matrix
 
@@ -1269,7 +1269,7 @@ TEST(MatrixDestructorFutures, NonConstAfterRead) {
 
     auto shared_future = matrix.read(LocalTileIndex(0, 0));
     last_task = shared_future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
-      hpx::this_thread::sleep_for(WAIT_GUARD);
+      hpx::this_thread::sleep_for(wait_guard);
       EXPECT_TRUE(is_exited_from_scope);
     });
   }
@@ -1287,7 +1287,7 @@ TEST(MatrixDestructorFutures, NonConstAfterReadWrite) {
 
     auto future = matrix(LocalTileIndex(0, 0));
     last_task = future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
-      hpx::this_thread::sleep_for(WAIT_GUARD);
+      hpx::this_thread::sleep_for(wait_guard);
       EXPECT_TRUE(is_exited_from_scope);
     });
   }
@@ -1306,7 +1306,7 @@ TEST(MatrixDestructorFutures, NonConstAfterRead_UserMemory) {
 
     auto shared_future = matrix.read(LocalTileIndex(0, 0));
     last_task = shared_future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
-      hpx::this_thread::sleep_for(WAIT_GUARD);
+      hpx::this_thread::sleep_for(wait_guard);
       EXPECT_TRUE(is_exited_from_scope);
     });
   }
@@ -1325,7 +1325,7 @@ TEST(MatrixDestructorFutures, NonConstAfterReadWrite_UserMemory) {
 
     auto future = matrix(LocalTileIndex(0, 0));
     last_task = future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
-      hpx::this_thread::sleep_for(WAIT_GUARD);
+      hpx::this_thread::sleep_for(wait_guard);
       EXPECT_TRUE(is_exited_from_scope);
     });
   }
@@ -1344,7 +1344,7 @@ TEST(MatrixDestructorFutures, ConstAfterRead_UserMemory) {
 
     auto sf = matrix.read(LocalTileIndex(0, 0));
     last_task = sf.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
-      hpx::this_thread::sleep_for(WAIT_GUARD);
+      hpx::this_thread::sleep_for(wait_guard);
       EXPECT_TRUE(is_exited_from_scope);
     });
   }
@@ -1386,7 +1386,7 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
       // start a task (if it has at least a local part...otherwise there is no tile to work on)
       if (has_local)
         matrix.read(tile_tl).then(hpx::launch::async, [&guard](auto&&) {
-          hpx::this_thread::sleep_for(WAIT_GUARD);
+          hpx::this_thread::sleep_for(wait_guard);
           guard = true;
         });
 

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -1393,7 +1393,7 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
       // everyone wait on its local part...
       // this means that it is possible to call it also on empty local matrices, they just don't
       // have anything to wait for
-      matrix.syncAll();
+      matrix.waitLocalTiles();
 
       // after the sync barrier, start a task on a tile (another one/the same) expecting that
       // the previous task has been fully completed (and the future mechanism still works)

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -1345,7 +1345,7 @@ TEST(MatrixDestructorFutures, ConstAfterRead_UserMemory) {
     auto sf = matrix.read(LocalTileIndex(0, 0));
     last_task = sf.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
       hpx::this_thread::sleep_for(WAIT_GUARD);
-      EXPECT_FALSE(is_exited_from_scope);
+      EXPECT_TRUE(is_exited_from_scope);
     });
   }
   is_exited_from_scope = true;


### PR DESCRIPTION
Close #332 

This PR is a breaking change for codes dealing with `Matrix`es built from user provided memory, since a manual synchronization barrier would be needed from now on.

On the opposite, it represents an interesting improvement for `Matrix`es that internally allocates memory, since it removes implicit synchronization barriers that could limit performance and flexibility.

See issue #332 for additional details.