### PR TITLE
Move codecov init and fetch of upload codecov script to deploy image

### DIFF
--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -14,11 +14,6 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     git tar wget curl gpg-agent jq tzdata && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cd /usr/local/bin && \
-  curl -Ls https://codecov.io/bash > codecov.sh && \
-  echo "d6aa3207c4908d123bd8af62ec0538e3f2b9f257c3de62fad4e29cd3b59b41d9 codecov.sh" | sha256sum --check --quiet && \
-  chmod +x codecov.sh
-
 # Install cmake
 RUN wget -qO- "https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 

--- a/ci/docker/codecov/deploy.Dockerfile
+++ b/ci/docker/codecov/deploy.Dockerfile
@@ -88,11 +88,6 @@ COPY --from=builder ${DEPLOY} ${DEPLOY}
 # cause race conditions in gcov.
 COPY --from=builder ${SOURCE} ${SOURCE}
 
-ENV LOCAL_REPORTS /codecov-reports
-
-RUN mkdir -p "$LOCAL_REPORTS" && \
-    lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "$LOCAL_REPORTS/baseline-codecov.info" &> /dev/null
-
 RUN cd /usr/local/bin && \
   curl -Ls https://codecov.io/bash > codecov.sh && \
   echo "d6aa3207c4908d123bd8af62ec0538e3f2b9f257c3de62fad4e29cd3b59b41d9 codecov.sh" | sha256sum --check --quiet && \
@@ -113,3 +108,8 @@ ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
 RUN echo "${DEPLOY}/usr/lib/" > /etc/ld.so.conf.d/dlaf.conf && ldconfig
 
 WORKDIR ${BUILD}
+
+ENV LOCAL_REPORTS /codecov-reports
+RUN mkdir -p ${LOCAL_REPORTS} && \
+    lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "${LOCAL_REPORTS}/baseline-codecov.info"
+

--- a/ci/docker/codecov/deploy.Dockerfile
+++ b/ci/docker/codecov/deploy.Dockerfile
@@ -112,4 +112,3 @@ WORKDIR ${BUILD}
 ENV LOCAL_REPORTS /codecov-reports
 RUN mkdir -p ${LOCAL_REPORTS} && \
     lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "${LOCAL_REPORTS}/baseline-codecov.info"
-

--- a/ci/docker/codecov/deploy.Dockerfile
+++ b/ci/docker/codecov/deploy.Dockerfile
@@ -88,7 +88,15 @@ COPY --from=builder ${DEPLOY} ${DEPLOY}
 # cause race conditions in gcov.
 COPY --from=builder ${SOURCE} ${SOURCE}
 
-COPY --from=builder /usr/local/bin/codecov.sh /usr/local/bin/codecov.sh
+ENV LOCAL_REPORTS /codecov-reports
+
+RUN mkdir -p "$LOCAL_REPORTS" && \
+    lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "$LOCAL_REPORTS/baseline-codecov.info" &> /dev/null
+
+RUN cd /usr/local/bin && \
+  curl -Ls https://codecov.io/bash > codecov.sh && \
+  echo "d6aa3207c4908d123bd8af62ec0538e3f2b9f257c3de62fad4e29cd3b59b41d9 codecov.sh" | sha256sum --check --quiet && \
+  chmod +x codecov.sh
 
 # Make it easy to call our binaries.
 ENV PATH="${DEPLOY}/usr/bin:$PATH"

--- a/ci/mpi-ctest
+++ b/ci/mpi-ctest
@@ -1,17 +1,10 @@
 #!/bin/bash -e
 
 if [[ "$ENABLE_COVERAGE" == "YES" ]]; then
-    TZ=CET date +"Start initialization of codecov reports from rank $SLURM_PROCID at: %H:%M:%S %z"
-
-    LOCAL_REPORTS="/codecov-reports"
     SHARED_REPORTS="$CI_PROJECT_DIR/codecov-reports"
     REPORT_NAME=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
 
-    mkdir -p "$LOCAL_REPORTS"
     mkdir -p "$SHARED_REPORTS"
-    lcov --no-external --capture --initial --base-directory /DLA-Future --directory /DLA-Future-build --output-file "$LOCAL_REPORTS/baseline-codecov.info" &> /dev/null
-
-    TZ=CET date +"Done initialization of codecov reports from rank $SLURM_PROCID at: %H:%M:%S %z"
 fi;
 
 pushd /DLA-Future-build > /dev/null


### PR DESCRIPTION
We are often hitting test timelimit in codecov tests.

The simplest solution is to increase the limit, but as codecov initialization is done in all tests by each rank in the same way I moved it directly in the deploy image.

Moreover I also moved the fetch of the codecov upload script (and checksum check) in the deploy image as well.
(I don't think it is a good idea to rebuild the full build image, just because a test script has changed.)