### PR TITLE
Fix apple-clang compiler crash

### DIFF
--- a/test/unit/test_types.cpp
+++ b/test/unit/test_types.cpp
@@ -23,11 +23,15 @@ using dlaf::common::internal::source_location;
 
 const char* ERROR_MESSAGE = "\\[ERROR\\]";
 
-template <class T, class C = T>
-const auto LOWER_BOUND = []() { return static_cast<C>(std::numeric_limits<T>::min()); };
+template <class Type, class ContainerType = Type>
+const ContainerType LOWER_BOUND() {
+ return static_cast<ContainerType>(std::numeric_limits<Type>::min());
+}
 
-template <class T, class C = T>
-const auto UPPER_BOUND = []() { return static_cast<C>(std::numeric_limits<T>::max()); };
+template <class Type, class ContainerType = Type>
+const ContainerType UPPER_BOUND() {
+ return static_cast<ContainerType>(std::numeric_limits<Type>::max());
+}
 
 /// Check that no alteration happens during cast From -> To with @param cast_func and dlaf::integral_cast.
 ///

--- a/test/unit/test_types.cpp
+++ b/test/unit/test_types.cpp
@@ -25,12 +25,12 @@ const char* ERROR_MESSAGE = "\\[ERROR\\]";
 
 template <class Type, class ContainerType = Type>
 const ContainerType LOWER_BOUND() {
- return static_cast<ContainerType>(std::numeric_limits<Type>::min());
+  return static_cast<ContainerType>(std::numeric_limits<Type>::min());
 }
 
 template <class Type, class ContainerType = Type>
 const ContainerType UPPER_BOUND() {
- return static_cast<ContainerType>(std::numeric_limits<Type>::max());
+  return static_cast<ContainerType>(std::numeric_limits<Type>::max());
 }
 
 /// Check that no alteration happens during cast From -> To with @param cast_func and dlaf::integral_cast.


### PR DESCRIPTION
For reference
```
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

It was crashing with

```
➜  build git:(master) make test_types
[ 62%] Built target dlaf.core
[ 75%] Built target gtest
[ 87%] Built target gtest_main
Consolidate compiler generated dependencies of target test_types
[ 93%] Building CXX object test/unit/CMakeFiles/test_types.dir/test_types.cpp.o
clang: error: unable to execute command: Illegal instruction: 4
clang: error: clang frontend command failed due to signal (use -v to see invocation)
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
clang: note: diagnostic msg: PLEASE submit a bug report to http://developer.apple.com/bugreporter/ and include the crash backtrace, preprocessed source, and associated run script.
clang: note: diagnostic msg:
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /var/folders/c9/v21gts9n7rs9cycnxcdzr__80000gn/T/test_types-9c027c.cpp
clang: note: diagnostic msg: /var/folders/c9/v21gts9n7rs9cycnxcdzr__80000gn/T/test_types-9c027c.sh
clang: note: diagnostic msg: /var/folders/c9/v21gts9n7rs9cycnxcdzr__80000gn/T/test_types-9c027c.crash
clang: note: diagnostic msg:

********************
make[3]: *** [test/unit/CMakeFiles/test_types.dir/test_types.cpp.o] Error 254
make[2]: *** [test/unit/CMakeFiles/test_types.dir/all] Error 2
make[1]: *** [test/unit/CMakeFiles/test_types.dir/rule] Error 2
make: *** [test_types] Error 2
```

apparently for an infinite recursion happening due to these lambdas.

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   clang                               0x0000000103f2d6d4 clang::VarDecl::isThisDeclarationADefinition(clang::ASTContext&) const + 4
1   clang                               0x0000000106fea3b0 clang::VarDecl::getDefinition() + 128
2   clang                               0x0000000106fe0ca6 clang::VarDecl::getTemplateInstantiationPattern() const + 1478
3   clang                               0x0000000105b67caa isDeclareTargetDeclaration(clang::ValueDecl const*) + 170
4   clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
5   clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
6   clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
7   clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
8   clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
...
504 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
505 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
506 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
507 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
508 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
509 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
510 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
511 clang                               0x0000000105b67cb7 isDeclareTargetDeclaration(clang::ValueDecl const*) + 183
```