### PR TITLE
Discussion (minor): handleRecvTile non-const

### DIFF
--- a/include/dlaf/communication/kernels.h
+++ b/include/dlaf/communication/kernels.h
@@ -40,13 +40,11 @@ DLAF_MAKE_CALLABLE_OBJECT(sendBcast);
 
 // Non-blocking receiver broadcast
 template <class T, Device D>
-matrix::Tile<const T, D> recvBcast(matrix::Tile<T, D> tile, comm::IndexT_MPI root_rank,
-                                   common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
-  using ConstTile_t = matrix::Tile<const T, D>;
-
+matrix::Tile<T, D> recvBcast(matrix::Tile<T, D> tile, comm::IndexT_MPI root_rank,
+                             common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
   auto msg = comm::make_message(common::make_data(tile));
   MPI_Ibcast(msg.data(), msg.count(), msg.mpi_type(), root_rank, pcomm.ref(), req);
-  return ConstTile_t(std::move(tile));
+  return std::move(tile);
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(recvBcast);
@@ -75,9 +73,9 @@ void scheduleSendBcast(Executor&& ex, Future<matrix::Tile<const T, D>> tile,
 }
 
 template <class T, Device D, class Executor>
-hpx::future<matrix::Tile<const T, D>> scheduleRecvBcast(
-    Executor&& ex, hpx::future<matrix::Tile<T, D>> tile, comm::IndexT_MPI root_rank,
-    hpx::future<common::PromiseGuard<Communicator>> pcomm) {
+hpx::future<matrix::Tile<T, D>> scheduleRecvBcast(Executor&& ex, hpx::future<matrix::Tile<T, D>> tile,
+                                                  comm::IndexT_MPI root_rank,
+                                                  hpx::future<common::PromiseGuard<Communicator>> pcomm) {
   return internal::handleRecvTile<D>(hpx::dataflow(std::forward<Executor>(ex),
                                                    hpx::util::unwrapping(recvBcast_o), std::move(tile),
                                                    root_rank, std::move(pcomm)));

--- a/include/dlaf/communication/rdma.h
+++ b/include/dlaf/communication/rdma.h
@@ -54,7 +54,7 @@ auto prepareSendTile(hpx::shared_future<matrix::Tile<const T, D>> tile) {
 /// the CPU. This helper duplicates to the GPU if the first template parameter
 /// is a GPU device. The first template parameter must be given.
 template <Device D, typename T>
-auto handleRecvTile(hpx::future<matrix::Tile<const T, CommunicationDevice<D>::value>> tile) {
+auto handleRecvTile(hpx::future<matrix::Tile<T, CommunicationDevice<D>::value>> tile) {
   return matrix::duplicateIfNeeded<D>(std::move(tile));
 }
 }


### PR DESCRIPTION
This PR is just a change over the #309 to show a possible change in the API.

With reference to this comment
https://github.com/eth-cscs/DLA-Future/pull/309/commits/cb3933114a8cfdddfd2e95b60b94ec24934cc824/#r621351681

I forgot, in case there is, the reason why we prefer to return `ConstTile_t` from `recv` functions. Maybe I'm missing some use-cases.

In particular the main point about this I think it is if we prefer something like
> return `shared_future<ConstTile>` from schedule functions, so that there is just a read-only access to the result and in case a read-write access to the result is needed, the user has to go through the matrix/panel to get back a rw tile

I didn't change the `recvBcastAlloc` in the same way, because of limitations imposed by the current usage, i.e. cholesky stores returned tiles in a `vector<shared_future<Tile>>`. 