### PR TITLE
Don't disable CUDA polling when finalizing DLAF

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -135,7 +135,6 @@ struct Init<Backend::GPU> {
     finalizeNpCudaStreamPool();
     finalizeHpCudaStreamPool();
     finalizeCublasHandlePool();
-    hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool("default"));
   }
 };
 #endif


### PR DESCRIPTION
Analogously to the MPI polling, we should not/don't need to disable CUDA polling at DLAF finalization (see: https://gitlab.com/cscs-ci/eth-cscs/DLA-Future/-/jobs/1219016879).