### PR TITLE
Initial sender/receiver adaptations for tile algorithms

### DIFF
--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -95,6 +95,7 @@ RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O 
       -DTCMALLOC_ROOT=$GPERFTOOLS_PATH \
       -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_CXX_FLAGS_DEBUG="-g -Og -fno-omit-frame-pointer" \
+      -DHPX_WITH_CXX17=On \
       -DHPX_WITH_SANITIZERS=ON \
       -DHPX_WITH_STACK_OVERFLOW_DETECTION=OFF \
       -DHPX_WITH_MAX_CPU_COUNT=128 \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -94,6 +94,7 @@ RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O 
       -DTCMALLOC_ROOT=$GPERFTOOLS_PATH \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_INSTALL_PREFIX=$HPX_PATH \
+      -DHPX_WITH_CXX17=On \
       -DHPX_WITH_MAX_CPU_COUNT=128 \
       -DHPX_WITH_NETWORKING=OFF \
       -DHPX_WITH_ASYNC_MPI=ON \

--- a/include/dlaf/auxiliary/norm/mc.h
+++ b/include/dlaf/auxiliary/norm/mc.h
@@ -51,8 +51,8 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
   using dlaf::common::make_data;
   using hpx::unwrapping;
 
-  using dlaf::tile::lange;
-  using dlaf::tile::lantr;
+  using dlaf::tile::internal::lange;
+  using dlaf::tile::internal::lantr;
 
   using NormT = dlaf::BaseType<T>;
 

--- a/include/dlaf/blas/tile.h
+++ b/include/dlaf/blas/tile.h
@@ -13,6 +13,10 @@
 
 #include "dlaf/common/callable_object.h"
 #include "dlaf/matrix/tile.h"
+#include "dlaf/sender/make_sender_algorithm_overloads.h"
+#include "dlaf/sender/partial_transform.h"
+#include "dlaf/sender/policy.h"
+#include "dlaf/sender/transform.h"
 #include "dlaf/types.h"
 #include "dlaf/util_blas.h"
 
@@ -28,9 +32,145 @@ namespace dlaf {
 namespace tile {
 using matrix::Tile;
 
-// See BLAS documentation for more details.
+#ifdef DLAF_DOXYGEN
 
 /// Computes general matrix matrix multiplication.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void gemm(const blas::Op op_a, const blas::Op op_b, const T alpha, const Tile<const T, D>& a,
+          const Tile<const T, D>& b, const T beta, const Tile<T, D>& c);
+
+/// \overload gemm
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto gemm(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload gemm
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto gemm(const dlaf::internal::Policy<B>& p);
+
+/// Computes matrix matrix multiplication where matrix @p a is hermitian (symmetric if T is real).
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void hemm(const blas::Side side, const blas::Uplo uplo, const T alpha, const Tile<const T, D>& a,
+          const Tile<const T, D>& b, const T beta, const Tile<T, D>& c);
+
+/// \overload hemm
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto hemm(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload hemm
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto hemm(const dlaf::internal::Policy<B>& p);
+
+/// Performs a rank 2k update of hermitian (symmetric if T is real) tile @p a.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void her2k(const blas::Uplo uplo, const blas::Op op, const T alpha, const Tile<const T, D>& a,
+           const Tile<const T, D>& b, const BaseType<T> beta, const Tile<T, D>& c);
+
+/// \overload her2k
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto her2k(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload her2k
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto her2k(const dlaf::internal::Policy<B>& p);
+
+/// Performs a rank k update of hermitian (symmetric if T is real) tile @p a.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void herk(const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha, const Tile<const T, D>& a,
+          const BaseType<T> beta, const Tile<T, D>& c);
+
+/// \overload herk
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto herk(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload herk
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto herk(const dlaf::internal::Policy<B>& p);
+
+/// Performs a matrix-matrix multiplication involving a triangular matrix.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void trmm(const dlaf::internal::Policy<B>& policy, const blas::Side side, const blas::Uplo uplo,
+          const blas::Op op, const blas::Diag diag, const T alpha, const Tile<const T, D>& a,
+          const Tile<T, D>& b);
+
+/// \overload trmm
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto trmm(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload trmm
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto trmm(const dlaf::internal::Policy<B>& p);
+
+/// Performs a triangular solve.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void trsm(const dlaf::internal::Policy<B>& policy, const blas::Side side, const blas::Uplo uplo,
+          const blas::Op op, const blas::Diag diag, const T alpha, const Tile<const T, D>& a,
+          const Tile<T, D>& b);
+
+/// \overload trsm
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto trsm(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload trsm
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto trsm(const dlaf::internal::Policy<B>& p);
+#else
+
+namespace internal {
+
 template <class T>
 void gemm(const blas::Op op_a, const blas::Op op_b, const T alpha, const Tile<const T, Device::CPU>& a,
           const Tile<const T, Device::CPU>& b, const T beta, const Tile<T, Device::CPU>& c) noexcept {
@@ -39,7 +179,6 @@ void gemm(const blas::Op op_a, const blas::Op op_b, const T alpha, const Tile<co
              beta, c.ptr(), c.ld());
 }
 
-/// Computes matrix matrix multiplication where matrix @p a is hermitian (symmetric if T is real).
 template <class T>
 void hemm(const blas::Side side, const blas::Uplo uplo, const T alpha,
           const Tile<const T, Device::CPU>& a, const Tile<const T, Device::CPU>& b, const T beta,
@@ -49,7 +188,6 @@ void hemm(const blas::Side side, const blas::Uplo uplo, const T alpha,
              c.ptr(), c.ld());
 }
 
-/// Performs a rank 2k update of hermitian (symmetric if T is real) tile a.
 template <class T>
 void her2k(const blas::Uplo uplo, const blas::Op op, const T alpha, const Tile<const T, Device::CPU>& a,
            const Tile<const T, Device::CPU>& b, const BaseType<T> beta,
@@ -59,7 +197,6 @@ void her2k(const blas::Uplo uplo, const blas::Op op, const T alpha, const Tile<c
               c.ptr(), c.ld());
 }
 
-/// Performs a rank k update of hermitian (symmetric if T is real) tile @p a.
 template <class T>
 void herk(const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha,
           const Tile<const T, Device::CPU>& a, const BaseType<T> beta,
@@ -87,7 +224,6 @@ void trsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, const
 }
 
 #ifdef DLAF_WITH_CUDA
-namespace internal {
 
 #define DLAF_DECLARE_CUBLAS_OP(Name) \
   template <typename T>              \
@@ -137,78 +273,69 @@ DLAF_DEFINE_CUBLAS_OP(Trsm, float, Strsm);
 DLAF_DEFINE_CUBLAS_OP(Trsm, double, Dtrsm);
 DLAF_DEFINE_CUBLAS_OP(Trsm, std::complex<float>, Ctrsm);
 DLAF_DEFINE_CUBLAS_OP(Trsm, std::complex<double>, Ztrsm);
-}
 
-/// Computes general matrix matrix multiplication.
 template <class T>
 void gemm(cublasHandle_t handle, const blas::Op op_a, const blas::Op op_b, const T alpha,
           const matrix::Tile<const T, Device::GPU>& a, const matrix::Tile<const T, Device::GPU>& b,
           const T beta, const matrix::Tile<T, Device::GPU>& c) {
-  auto s = tile::internal::getGemmSizes(op_a, op_b, a, b, c);
-  internal::CublasGemm<T>::call(handle, util::blasToCublas(op_a), util::blasToCublas(op_b), s.m, s.n,
-                                s.k, util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()),
-                                a.ld(), util::blasToCublasCast(b.ptr()), b.ld(),
-                                util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), c.ld());
+  auto s = getGemmSizes(op_a, op_b, a, b, c);
+  CublasGemm<T>::call(handle, util::blasToCublas(op_a), util::blasToCublas(op_b), s.m, s.n, s.k,
+                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                      util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
+                      util::blasToCublasCast(c.ptr()), c.ld());
 }
 
-/// Computes matrix matrix multiplication where matrix @p a is hermitian (symmetric if T is real).
 template <class T>
 void hemm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, const T alpha,
           const Tile<const T, Device::GPU>& a, const Tile<const T, Device::GPU>& b, const T beta,
           const Tile<T, Device::GPU>& c) {
-  auto s = tile::internal::getHemmSizes(side, a, b, c);
-  internal::CublasHemm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), s.m, s.n,
-                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                                util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
-                                util::blasToCublasCast(c.ptr()), c.ld());
+  auto s = getHemmSizes(side, a, b, c);
+  CublasHemm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), s.m, s.n,
+                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                      util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
+                      util::blasToCublasCast(c.ptr()), c.ld());
 }
 
-/// Performs a rank 2k update of hermitian (symmetric if T is real) tile @p a.
 template <class T>
 void her2k(cublasHandle_t handle, const blas::Uplo uplo, const blas::Op op, const T alpha,
            const matrix::Tile<const T, Device::GPU>& a, const Tile<const T, Device::GPU>& b,
            const BaseType<T> beta, const matrix::Tile<T, Device::GPU>& c) {
-  auto s = tile::internal::getHer2kSizes(op, a, b, c);
-  internal::CublasHer2k<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), s.n, s.k,
-                                 util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                                 util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
-                                 util::blasToCublasCast(c.ptr()), c.ld());
+  auto s = getHer2kSizes(op, a, b, c);
+  CublasHer2k<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), s.n, s.k,
+                       util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                       util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
+                       util::blasToCublasCast(c.ptr()), c.ld());
 }
 
-/// Performs a rank k update of hermitian (symmetric if T is real) tile @p a.
 template <class T>
 void herk(cublasHandle_t handle, const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha,
           const matrix::Tile<const T, Device::GPU>& a, const BaseType<T> beta,
           const matrix::Tile<T, Device::GPU>& c) {
-  auto s = tile::internal::getHerkSizes(op, a, c);
-  internal::CublasHerk<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), s.n, s.k,
-                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                                util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), c.ld());
+  auto s = getHerkSizes(op, a, c);
+  CublasHerk<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), s.n, s.k,
+                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
+                      util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), c.ld());
 }
 
-/// Performs a matrix-matrix multiplication, involving a triangular matrix.
 template <class T>
 void trmm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, const blas::Op op,
           const blas::Diag diag, const T alpha, const matrix::Tile<const T, Device::GPU>& a,
           const matrix::Tile<T, Device::GPU>& b) {
   auto s = tile::internal::getTrmmSizes(side, a, b);
-  internal::CublasTrmm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo),
-                                util::blasToCublas(op), util::blasToCublas(diag), s.m, s.n,
-                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                                util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(b.ptr()),
-                                b.ld());
+  CublasTrmm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), util::blasToCublas(op),
+                      util::blasToCublas(diag), s.m, s.n, util::blasToCublasCast(&alpha),
+                      util::blasToCublasCast(a.ptr()), a.ld(), util::blasToCublasCast(b.ptr()), b.ld(),
+                      util::blasToCublasCast(b.ptr()), b.ld());
 }
 
-/// Performs a triangular solve.
 template <class T>
 void trsm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, const blas::Op op,
           const blas::Diag diag, const T alpha, const matrix::Tile<const T, Device::GPU>& a,
           const matrix::Tile<T, Device::GPU>& b) {
-  auto s = tile::internal::getTrsmSizes(side, a, b);
-  internal::CublasTrsm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo),
-                                util::blasToCublas(op), util::blasToCublas(diag), s.m, s.n,
-                                util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                                util::blasToCublasCast(b.ptr()), b.ld());
+  auto s = getTrsmSizes(side, a, b);
+  CublasTrsm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), util::blasToCublas(op),
+                      util::blasToCublas(diag), s.m, s.n, util::blasToCublasCast(&alpha),
+                      util::blasToCublasCast(a.ptr()), a.ld(), util::blasToCublasCast(b.ptr()), b.ld());
 }
 #endif
 
@@ -218,6 +345,15 @@ DLAF_MAKE_CALLABLE_OBJECT(her2k);
 DLAF_MAKE_CALLABLE_OBJECT(herk);
 DLAF_MAKE_CALLABLE_OBJECT(trmm);
 DLAF_MAKE_CALLABLE_OBJECT(trsm);
+}
 
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(gemm, internal::gemm_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(hemm, internal::hemm_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(her2k, internal::her2k_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(herk, internal::herk_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(trmm, internal::trmm_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(trsm, internal::trsm_o)
+
+#endif
 }
 }

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -115,3 +115,6 @@ inline void do_assert(bool expr, const common::internal::source_location& loc, c
 #endif
 
 #define DLAF_UNIMPLEMENTED(...) DLAF_ASSERT(false, "Not yet implemented!", __VA_ARGS__)
+
+#define DLAF_STATIC_UNIMPLEMENTED(DummyType) \
+  static_assert(sizeof(DummyType) == 0, "Not yet implemented!")

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -93,7 +93,7 @@ struct scheduleRecvBcastImpl {
     auto comm_tile = hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
                                    tile_size, root_rank, std::move(pcomm));
     hpx::dataflow(dlaf::getCopyExecutor<CommunicationDevice<D>::value, D>(),
-                  matrix::unwrapExtendTiles(matrix::copy_o), std::move(comm_tile),
+                  matrix::unwrapExtendTiles(matrix::internal::copy_o), std::move(comm_tile),
                   std::move(tile_shared));
   }
 };

--- a/include/dlaf/cublas/executor.h
+++ b/include/dlaf/cublas/executor.h
@@ -31,51 +31,13 @@
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/error.h"
+#include "dlaf/cublas/handle_pool.h"
 #include "dlaf/cuda/error.h"
 #include "dlaf/cuda/executor.h"
 
 namespace dlaf {
 namespace cublas {
 namespace internal {
-class HandlePoolImpl {
-  int device_;
-  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
-  std::vector<cublasHandle_t> handles_;
-  cublasPointerMode_t ptr_mode_;
-
-public:
-  HandlePoolImpl(int device, cublasPointerMode_t ptr_mode)
-      : device_(device), handles_(num_worker_threads_), ptr_mode_(ptr_mode) {
-    DLAF_CUDA_CALL(cudaSetDevice(device_));
-
-    for (auto& h : handles_) {
-      DLAF_CUBLAS_CALL(cublasCreate(&h));
-    }
-  }
-
-  HandlePoolImpl& operator=(HandlePoolImpl&&) = default;
-  HandlePoolImpl(HandlePoolImpl&&) = default;
-  HandlePoolImpl(const HandlePoolImpl&) = delete;
-  HandlePoolImpl& operator=(const HandlePoolImpl&) = delete;
-
-  ~HandlePoolImpl() {
-    for (auto& h : handles_) {
-      DLAF_CUBLAS_CALL(cublasDestroy(h));
-    }
-  }
-
-  cublasHandle_t getNextHandle(cudaStream_t stream) {
-    cublasHandle_t handle = handles_[hpx::get_worker_thread_num()];
-    DLAF_CUDA_CALL(cudaSetDevice(device_));
-    DLAF_CUBLAS_CALL(cublasSetStream(handle, stream));
-    DLAF_CUBLAS_CALL(cublasSetPointerMode(handle, ptr_mode_));
-    return handle;
-  }
-
-  int getDevice() {
-    return device_;
-  }
-};
 
 template <bool IsCallable, typename F, typename... Ts>
 struct isAsyncCublasCallableImpl : std::false_type {
@@ -98,37 +60,6 @@ struct isDataflowCublasCallable
                         decltype(hpx::tuple_cat(hpx::tie(std::declval<cublasHandle_t&>()),
                                                 std::declval<Futures>()))> {};
 }
-
-/// A pool of cuBLAS handles with reference semantics (copying points to the
-/// same underlying cuBLAS handles, last reference destroys the references).
-/// Allows access to cuBLAS handles associated with a particular stream. The
-/// user must ensure that the handle pool and the stream use the same device.
-/// Each HPX worker thread is assigned thread local cuBLAS handle.
-class HandlePool {
-  std::shared_ptr<internal::HandlePoolImpl> handles_ptr_;
-
-public:
-  HandlePool(int device = 0, cublasPointerMode_t ptr_mode = CUBLAS_POINTER_MODE_HOST)
-      : handles_ptr_(std::make_shared<internal::HandlePoolImpl>(device, ptr_mode)) {}
-
-  cublasHandle_t getNextHandle(cudaStream_t stream) {
-    DLAF_ASSERT(bool(handles_ptr_), "");
-    return handles_ptr_->getNextHandle(stream);
-  }
-
-  int getDevice() {
-    DLAF_ASSERT(bool(handles_ptr_), "");
-    return handles_ptr_->getDevice();
-  }
-
-  bool operator==(HandlePool const& rhs) const noexcept {
-    return handles_ptr_ == rhs.handles_ptr_;
-  }
-
-  bool operator!=(HandlePool const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
-};
 
 /// An executor for cuBLAS functions. Uses handles and streams from the given
 /// HandlePool and StreamPool. A cuBLAS function is defined as any function that

--- a/include/dlaf/cublas/handle_pool.h
+++ b/include/dlaf/cublas/handle_pool.h
@@ -1,0 +1,109 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#ifdef DLAF_WITH_CUDA
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+#include <hpx/local/runtime.hpp>
+
+#include "dlaf/common/assert.h"
+#include "dlaf/cublas/error.h"
+#include "dlaf/cuda/error.h"
+#include "dlaf/cuda/executor.h"
+
+namespace dlaf {
+namespace cublas {
+namespace internal {
+class HandlePoolImpl {
+  int device_;
+  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
+  std::vector<cublasHandle_t> handles_;
+  cublasPointerMode_t ptr_mode_;
+
+public:
+  HandlePoolImpl(int device, cublasPointerMode_t ptr_mode)
+      : device_(device), handles_(num_worker_threads_), ptr_mode_(ptr_mode) {
+    DLAF_CUDA_CALL(cudaSetDevice(device_));
+
+    for (auto& h : handles_) {
+      DLAF_CUBLAS_CALL(cublasCreate(&h));
+    }
+  }
+
+  HandlePoolImpl& operator=(HandlePoolImpl&&) = default;
+  HandlePoolImpl(HandlePoolImpl&&) = default;
+  HandlePoolImpl(const HandlePoolImpl&) = delete;
+  HandlePoolImpl& operator=(const HandlePoolImpl&) = delete;
+
+  ~HandlePoolImpl() {
+    for (auto& h : handles_) {
+      DLAF_CUBLAS_CALL(cublasDestroy(h));
+    }
+  }
+
+  cublasHandle_t getNextHandle(cudaStream_t stream) {
+    cublasHandle_t handle = handles_[hpx::get_worker_thread_num()];
+    DLAF_CUDA_CALL(cudaSetDevice(device_));
+    DLAF_CUBLAS_CALL(cublasSetStream(handle, stream));
+    DLAF_CUBLAS_CALL(cublasSetPointerMode(handle, ptr_mode_));
+    return handle;
+  }
+
+  int getDevice() {
+    return device_;
+  }
+};
+}
+
+/// A pool of cuBLAS handles with reference semantics (copying points to the
+/// same underlying cuBLAS handles, last reference destroys the references).
+/// Allows access to cuBLAS handles associated with a particular stream. The
+/// user must ensure that the handle pool and the stream use the same device.
+/// Each HPX worker thread is assigned thread local cuBLAS handle.
+class HandlePool {
+  std::shared_ptr<internal::HandlePoolImpl> handles_ptr_;
+
+public:
+  HandlePool(int device = 0, cublasPointerMode_t ptr_mode = CUBLAS_POINTER_MODE_HOST)
+      : handles_ptr_(std::make_shared<internal::HandlePoolImpl>(device, ptr_mode)) {}
+
+  cublasHandle_t getNextHandle(cudaStream_t stream) {
+    DLAF_ASSERT(bool(handles_ptr_), "");
+    return handles_ptr_->getNextHandle(stream);
+  }
+
+  int getDevice() {
+    DLAF_ASSERT(bool(handles_ptr_), "");
+    return handles_ptr_->getDevice();
+  }
+
+  bool operator==(HandlePool const& rhs) const noexcept {
+    return handles_ptr_ == rhs.handles_ptr_;
+  }
+
+  bool operator!=(HandlePool const& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+};
+}
+}
+
+#endif

--- a/include/dlaf/cuda/executor.h
+++ b/include/dlaf/cuda/executor.h
@@ -28,107 +28,10 @@
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cuda/error.h"
+#include "dlaf/cuda/stream_pool.h"
 
 namespace dlaf {
 namespace cuda {
-namespace internal {
-
-struct StreamPoolImpl {
-  int device_;
-  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
-  std::size_t num_streams_per_worker_thread_;
-  std::vector<cudaStream_t> streams_;
-  std::vector<hpx::util::cache_aligned_data<std::size_t>> current_stream_idxs_;
-
-  StreamPoolImpl(int device, std::size_t num_streams_per_worker_thread,
-                 hpx::threads::thread_priority hpx_thread_priority)
-      : device_(device), num_streams_per_worker_thread_(num_streams_per_worker_thread),
-        streams_(num_worker_threads_ * num_streams_per_worker_thread),
-        current_stream_idxs_(num_worker_threads_, {std::size_t(0)}) {
-    DLAF_CUDA_CALL(cudaSetDevice(device));
-
-    // We map hpx::threads::thread_priority::high to the highest CUDA stream
-    // priority, and the rest to the lowest. Typically CUDA streams will only
-    // have two priorities.
-    int least_priority, greatest_priority;
-    DLAF_CUDA_CALL(cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
-    int stream_priority = least_priority;
-    if (hpx_thread_priority == hpx::threads::thread_priority::high) {
-      stream_priority = greatest_priority;
-    }
-
-    for (auto& s : streams_) {
-      DLAF_CUDA_CALL(cudaStreamCreateWithPriority(&s, cudaStreamNonBlocking, stream_priority));
-    }
-  }
-
-  StreamPoolImpl& operator=(StreamPoolImpl&&) = default;
-  StreamPoolImpl(StreamPoolImpl&&) = default;
-  StreamPoolImpl(const StreamPoolImpl&) = delete;
-  StreamPoolImpl& operator=(const StreamPoolImpl&) = delete;
-
-  ~StreamPoolImpl() {
-    for (auto& s : streams_) {
-      DLAF_CUDA_CALL(cudaStreamDestroy(s));
-    }
-  }
-
-  cudaStream_t getNextStream() {
-    // Set the device corresponding to the CUBLAS handle.
-    //
-    // The CUBLAS library context is tied to the current CUDA device [1]. A previous task scheduled on
-    // the same thread may have set a different device, this makes sure the correct device is used. The
-    // function is considered very low overhead call [2].
-    //
-    // [1]: https://docs.nvidia.com/cuda/cublas/index.html#cublascreate
-    // [2]: CUDA Runtime API, section 5.1 Device Management
-    DLAF_CUDA_CALL(cudaSetDevice(device_));
-    const std::size_t worker_thread_num = hpx::get_worker_thread_num();
-    DLAF_ASSERT(worker_thread_num != std::size_t(-1), worker_thread_num);
-    std::size_t stream_idx =
-        worker_thread_num * num_streams_per_worker_thread_ +
-        (++current_stream_idxs_[worker_thread_num].data_ % num_streams_per_worker_thread_);
-
-    return streams_[stream_idx];
-  }
-
-  int getDevice() {
-    return device_;
-  }
-};
-}
-
-/// A pool of CUDA streams with reference semantics (copying points to the same
-/// underlying CUDA streams, last reference destroys the references).  Allows
-/// access to CUDA streams in a round-robin fashion.  Each HPX worker thread is
-/// assigned a set of thread local CUDA streams.
-class StreamPool {
-  std::shared_ptr<internal::StreamPoolImpl> streams_ptr_;
-
-public:
-  StreamPool(int device = 0, std::size_t num_streams_per_worker_thread = 3,
-             hpx::threads::thread_priority hpx_thread_priority = hpx::threads::thread_priority::default_)
-      : streams_ptr_(std::make_shared<internal::StreamPoolImpl>(device, num_streams_per_worker_thread,
-                                                                hpx_thread_priority)) {}
-
-  cudaStream_t getNextStream() {
-    DLAF_ASSERT(bool(streams_ptr_), "");
-    return streams_ptr_->getNextStream();
-  }
-
-  int getDevice() {
-    DLAF_ASSERT(bool(streams_ptr_), "");
-    return streams_ptr_->getDevice();
-  }
-
-  bool operator==(StreamPool const& rhs) const noexcept {
-    return streams_ptr_ == rhs.streams_ptr_;
-  }
-
-  bool operator!=(StreamPool const& rhs) const noexcept {
-    return !(*this == rhs);
-  }
-};
 
 /// An executor for CUDA functions. Uses streams from the given StreamPool. A
 /// CUDA function is defined as any function that takes a CUDA stream as the

--- a/include/dlaf/cuda/stream_pool.h
+++ b/include/dlaf/cuda/stream_pool.h
@@ -1,0 +1,134 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#ifdef DLAF_WITH_CUDA
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include <hpx/include/util.hpp>
+#include <hpx/local/runtime.hpp>
+#include <hpx/thread.hpp>
+
+#include "dlaf/common/assert.h"
+#include "dlaf/cuda/error.h"
+
+namespace dlaf {
+namespace cuda {
+namespace internal {
+
+struct StreamPoolImpl {
+  int device_;
+  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
+  std::size_t num_streams_per_worker_thread_;
+  std::vector<cudaStream_t> streams_;
+  std::vector<hpx::util::cache_aligned_data<std::size_t>> current_stream_idxs_;
+
+  StreamPoolImpl(int device, std::size_t num_streams_per_worker_thread,
+                 hpx::threads::thread_priority hpx_thread_priority)
+      : device_(device), num_streams_per_worker_thread_(num_streams_per_worker_thread),
+        streams_(num_worker_threads_ * num_streams_per_worker_thread),
+        current_stream_idxs_(num_worker_threads_, {std::size_t(0)}) {
+    DLAF_CUDA_CALL(cudaSetDevice(device));
+
+    // We map hpx::threads::thread_priority::high to the highest CUDA stream
+    // priority, and the rest to the lowest. Typically CUDA streams will only
+    // have two priorities.
+    int least_priority, greatest_priority;
+    DLAF_CUDA_CALL(cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority));
+    int stream_priority = least_priority;
+    if (hpx_thread_priority == hpx::threads::thread_priority::high) {
+      stream_priority = greatest_priority;
+    }
+
+    for (auto& s : streams_) {
+      DLAF_CUDA_CALL(cudaStreamCreateWithPriority(&s, cudaStreamNonBlocking, stream_priority));
+    }
+  }
+
+  StreamPoolImpl& operator=(StreamPoolImpl&&) = default;
+  StreamPoolImpl(StreamPoolImpl&&) = default;
+  StreamPoolImpl(const StreamPoolImpl&) = delete;
+  StreamPoolImpl& operator=(const StreamPoolImpl&) = delete;
+
+  ~StreamPoolImpl() {
+    for (auto& s : streams_) {
+      DLAF_CUDA_CALL(cudaStreamDestroy(s));
+    }
+  }
+
+  cudaStream_t getNextStream() {
+    // Set the device corresponding to the CUBLAS handle.
+    //
+    // The CUBLAS library context is tied to the current CUDA device [1]. A previous task scheduled on
+    // the same thread may have set a different device, this makes sure the correct device is used. The
+    // function is considered very low overhead call [2].
+    //
+    // [1]: https://docs.nvidia.com/cuda/cublas/index.html#cublascreate
+    // [2]: CUDA Runtime API, section 5.1 Device Management
+    DLAF_CUDA_CALL(cudaSetDevice(device_));
+    const std::size_t worker_thread_num = hpx::get_worker_thread_num();
+    DLAF_ASSERT(worker_thread_num != std::size_t(-1), worker_thread_num);
+    std::size_t stream_idx =
+        worker_thread_num * num_streams_per_worker_thread_ +
+        (++current_stream_idxs_[worker_thread_num].data_ % num_streams_per_worker_thread_);
+
+    return streams_[stream_idx];
+  }
+
+  int getDevice() {
+    return device_;
+  }
+};
+}
+
+/// A pool of CUDA streams with reference semantics (copying points to the same
+/// underlying CUDA streams, last reference destroys the references).  Allows
+/// access to CUDA streams in a round-robin fashion.  Each HPX worker thread is
+/// assigned a set of thread local CUDA streams.
+class StreamPool {
+  std::shared_ptr<internal::StreamPoolImpl> streams_ptr_;
+
+public:
+  StreamPool(int device = 0, std::size_t num_streams_per_worker_thread = 3,
+             hpx::threads::thread_priority hpx_thread_priority = hpx::threads::thread_priority::default_)
+      : streams_ptr_(std::make_shared<internal::StreamPoolImpl>(device, num_streams_per_worker_thread,
+                                                                hpx_thread_priority)) {}
+
+  cudaStream_t getNextStream() {
+    DLAF_ASSERT(bool(streams_ptr_), "");
+    return streams_ptr_->getNextStream();
+  }
+
+  int getDevice() {
+    DLAF_ASSERT(bool(streams_ptr_), "");
+    return streams_ptr_->getDevice();
+  }
+
+  bool operator==(StreamPool const& rhs) const noexcept {
+    return streams_ptr_ == rhs.streams_ptr_;
+  }
+
+  bool operator!=(StreamPool const& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+};
+}
+}
+
+#endif

--- a/include/dlaf/cusolver/handle_pool.h
+++ b/include/dlaf/cusolver/handle_pool.h
@@ -1,0 +1,104 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#ifdef DLAF_WITH_CUDA
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <cusolverDn.h>
+
+#include <hpx/local/runtime.hpp>
+
+#include "dlaf/common/assert.h"
+#include "dlaf/cuda/error.h"
+#include "dlaf/cusolver/error.h"
+
+namespace dlaf {
+namespace cusolver {
+namespace internal {
+class HandlePoolImpl {
+  int device_;
+  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
+  std::vector<cusolverDnHandle_t> handles_;
+
+public:
+  HandlePoolImpl(int device) : device_(device), handles_(num_worker_threads_) {
+    DLAF_CUDA_CALL(cudaSetDevice(device_));
+
+    for (auto& h : handles_) {
+      DLAF_CUSOLVER_CALL(cusolverDnCreate(&h));
+    }
+  }
+
+  HandlePoolImpl& operator=(HandlePoolImpl&&) = default;
+  HandlePoolImpl(HandlePoolImpl&&) = default;
+  HandlePoolImpl(const HandlePoolImpl&) = delete;
+  HandlePoolImpl& operator=(const HandlePoolImpl&) = delete;
+
+  ~HandlePoolImpl() {
+    for (auto& h : handles_) {
+      DLAF_CUSOLVER_CALL(cusolverDnDestroy(h));
+    }
+  }
+
+  cusolverDnHandle_t getNextHandle(cudaStream_t stream) {
+    cusolverDnHandle_t handle = handles_[hpx::get_worker_thread_num()];
+    DLAF_CUDA_CALL(cudaSetDevice(device_));
+    DLAF_CUSOLVER_CALL(cusolverDnSetStream(handle, stream));
+    return handle;
+  }
+
+  int getDevice() {
+    return device_;
+  }
+};
+}
+
+/// A pool of cuSOLVER handles with reference semantics (copying points to the
+/// same underlying cuSOLVER handles, last reference destroys the handles).
+/// Allows access to cuSOLVER handles associated with a particular stream. The
+/// user must ensure that the handle pool and the stream use the same device.
+/// Each HPX worker thread is assigned thread local cuSOLVER handle.
+class HandlePool {
+  std::shared_ptr<internal::HandlePoolImpl> handles_ptr_;
+
+public:
+  HandlePool(int device = 0) : handles_ptr_(std::make_shared<internal::HandlePoolImpl>(device)) {}
+
+  cusolverDnHandle_t getNextHandle(cudaStream_t stream) {
+    DLAF_ASSERT(bool(handles_ptr_), "");
+    return handles_ptr_->getNextHandle(stream);
+  }
+
+  int getDevice() {
+    DLAF_ASSERT(bool(handles_ptr_), "");
+    return handles_ptr_->getDevice();
+  }
+
+  bool operator==(HandlePool const& rhs) const noexcept {
+    return handles_ptr_ == rhs.handles_ptr_;
+  }
+
+  bool operator!=(HandlePool const& rhs) const noexcept {
+    return !(*this == rhs);
+  }
+};
+}
+}
+
+#endif

--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -38,7 +38,7 @@ template <class T>
 void copySingleTile(hpx::shared_future<matrix::Tile<const T, Device::CPU>> in,
                     hpx::future<matrix::Tile<T, Device::CPU>> out) {
   hpx::dataflow(dlaf::getCopyExecutor<Device::CPU, Device::CPU>(),
-                matrix::unwrapExtendTiles(matrix::copy_o), in, std::move(out));
+                matrix::unwrapExtendTiles(matrix::internal::copy_o), in, std::move(out));
 }
 
 template <class Executor, Device device, class T>

--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -138,8 +138,8 @@ void BackTransformation<Backend::MC, Device::CPU, T>::call_FC(
                                        nr_reflectors_last_block}});
         }
         copySingleTile(tile_v, panelV(ik));
-        hpx::dataflow(hpx::launch::sync, matrix::unwrapExtendTiles(tile::laset<T>),
-                      lapack::MatrixType::Upper, 0.f, 1.f, panelV(ik));
+        hpx::dataflow(hpx::launch::sync, matrix::uwnrapExtendTiles(tile::internal::laset_o), lapack::MatrixType::Upper, T(0), T(1),
+                      panelV(ik));
       }
       else {
         panelV.setTile(ik, mat_v.read(ik));

--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -260,8 +260,8 @@ void BackTransformation<Backend::MC, Device::CPU, T>::call_FC(
                            {dist_v.tileSize(GlobalTileIndex(i, k)).rows(), nr_reflectors_last_block}});
           }
           copySingleTile(tile_v, panelV(ik_panel));
-          hpx::dataflow(hpx::launch::sync, matrix::unwrapExtendTiles(tile::laset<T>),
-                        lapack::MatrixType::Upper, 0.f, 1.f, panelV(ik_panel));
+          hpx::dataflow(hpx::launch::sync, matrix::unwrapExtendTiles(tile::internal::laset_o),
+                        lapack::MatrixType::Upper, T(0), T(1), panelV(ik_panel));
         }
         else {
           panelV.setTile(ik_panel, mat_v.read(GlobalTileIndex(i, k)));

--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -138,8 +138,8 @@ void BackTransformation<Backend::MC, Device::CPU, T>::call_FC(
                                        nr_reflectors_last_block}});
         }
         copySingleTile(tile_v, panelV(ik));
-        hpx::dataflow(hpx::launch::sync, matrix::uwnrapExtendTiles(tile::internal::laset_o), lapack::MatrixType::Upper, T(0), T(1),
-                      panelV(ik));
+        hpx::dataflow(hpx::launch::sync, matrix::unwrapExtendTiles(tile::internal::laset_o),
+                      lapack::MatrixType::Upper, T(0), T(1), panelV(ik));
       }
       else {
         panelV.setTile(ik, mat_v.read(ik));

--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -44,24 +44,24 @@ void copySingleTile(hpx::shared_future<matrix::Tile<const T, Device::CPU>> in,
 template <class Executor, Device device, class T>
 void trmmPanel(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> t,
                hpx::future<matrix::Tile<T, device>> w) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Right, blas::Uplo::Upper,
-                blas::Op::ConjTrans, blas::Diag::NonUnit, T(1.0), t, std::move(w));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::trmm_o), blas::Side::Right,
+                blas::Uplo::Upper, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1.0), t, std::move(w));
 }
 
 template <class Executor, Device device, class T>
 void gemmUpdateW2(Executor&& ex, hpx::future<matrix::Tile<T, device>> w,
                   hpx::shared_future<matrix::Tile<const T, device>> c,
                   hpx::future<matrix::Tile<T, device>> w2) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::ConjTrans, blas::Op::NoTrans,
-                T(1.0), w, c, T(1.0), std::move(w2));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), blas::Op::ConjTrans,
+                blas::Op::NoTrans, T(1.0), w, c, T(1.0), std::move(w2));
 }
 
 template <class Executor, Device device, class T>
 void gemmTrailingMatrix(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> v,
                         hpx::shared_future<matrix::Tile<const T, device>> w2,
                         hpx::future<matrix::Tile<T, device>> c) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans, blas::Op::NoTrans,
-                T(-1.0), v, w2, T(1.0), std::move(c));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), blas::Op::NoTrans,
+                blas::Op::NoTrans, T(-1.0), v, w2, T(1.0), std::move(c));
 }
 
 // Implementation based on:

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -39,32 +39,33 @@ namespace internal {
 
 namespace gentostd_l {
 template <Backend backend, class AKKSender, class LKKSender>
-void hegstDiagTile(AKKSender&& a_kk, LKKSender&& l_kk) {
+void hegstDiagTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LKKSender&& l_kk) {
   dlaf::internal::whenAllLift(1, blas::Uplo::Lower, std::forward<AKKSender>(a_kk),
                               std::forward<LKKSender>(l_kk)) |
-      dlaf::tile::hegst(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::hegst(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class LKKSender, class AIKSender>
-void trsmPanelTile(LKKSender&& l_kk, AIKSender&& a_ik) {
+void trsmPanelTile(hpx::threads::thread_priority priority, LKKSender&& l_kk, AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LKKSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::ConjTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LKKSender>(l_kk),
                               std::forward<AIKSender>(a_ik)) |
-      dlaf::tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class AKKSender, class LIKSender, class AIKSender>
-void hemmPanelTile(AKKSender&& a_kk, LIKSender&& l_ik, AIKSender&& a_ik) {
+void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIKSender&& l_ik,
+                   AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<AKKSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, ElementType(-0.5),
                               std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
-      dlaf::tile::hemm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::hemm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
@@ -93,56 +94,58 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&
 }
 
 template <Backend backend, class LJJSender, class AJKSender>
-void trsmPanelUpdateTile(LJJSender&& l_jj, AJKSender a_jk) {
+void trsmPanelUpdateTile(hpx::threads::thread_priority priority, LJJSender&& l_jj, AJKSender a_jk) {
   using ElementType = dlaf::internal::SenderElementType<LJJSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LJJSender>(l_jj),
                               std::forward<AJKSender>(a_jk)) |
-      dlaf::tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class LIJSender, class AJKSender, class AIKSender>
-void gemmPanelUpdateTile(LIJSender&& l_ij, AJKSender&& a_jk, AIKSender&& a_ik) {
+void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_ij, AJKSender&& a_jk,
+                         AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LIJSender>;
 
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, ElementType(-1.0),
                               std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
-      dlaf::tile::gemm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::normal)) |
+      dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 }
 
 namespace gentostd_u {
 template <Backend backend, class AKKSender, class LKKSender>
-void hegstDiagTile(AKKSender&& a_kk, LKKSender&& l_kk) {
+void hegstDiagTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LKKSender&& l_kk) {
   dlaf::internal::whenAllLift(1, blas::Uplo::Upper, std::forward<AKKSender>(a_kk),
                               std::forward<LKKSender>(l_kk)) |
-      dlaf::tile::hegst(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::hegst(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class LKKSender, class AIKSender>
-void trsmPanelTile(LKKSender&& l_kk, AIKSender&& a_ik) {
+void trsmPanelTile(hpx::threads::thread_priority priority, LKKSender&& l_kk, AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LKKSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::ConjTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LKKSender>(l_kk),
                               std::forward<AIKSender>(a_ik)) |
-      dlaf::tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class AKKSender, class LIKSender, class AIKSender>
-void hemmPanelTile(AKKSender&& a_kk, LIKSender&& l_ik, AIKSender&& a_ik) {
+void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIKSender&& l_ik,
+                   AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<AKKSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, ElementType(-0.5),
                               std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
-      dlaf::tile::hemm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::hemm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
@@ -171,24 +174,25 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&
 }
 
 template <Backend backend, class LJJSender, class AJKSender>
-void trsmPanelUpdateTile(LJJSender&& l_jj, AJKSender a_jk) {
+void trsmPanelUpdateTile(hpx::threads::thread_priority priority, LJJSender&& l_jj, AJKSender a_jk) {
   using ElementType = dlaf::internal::SenderElementType<LJJSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LJJSender>(l_jj),
                               std::forward<AJKSender>(a_jk)) |
-      dlaf::tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class LIJSender, class AJKSender, class AIKSender>
-void gemmPanelUpdateTile(LIJSender&& l_ij, AJKSender&& a_jk, AIKSender&& a_ik) {
+void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_ij, AJKSender&& a_jk,
+                         AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LIJSender>;
 
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, ElementType(-1.0),
                               std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
-      dlaf::tile::gemm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::normal)) |
+      dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
       hpx::execution::experimental::detach();
 }
 }
@@ -198,6 +202,8 @@ void gemmPanelUpdateTile(LIJSender&& l_ij, AJKSender&& a_jk, AIKSender&& a_ik) {
 template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, device>& mat_l) {
   using namespace gentostd_l;
+  using hpx::threads::thread_priority;
+
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
 
@@ -205,7 +211,8 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
     const LocalTileIndex kk{k, k};
 
     // Direct transformation to standard eigenvalue problem of the diagonal tile
-    hegstDiagTile<backend>(mat_a.readwrite_sender(kk), mat_l.readwrite_sender(kk));
+    hegstDiagTile<backend>(thread_priority::high, mat_a.readwrite_sender(kk),
+                           mat_l.readwrite_sender(kk));
 
     // If there is no trailing matrix
     if (k == nrtile - 1)
@@ -213,8 +220,9 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ik{i, k};
-      trsmPanelTile<backend>(mat_l.read_sender(kk), mat_a.readwrite_sender(ik));
-      hemmPanelTile<backend>(mat_a.read_sender(kk), mat_l.read_sender(ik), mat_a.readwrite_sender(ik));
+      trsmPanelTile<backend>(thread_priority::high, mat_l.read_sender(kk), mat_a.readwrite_sender(ik));
+      hemmPanelTile<backend>(thread_priority::high, mat_a.read_sender(kk), mat_l.read_sender(ik),
+                             mat_a.readwrite_sender(ik));
     }
 
     for (SizeType j = k + 1; j < nrtile; ++j) {
@@ -222,7 +230,7 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
       const LocalTileIndex jk{j, k};
       // first trailing panel gets high priority (look ahead).
       const auto trailing_matrix_priority =
-          (j == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
+          (j == k + 1) ? thread_priority::high : thread_priority::normal;
 
       her2kTrailingDiagTile<backend>(trailing_matrix_priority, mat_a.read_sender(jk),
                                      mat_l.read_sender(jk), mat_a.readwrite_sender(jj));
@@ -239,19 +247,21 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ik{i, k};
-      hemmPanelTile<backend>(mat_a.read_sender(kk), mat_l.read_sender(ik), mat_a.readwrite_sender(ik));
+      hemmPanelTile<backend>(thread_priority::high, mat_a.read_sender(kk), mat_l.read_sender(ik),
+                             mat_a.readwrite_sender(ik));
     }
 
     for (SizeType j = k + 1; j < nrtile; ++j) {
       const LocalTileIndex jj{j, j};
       const LocalTileIndex jk{j, k};
-      trsmPanelUpdateTile<backend>(mat_l.read_sender(jj), mat_a.readwrite_sender(jk));
+      trsmPanelUpdateTile<backend>(thread_priority::high, mat_l.read_sender(jj),
+                                   mat_a.readwrite_sender(jk));
 
       for (SizeType i = j + 1; i < nrtile; ++i) {
         const LocalTileIndex ij{i, j};
         const LocalTileIndex ik{i, k};
-        gemmPanelUpdateTile<backend>(mat_l.read_sender(ij), mat_a.read_sender(jk),
-                                     mat_a.readwrite_sender(ik));
+        gemmPanelUpdateTile<backend>(thread_priority::normal, mat_l.read_sender(ij),
+                                     mat_a.read_sender(jk), mat_a.readwrite_sender(ik));
       }
     }
   }
@@ -261,6 +271,8 @@ template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a,
                                           Matrix<T, device>& mat_l) {
   using namespace gentostd_l;
+  using hpx::threads::thread_priority;
+
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
@@ -328,7 +340,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex kj_panelT{Coord::Col, j_local};
         const LocalTileIndex kj(kk_offset.rows(), j_local);
 
-        trsmPanelUpdateTile<backend>(l_panel.read_sender(kk_panel), mat_a.readwrite_sender(kj));
+        trsmPanelUpdateTile<backend>(thread_priority::high, l_panel.read_sender(kk_panel),
+                                     mat_a.readwrite_sender(kj));
 
         a_panelT.setTile(kj_panelT, mat_a.read(kj));
       }
@@ -344,8 +357,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
           const LocalTileIndex kj_panelT{Coord::Col, j_local};
           const LocalTileIndex ij{i_local, j_local};
 
-          gemmPanelUpdateTile<backend>(l_panel.read_sender(ik_panel), a_panelT.read_sender(kj_panelT),
-                                       mat_a.readwrite_sender(ij));
+          gemmPanelUpdateTile<backend>(thread_priority::normal, l_panel.read_sender(ik_panel),
+                                       a_panelT.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
         }
       }
     }
@@ -354,7 +367,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 
     // Direct transformation to standard eigenvalue problem of the diagonal tile
     if (kk_rank == this_rank)
-      hegstDiagTile<backend>(mat_a.readwrite_sender(kk), mat_l.readwrite_sender(kk));
+      hegstDiagTile<backend>(thread_priority::high, mat_a.readwrite_sender(kk),
+                             mat_l.readwrite_sender(kk));
 
     // If there is no trailing matrix
     if (k == nrtile - 1)
@@ -381,9 +395,10 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex ik_panel(Coord::Row, i_local);
         const LocalTileIndex ik(i_local, distr.localTileFromGlobalTile<Coord::Col>(k));
 
-        trsmPanelTile<backend>(l_panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(ik));
-        hemmPanelTile<backend>(a_panelT.read_sender(diag_wp_idx), mat_l.read_sender(ik),
+        trsmPanelTile<backend>(thread_priority::high, l_panelT.read_sender(diag_wp_idx),
                                mat_a.readwrite_sender(ik));
+        hemmPanelTile<backend>(thread_priority::high, a_panelT.read_sender(diag_wp_idx),
+                               mat_l.read_sender(ik), mat_a.readwrite_sender(ik));
 
         // keep diagonal tile for later.
         a_diag = a_panelT.read(diag_wp_idx);
@@ -409,7 +424,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
       const auto j_local = distr.localTileFromGlobalTile<Coord::Col>(j);
       // first trailing panel gets high priority (look ahead).
       const auto trailing_matrix_priority =
-          (j == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
+          (j == k + 1) ? thread_priority::high : thread_priority::normal;
       if (this_rank.row() == owner.row()) {
         const auto i_local = distr.localTileFromGlobalTile<Coord::Row>(j);
 
@@ -430,12 +445,10 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex kj_panelT{Coord::Col, j_local};
         const LocalTileIndex ij{i_local, j_local};
 
-        gemmTrailingMatrixTile<backend>(hpx::threads::thread_priority::normal,
-                                        a_panel.read_sender(ik_panel), l_panelT.read_sender(kj_panelT),
-                                        mat_a.readwrite_sender(ij));
-        gemmTrailingMatrixTile<backend>(hpx::threads::thread_priority::normal,
-                                        l_panel.read_sender(ik_panel), a_panelT.read_sender(kj_panelT),
-                                        mat_a.readwrite_sender(ij));
+        gemmTrailingMatrixTile<backend>(thread_priority::normal, a_panel.read_sender(ik_panel),
+                                        l_panelT.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
+        gemmTrailingMatrixTile<backend>(thread_priority::normal, l_panel.read_sender(ik_panel),
+                                        a_panelT.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
       }
     }
 
@@ -450,8 +463,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Row, i_local);
         const LocalTileIndex ik(i_local, distr.localTileFromGlobalTile<Coord::Col>(k));
 
-        hemmPanelTile<backend>(hpx::execution::experimental::keep_future(a_diag), mat_l.read_sender(ik),
-                               mat_a.readwrite_sender(ik));
+        hemmPanelTile<backend>(thread_priority::high, hpx::execution::experimental::keep_future(a_diag),
+                               mat_l.read_sender(ik), mat_a.readwrite_sender(ik));
       }
     }
   }
@@ -460,6 +473,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_U(Matrix<T, device>& mat_a, Matrix<T, device>& mat_u) {
   using namespace gentostd_u;
+  using hpx::threads::thread_priority;
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -468,7 +482,8 @@ void GenToStd<backend, device, T>::call_U(Matrix<T, device>& mat_a, Matrix<T, de
     const LocalTileIndex kk{k, k};
 
     // Direct transformation to standard eigenvalue problem of the diagonal tile
-    hegstDiagTile<backend>(mat_a.readwrite_sender(kk), mat_u.readwrite_sender(kk));
+    hegstDiagTile<backend>(thread_priority::high, mat_a.readwrite_sender(kk),
+                           mat_u.readwrite_sender(kk));
 
     // If there is no trailing matrix
     if (k == nrtile - 1)
@@ -476,8 +491,9 @@ void GenToStd<backend, device, T>::call_U(Matrix<T, device>& mat_a, Matrix<T, de
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ki{k, i};
-      trsmPanelTile<backend>(mat_u.read_sender(kk), mat_a.readwrite_sender(ki));
-      hemmPanelTile<backend>(mat_a.read_sender(kk), mat_u.read_sender(ki), mat_a.readwrite_sender(ki));
+      trsmPanelTile<backend>(thread_priority::high, mat_u.read_sender(kk), mat_a.readwrite_sender(ki));
+      hemmPanelTile<backend>(thread_priority::high, mat_a.read_sender(kk), mat_u.read_sender(ki),
+                             mat_a.readwrite_sender(ki));
     }
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
@@ -485,7 +501,7 @@ void GenToStd<backend, device, T>::call_U(Matrix<T, device>& mat_a, Matrix<T, de
       const LocalTileIndex ki{k, i};
       // first trailing panel gets high priority (look ahead).
       const auto trailing_matrix_priority =
-          (i == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
+          (i == k + 1) ? thread_priority::high : thread_priority::normal;
 
       her2kTrailingDiagTile<backend>(trailing_matrix_priority, mat_a.read_sender(ki),
                                      mat_u.read_sender(ki), mat_a.readwrite_sender(ii));
@@ -502,19 +518,21 @@ void GenToStd<backend, device, T>::call_U(Matrix<T, device>& mat_a, Matrix<T, de
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ki{k, i};
-      hemmPanelTile<backend>(mat_a.read_sender(kk), mat_u.read_sender(ki), mat_a.readwrite_sender(ki));
+      hemmPanelTile<backend>(thread_priority::high, mat_a.read_sender(kk), mat_u.read_sender(ki),
+                             mat_a.readwrite_sender(ki));
     }
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ii{i, i};
       const LocalTileIndex ki{k, i};
-      trsmPanelUpdateTile<backend>(mat_u.read_sender(ii), mat_a.readwrite_sender(ki));
+      trsmPanelUpdateTile<backend>(thread_priority::high, mat_u.read_sender(ii),
+                                   mat_a.readwrite_sender(ki));
 
       for (SizeType j = i + 1; j < nrtile; ++j) {
         const LocalTileIndex ij{i, j};
         const LocalTileIndex kj{k, j};
-        gemmPanelUpdateTile<backend>(mat_a.read_sender(ki), mat_u.read_sender(ij),
-                                     mat_a.readwrite_sender(kj));
+        gemmPanelUpdateTile<backend>(thread_priority::normal, mat_a.read_sender(ki),
+                                     mat_u.read_sender(ij), mat_a.readwrite_sender(kj));
       }
     }
   }
@@ -524,6 +542,8 @@ template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a,
                                           Matrix<T, device>& mat_u) {
   using namespace gentostd_u;
+  using hpx::threads::thread_priority;
+
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
@@ -592,7 +612,8 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex ki_panelT{Coord::Row, i_local};
         const LocalTileIndex ik(i_local, kk_offset.cols());
 
-        trsmPanelUpdateTile<backend>(u_panel.read_sender(kk_panel), mat_a.readwrite_sender(ik));
+        trsmPanelUpdateTile<backend>(thread_priority::high, u_panel.read_sender(kk_panel),
+                                     mat_a.readwrite_sender(ik));
 
         a_panelT.setTile(ki_panelT, mat_a.read(ik));
       }
@@ -608,8 +629,8 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
           const LocalTileIndex ik_panelT{Coord::Row, i_local};
           const LocalTileIndex ij{i_local, j_local};
 
-          gemmPanelUpdateTile<backend>(a_panelT.read_sender(ik_panelT), u_panel.read_sender(kj_panel),
-                                       mat_a.readwrite_sender(ij));
+          gemmPanelUpdateTile<backend>(thread_priority::normal, a_panelT.read_sender(ik_panelT),
+                                       u_panel.read_sender(kj_panel), mat_a.readwrite_sender(ij));
         }
       }
     }
@@ -618,7 +639,8 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
 
     // Direct transformation to standard eigenvalue problem of the diagonal tile
     if (kk_rank == this_rank)
-      hegstDiagTile<backend>(mat_a.readwrite_sender(kk), mat_u.readwrite_sender(kk));
+      hegstDiagTile<backend>(thread_priority::high, mat_a.readwrite_sender(kk),
+                             mat_u.readwrite_sender(kk));
 
     // If there is no trailing matrix
     if (k == nrtile - 1)
@@ -645,9 +667,10 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex kj_panel(Coord::Col, j_local);
         const LocalTileIndex kj(distr.localTileFromGlobalTile<Coord::Row>(k), j_local);
 
-        trsmPanelTile<backend>(u_panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(kj));
-        hemmPanelTile<backend>(a_panelT.read_sender(diag_wp_idx), mat_u.read_sender(kj),
+        trsmPanelTile<backend>(thread_priority::high, u_panelT.read_sender(diag_wp_idx),
                                mat_a.readwrite_sender(kj));
+        hemmPanelTile<backend>(thread_priority::high, a_panelT.read_sender(diag_wp_idx),
+                               mat_u.read_sender(kj), mat_a.readwrite_sender(kj));
 
         // keep diagonal tile for later.
         a_diag = a_panelT.read(diag_wp_idx);
@@ -673,7 +696,7 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
       const auto i_local = distr.localTileFromGlobalTile<Coord::Row>(i);
       // first trailing panel gets high priority (look ahead).
       const auto trailing_matrix_priority =
-          (i == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
+          (i == k + 1) ? thread_priority::high : thread_priority::normal;
       if (this_rank.col() == owner.col()) {
         const auto j_local = distr.localTileFromGlobalTile<Coord::Col>(i);
 
@@ -694,12 +717,10 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex kj_panelT{Coord::Col, j_local};
         const LocalTileIndex ij{i_local, j_local};
 
-        gemmTrailingMatrixTile<backend>(hpx::threads::thread_priority::normal,
-                                        a_panelT.read_sender(ki_panel), u_panel.read_sender(kj_panelT),
-                                        mat_a.readwrite_sender(ij));
-        gemmTrailingMatrixTile<backend>(hpx::threads::thread_priority::normal,
-                                        u_panelT.read_sender(ki_panel), a_panel.read_sender(kj_panelT),
-                                        mat_a.readwrite_sender(ij));
+        gemmTrailingMatrixTile<backend>(thread_priority::normal, a_panelT.read_sender(ki_panel),
+                                        u_panel.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
+        gemmTrailingMatrixTile<backend>(thread_priority::normal, u_panelT.read_sender(ki_panel),
+                                        a_panel.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
       }
     }
 
@@ -714,8 +735,8 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Col, j_local);
         const LocalTileIndex ki(distr.localTileFromGlobalTile<Coord::Row>(k), j_local);
 
-        hemmPanelTile<backend>(hpx::execution::experimental::keep_future(a_diag), mat_u.read_sender(ki),
-                               mat_a.readwrite_sender(ki));
+        hemmPanelTile<backend>(thread_priority::high, hpx::execution::experimental::keep_future(a_diag),
+                               mat_u.read_sender(ki), mat_a.readwrite_sender(ki));
       }
     }
   }

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -9,6 +9,7 @@
 //
 #pragma once
 
+#include <hpx/local/execution.hpp>
 #include <hpx/local/future.hpp>
 #include <hpx/local/unwrap.hpp>
 
@@ -35,75 +36,82 @@ namespace dlaf {
 namespace eigensolver {
 namespace internal {
 
-namespace gentostd_l {
-template <class Executor, Device device, class T>
-void hegstDiagTile(Executor&& executor_hp, hpx::future<matrix::Tile<T, device>> a_kk,
-                   hpx::future<matrix::Tile<T, device>> l_kk) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::hegst_o), 1, blas::Uplo::Lower,
-                std::move(a_kk), std::move(l_kk));
+template <Backend backend, class AKKSender, class LKKSender>
+void hegstDiagTile(AKKSender&& a_kk, LKKSender&& l_kk) {
+  dlaf::internal::whenAllLift(1, blas::Uplo::Lower, std::forward<AKKSender>(a_kk),
+                              std::forward<LKKSender>(l_kk)) |
+      dlaf::tile::hegst(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      hpx::execution::experimental::detach();
 }
 
-template <class Executor, Device device, class T>
-void trsmPanelTile(Executor&& executor_hp, hpx::shared_future<matrix::Tile<const T, device>> l_kk,
-                   hpx::future<matrix::Tile<T, device>> a_ik) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::trsm_o), blas::Side::Right,
-                blas::Uplo::Lower, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1.0), l_kk,
-                std::move(a_ik));
+template <Backend backend, class T, class LKKSender, class AIKSender>
+void trsmPanelTile(LKKSender&& l_kk, AIKSender&& a_ik) {
+  dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::ConjTrans,
+                              blas::Diag::NonUnit, T(1.0), std::forward<LKKSender>(l_kk),
+                              std::forward<AIKSender>(a_ik)) |
+      dlaf::tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      hpx::execution::experimental::detach();
 }
 
-template <class Executor, Device device, class T>
-void hemmPanelTile(Executor&& executor_hp, hpx::shared_future<matrix::Tile<const T, device>> a_kk,
-                   hpx::shared_future<matrix::Tile<const T, device>> l_ik,
-                   hpx::future<matrix::Tile<T, device>> a_ik) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::hemm_o), blas::Side::Right,
-                blas::Uplo::Lower, T(-0.5), a_kk, l_ik, T(1.0), std::move(a_ik));
+template <Backend backend, class T, class AKKSender, class LIKSender, class AIKSender>
+void hemmPanelTile(AKKSender&& a_kk, LIKSender&& l_ik, AIKSender&& a_ik) {
+  dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, T(-0.5),
+                              std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik), T(1.0),
+                              std::forward<AIKSender>(a_ik)) |
+      dlaf::tile::hemm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      hpx::execution::experimental::detach();
 }
 
-template <class Executor, Device device, class T>
-void her2kTrailingDiagTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> a_jk,
-                           hpx::shared_future<matrix::Tile<const T, device>> l_jk,
-                           hpx::future<matrix::Tile<T, device>> a_kk) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::her2k_o), blas::Uplo::Lower, blas::Op::NoTrans,
-                T(-1.0), a_jk, l_jk, BaseType<T>(1.0), std::move(a_kk));
+template <Backend backend, class T, class AJKSender, class LJKSender, class AKKSender>
+void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a_jk, LJKSender&& l_jk,
+                           AKKSender&& a_kk) {
+  dlaf::internal::whenAllLift(blas::Uplo::Lower, blas::Op::NoTrans, T(-1.0),
+                              std::forward<AJKSender>(a_jk), std::forward<LJKSender>(l_jk),
+                              BaseType<T>(1.0), std::forward<AKKSender>(a_kk)) |
+      dlaf::tile::her2k(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::detach();
 }
 
-template <class Executor, Device device, class T>
-void gemmTrailingMatrixTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> mat_ik,
-                            hpx::shared_future<matrix::Tile<const T, device>> mat_jk,
-                            hpx::future<matrix::Tile<T, device>> a_ij) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans, blas::Op::ConjTrans,
-                T(-1.0), mat_ik, mat_jk, T(1.0), std::move(a_ij));
+template <Backend backend, class T, class MatIKSender, class MatJKSender, class AIJSender>
+void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&& mat_ik,
+                            MatJKSender&& mat_jk, AIJSender a_ij) {
+  dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::ConjTrans, T(-1.0),
+                              std::forward<MatIKSender>(mat_ik), std::forward<MatJKSender>(mat_jk),
+                              T(1.0), std::forward<AIJSender>(a_ij)) |
+      dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::detach();
 }
 
-template <class Executor, Device device, class T>
-void trsmPanelUpdateTile(Executor&& executor_hp, hpx::shared_future<matrix::Tile<const T, device>> l_jj,
-                         hpx::future<matrix::Tile<T, device>> a_jk) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::trsm_o), blas::Side::Left,
-                blas::Uplo::Lower, blas::Op::NoTrans, blas::Diag::NonUnit, T(1.0), l_jj,
-                std::move(a_jk));
+template <Backend backend, class T, class LJJSender, class AJKSender>
+void trsmPanelUpdateTile(LJJSender&& l_jj, AJKSender a_jk) {
+  dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans,
+                              blas::Diag::NonUnit, T(1.0), std::forward<LJJSender>(l_jj),
+                              std::forward<AJKSender>(a_jk)) |
+      dlaf::tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
+      hpx::execution::experimental::detach();
 }
 
-template <class Executor, Device device, class T>
-void gemmPanelUpdateTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> l_ij,
-                         hpx::shared_future<matrix::Tile<const T, device>> a_jk,
-                         hpx::future<matrix::Tile<T, device>> a_ik) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans, blas::Op::NoTrans,
-                T(-1.0), l_ij, a_jk, T(1.0), std::move(a_ik));
-}
+template <Backend backend, class T, class LIJSender, class AJKSender, class AIKSender>
+void gemmPanelUpdateTile(LIJSender&& l_ij, AJKSender&& a_jk, AIKSender&& a_ik) {
+  dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, T(-1.0),
+                              std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk), T(1.0),
+                              std::forward<AIKSender>(a_ik)) |
+      dlaf::tile::gemm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::normal)) |
+      hpx::execution::experimental::detach();
 }
 
 namespace gentostd_u {
 template <class Executor, Device device, class T>
 void hegstDiagTile(Executor&& executor_hp, hpx::future<matrix::Tile<T, device>> a_kk,
                    hpx::future<matrix::Tile<T, device>> u_kk) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::hegst_o), 1, blas::Uplo::Upper,
+  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::internal::hegst_o), 1, blas::Uplo::Upper,
                 std::move(a_kk), std::move(u_kk));
 }
 
 template <class Executor, Device device, class T>
 void trsmPanelTile(Executor&& executor_hp, hpx::shared_future<matrix::Tile<const T, device>> u_kk,
                    hpx::future<matrix::Tile<T, device>> a_ki) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::trsm_o), blas::Side::Left,
+  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::internal::trsm_o), blas::Side::Left,
                 blas::Uplo::Upper, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1.0), u_kk,
                 std::move(a_ki));
 }
@@ -112,7 +120,7 @@ template <class Executor, Device device, class T>
 void hemmPanelTile(Executor&& executor_hp, hpx::shared_future<matrix::Tile<const T, device>> a_kk,
                    hpx::shared_future<matrix::Tile<const T, device>> u_ki,
                    hpx::future<matrix::Tile<T, device>> a_ki) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::hemm_o), blas::Side::Left,
+  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::internal::hemm_o), blas::Side::Left,
                 blas::Uplo::Upper, T(-0.5), a_kk, u_ki, T(1.0), std::move(a_ki));
 }
 
@@ -120,22 +128,22 @@ template <class Executor, Device device, class T>
 void her2kTrailingDiagTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> a_ki,
                            hpx::shared_future<matrix::Tile<const T, device>> u_ki,
                            hpx::future<matrix::Tile<T, device>> a_ii) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::her2k_o), blas::Uplo::Upper, blas::Op::ConjTrans,
-                T(-1.0), a_ki, u_ki, BaseType<T>(1.0), std::move(a_ii));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::her2k_o), blas::Uplo::Upper,
+                blas::Op::ConjTrans, T(-1.0), a_ki, u_ki, BaseType<T>(1.0), std::move(a_ii));
 }
 
 template <class Executor, Device device, class T>
 void gemmTrailingMatrixTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> mat_ki,
                             hpx::shared_future<matrix::Tile<const T, device>> mat_kj,
                             hpx::future<matrix::Tile<T, device>> a_ij) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::ConjTrans, blas::Op::NoTrans,
-                T(-1.0), mat_ki, mat_kj, T(1.0), std::move(a_ij));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), blas::Op::ConjTrans,
+                blas::Op::NoTrans, T(-1.0), mat_ki, mat_kj, T(1.0), std::move(a_ij));
 }
 
 template <class Executor, Device device, class T>
 void trsmPanelUpdateTile(Executor&& executor_hp, hpx::shared_future<matrix::Tile<const T, device>> u_ii,
                          hpx::future<matrix::Tile<T, device>> a_ki) {
-  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::trsm_o), blas::Side::Right,
+  hpx::dataflow(executor_hp, matrix::unwrapExtendTiles(tile::internal::trsm_o), blas::Side::Right,
                 blas::Uplo::Upper, blas::Op::NoTrans, blas::Diag::NonUnit, T(1.0), u_ii,
                 std::move(a_ki));
 }
@@ -144,8 +152,8 @@ template <class Executor, Device device, class T>
 void gemmPanelUpdateTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T, device>> a_ki,
                          hpx::shared_future<matrix::Tile<const T, device>> u_ij,
                          hpx::future<matrix::Tile<T, device>> a_kj) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans, blas::Op::NoTrans,
-                T(-1.0), a_ki, u_ij, T(1.0), std::move(a_kj));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), blas::Op::NoTrans,
+                blas::Op::NoTrans, T(-1.0), a_ki, u_ij, T(1.0), std::move(a_kj));
 }
 }
 
@@ -153,10 +161,6 @@ void gemmPanelUpdateTile(Executor&& ex, hpx::shared_future<matrix::Tile<const T,
 // eigenproblem (xHEGST)
 template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, device>& mat_l) {
-  using namespace gentostd_l;
-  auto executor_hp = dlaf::getHpExecutor<backend>();
-  auto executor_np = dlaf::getNpExecutor<backend>();
-
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
 
@@ -164,7 +168,7 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
     const LocalTileIndex kk{k, k};
 
     // Direct transformation to standard eigenvalue problem of the diagonal tile
-    hegstDiagTile(executor_hp, mat_a(kk), mat_l(kk));
+    hegstDiagTile<backend>(mat_a.readwrite_sender(kk), mat_l.readwrite_sender(kk));
 
     // If there is no trailing matrix
     if (k == nrtile - 1)
@@ -172,40 +176,45 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ik{i, k};
-      trsmPanelTile(executor_hp, mat_l.read(kk), mat_a(ik));
-      hemmPanelTile(executor_hp, mat_a.read(kk), mat_l.read(ik), mat_a(ik));
+      trsmPanelTile<backend, T>(mat_l.read_sender(kk), mat_a.readwrite_sender(ik));
+      hemmPanelTile<backend, T>(mat_a.read_sender(kk), mat_l.read_sender(ik), mat_a(ik));
     }
 
     for (SizeType j = k + 1; j < nrtile; ++j) {
       const LocalTileIndex jj{j, j};
       const LocalTileIndex jk{j, k};
       // first trailing panel gets high priority (look ahead).
-      auto& trailing_matrix_executor = (j == k + 1) ? executor_hp : executor_np;
+      const auto trailing_matrix_priority =
+          (j == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
 
-      her2kTrailingDiagTile(trailing_matrix_executor, mat_a.read(jk), mat_l.read(jk), mat_a(jj));
+      her2kTrailingDiagTile<backend, T>(trailing_matrix_priority, mat_a.read_sender(jk),
+                                        mat_l.read_sender(jk), mat_a.readwrite_sender(jj));
 
       for (SizeType i = j + 1; i < nrtile; ++i) {
         const LocalTileIndex ik{i, k};
         const LocalTileIndex ij{i, j};
-        gemmTrailingMatrixTile(trailing_matrix_executor, mat_a.read(ik), mat_l.read(jk), mat_a(ij));
-        gemmTrailingMatrixTile(trailing_matrix_executor, mat_l.read(ik), mat_a.read(jk), mat_a(ij));
+        gemmTrailingMatrixTile<backend, T>(trailing_matrix_priority, mat_a.read_sender(ik),
+                                           mat_l.read_sender(jk), mat_a.readwrite_sender(ij));
+        gemmTrailingMatrixTile<backend, T>(trailing_matrix_priority, mat_l.read_sender(ik),
+                                           mat_a.read_sender(jk), mat_a.readwrite_sender(ij));
       }
     }
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const LocalTileIndex ik{i, k};
-      hemmPanelTile(executor_np, mat_a.read(kk), mat_l.read(ik), mat_a(ik));
+      hemmPanelTile<backend, T>(mat_a.read_sender(kk), mat_l.read_sender(ik), mat_a(ik));
     }
 
     for (SizeType j = k + 1; j < nrtile; ++j) {
       const LocalTileIndex jj{j, j};
       const LocalTileIndex jk{j, k};
-      trsmPanelUpdateTile(executor_hp, mat_l.read(jj), mat_a(jk));
+      trsmPanelUpdateTile<backend, T>(mat_l.read_sender(jj), mat_a.readwrite_sender(jk));
 
       for (SizeType i = j + 1; i < nrtile; ++i) {
         const LocalTileIndex ij{i, j};
         const LocalTileIndex ik{i, k};
-        gemmPanelUpdateTile(executor_np, mat_l.read(ij), mat_a.read(jk), mat_a(ik));
+        gemmPanelUpdateTile<backend, T>(mat_l.read_sender(ij), mat_a.read_sender(jk),
+                                        mat_a.readwrite_sender(ik));
       }
     }
   }
@@ -214,9 +223,6 @@ void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, de
 template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a,
                                           Matrix<T, device>& mat_l) {
-  using namespace gentostd_l;
-  auto executor_hp = dlaf::getHpExecutor<backend>();
-  auto executor_np = dlaf::getNpExecutor<backend>();
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
@@ -284,7 +290,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex kj_panelT{Coord::Col, j_local};
         const LocalTileIndex kj(kk_offset.rows(), j_local);
 
-        trsmPanelUpdateTile(executor_hp, l_panel.read(kk_panel), mat_a(kj));
+        trsmPanelUpdateTile<backend, T>(l_panel.read_sender(kk_panel), mat_a(kj));
 
         a_panelT.setTile(kj_panelT, mat_a.read(kj));
       }
@@ -300,7 +306,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
           const LocalTileIndex kj_panelT{Coord::Col, j_local};
           const LocalTileIndex ij{i_local, j_local};
 
-          gemmPanelUpdateTile(executor_np, l_panel.read(ik_panel), a_panelT.read(kj_panelT), mat_a(ij));
+          gemmPanelUpdateTile<backend, T>(l_panel.read_sender(ik_panel), a_panelT.read_sender(kj_panelT),
+                                          mat_a.readwrite_sender(ij));
         }
       }
     }
@@ -309,7 +316,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 
     // Direct transformation to standard eigenvalue problem of the diagonal tile
     if (kk_rank == this_rank)
-      hegstDiagTile(executor_hp, mat_a(kk), mat_l(kk));
+      hegstDiagTile<backend>(mat_a.readwrite_sender(kk), mat_l.readwrite_sender(kk));
 
     // If there is no trailing matrix
     if (k == nrtile - 1)
@@ -336,8 +343,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex ik_panel(Coord::Row, i_local);
         const LocalTileIndex ik(i_local, distr.localTileFromGlobalTile<Coord::Col>(k));
 
-        trsmPanelTile(executor_hp, l_panelT.read(diag_wp_idx), mat_a(ik));
-        hemmPanelTile(executor_hp, a_panelT.read(diag_wp_idx), mat_l.read(ik), mat_a(ik));
+        trsmPanelTile<backend, T>(l_panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(ik));
+        hemmPanelTile<backend, T>(a_panelT.read_sender(diag_wp_idx), mat_l.read_sender(ik), mat_a(ik));
 
         // keep diagonal tile for later.
         a_diag = a_panelT.read(diag_wp_idx);
@@ -362,13 +369,15 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 
       const auto j_local = distr.localTileFromGlobalTile<Coord::Col>(j);
       // first trailing panel gets high priority (look ahead).
-      auto& trailing_matrix_executor = (j == k + 1) ? executor_hp : executor_np;
+      const auto trailing_matrix_priority =
+          (j == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
       if (this_rank.row() == owner.row()) {
         const auto i_local = distr.localTileFromGlobalTile<Coord::Row>(j);
 
-        her2kTrailingDiagTile(trailing_matrix_executor, a_panel.read({Coord::Row, i_local}),
-                              l_panel.read({Coord::Row, i_local}),
-                              mat_a(LocalTileIndex{i_local, j_local}));
+        her2kTrailingDiagTile<backend, T>(trailing_matrix_priority,
+                                          a_panel.read_sender({Coord::Row, i_local}),
+                                          l_panel.read_sender({Coord::Row, i_local}),
+                                          mat_a.readwrite_sender(LocalTileIndex{i_local, j_local}));
       }
 
       for (SizeType i = j + 1; i < nrtile; ++i) {
@@ -382,8 +391,12 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex kj_panelT{Coord::Col, j_local};
         const LocalTileIndex ij{i_local, j_local};
 
-        gemmTrailingMatrixTile(executor_np, a_panel.read(ik_panel), l_panelT.read(kj_panelT), mat_a(ij));
-        gemmTrailingMatrixTile(executor_np, l_panel.read(ik_panel), a_panelT.read(kj_panelT), mat_a(ij));
+        gemmTrailingMatrixTile<backend, T>(hpx::threads::thread_priority::normal,
+                                           a_panel.read_sender(ik_panel),
+                                           l_panelT.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
+        gemmTrailingMatrixTile<backend, T>(hpx::threads::thread_priority::normal,
+                                           l_panel.read_sender(ik_panel),
+                                           a_panelT.read_sender(kj_panelT), mat_a.readwrite_sender(ij));
       }
     }
 
@@ -398,7 +411,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Row, i_local);
         const LocalTileIndex ik(i_local, distr.localTileFromGlobalTile<Coord::Col>(k));
 
-        hemmPanelTile(executor_hp, a_diag, mat_l.read(ik), mat_a(ik));
+        hemmPanelTile<backend, T>(hpx::execution::experimental::keep_future(a_diag),
+                                  mat_l.read_sender(ik), mat_a.readwrite_sender(ik));
       }
     }
   }

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -304,7 +304,7 @@ void setupReflectorPanelV(bool has_head, const LocalTileSize& ai_offset, const S
 
   if (has_head) {
     auto setupV0 = hpx::unwrapping([](auto&& tile_v, const auto& tile_a) {
-      copy(tile_a, tile_v);
+      matrix::internal::copy(tile_a, tile_v);
       tile::internal::laset(lapack::MatrixType::Upper, T(0), T(1), tile_v);
     });
 
@@ -336,7 +336,7 @@ void trmmComputeW(PanelT<Coord::Col, T>& w, MatrixLikeT& v, hpx::shared_future<C
     // Note:
     // Since V0 is well-formed, by copying V0 to W we are also resetting W where the matrix is not going
     // to be computed.
-    copy(tile_v, tile_w);
+    matrix::internal::copy(tile_v, tile_w);
 
     // W = V . T
     using namespace blas;

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -216,8 +216,8 @@ void updateTrailingPanel(const bool has_head, const std::vector<TileT<T>>& panel
 template <class Executor, class T>
 void hemmDiag(const Executor& ex, hpx::shared_future<TileT<const T>> tile_a,
               hpx::shared_future<TileT<const T>> tile_w, hpx::future<TileT<T>> tile_x) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::hemm_o), blas::Side::Left, blas::Uplo::Lower, T(1),
-                std::move(tile_a), std::move(tile_w), T(1), std::move(tile_x));
+  hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::hemm_o), blas::Side::Left,
+                blas::Uplo::Lower, T(1), std::move(tile_a), std::move(tile_w), T(1), std::move(tile_x));
 }
 
 // X += op(A) * W
@@ -231,16 +231,16 @@ void hemmOffDiag(const Executor& ex, blas::Op op, hpx::shared_future<TileT<const
 template <class Executor, class T>
 void her2kDiag(const Executor& ex, hpx::shared_future<TileT<const T>> tile_v,
                hpx::shared_future<TileT<const T>> tile_x, hpx::future<TileT<T>> tile_a) {
-  dataflow(ex, matrix::unwrapExtendTiles(tile::internal::her2k_o), blas::Uplo::Lower, blas::Op::NoTrans, T(-1),
-           std::move(tile_v), std::move(tile_x), BaseType<T>(1), std::move(tile_a));
+  dataflow(ex, matrix::unwrapExtendTiles(tile::internal::her2k_o), blas::Uplo::Lower, blas::Op::NoTrans,
+           T(-1), std::move(tile_v), std::move(tile_x), BaseType<T>(1), std::move(tile_a));
 }
 
 // C -= A . B*
 template <class Executor, class T>
 void her2kOffDiag(const Executor& ex, hpx::shared_future<TileT<const T>> tile_a,
                   hpx::shared_future<TileT<const T>> tile_b, hpx::future<TileT<T>> tile_c) {
-  dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), blas::Op::NoTrans, blas::Op::ConjTrans, T(-1),
-           std::move(tile_a), std::move(tile_b), T(1), std::move(tile_c));
+  dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), blas::Op::NoTrans, blas::Op::ConjTrans,
+           T(-1), std::move(tile_a), std::move(tile_b), T(1), std::move(tile_c));
 }
 
 namespace local {

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -305,7 +305,7 @@ void setupReflectorPanelV(bool has_head, const LocalTileSize& ai_offset, const S
   if (has_head) {
     auto setupV0 = hpx::unwrapping([](auto&& tile_v, const auto& tile_a) {
       copy(tile_a, tile_v);
-      tile::laset(lapack::MatrixType::Upper, T(0), T(1), tile_v);
+      tile::internal::laset(lapack::MatrixType::Upper, T(0), T(1), tile_v);
     });
 
     // Note:
@@ -420,7 +420,7 @@ void gemmComputeW2(MatrixT<T>& w2, ConstPanelT<Coord::Col, T>& w, ConstPanelT<Co
   // Not all ranks in the column always hold at least a tile in the panel Ai, but all ranks in
   // the column are going to participate to the reduce. For them, it is important to set the
   // partial result W2 to zero.
-  hpx::dataflow(ex, unwrapExtendTiles(tile::set0<T>), w2(LocalTileIndex(0, 0)));
+  hpx::dataflow(ex, unwrapExtendTiles(tile::internal::set0_o), w2(LocalTileIndex(0, 0)));
 
   // GEMM W2 = W* . X
   for (const auto& index_tile : w.iteratorLocal())

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -35,33 +35,144 @@ namespace dlaf {
 namespace factorization {
 namespace internal {
 
+// TODO: Move.
+template <typename ValueTypes>
+struct sender_single_value_type_impl {};
+
+template <typename T>
+struct sender_single_value_type_impl<hpx::util::pack<hpx::util::pack<T>>> {
+  using type = T;
+};
+
+// We are only interested in the types wrapped by future and shared_future since
+// we will internally unwrap them.
+template <typename T>
+struct sender_single_value_type_impl<hpx::util::pack<hpx::util::pack<hpx::future<T>>>> {
+  using type = T;
+};
+
+template <typename T>
+struct sender_single_value_type_impl<hpx::util::pack<hpx::util::pack<hpx::shared_future<T>>>> {
+  using type = T;
+};
+
+// Contains a typedef type if and only if the sender sends a single type. If
+// that is the case, type will be defined to the type sent by the sender.
+template <typename Sender>
+struct sender_single_value_type
+    : sender_single_value_type_impl<typename hpx::execution::experimental::sender_traits<
+          Sender>::template value_types<hpx::util::pack, hpx::util::pack>> {};
+
+template <typename Sender>
+using sender_single_value_type_t = typename sender_single_value_type<Sender>::type;
+
+template <typename T>
+struct tile_sender_element_type_impl {
+  using type = typename T::ElementType;
+};
+
+// Contains a typedef type if and only if the sender sends a single Tile. If
+// that is the case, type will be defined to ElementType of the Tile.
+template <typename Sender>
+struct tile_sender_element_type : tile_sender_element_type_impl<sender_single_value_type_t<Sender>> {};
+
+template <typename Sender>
+using tile_sender_element_type_t = typename tile_sender_element_type<Sender>::type;
+
+// Contains a boolean variable value which is true if and only if the given type
+// is a Tile.
+template <typename T>
+struct is_tile : std::false_type {};
+
+template <typename T, Device device>
+struct is_tile<matrix::Tile<T, device>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_tile_v = is_tile<T>::value;
+
+// Contains a boolean variable value which is true if and only if the given type
+// is a Tile with const ElementType.
+template <typename T>
+struct is_const_tile : std::false_type {};
+
+template <typename T, Device device>
+struct is_const_tile<matrix::Tile<const T, device>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_const_tile_v = is_const_tile<T>::value;
+
+template <typename Sender, typename Enable = void>
+struct is_sender_of_tile : std::false_type {};
+
+// Contains a boolean variable value which is true if and only if the given sender
+// sends a Tile.
+template <typename Sender>
+struct is_sender_of_tile<Sender, std::enable_if_t<is_tile_v<sender_single_value_type_t<Sender>>>>
+    : std::true_type {};
+
+template <typename Sender>
+inline constexpr bool is_sender_of_tile_v = is_sender_of_tile<Sender>::value;
+
+// Contains a boolean variable value which is true if and only if the given sender
+// sends a Tile with const element type.
+template <typename Sender, typename Enable = void>
+struct is_sender_of_const_tile : std::false_type {};
+
+template <typename Sender>
+struct is_sender_of_const_tile<Sender,
+                               std::enable_if_t<is_const_tile_v<sender_single_value_type_t<Sender>>>>
+    : std::true_type {};
+
+template <typename Sender>
+inline constexpr bool is_sender_of_const_tile_v = is_sender_of_const_tile<Sender>::value;
+
+// Contains a boolean variable value which is true if and only all given senders
+// send a tile and the element type of the tiles are the same.
+template <typename Sender, typename... Senders>
+struct have_same_element_types
+    : std::conjunction<
+          std::is_same<tile_sender_element_type_t<Sender>, tile_sender_element_type_t<Senders>>...> {};
+
+template <typename... Senders>
+inline constexpr bool have_same_element_types_v = have_same_element_types<Senders...>::value;
+
 namespace cholesky_l {
 template <Backend backend, class MatrixTileSender>
 void potrfDiagTile(MatrixTileSender&& matrix_tile) {
-  // TODO:
-  // - when_all(...) | algo(policy) | detach()?
-  // - algo(policy, when_all(...)) | detach?
-  // - detach(algo(policy, when_all(...)))?
-  tile::potrf(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::normal),
-              dlaf::internal::whenAllLift(blas::Uplo::Lower,
-                                          std::forward<MatrixTileSender>(matrix_tile))) |
+  static_assert(is_sender_of_tile_v<MatrixTileSender>);
+
+  dlaf::internal::whenAllLift(blas::Uplo::Lower, std::forward<MatrixTileSender>(matrix_tile)) |
+      tile::potrf(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::normal)) |
       hpx::execution::experimental::detach();
 }
 
-template <Backend backend, class T, class KKTileSender, class MatrixTileSender>
+template <Backend backend, class KKTileSender, class MatrixTileSender>
 void trsmPanelTile(KKTileSender&& kk_tile, MatrixTileSender&& matrix_tile) {
+  static_assert(is_sender_of_const_tile_v<KKTileSender>);
+  static_assert(is_sender_of_tile_v<MatrixTileSender>);
+  static_assert(have_same_element_types_v<KKTileSender, MatrixTileSender>);
+
+  using element_type = tile_sender_element_type_t<KKTileSender>;
+
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::ConjTrans,
-                              blas::Diag::NonUnit, T(1.0), std::forward<KKTileSender>(kk_tile),
+                              blas::Diag::NonUnit, element_type(1.0),
+                              std::forward<KKTileSender>(kk_tile),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
       hpx::execution::experimental::detach();
 }
 
-template <Backend backend, class T, class PanelTileSender, class MatrixTileSender>
+template <Backend backend, class PanelTileSender, class MatrixTileSender>
 void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSender&& panel_tile,
                           MatrixTileSender&& matrix_tile) {
-  dlaf::internal::whenAllLift(blas::Uplo::Lower, blas::Op::NoTrans, BaseType<T>(-1.0),
-                              std::forward<PanelTileSender>(panel_tile), BaseType<T>(1.0),
+  static_assert(is_sender_of_const_tile_v<PanelTileSender>);
+  static_assert(is_sender_of_tile_v<MatrixTileSender>);
+  static_assert(have_same_element_types_v<PanelTileSender, MatrixTileSender>);
+
+  using base_element_type = BaseType<tile_sender_element_type_t<PanelTileSender>>;
+
+  dlaf::internal::whenAllLift(blas::Uplo::Lower, blas::Op::NoTrans, base_element_type(-1.0),
+                              std::forward<PanelTileSender>(panel_tile), base_element_type(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::herk(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
@@ -85,20 +196,33 @@ void potrfDiagTile(MatrixTileSender&& matrix_tile) {
       hpx::execution::experimental::detach();
 }
 
-template <Backend backend, class T, class KKTileSender, class MatrixTileSender>
+template <Backend backend, class KKTileSender, class MatrixTileSender>
 void trsmPanelTile(KKTileSender&& kk_tile, MatrixTileSender&& matrix_tile) {
+  static_assert(is_sender_of_const_tile_v<KKTileSender>);
+  static_assert(is_sender_of_tile_v<MatrixTileSender>);
+  static_assert(have_same_element_types_v<KKTileSender, MatrixTileSender>);
+
+  using element_type = tile_sender_element_type_t<KKTileSender>;
+
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::ConjTrans,
-                              blas::Diag::NonUnit, T(1.0), std::forward<KKTileSender>(kk_tile),
+                              blas::Diag::NonUnit, element_type(1.0),
+                              std::forward<KKTileSender>(kk_tile),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
       hpx::execution::experimental::detach();
 }
 
-template <Backend backend, class T, class PanelTileSender, class MatrixTileSender>
+template <Backend backend, class PanelTileSender, class MatrixTileSender>
 void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSender&& panel_tile,
                           MatrixTileSender&& matrix_tile) {
-  dlaf::internal::whenAllLift(blas::Uplo::Upper, blas::Op::ConjTrans, BaseType<T>(-1.0),
-                              std::forward<PanelTileSender>(panel_tile), BaseType<T>(1.0),
+  static_assert(is_sender_of_const_tile_v<PanelTileSender>);
+  static_assert(is_sender_of_tile_v<MatrixTileSender>);
+  static_assert(have_same_element_types_v<PanelTileSender, MatrixTileSender>);
+
+  using base_element_type = BaseType<tile_sender_element_type_t<PanelTileSender>>;
+
+  dlaf::internal::whenAllLift(blas::Uplo::Upper, blas::Op::ConjTrans, base_element_type(-1.0),
+                              std::forward<PanelTileSender>(panel_tile), base_element_type(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::herk(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
@@ -130,7 +254,7 @@ void Cholesky<backend, device, T>::call_L(Matrix<T, device>& mat_a) {
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       // Update panel mat_a(i,k) with trsm (blas operation), using data mat_a.read(k,k)
-      trsmPanelTile<backend, T>(mat_a.read_sender(kk), mat_a.readwrite_sender(LocalTileIndex{i, k}));
+      trsmPanelTile<backend>(mat_a.read_sender(kk), mat_a.readwrite_sender(LocalTileIndex{i, k}));
     }
 
     for (SizeType j = k + 1; j < nrtile; ++j) {
@@ -139,8 +263,8 @@ void Cholesky<backend, device, T>::call_L(Matrix<T, device>& mat_a) {
           (j == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
 
       // Update trailing matrix: diagonal element mat_a(j,j), reading mat_a.read(j,k), using herk (blas operation)
-      herkTrailingDiagTile<backend, T>(trailing_matrix_priority, mat_a.read_sender(LocalTileIndex{j, k}),
-                                       mat_a.readwrite_sender(LocalTileIndex{j, j}));
+      herkTrailingDiagTile<backend>(trailing_matrix_priority, mat_a.read_sender(LocalTileIndex{j, k}),
+                                    mat_a.readwrite_sender(LocalTileIndex{j, j}));
 
       for (SizeType i = j + 1; i < nrtile; ++i) {
         // Update remaining trailing matrix mat_a(i,j), reading mat_a.read(i,k) and mat_a.read(j,k),
@@ -209,7 +333,7 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Row, i);
         const LocalTileIndex ik_idx(i, distr.localTileFromGlobalTile<Coord::Col>(k));
 
-        trsmPanelTile<backend, T>(panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(ik_idx));
+        trsmPanelTile<backend>(panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(ik_idx));
 
         panel.setTile(local_idx, mat_a.read(ik_idx));
       }
@@ -235,8 +359,8 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
       if (this_rank.row() == owner.row()) {
         const auto i = distr.localTileFromGlobalTile<Coord::Row>(jt_idx);
 
-        herkTrailingDiagTile<backend, T>(trailing_matrix_priority, panel.read_sender({Coord::Row, i}),
-                                         mat_a.readwrite_sender(LocalTileIndex{i, j}));
+        herkTrailingDiagTile<backend>(trailing_matrix_priority, panel.read_sender({Coord::Row, i}),
+                                      mat_a.readwrite_sender(LocalTileIndex{i, j}));
       }
 
       for (SizeType i_idx = jt_idx + 1; i_idx < nrtile; ++i_idx) {
@@ -274,15 +398,15 @@ void Cholesky<backend, device, T>::call_U(Matrix<T, device>& mat_a) {
     potrfDiagTile<backend>(mat_a.readwrite_sender(kk));
 
     for (SizeType j = k + 1; j < nrtile; ++j) {
-      trsmPanelTile<backend, T>(mat_a.read_sender(kk), mat_a.readwrite_sender(LocalTileIndex{k, j}));
+      trsmPanelTile<backend>(mat_a.read_sender(kk), mat_a.readwrite_sender(LocalTileIndex{k, j}));
     }
 
     for (SizeType i = k + 1; i < nrtile; ++i) {
       const auto trailing_matrix_priority =
           (i == k + 1) ? hpx::threads::thread_priority::high : hpx::threads::thread_priority::normal;
 
-      herkTrailingDiagTile<backend, T>(trailing_matrix_priority, mat_a.read_sender(LocalTileIndex{k, i}),
-                                       mat_a.readwrite_sender(LocalTileIndex{i, i}));
+      herkTrailingDiagTile<backend>(trailing_matrix_priority, mat_a.read_sender(LocalTileIndex{k, i}),
+                                    mat_a.readwrite_sender(LocalTileIndex{i, i}));
 
       for (SizeType j = i + 1; j < nrtile; ++j) {
         gemmTrailingMatrixTile<backend, T>(hpx::threads::thread_priority::normal,
@@ -349,7 +473,7 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Col, j);
         const LocalTileIndex kj_idx(distr.localTileFromGlobalTile<Coord::Row>(k), j);
 
-        trsmPanelTile<backend, T>(panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(kj_idx));
+        trsmPanelTile<backend>(panelT.read_sender(diag_wp_idx), mat_a.readwrite_sender(kj_idx));
 
         panel.setTile(local_idx, mat_a.read(kj_idx));
       }
@@ -375,8 +499,8 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
       if (this_rank.col() == owner.col()) {
         const auto j = distr.localTileFromGlobalTile<Coord::Col>(it_idx);
 
-        herkTrailingDiagTile<backend, T>(trailing_matrix_priority, panel.read_sender({Coord::Col, j}),
-                                         mat_a.readwrite_sender(LocalTileIndex{i, j}));
+        herkTrailingDiagTile<backend>(trailing_matrix_priority, panel.read_sender({Coord::Col, j}),
+                                      mat_a.readwrite_sender(LocalTileIndex{i, j}));
       }
 
       for (SizeType j_idx = it_idx + 1; j_idx < nrtile; ++j_idx) {

--- a/include/dlaf/factorization/qr/t_factor_mc.h
+++ b/include/dlaf/factorization/qr/t_factor_mc.h
@@ -178,7 +178,7 @@ void QR_Tfactor<Backend::MC, Device::CPU, T>::call(const SizeType k, Matrix<cons
   const GlobalTileIndex v_end{v.nrTiles().rows(), std::min(v.nrTiles().cols(), v_start.col() + 1)};
 
   t = t.then(getHpExecutor<Backend::MC>(), hpx::unwrapping([](auto&& tile) {
-               tile::set0<T>(tile);
+               tile::internal::set0<T>(tile);
                return std::move(tile);
              }));
 
@@ -247,7 +247,7 @@ void QR_Tfactor<Backend::MC, Device::CPU, T>::call(
   const LocalTileIndex v_end_loc{dist.localNrTiles().rows(), v_start_loc.col() + 1};
 
   t = t.then(getHpExecutor<Backend::MC>(), hpx::unwrapping([](auto&& tile) {
-               tile::set0<T>(tile);
+               tile::internal::set0<T>(tile);
                return std::move(tile);
              }));
 

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -91,13 +91,15 @@ void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, 
 ///
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
-dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p, const lapack::Norm norm, const Tile<T, Device::CPU>& a);
+dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p, const lapack::Norm norm,
+                        const Tile<T, Device::CPU>& a);
 
 /// \overload lange
 ///
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
-template <Backend B, typename Sender, typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
 dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload lange
@@ -117,14 +119,15 @@ dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p);
 ///
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
-dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p, const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
-                        const Tile<T, Device::CPU>& a);
+dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p, const lapack::Norm norm,
+                        const blas::Uplo uplo, const blas::Diag diag, const Tile<T, Device::CPU>& a);
 
 /// \overload lantr
 ///
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
-template <Backend B, typename Sender, typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
 dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload lantr
@@ -138,13 +141,15 @@ dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p);
 ///
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
-void laset(const dlaf::internal::Policy<B>& p, const lapack::MatrixType type, T alpha, T beta, const Tile<T, Device::CPU>& tile);
+void laset(const dlaf::internal::Policy<B>& p, const lapack::MatrixType type, T alpha, T beta,
+           const Tile<T, Device::CPU>& tile);
 
 /// \overload laset
 ///
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
-template <Backend B, typename Sender, typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
 void laset(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload laset
@@ -164,7 +169,8 @@ void set0(const dlaf::internal::Policy<B>& p, const Tile<T, Device::CPU>& tile);
 ///
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
-template <Backend B, typename Sender, typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
 void set0(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload set0
@@ -395,13 +401,14 @@ dlaf::BaseType<T> lange(cusolverDnHandle_t, const lapack::Norm norm, const Tile<
 }
 
 template <class T>
-dlaf::BaseType<T> lantr(cusolverDnHandle_t, const lapack::Norm norm, const blas::Uplo uplo, const blas::Diag diag,
-                        const Tile<T, Device::GPU>& a) {
+dlaf::BaseType<T> lantr(cusolverDnHandle_t, const lapack::Norm norm, const blas::Uplo uplo,
+                        const blas::Diag diag, const Tile<T, Device::GPU>& a) {
   static_assert(sizeof(T) == 0, "lantr is unimplemented for Backend::GPU");
 }
 
 template <class T>
-void laset(cusolverDnHandle_t, const lapack::MatrixType type, T alpha, T beta, const Tile<T, Device::GPU>& tile) {
+void laset(cusolverDnHandle_t, const lapack::MatrixType type, T alpha, T beta,
+           const Tile<T, Device::GPU>& tile) {
   static_assert(sizeof(T) == 0, "laset is unimplemented for Backend::GPU");
 }
 

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -397,24 +397,24 @@ void assertExtendInfo(F assertFunc, cusolverDnHandle_t handle, CusolverInfo<T>&&
 
 template <class T>
 dlaf::BaseType<T> lange(cusolverDnHandle_t, const lapack::Norm norm, const Tile<T, Device::GPU>& a) {
-  static_assert(sizeof(T) == 0, "lange is unimplemented for Backend::GPU");
+  DLAF_STATIC_UNIMPLEMENTED(sizeof(T) == 0);
 }
 
 template <class T>
 dlaf::BaseType<T> lantr(cusolverDnHandle_t, const lapack::Norm norm, const blas::Uplo uplo,
                         const blas::Diag diag, const Tile<T, Device::GPU>& a) {
-  static_assert(sizeof(T) == 0, "lantr is unimplemented for Backend::GPU");
+  DLAF_STATIC_UNIMPLEMENTED(sizeof(T) == 0);
 }
 
 template <class T>
 void laset(cusolverDnHandle_t, const lapack::MatrixType type, T alpha, T beta,
            const Tile<T, Device::GPU>& tile) {
-  static_assert(sizeof(T) == 0, "laset is unimplemented for Backend::GPU");
+  DLAF_STATIC_UNIMPLEMENTED(sizeof(T) == 0);
 }
 
 template <class T>
 void set0(cusolverDnHandle_t, const Tile<T, Device::GPU>& tile) {
-  static_assert(sizeof(T) == 0, "set0 is unimplemented for Backend::GPU");
+  DLAF_STATIC_UNIMPLEMENTED(sizeof(T) == 0);
 }
 
 template <class T>

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -30,6 +30,10 @@
 #include "dlaf/lapack/enum_output.h"
 #include "dlaf/matrix/index.h"
 #include "dlaf/matrix/tile.h"
+#include "dlaf/sender/make_sender_algorithm_overloads.h"
+#include "dlaf/sender/partial_transform.h"
+#include "dlaf/sender/policy.h"
+#include "dlaf/sender/transform.h"
 #include "dlaf/types.h"
 #include "dlaf/util_tile.h"
 
@@ -45,31 +49,6 @@ namespace tile {
 using matrix::Tile;
 
 // See LAPACK documentation for more details.
-
-/// Reduce a Hermitian definite generalized eigenproblem to standard form.
-///
-/// If @p itype = 1, the problem is A*x = lambda*B*x,
-/// and A is overwritten by inv(U**H)*A*inv(U) or inv(L)*A*inv(L**H).
-///
-/// If @p itype = 2 or 3, the problem is A*B*x = lambda*x or
-/// B*A*x = lambda*x, and A is overwritten by U*A*(U**H) or (L**H)*A*L.
-/// B must have been previously factorized as (U**H)*U or L*(L**H) by potrf().
-///
-/// @pre a must be a complex Hermitian matrix or a symmetric real matrix (A),
-/// @pre b must be the triangular factor from the Cholesky factorization of B,
-/// @throw std::runtime_error if the tile was not positive definite.
-template <class T>
-void hegst(const int itype, const blas::Uplo uplo, const Tile<T, Device::CPU>& a,
-           const Tile<T, Device::CPU>& b) {
-  DLAF_ASSERT(square_size(a), a);
-  DLAF_ASSERT(square_size(b), b);
-  DLAF_ASSERT(a.size() == b.size(), a, b);
-  DLAF_ASSERT(itype >= 1 && itype <= 3, itype);
-
-  auto info = lapack::hegst(itype, uplo, a.size().cols(), a.ptr(), a.ld(), b.ptr(), b.ld());
-
-  DLAF_ASSERT(info == 0, info);
-}
 
 /// Copies all elements from Tile a to Tile b.
 ///
@@ -134,10 +113,125 @@ dlaf::BaseType<T> lantr(const lapack::Norm norm, const blas::Uplo uplo, const bl
   return lapack::lantr(norm, uplo, diag, a.size().rows(), a.size().cols(), a.ptr(), a.ld());
 }
 
+/// Set off-diagonal (@param alpha) and diagonal (@param betea) elements of Tile @param tile.
+template <class T>
+void laset(const lapack::MatrixType type, T alpha, T beta, const Tile<T, Device::CPU>& tile) {
+  DLAF_ASSERT((type == lapack::MatrixType::General || type == lapack::MatrixType::Lower ||
+               type == lapack::MatrixType::Upper),
+              type);
+
+  const SizeType m = tile.size().rows();
+  const SizeType n = tile.size().cols();
+
+  lapack::laset(type, m, n, alpha, beta, tile.ptr(), tile.ld());
+}
+
+/// Set zero all the elements of Tile @param tile.
+template <class T>
+void set0(const Tile<T, Device::CPU>& tile) {
+  tile::laset(lapack::MatrixType::General, static_cast<T>(0.0), static_cast<T>(0.0), tile);
+}
+
+#ifdef DLAF_DOXYGEN
+
+/// Reduce a Hermitian definite generalized eigenproblem to standard form.
+///
+/// If @p itype = 1, the problem is A*x = lambda*B*x,
+/// and A is overwritten by inv(U**H)*A*inv(U) or inv(L)*A*inv(L**H).
+///
+/// If @p itype = 2 or 3, the problem is A*B*x = lambda*x or
+/// B*A*x = lambda*x, and A is overwritten by U*A*(U**H) or (L**H)*A*L.
+/// B must have been previously factorized as (U**H)*U or L*(L**H) by potrf().
+///
+/// @pre a must be a complex Hermitian matrix or a symmetric real matrix (A),
+/// @pre b must be the triangular factor from the Cholesky factorization of B,
+/// @throw std::runtime_error if the tile was not positive definite.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void hegst(const dlaf::internal::Policy<B>&, const int itype, const blas::Uplo uplo, const Tile<T, D>& a,
+           const Tile<T, D>& b);
+
+/// \overload hegst
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto hegst(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload hegst
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto hegst(const dlaf::internal::Policy<B>& p);
+
 /// Compute the cholesky decomposition of a (with return code).
 ///
 /// Only the upper or lower triangular elements are referenced according to @p uplo.
 /// @returns info = 0 on success or info > 0 if the tile is not positive definite.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+auto potrfInfo(const dlaf::internal::Policy<B>&, const blas::Uplo uplo, const Tile<T, D>& a);
+
+/// \overload potrfInfo
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto potrfInfo(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload potrfInfo
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto potrfInfo(const dlaf::internal::Policy<B>& p);
+
+/// Compute the cholesky decomposition of a.
+///
+/// Only the upper or lower triangular elements are referenced according to @p uplo.
+/// @pre matrix @p a is square,
+/// @pre matrix @p a is positive definite.
+///
+/// This overload blocks until completion of the algorithm.
+template <Backend B, class T, Device D>
+void potrf(const dlaf::internal::Policy<B>& p, const blas::Uplo uplo, const Tile<T, D>& a);
+
+/// \overload potrf
+///
+/// This overload takes a policy argument and a sender which must send all required arguments for the
+/// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
+template <Backend B, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+auto potrf(const dlaf::internal::Policy<B>& p, Sender&& s);
+
+/// \overload potrf
+///
+/// This overload partially applies the algorithm with a policy for later use with operator| with a
+/// sender on the left-hand side.
+template <Backend B>
+auto potrf(const dlaf::internal::Policy<B>& p);
+
+#else
+
+namespace internal {
+template <class T>
+void hegst(const int itype, const blas::Uplo uplo, const Tile<T, Device::CPU>& a,
+           const Tile<T, Device::CPU>& b) {
+  DLAF_ASSERT(square_size(a), a);
+  DLAF_ASSERT(square_size(b), b);
+  DLAF_ASSERT(a.size() == b.size(), a, b);
+  DLAF_ASSERT(itype >= 1 && itype <= 3, itype);
+
+  auto info = lapack::hegst(itype, uplo, a.size().cols(), a.ptr(), a.ld(), b.ptr(), b.ld());
+
+  DLAF_ASSERT(info == 0, info);
+}
+
 template <class T>
 long long potrfInfo(const blas::Uplo uplo, const Tile<T, Device::CPU>& a) {
   DLAF_ASSERT(square_size(a), a);
@@ -148,11 +242,6 @@ long long potrfInfo(const blas::Uplo uplo, const Tile<T, Device::CPU>& a) {
   return info;
 }
 
-/// Compute the cholesky decomposition of a.
-///
-/// Only the upper or lower triangular elements are referenced according to @p uplo.
-/// @pre matrix @p a is square,
-/// @pre matrix @p a is positive definite.
 template <class T>
 void potrf(const blas::Uplo uplo, const Tile<T, Device::CPU>& a) noexcept {
   auto info = potrfInfo(uplo, a);
@@ -265,28 +354,15 @@ void potrf(cusolverDnHandle_t handle, const blas::Uplo uplo, const matrix::Tile<
 }
 #endif
 
-/// Set off-diagonal (@param alpha) and diagonal (@param betea) elements of Tile @param tile.
-template <class T>
-void laset(const lapack::MatrixType type, T alpha, T beta, const Tile<T, Device::CPU>& tile) {
-  DLAF_ASSERT((type == lapack::MatrixType::General || type == lapack::MatrixType::Lower ||
-               type == lapack::MatrixType::Upper),
-              type);
-
-  const SizeType m = tile.size().rows();
-  const SizeType n = tile.size().cols();
-
-  lapack::laset(type, m, n, alpha, beta, tile.ptr(), tile.ld());
-}
-
-/// Set zero all the elements of Tile @param tile.
-template <class T>
-void set0(const Tile<T, Device::CPU>& tile) {
-  tile::laset(lapack::MatrixType::General, static_cast<T>(0.0), static_cast<T>(0.0), tile);
-}
-
 DLAF_MAKE_CALLABLE_OBJECT(hegst);
 DLAF_MAKE_CALLABLE_OBJECT(potrf);
 DLAF_MAKE_CALLABLE_OBJECT(potrfInfo);
+}
 
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(hegst, internal::hegst_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(potrf, internal::potrf_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(potrfInfo, internal::potrfInfo_o)
+
+#endif
 }
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -61,7 +61,7 @@ template <typename T>
 struct CopyTile<T, Device::CPU, Device::CPU> {
   static void call(const matrix::Tile<const T, Device::CPU>& source,
                    const matrix::Tile<T, Device::CPU>& destination) {
-    dlaf::tile::internal::lacpy<T>(source, destination);
+    dlaf::tile::lacpy<T>(source, destination);
   }
 };
 
@@ -157,7 +157,7 @@ void copy(const Tile<const T, Source>& source, const Tile<T, Destination>& desti
 template <class T>
 void copy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, Device::CPU>& in,
           TileElementIndex out_idx, const Tile<T, Device::CPU>& out) {
-  dlaf::tile::internal::lacpy<T>(region, in_idx, in, out_idx, out);
+  dlaf::tile::lacpy<T>(region, in_idx, in, out_idx, out);
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(copy);

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -61,7 +61,7 @@ template <typename T>
 struct CopyTile<T, Device::CPU, Device::CPU> {
   static void call(const matrix::Tile<const T, Device::CPU>& source,
                    const matrix::Tile<T, Device::CPU>& destination) {
-    dlaf::tile::lacpy<T>(source, destination);
+    dlaf::tile::internal::lacpy<T>(source, destination);
   }
 };
 
@@ -157,7 +157,7 @@ void copy(const Tile<const T, Source>& source, const Tile<T, Destination>& desti
 template <class T>
 void copy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, Device::CPU>& in,
           TileElementIndex out_idx, const Tile<T, Device::CPU>& out) {
-  dlaf::tile::lacpy<T>(region, in_idx, in, out_idx, out);
+  dlaf::tile::internal::lacpy<T>(region, in_idx, in, out_idx, out);
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(copy);

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -128,6 +128,14 @@ public:
     return operator()(this->distribution().localTileIndex(index));
   }
 
+  auto readwrite_sender(const LocalTileIndex& index) noexcept {
+    return this->operator()(index);
+  }
+
+  auto readwrite_sender(const GlobalTileIndex& index) {
+    return readwrite_sender(this->distribution().localTileIndex(index));
+  }
+
 protected:
   using Matrix<const T, device>::tileLinearIndex;
 
@@ -173,6 +181,16 @@ public:
   /// @pre index.isIn(globalNrTiles()).
   hpx::shared_future<ConstTileType> read(const GlobalTileIndex& index) {
     return read(distribution().localTileIndex(index));
+  }
+
+  auto read_sender(const LocalTileIndex& index) noexcept {
+    // We want to explicitly deal with the shared_future, not the const& to the
+    // value.
+    return hpx::execution::experimental::keep_future(read(index));
+  }
+
+  auto read_sender(const GlobalTileIndex& index) {
+    return read_sender(distribution().localTileIndex(index));
   }
 
   /// Synchronization barrier for all local tiles in the matrix

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -126,6 +126,10 @@ struct Panel<axis, const T, D> {
     }
   }
 
+  auto read_sender(const LocalTileIndex& index) {
+    return hpx::execution::experimental::keep_future(read(index));
+  }
+
   /// Set the panel to enable access to the range of tiles [start, end)
   ///
   /// With respect to the parent matrix.
@@ -404,12 +408,15 @@ struct Panel : public Panel<axis, const T, device> {
       return splitTile(tile, {{0, 0}, tileSize(index)});
   }
 
+  auto readwrite_sender(const LocalTileIndex& index) {
+    return hpx::execution::experimental::keep_future(this->operator()(index));
+  }
+
 protected:
   using BaseT = Panel<axis, const T, device>;
   using BaseT::dim_;
   using BaseT::has_been_used_;
   using BaseT::tileSize;
 };
-
 }
 }

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -213,7 +213,7 @@ Tile<const T, device>::Tile(Tile&& rhs) noexcept
 template <class T, Device device>
 Tile<const T, device>::~Tile() {
   if (p_) {
-    if (std::uncaught_exception())
+    if (std::uncaught_exceptions() > 0)
       p_->set_exception(std::make_exception_ptr(ContinuationException{}));
     else
       p_->set_value(Tile<ElementType, device>(size_, std::move(memory_view_), ld_));

--- a/include/dlaf/multiplication/triangular/impl.h
+++ b/include/dlaf/multiplication/triangular/impl.h
@@ -38,8 +38,8 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Left,
-                blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
                 std::move(out_tile));
 }
 
@@ -48,8 +48,8 @@ void gemm_trailing_matrix_tile(Executor&& ex, T beta,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans,
-                blas::Op::NoTrans, beta, std::move(a_tile), std::move(b_tile), T(1.0),
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o),
+                blas::Op::NoTrans, blas::Op::NoTrans, beta, std::move(a_tile), std::move(b_tile), T(1.0),
                 std::move(c_tile));
 }
 }
@@ -59,8 +59,9 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Op op, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Left,
-                blas::Uplo::Lower, op, diag, alpha, std::move(in_tile), std::move(out_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Left, blas::Uplo::Lower, op, diag, alpha, std::move(in_tile),
+                std::move(out_tile));
 }
 
 template <class Executor, class T, Device D>
@@ -68,7 +69,7 @@ void gemm_trailing_matrix_tile(Executor&& ex, blas::Op op, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), op,
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o), op,
                 blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
                 std::move(c_tile));
 }
@@ -79,8 +80,8 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Left,
-                blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
                 std::move(out_tile));
 }
 
@@ -89,9 +90,9 @@ void gemm_trailing_matrix_tile(Executor&& ex, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans,
-                blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
-                std::move(c_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o),
+                blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile),
+                T(1.0), std::move(c_tile));
 }
 }
 
@@ -100,8 +101,9 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Op op, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Left,
-                blas::Uplo::Upper, op, diag, alpha, std::move(in_tile), std::move(out_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Left, blas::Uplo::Upper, op, diag, alpha, std::move(in_tile),
+                std::move(out_tile));
 }
 
 template <class Executor, class T, Device D>
@@ -109,7 +111,7 @@ void gemm_trailing_matrix_tile(Executor&& ex, blas::Op op, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), op,
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o), op,
                 blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
                 std::move(c_tile));
 }
@@ -120,8 +122,8 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Right,
-                blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
                 std::move(out_tile));
 }
 
@@ -130,9 +132,9 @@ void gemm_trailing_matrix_tile(Executor&& ex, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans,
-                blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
-                std::move(c_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o),
+                blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile),
+                T(1.0), std::move(c_tile));
 }
 }
 
@@ -141,8 +143,9 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Op op, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Right,
-                blas::Uplo::Lower, op, diag, alpha, std::move(in_tile), std::move(out_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Right, blas::Uplo::Lower, op, diag, alpha, std::move(in_tile),
+                std::move(out_tile));
 }
 
 template <class Executor, class T, Device D>
@@ -150,8 +153,9 @@ void gemm_trailing_matrix_tile(Executor&& ex, blas::Op op, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans,
-                op, alpha, std::move(a_tile), std::move(b_tile), T(1.0), std::move(c_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o),
+                blas::Op::NoTrans, op, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
+                std::move(c_tile));
 }
 }
 
@@ -160,8 +164,8 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Right,
-                blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha, std::move(in_tile),
                 std::move(out_tile));
 }
 
@@ -170,9 +174,9 @@ void gemm_trailing_matrix_tile(Executor&& ex, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans,
-                blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
-                std::move(c_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o),
+                blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::move(a_tile), std::move(b_tile),
+                T(1.0), std::move(c_tile));
 }
 }
 
@@ -181,8 +185,9 @@ template <class Executor, class T, Device D>
 void trmm_B_panel_tile(Executor&& ex, blas::Op op, blas::Diag diag, T alpha,
                        hpx::shared_future<matrix::Tile<const T, D>> in_tile,
                        hpx::future<matrix::Tile<T, D>> out_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::trmm_o), blas::Side::Right,
-                blas::Uplo::Upper, op, diag, alpha, std::move(in_tile), std::move(out_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::trmm_o),
+                blas::Side::Right, blas::Uplo::Upper, op, diag, alpha, std::move(in_tile),
+                std::move(out_tile));
 }
 
 template <class Executor, class T, Device D>
@@ -190,8 +195,9 @@ void gemm_trailing_matrix_tile(Executor&& ex, blas::Op op, T alpha,
                                hpx::shared_future<matrix::Tile<const T, D>> a_tile,
                                hpx::shared_future<matrix::Tile<const T, D>> b_tile,
                                hpx::future<matrix::Tile<T, D>> c_tile) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::gemm_o), blas::Op::NoTrans,
-                op, alpha, std::move(a_tile), std::move(b_tile), T(1.0), std::move(c_tile));
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(tile::internal::gemm_o),
+                blas::Op::NoTrans, op, alpha, std::move(a_tile), std::move(b_tile), T(1.0),
+                std::move(c_tile));
 }
 }
 

--- a/include/dlaf/sender/lift_non_sender.h
+++ b/include/dlaf/sender/lift_non_sender.h
@@ -1,0 +1,30 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/local/execution.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace dlaf {
+namespace internal {
+/// Makes a sender out of the input, if it is not already a sender.
+template <typename S>
+decltype(auto) liftNonSender(S&& s) {
+  if constexpr (hpx::execution::experimental::is_sender_v<S>) {
+    return std::forward<S>(s);
+  }
+  else {
+    return hpx::execution::experimental::just(std::forward<S>(s));
+  }
+}
+}
+}

--- a/include/dlaf/sender/make_sender_algorithm_overloads.h
+++ b/include/dlaf/sender/make_sender_algorithm_overloads.h
@@ -1,0 +1,50 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include <hpx/local/execution.hpp>
+
+#include "dlaf/sender/partial_transform.h"
+#include "dlaf/sender/policy.h"
+#include "dlaf/sender/transform.h"
+
+/// Helper macro for generating overloads of algorithms that work with senders. The overloads will be
+/// named fname. callable is the callable object that will be used internall for the transform. It
+/// generates three overloads:
+///
+/// 1. One that takes a policy and a sender. The sender must send the required types of arguments for the
+///    callable (e.g. tiles and constants for a tile algorithm).
+/// 2. One that takes only a policy. This overload returns a partially applied algorithm that can be used
+///    with operator|. fname(policy, sender) is equivalent to fname(policy)(sender) and sender |
+///    fname(policy).
+/// 3. One that takes a policy and the arguments required by the callable. This is almost equivalent to
+///    calling the callable directly with the required arguments, with the difference that this overload
+///    does the required synchronization before returning in cases when the callable is not blocking.
+#define DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(fname, callable)                                   \
+  template <Backend B, typename Sender,                                                         \
+            typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>     \
+  auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                   \
+    return dlaf::internal::transform<B>(p, callable, std::forward<Sender>(s));                  \
+  }                                                                                             \
+                                                                                                \
+  template <Backend B>                                                                          \
+  auto fname(const dlaf::internal::Policy<B> p) {                                               \
+    return dlaf::internal::PartialTransform{p, callable};                                       \
+  }                                                                                             \
+                                                                                                \
+  template <Backend B, typename T1, typename T2, typename... Ts>                                \
+  void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                 \
+    hpx::execution::experimental::sync_wait(                                                    \
+        fname(p, hpx::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
+                                                    std::forward<Ts>(ts)...)));                 \
+  }

--- a/include/dlaf/sender/partial_transform.h
+++ b/include/dlaf/sender/partial_transform.h
@@ -20,7 +20,7 @@
 namespace dlaf {
 namespace internal {
 /// A partially applied transform, with the policy and callable object given,
-/// but the predecesor sender missing. The predecessor sender is applied when
+/// but the predecessor sender missing. The predecessor sender is applied when
 /// calling the operator| overload.
 template <Backend B, typename F>
 class PartialTransform {

--- a/include/dlaf/sender/partial_transform.h
+++ b/include/dlaf/sender/partial_transform.h
@@ -42,6 +42,6 @@ public:
 };
 
 template <Backend B, typename F>
-PartialTransform(const Policy<B> policy, F&& f) -> PartialTransform<B, std::decay_t<F>>;
+PartialTransform(const Policy<B> policy, F&& f)->PartialTransform<B, std::decay_t<F>>;
 }
 }

--- a/include/dlaf/sender/partial_transform.h
+++ b/include/dlaf/sender/partial_transform.h
@@ -1,0 +1,47 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/local/execution.hpp>
+
+#include <type_traits>
+#include <utility>
+
+#include "dlaf/sender/policy.h"
+#include "dlaf/sender/transform.h"
+
+namespace dlaf {
+namespace internal {
+/// A partially applied transform, with the policy and callable object given,
+/// but the predecesor sender missing. The predecessor sender is applied when
+/// calling the operator| overload.
+template <Backend B, typename F>
+class PartialTransform {
+  const Policy<B> policy_;
+  std::decay_t<F> f_;
+
+public:
+  template <typename F_>
+  PartialTransform(const Policy<B> policy, F_&& f) : policy_(policy), f_(std::forward<F_>(f)) {}
+  PartialTransform(PartialTransform&&) = default;
+  PartialTransform(PartialTransform const&) = default;
+  PartialTransform& operator=(PartialTransform&&) = default;
+  PartialTransform& operator=(PartialTransform const&) = default;
+
+  template <typename Sender>
+  friend auto operator|(Sender&& sender, const PartialTransform pa) {
+    return transform<B>(pa.policy_, std::move(pa.f_), std::forward<Sender>(sender));
+  }
+};
+
+template <Backend B, typename F>
+PartialTransform(const Policy<B> policy, F&& f) -> PartialTransform<B, std::decay_t<F>>;
+}
+}

--- a/include/dlaf/sender/policy.h
+++ b/include/dlaf/sender/policy.h
@@ -1,0 +1,39 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/local/execution.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace dlaf {
+namespace internal {
+/// A policy class for use as a tag for dispatching algorithms to a particular
+/// backend.
+template <Backend B>
+class Policy {
+private:
+  const hpx::threads::thread_priority priority_ = hpx::threads::thread_priority::normal;
+
+public:
+  Policy() = default;
+  explicit Policy(hpx::threads::thread_priority priority) : priority_(priority) {}
+  Policy(Policy&&) = default;
+  Policy(Policy const&) = default;
+  Policy& operator=(Policy&&) = default;
+  Policy& operator=(Policy const&) = default;
+
+  hpx::threads::thread_priority priority() const noexcept {
+    return priority_;
+  }
+};
+}
+}

--- a/include/dlaf/sender/traits.h
+++ b/include/dlaf/sender/traits.h
@@ -1,0 +1,49 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/future.hpp>
+
+namespace dlaf::internal {
+template <typename...>
+struct TypeList {};
+
+template <typename ValueTypes>
+struct SenderSingleValueTypeImpl {};
+
+template <typename T>
+struct SenderSingleValueTypeImpl<TypeList<TypeList<T>>> {
+  using type = T;
+};
+
+// We are only interested in the types wrapped by future and shared_future since
+// we will internally unwrap them.
+template <typename T>
+struct SenderSingleValueTypeImpl<TypeList<TypeList<hpx::future<T>>>> {
+  using type = T;
+};
+
+template <typename T>
+struct SenderSingleValueTypeImpl<TypeList<TypeList<hpx::shared_future<T>>>> {
+  using type = T;
+};
+
+// The type sent by Sender, if Sender sends exactly one type.
+template <typename Sender>
+using SenderSingleValueType =
+    typename SenderSingleValueTypeImpl<typename hpx::execution::experimental::sender_traits<
+        Sender>::template value_types<TypeList, TypeList>>::type;
+
+// The type of an embedded ElementType in the value_types of Sender, if it
+// exists and Sender sends exactly one type.
+template <typename Sender>
+using SenderElementType = typename SenderSingleValueType<Sender>::ElementType;
+}

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -128,7 +128,7 @@ struct Transform<Backend::GPU> {
       std::decay_t<F> f;
 
       template <typename E>
-      void set_error(E&& e) && noexcept {
+          void set_error(E&& e) && noexcept {
         hpx::execution::experimental::set_error(std::move(r), std::forward<E>(e));
       }
 

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -85,10 +85,12 @@ struct Transform<Backend::GPU> {
       }
       else if constexpr (is_cublas_handle_invocable) {
         (void) cusolver_handle;
+        (void) stream;
         return std::invoke(hpx::unwrapping(std::forward<G>(g)), cublas_handle, us...);
       }
       else if constexpr (is_cusolver_handle_invocable) {
         (void) cublas_handle;
+        (void) stream;
         return std::invoke(hpx::unwrapping(std::forward<G>(g)), cusolver_handle, us...);
       }
     }

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -1,0 +1,227 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <hpx/local/execution.hpp>
+#include <hpx/local/unwrap.hpp>
+
+#include "dlaf/init.h"
+#include "dlaf/sender/policy.h"
+#include "dlaf/sender/typelist.h"
+#include "dlaf/sender/when_all_lift.h"
+#include "dlaf/types.h"
+
+#ifdef DLAF_WITH_CUDA
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <cusolverDn.h>
+
+#include "dlaf/cublas/handle_pool.h"
+#include "dlaf/cuda/stream_pool.h"
+#include "dlaf/cusolver/handle_pool.h"
+#endif
+
+namespace dlaf {
+namespace internal {
+/// DLAF-specific transform, templated on a backend. This, together with
+/// when_all, takes the place of dataflow(executor, ...) for futures.
+template <Backend B>
+struct Transform;
+
+/// The Backend::MC specialization uses regular thread pool scheduler from HPX.
+template <>
+struct Transform<Backend::MC> {
+  template <typename S, typename F>
+  static auto call(const Policy<Backend::MC> policy, S&& s, F&& f) {
+    namespace ex = hpx::execution::experimental;
+    return ex::transform(ex::on(std::forward<S>(s),
+                                ex::with_priority(ex::thread_pool_scheduler{}, policy.priority())),
+                         hpx::unwrapping(std::forward<F>(f)));
+  }
+};
+
+#ifdef DLAF_WITH_CUDA
+/// The Backend::GPU specialization uses a custom sender. The custom sender,
+/// when connected to a receiver, chooses an approprate stream or handle pool
+/// depending on what the callable accepts, calls the given callable with an
+/// element from a pool, and signals the receiver when the operation is ready
+/// (notified using a CUDA event).
+template <>
+struct Transform<Backend::GPU> {
+  template <typename S, typename F>
+  struct GPUTransformSender {
+    cuda::StreamPool stream_pool;
+    cublas::HandlePool cublas_handle_pool;
+    cusolver::HandlePool cusolver_handle_pool;
+    std::decay_t<S> s;
+    std::decay_t<F> f;
+
+    template <typename G, typename... Us>
+    static auto call_helper(cudaStream_t stream, cublasHandle_t cublas_handle,
+                            cusolverDnHandle_t cusolver_handle, G&& g, Us&... us) {
+      using unwrapping_function_type = decltype(hpx::unwrapping(std::forward<G>(g)));
+      constexpr bool is_cuda_stream_invocable =
+          std::is_invocable_v<unwrapping_function_type, Us&..., cudaStream_t>;
+      constexpr bool is_cublas_handle_invocable =
+          std::is_invocable_v<unwrapping_function_type, cublasHandle_t, Us&...>;
+      constexpr bool is_cusolver_handle_invocable =
+          std::is_invocable_v<unwrapping_function_type, cusolverDnHandle_t, Us&...>;
+      static_assert(is_cuda_stream_invocable || is_cublas_handle_invocable ||
+                        is_cusolver_handle_invocable,
+                    "function passed to transform<GPU> must be invocable with a cublasStream_t as the "
+                    "last argument or a cublasHandle_t/cusolverDnHandle_t as the first argument");
+
+      if constexpr (is_cuda_stream_invocable) {
+        (void) cublas_handle;
+        (void) cusolver_handle;
+        return std::invoke(hpx::unwrapping(std::forward<G>(g)), us..., stream);
+      }
+      else if constexpr (is_cublas_handle_invocable) {
+        (void) cusolver_handle;
+        return std::invoke(hpx::unwrapping(std::forward<G>(g)), cublas_handle, us...);
+      }
+      else if constexpr (is_cusolver_handle_invocable) {
+        (void) cublas_handle;
+        return std::invoke(hpx::unwrapping(std::forward<G>(g)), cusolver_handle, us...);
+      }
+    }
+
+    template <typename Tuple>
+    struct invoke_result_helper;
+
+    template <template <typename...> class Tuple, typename... Ts>
+    struct invoke_result_helper<Tuple<Ts...>> {
+      using result_type = decltype(
+          call_helper(std::declval<cudaStream_t&>(), std::declval<cublasHandle_t&>(),
+                      std::declval<cusolverDnHandle_t&>(), std::declval<F>(), std::declval<Ts&>()...));
+      using type =
+          typename std::conditional<std::is_void<result_type>::value, Tuple<>, Tuple<result_type>>::type;
+    };
+
+    template <template <typename...> class Tuple, template <typename...> class Variant>
+    using value_types = dlaf::internal::UniquePackT<dlaf::internal::TransformPackT<
+        typename hpx::execution::experimental::sender_traits<S>::template value_types<Tuple, Variant>,
+        invoke_result_helper>>;
+
+    template <template <typename...> class Variant>
+    using error_types = dlaf::internal::UniquePackT<dlaf::internal::PrependPackT<
+        typename hpx::execution::experimental::sender_traits<S>::template error_types<Variant>,
+        std::exception_ptr>>;
+
+    static constexpr bool sends_done = false;
+
+    template <typename R>
+    struct GPUTransformReceiver {
+      cuda::StreamPool stream_pool;
+      cublas::HandlePool cublas_handle_pool;
+      cusolver::HandlePool cusolver_handle_pool;
+      std::decay_t<R> r;
+      std::decay_t<F> f;
+
+      template <typename E>
+      void set_error(E&& e) && noexcept {
+        hpx::execution::experimental::set_error(std::move(r), std::forward<E>(e));
+      }
+
+      void set_done() && noexcept {
+        hpx::execution::experimental::set_done(std::move(r));
+      }
+
+      template <typename... Ts>
+      void set_value(Ts&&... ts) noexcept {
+        try {
+          cudaStream_t stream = stream_pool.getNextStream();
+          cublasHandle_t cublas_handle = cublas_handle_pool.getNextHandle(stream);
+          cusolverDnHandle_t cusolver_handle = cusolver_handle_pool.getNextHandle(stream);
+
+          // NOTE: We do not forward ts because we keep the pack alive longer in
+          // the continuation.
+          if constexpr (std::is_void_v<decltype(
+                            call_helper(stream, cublas_handle, cusolver_handle, std::move(f), ts...))>) {
+            call_helper(stream, cublas_handle, cusolver_handle, std::move(f), ts...);
+            hpx::cuda::experimental::detail::add_event_callback(
+                [r = std::move(r),
+                 keep_alive =
+                     std::make_tuple(std::forward<Ts>(ts)..., std::move(stream_pool),
+                                     std::move(cublas_handle_pool),
+                                     std::move(cusolver_handle_pool))](cudaError_t status) mutable {
+                  DLAF_CUDA_CALL(status);
+                  hpx::execution::experimental::set_value(std::move(r));
+                },
+                stream);
+          }
+          else {
+            auto res = call_helper(stream, cublas_handle, cusolver_handle, std::move(f), ts...);
+            hpx::cuda::experimental::detail::add_event_callback(
+                [r = std::move(r), res = std::move(res),
+                 keep_alive =
+                     std::make_tuple(std::forward<Ts>(ts)..., std::move(stream_pool),
+                                     std::move(cublas_handle_pool),
+                                     std::move(cusolver_handle_pool))](cudaError_t status) mutable {
+                  DLAF_CUDA_CALL(status);
+                  hpx::execution::experimental::set_value(std::move(r), std::move(res));
+                },
+                stream);
+          }
+        }
+        catch (...) {
+          hpx::execution::experimental::set_error(std::move(r), std::current_exception());
+        }
+      }
+    };
+
+    template <typename R>
+    auto connect(R&& r) && {
+      return hpx::execution::experimental::connect(std::move(s),
+                                                   GPUTransformReceiver<R>{stream_pool,
+                                                                           cublas_handle_pool,
+                                                                           cusolver_handle_pool,
+                                                                           std::forward<R>(r),
+                                                                           std::move(f)});
+    }
+  };
+
+  template <typename S, typename F>
+  static auto call(const Policy<Backend::GPU> policy, S&& s, F&& f) {
+    return GPUTransformSender<S, F>{policy.priority() >= hpx::threads::thread_priority::high
+                                        ? getHpCudaStreamPool()
+                                        : getNpCudaStreamPool(),
+                                    getCublasHandlePool(), getCusolverHandlePool(), std::forward<S>(s),
+                                    std::forward<F>(f)};
+  }
+};
+#endif
+
+/// Lazy transform. This does not submit the work and returns a sender.
+template <Backend B, typename F, typename Sender,
+          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+[[nodiscard]] decltype(auto) transform(const Policy<B> policy, F&& f, Sender&& sender) {
+  return internal::Transform<B>::call(policy, std::forward<Sender>(sender), std::forward<F>(f));
+}
+
+/// Lazy transform. This does not submit the work and returns a sender. First
+/// lifts non-senders into senders using just, and then calls transform with a
+/// when_all sender of the lifted senders.
+template <Backend B, typename F, typename... Ts>
+[[nodiscard]] decltype(auto) transformLift(const Policy<B> policy, F&& f, Ts&&... ts) {
+  return internal::Transform<B>::call(policy, internal::whenAllLift(std::forward<Ts>(ts)...),
+                                      std::forward<F>(f));
+}
+
+/// Fire-and-forget transform. This submits the work and returns void. First
+/// lifts non-senders into senders using just, and then calls transform with a
+/// when_all sender of the lifted senders.
+template <Backend B, typename F, typename... Ts>
+void transformLiftDetach(const Policy<B> policy, F&& f, Ts&&... ts) {
+  hpx::execution::experimental::detach(
+      transformLift<B>(policy, std::forward<F>(f), std::forward<Ts>(ts)...));
+}
+}
+}

--- a/include/dlaf/sender/typelist.h
+++ b/include/dlaf/sender/typelist.h
@@ -1,0 +1,76 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <type_traits>
+
+namespace dlaf {
+namespace internal {
+
+template <typename T, typename... Ts>
+struct Contains;
+
+template <typename T>
+struct Contains<T> : std::false_type {};
+
+template <typename T, typename... Ts>
+struct Contains<T, T, Ts...> : std::true_type {};
+
+template <typename T, typename U, typename... Ts>
+struct Contains<T, U, Ts...> : Contains<T, Ts...> {};
+
+template <typename T, typename... Ts>
+inline constexpr bool ContainsV = Contains<T, Ts...>::value;
+
+template <typename PackUnique, typename PackRest>
+struct UniquePackHelper;
+
+template <template <typename...> class Pack, typename... Ts>
+struct UniquePackHelper<Pack<Ts...>, Pack<>> {
+  using type = Pack<Ts...>;
+};
+
+template <template <typename...> class Pack, typename... Ts, typename U, typename... Us>
+struct UniquePackHelper<Pack<Ts...>, Pack<U, Us...>>
+    : std::conditional<ContainsV<U, Ts...>, UniquePackHelper<Pack<Ts...>, Pack<Us...>>,
+                       UniquePackHelper<Pack<Ts..., U>, Pack<Us...>>>::type {};
+
+template <typename Pack>
+struct UniquePack;
+
+template <template <typename...> class Pack, typename... Ts>
+struct UniquePack<Pack<Ts...>> : UniquePackHelper<Pack<>, Pack<Ts...>> {};
+
+template <typename Pack>
+using UniquePackT = typename UniquePack<Pack>::type;
+
+template <typename Pack, template <typename> class Transformer>
+struct TransformPack;
+
+template <template <typename> class Transformer, template <typename...> class Pack, typename... Ts>
+struct TransformPack<Pack<Ts...>, Transformer> {
+  using type = Pack<typename Transformer<Ts>::type...>;
+};
+
+template <typename Pack, template <typename> class Transformer>
+using TransformPackT = typename TransformPack<Pack, Transformer>::type;
+
+template <typename Pack, typename T>
+struct PrependPack;
+
+template <typename T, template <typename...> class Pack, typename... Ts>
+struct PrependPack<Pack<Ts...>, T> {
+  using type = Pack<T, Ts...>;
+};
+
+template <typename Pack, typename T>
+using PrependPackT = typename PrependPack<Pack, T>::type;
+}
+}

--- a/include/dlaf/sender/when_all_lift.h
+++ b/include/dlaf/sender/when_all_lift.h
@@ -1,0 +1,28 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2020-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include <hpx/local/execution.hpp>
+
+#include "dlaf/sender/lift_non_sender.h"
+
+namespace dlaf {
+namespace internal {
+/// Helper function which behaves similarly to when_all with the exception that
+/// non-senders are first turned into senders using just.
+template <typename... Ts>
+auto whenAllLift(Ts&&... ts) {
+  return hpx::execution::experimental::when_all(liftNonSender<Ts>(std::forward<Ts>(ts))...);
+}
+}
+}

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -198,7 +198,7 @@ void Triangular<backend, device, T>::call_LLN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType i = k + 1; i < m; ++i) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
@@ -289,7 +289,7 @@ void Triangular<backend, device, T>::call_LUT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType i = k + 1; i < m; ++i) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
@@ -320,7 +320,7 @@ void Triangular<backend, device, T>::call_RLN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType j = k - 1; j >= 0; --j) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto priority = (j == k - 1) ? thread_priority::high : thread_priority::normal;
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
         gemmTrailingMatrixTile<backend>(priority, beta, mat_b.read_sender(ik),
@@ -350,7 +350,7 @@ void Triangular<backend, device, T>::call_RLT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType j = k + 1; j < n; ++j) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto priority = (j == k + 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
@@ -381,7 +381,7 @@ void Triangular<backend, device, T>::call_RUN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType j = k + 1; j < n; ++j) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto priority = (j == k + 1) ? thread_priority::high : thread_priority::normal;
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
         gemmTrailingMatrixTile<backend>(priority, beta, mat_b.read_sender(ik),
@@ -411,7 +411,7 @@ void Triangular<backend, device, T>::call_RUT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType j = k - 1; j >= 0; --j) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto priority = (j == k - 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -37,11 +37,11 @@ namespace solver {
 namespace internal {
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+                    OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -55,11 +55,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
 
 namespace triangular_llt {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Op op, blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -73,11 +73,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
 
 namespace triangular_lun {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+                    OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -91,11 +91,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
 
 namespace triangular_lut {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Op op, blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -109,11 +109,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
 
 namespace triangular_rln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+                    OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -127,11 +127,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
 
 namespace triangular_rlt {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Op op, blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -145,11 +145,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
 
 namespace triangular_run {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+                    OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -163,11 +163,11 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
 
 namespace triangular_rut {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(blas::Op op, blas::Diag diag, T alpha, InSender&& in_tile, OutSender&& out_tile) {
+void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(hpx::threads::thread_priority::high)) |
-      hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -193,8 +193,8 @@ void Triangular<backend, device, T>::call_LLN(blas::Diag diag, T alpha, Matrix<c
       auto kj = LocalTileIndex{k, j};
 
       // Triangular solve of k-th row Panel of B
-      trsmBPanelTile<backend>(diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(kj));
+      trsmBPanelTile<backend>(thread_priority::high, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(kj));
 
       for (SizeType i = k + 1; i < m; ++i) {
         // Choose queue priority
@@ -223,8 +223,8 @@ void Triangular<backend, device, T>::call_LLT(blas::Op op, blas::Diag diag, T al
     for (SizeType j = n - 1; j >= 0; --j) {
       auto kj = LocalTileIndex{k, j};
       // Triangular solve of k-th row Panel of B
-      trsmBPanelTile<backend>(op, diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(kj));
+      trsmBPanelTile<backend>(thread_priority::high, op, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(kj));
 
       for (SizeType i = k - 1; i >= 0; --i) {
         // Choose queue priority
@@ -254,8 +254,8 @@ void Triangular<backend, device, T>::call_LUN(blas::Diag diag, T alpha, Matrix<c
     for (SizeType j = n - 1; j >= 0; --j) {
       auto kj = LocalTileIndex{k, j};
       // Triangular solve of k-th row Panel of B
-      trsmBPanelTile<backend>(diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(kj));
+      trsmBPanelTile<backend>(thread_priority::high, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(kj));
 
       for (SizeType i = k - 1; i >= 0; --i) {
         // Choose queue priority
@@ -284,8 +284,8 @@ void Triangular<backend, device, T>::call_LUT(blas::Op op, blas::Diag diag, T al
       auto kj = LocalTileIndex{k, j};
 
       // Triangular solve of k-th row Panel of B
-      trsmBPanelTile<backend>(op, diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(kj));
+      trsmBPanelTile<backend>(thread_priority::high, op, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(kj));
 
       for (SizeType i = k + 1; i < m; ++i) {
         // Choose queue priority
@@ -315,8 +315,8 @@ void Triangular<backend, device, T>::call_RLN(blas::Diag diag, T alpha, Matrix<c
       auto ik = LocalTileIndex{i, k};
 
       // Triangular solve of k-th col Panel of B
-      trsmBPanelTile<backend>(diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(ik));
+      trsmBPanelTile<backend>(thread_priority::high, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(ik));
 
       for (SizeType j = k - 1; j >= 0; --j) {
         // Choose queue priority
@@ -345,8 +345,8 @@ void Triangular<backend, device, T>::call_RLT(blas::Op op, blas::Diag diag, T al
       auto ik = LocalTileIndex{i, k};
 
       // Triangular solve of k-th col Panel of B
-      trsmBPanelTile<backend>(op, diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(ik));
+      trsmBPanelTile<backend>(thread_priority::high, op, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(ik));
 
       for (SizeType j = k + 1; j < n; ++j) {
         // Choose queue priority
@@ -376,8 +376,8 @@ void Triangular<backend, device, T>::call_RUN(blas::Diag diag, T alpha, Matrix<c
       auto ik = LocalTileIndex{i, k};
 
       // Triangular solve of k-th col Panel of B
-      trsmBPanelTile<backend>(diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(ik));
+      trsmBPanelTile<backend>(thread_priority::high, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(ik));
 
       for (SizeType j = k + 1; j < n; ++j) {
         // Choose queue priority
@@ -406,8 +406,8 @@ void Triangular<backend, device, T>::call_RUT(blas::Op op, blas::Diag diag, T al
       auto ik = LocalTileIndex{i, k};
 
       // Triangular solve of k-th col Panel of B
-      trsmBPanelTile<backend>(op, diag, alpha, mat_a.read_sender(LocalTileIndex{k, k}),
-                              mat_b.readwrite_sender(ik));
+      trsmBPanelTile<backend>(thread_priority::high, op, diag, alpha,
+                              mat_a.read_sender(LocalTileIndex{k, k}), mat_b.readwrite_sender(ik));
 
       for (SizeType j = k - 1; j >= 0; --j) {
         // Choose queue priority
@@ -486,7 +486,8 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
         const LocalTileIndex kj(k_local_row, j_local);
         const LocalTileIndex kj_panel(Coord::Col, j_local);
 
-        trsmBPanelTile<backend>(diag, alpha, a_panel.read_sender(kk_panel), mat_b.readwrite_sender(kj));
+        trsmBPanelTile<backend>(thread_priority::high, diag, alpha, a_panel.read_sender(kk_panel),
+                                mat_b.readwrite_sender(kj));
         b_panel.setTile(kj_panel, mat_b.read(kj));
       }
     }
@@ -578,7 +579,8 @@ void Triangular<backend, device, T>::call_LUN(comm::CommunicatorGrid grid, blas:
         const LocalTileIndex kj(k_local_row, j_local);
         const LocalTileIndex kj_panel(Coord::Col, j_local);
 
-        trsmBPanelTile<backend>(diag, alpha, a_panel.read_sender(kk_panel), mat_b.readwrite_sender(kj));
+        trsmBPanelTile<backend>(thread_priority::high, diag, alpha, a_panel.read_sender(kk_panel),
+                                mat_b.readwrite_sender(kj));
         b_panel.setTile(kj_panel, mat_b.read(kj));
       }
     }
@@ -670,7 +672,8 @@ void Triangular<backend, device, T>::call_RLN(comm::CommunicatorGrid grid, blas:
         const LocalTileIndex ik(i_local, k_local_col);
         const LocalTileIndex ik_panel(Coord::Row, i_local);
 
-        trsmBPanelTile<backend>(diag, alpha, a_panel.read_sender(kk_panel), mat_b.readwrite_sender(ik));
+        trsmBPanelTile<backend>(thread_priority::high, diag, alpha, a_panel.read_sender(kk_panel),
+                                mat_b.readwrite_sender(ik));
         b_panel.setTile(ik_panel, mat_b.read(ik));
       }
     }
@@ -763,7 +766,8 @@ void Triangular<backend, device, T>::call_RUN(comm::CommunicatorGrid grid, blas:
         const LocalTileIndex ik(i_local, k_local_col);
         const LocalTileIndex ik_panel(Coord::Row, i_local);
 
-        trsmBPanelTile<backend>(diag, alpha, a_panel.read_sender(kk_panel), mat_b.readwrite_sender(ik));
+        trsmBPanelTile<backend>(thread_priority::high, diag, alpha, a_panel.read_sender(kk_panel),
+                                mat_b.readwrite_sender(ik));
         b_panel.setTile(ik_panel, mat_b.read(ik));
       }
     }

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -198,11 +198,11 @@ void Triangular<backend, device, T>::call_LLN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType i = k + 1; i < m; ++i) {
         // Choose queue priority
-        const auto priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, beta, mat_a.read_sender(LocalTileIndex{i, k}),
+        gemmTrailingMatrixTile<backend>(trailing_priority, beta, mat_a.read_sender(LocalTileIndex{i, k}),
                                         mat_b.read_sender(kj),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
@@ -228,13 +228,13 @@ void Triangular<backend, device, T>::call_LLT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType i = k - 1; i >= 0; --i) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
 
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, op, beta, mat_a.read_sender(LocalTileIndex{k, i}),
-                                        mat_b.read_sender(kj),
+        gemmTrailingMatrixTile<backend>(trailing_priority, op, beta,
+                                        mat_a.read_sender(LocalTileIndex{k, i}), mat_b.read_sender(kj),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
     }
@@ -259,10 +259,10 @@ void Triangular<backend, device, T>::call_LUN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType i = k - 1; i >= 0; --i) {
         // Choose queue priority
-        const auto priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, beta, mat_a.read_sender(LocalTileIndex{i, k}),
+        gemmTrailingMatrixTile<backend>(trailing_priority, beta, mat_a.read_sender(LocalTileIndex{i, k}),
                                         mat_b.read_sender(kj),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
@@ -289,12 +289,12 @@ void Triangular<backend, device, T>::call_LUT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType i = k + 1; i < m; ++i) {
         // Choose queue priority
-        const auto priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, op, beta, mat_a.read_sender(LocalTileIndex{k, i}),
-                                        mat_b.read_sender(kj),
+        gemmTrailingMatrixTile<backend>(trailing_priority, op, beta,
+                                        mat_a.read_sender(LocalTileIndex{k, i}), mat_b.read_sender(kj),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
     }
@@ -320,10 +320,10 @@ void Triangular<backend, device, T>::call_RLN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType j = k - 1; j >= 0; --j) {
         // Choose queue priority
-        const auto priority = (j == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (j == k - 1) ? thread_priority::high : thread_priority::normal;
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, beta, mat_b.read_sender(ik),
+        gemmTrailingMatrixTile<backend>(trailing_priority, beta, mat_b.read_sender(ik),
                                         mat_a.read_sender(LocalTileIndex{k, j}),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
@@ -350,11 +350,11 @@ void Triangular<backend, device, T>::call_RLT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType j = k + 1; j < n; ++j) {
         // Choose queue priority
-        const auto priority = (j == k + 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (j == k + 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, op, beta, mat_b.read_sender(ik),
+        gemmTrailingMatrixTile<backend>(trailing_priority, op, beta, mat_b.read_sender(ik),
                                         mat_a.read_sender(LocalTileIndex{j, k}),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
@@ -381,10 +381,10 @@ void Triangular<backend, device, T>::call_RUN(blas::Diag diag, T alpha, Matrix<c
 
       for (SizeType j = k + 1; j < n; ++j) {
         // Choose queue priority
-        const auto priority = (j == k + 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (j == k + 1) ? thread_priority::high : thread_priority::normal;
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, beta, mat_b.read_sender(ik),
+        gemmTrailingMatrixTile<backend>(trailing_priority, beta, mat_b.read_sender(ik),
                                         mat_a.read_sender(LocalTileIndex{k, j}),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
@@ -411,11 +411,11 @@ void Triangular<backend, device, T>::call_RUT(blas::Op op, blas::Diag diag, T al
 
       for (SizeType j = k - 1; j >= 0; --j) {
         // Choose queue priority
-        const auto priority = (j == k - 1) ? thread_priority::high : thread_priority::normal;
+        const auto trailing_priority = (j == k - 1) ? thread_priority::high : thread_priority::normal;
 
         auto beta = static_cast<T>(-1.0) / alpha;
         // Update trailing matrix
-        gemmTrailingMatrixTile<backend>(priority, op, beta, mat_b.read_sender(ik),
+        gemmTrailingMatrixTile<backend>(trailing_priority, op, beta, mat_b.read_sender(ik),
                                         mat_a.read_sender(LocalTileIndex{j, k}),
                                         mat_b.readwrite_sender(LocalTileIndex{i, j}));
       }
@@ -499,7 +499,7 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
     for (SizeType i_local = bt_offset.row(); i_local < distr_a.localNrTiles().rows(); ++i_local) {
       // Choose queue priority
       auto i = distr_a.globalTileFromLocalTile<Coord::Row>(i_local);
-      const auto trailing_priority = (i == k - 1) ? thread_priority::high : thread_priority::normal;
+      const auto trailing_priority = (i == k + 1) ? thread_priority::high : thread_priority::normal;
 
       const LocalTileIndex ik_panel(Coord::Row, i_local);
 

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -140,14 +140,14 @@ public:
 template <class T, class ExecutorOrPolicy>
 void set0(ExecutorOrPolicy ex, Matrix<T, Device::CPU>& matrix) {
   for (const auto& idx : iterate_range2d(matrix.distribution().localNrTiles()))
-    matrix(idx).then(ex, hpx::unwrapping(tile::set0<T>));
+    matrix(idx).then(ex, hpx::unwrapping(tile::internal::set0_o));
 }
 
 /// Sets all the elements of all the tiles in the active range to zero
 template <class T, Coord axis, class ExecutorOrPolicy>
 void set0(ExecutorOrPolicy ex, Panel<axis, T, Device::CPU>& panel) {
   for (const auto& tile_idx : panel.iteratorLocal())
-    panel(tile_idx).then(ex, hpx::unwrapping(tile::set0<T>));
+    panel(tile_idx).then(ex, hpx::unwrapping(tile::internal::set0_o));
 }
 
 /// Set the elements of the matrix.

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -32,7 +32,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     # https://github.com/eth-cscs/DLA-Future/issues/420
     conflicts("umpire@6:")
 
-    depends_on("hpx cxxstd=14 networking=none +async_mpi")
+    depends_on("hpx cxxstd=17 networking=none +async_mpi")
     depends_on("hpx@1.7.0:")
     depends_on("hpx +cuda", when="+cuda")
 

--- a/test/include/dlaf_test/matrix/util_matrix_local.h
+++ b/test/include/dlaf_test/matrix/util_matrix_local.h
@@ -96,7 +96,7 @@ MatrixLocal<T> allGather(lapack::MatrixType mat_type, Matrix<const T, Device::CP
 
     auto& dest_tile = dest.tile(ij_tile);
     const auto& source_tile = source.read(ij_tile).get();
-    copy(source_tile, dest_tile);
+    matrix::internal::copy(source_tile, dest_tile);
   }
 
   return MatrixLocal<T>(std::move(dest));
@@ -127,7 +127,7 @@ MatrixLocal<T> allGather(lapack::MatrixType mat_type, Matrix<const T, Device::CP
     if (owner == rank) {
       const auto& source_tile = source.read(ij_tile).get();
       comm::sync::broadcast::send(comm_grid.fullCommunicator(), source_tile);
-      copy(source_tile, dest_tile);
+      matrix::internal::copy(source_tile, dest_tile);
     }
     else {
       comm::sync::broadcast::receive_from(comm_grid.rankFullCommunicator(owner),

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -106,7 +106,7 @@ struct CreateTile<T, Device::GPU> {
                                            const SizeType ld) {
     auto tile_host = CreateTile<T, Device::CPU>::createAndSet(val, size, ld);
     auto tile = createTile<std::remove_const_t<T>, Device::GPU>(size, ld);
-    copy(tile_host, tile);
+    dlaf::matrix::internal::copy(tile_host, tile);
     return Tile<T, Device::GPU>(std::move(tile));
   }
 };
@@ -179,7 +179,7 @@ template <class T, class ElementGetter, class ComparisonOp, class ErrorMessageGe
 void check(ElementGetter&& expected, const Tile<const T, Device::GPU>& tile, ComparisonOp comp,
            ErrorMessageGetter err_message, const char* file, const int line) {
   auto tile_host = createTile<std::remove_const_t<T>, Device::CPU>(tile.size(), tile.ld());
-  copy(tile, tile_host);
+  dlaf::matrix::internal::copy(tile, tile_host);
   check(std::forward<ElementGetter>(expected), tile_host, comp, err_message, file, line);
 }
 #endif

--- a/test/unit/communication/test_comm_executor.cpp
+++ b/test/unit/communication/test_comm_executor.cpp
@@ -9,6 +9,8 @@
 //
 
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
+
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -184,7 +184,7 @@ void testBacktransformationEigenv(comm::CommunicatorGrid grid, SizeType m, SizeT
   // Reset diagonal and upper values of V
   for (const auto& ij_tile : iterate_range2d(mat_v_loc.nrTiles())) {
     if (ij_tile.row() == ij_tile.col() + 1)
-      tile::laset<T>(lapack::MatrixType::Upper, 0.f, 1.f, mat_v_loc.tile(ij_tile));
+      tile::internal::laset<T>(lapack::MatrixType::Upper, 0.f, 1.f, mat_v_loc.tile(ij_tile));
   }
 
   common::internal::vector<hpx::shared_future<common::internal::vector<T>>> taus;

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -95,7 +95,7 @@ void testBacktransformationEigenv(SizeType m, SizeType n, SizeType mb, SizeType 
     const auto& source_tile = mat_v.read(ij_tile).get();
     copy(source_tile, v.tile(ij_tile));
     if (ij_tile.row() == ij_tile.col() + 1)
-      tile::laset<T>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij_tile));
+      tile::internal::laset<T>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij_tile));
   }
 
   // Create C local

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -125,8 +125,8 @@ void setupHermitianBand(MatrixLocal<T>& matrix, const SizeType& band_size) {
       if (!ij.isIn(matrix.nrTiles()))
         continue;
 
-      tile::set0(matrix.tile(ij));
-      tile::set0(matrix.tile(common::transposed(ij)));
+      tile::internal::set0(matrix.tile(ij));
+      tile::internal::set0(matrix.tile(common::transposed(ij)));
     }
   }
 

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -149,7 +149,7 @@ void splitReflectorsAndBand(MatrixLocal<T>& mat_v, MatrixLocal<T>& mat_b, const 
   for (SizeType diag = 0; diag <= 1; ++diag) {
     for (SizeType i = diag; i < mat_v.nrTiles().rows(); ++i) {
       const GlobalTileIndex idx(i, i - diag);
-      copy(mat_v.tile(idx), mat_b.tile(idx));
+      matrix::internal::copy(mat_v.tile(idx), mat_b.tile(idx));
     }
   }
 

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -267,7 +267,7 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessLocal) {
     for (const auto& ij_tile : iterate_range2d(v.nrTiles())) {
       // copy only the panel
       const auto& source_tile = v_input.read(ij_tile + v_offset).get();
-      copy(source_tile, v.tile(ij_tile));
+      matrix::internal::copy(source_tile, v.tile(ij_tile));
       if (ij_tile.row() == 0)
         tile::internal::laset<TypeParam>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij_tile));
     }
@@ -353,7 +353,7 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessDistributed) {
         // copy only the panel
         const GlobalTileSize v_offset{v_start.row(), v_start.col()};
         for (const auto& ij : iterate_range2d(v.nrTiles())) {
-          copy(a.tile_read(ij + v_offset), v.tile(ij));
+          matrix::internal::copy(a.tile_read(ij + v_offset), v.tile(ij));
           if (ij.row() == 0)
             tile::internal::laset<TypeParam>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij));
         }

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -269,7 +269,7 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessLocal) {
       const auto& source_tile = v_input.read(ij_tile + v_offset).get();
       copy(source_tile, v.tile(ij_tile));
       if (ij_tile.row() == 0)
-        tile::laset<TypeParam>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij_tile));
+        tile::internal::laset<TypeParam>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij_tile));
     }
 
     auto tmp = computeHAndTFactor(k, v);
@@ -355,7 +355,7 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessDistributed) {
         for (const auto& ij : iterate_range2d(v.nrTiles())) {
           copy(a.tile_read(ij + v_offset), v.tile(ij));
           if (ij.row() == 0)
-            tile::laset<TypeParam>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij));
+            tile::internal::laset<TypeParam>(lapack::MatrixType::Upper, 0.f, 1.f, v.tile(ij));
         }
 
         return v;

--- a/test/unit/matrix/test_matrix_mirror.cpp
+++ b/test/unit/matrix/test_matrix_mirror.cpp
@@ -98,14 +98,14 @@ void copyTest(CommunicatorGrid const& comm_grid, TestSizes const& test) {
   set(mat_source_cpu, el);
 
   Matrix<T, Source> mat(size, test.block_size, comm_grid);
-  copy(mat_source_cpu, mat);
+  matrix::copy(mat_source_cpu, mat);
 
   {
     MatrixMirror<T, Target, Source> mat_mirror(mat);
 
     copy(mat, mat_source_cpu);
     CHECK_MATRIX_EQ(el, mat_source_cpu);
-    copy(mat_mirror.get(), mat_target_cpu);
+    matrix::copy(mat_mirror.get(), mat_target_cpu);
     CHECK_MATRIX_EQ(el, mat_target_cpu);
 
     offset = 1.0;

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -227,7 +227,7 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
   static_assert(coord1D == decltype(panel)::CoordType, "coord types mismatch");
 
   auto setTile = [](const auto& tile, TypeParam value) noexcept {
-    tile::laset(lapack::MatrixType::General, value, value, tile);
+    tile::internal::laset(lapack::MatrixType::General, value, value, tile);
   };
 
   auto setAndCheck = [=, &matrix, &panel](std::string msg, SizeType head_loc, SizeType tail_loc) {

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -245,7 +245,7 @@ void testSet0(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
     panel.setRange(GlobalTileIndex(coord1D, head), GlobalTileIndex(coord1D, tail));
 
     for (const auto& idx : panel.iteratorLocal())
-      hpx::dataflow(hpx::unwrapping(tile::laset<TypeParam>), lapack::MatrixType::General, 1, 1,
+      hpx::dataflow(hpx::unwrapping(tile::internal::laset_o), lapack::MatrixType::General, TypeParam(1), TypeParam(1),
                     panel(idx));
 
     matrix::util::set0(hpx::launch::sync, panel);

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -245,8 +245,8 @@ void testSet0(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
     panel.setRange(GlobalTileIndex(coord1D, head), GlobalTileIndex(coord1D, tail));
 
     for (const auto& idx : panel.iteratorLocal())
-      hpx::dataflow(hpx::unwrapping(tile::internal::laset_o), lapack::MatrixType::General, TypeParam(1), TypeParam(1),
-                    panel(idx));
+      hpx::dataflow(hpx::unwrapping(tile::internal::laset_o), lapack::MatrixType::General, TypeParam(1),
+                    TypeParam(1), panel(idx));
 
     matrix::util::set0(hpx::launch::sync, panel);
 

--- a/test/unit/test_blas_tile/test_gemm.h
+++ b/test/unit/test_blas_tile/test_gemm.h
@@ -80,7 +80,7 @@ void testGemm(const blas::Op op_a, const blas::Op op_b, const SizeType m, const 
   auto b = createTile<CT, D>(el_op_b, size_b, ldb, op_b);
   auto c = createTile<T, D>(el_c, size_c, ldc);
 
-  invokeBlas<D>(tile::gemm_o, op_a, op_b, alpha, a, b, beta, c);
+  invokeBlas<D>(tile::internal::gemm_o, op_a, op_b, alpha, a, b, beta, c);
 
   std::stringstream s;
   s << "GEMM: " << op_a << ", " << op_b;

--- a/test/unit/test_blas_tile/test_hemm.h
+++ b/test/unit/test_blas_tile/test_hemm.h
@@ -114,7 +114,7 @@ void testHemm(const blas::Side side, const blas::Uplo uplo, const SizeType m, co
   auto b = createTile<CT, D>(el_b, size_b, ldb);
   auto c = createTile<T, D>(el_c, size_c, ldc);
 
-  invokeBlas<D>(tile::hemm_o, side, uplo, alpha, a, b, beta, c);
+  invokeBlas<D>(tile::internal::hemm_o, side, uplo, alpha, a, b, beta, c);
 
   std::stringstream s;
   s << "HEMM: " << side << ", " << uplo;

--- a/test/unit/test_blas_tile/test_her2k.h
+++ b/test/unit/test_blas_tile/test_her2k.h
@@ -87,7 +87,7 @@ void testHer2k(const blas::Uplo uplo, const blas::Op op, const SizeType n, const
   auto b = createTile<CT, D>(el_op_b, size_b, ldb, op);
   auto c = createTile<T, D>(el_c, size_c, ldc);
 
-  invokeBlas<D>(tile::her2k_o, uplo, op, alpha, a, b, beta, c);
+  invokeBlas<D>(tile::internal::her2k_o, uplo, op, alpha, a, b, beta, c);
 
   std::stringstream s;
   s << "HER2K: " << uplo << ", " << op;

--- a/test/unit/test_blas_tile/test_herk.h
+++ b/test/unit/test_blas_tile/test_herk.h
@@ -74,7 +74,7 @@ void testHerk(const blas::Uplo uplo, const blas::Op op_a, const SizeType n, cons
   auto a = createTile<CT, D>(el_op_a, size_a, lda, op_a);
   auto c = createTile<T, D>(el_c, size_c, ldc);
 
-  invokeBlas<D>(tile::herk_o, uplo, op_a, alpha, a, beta, c);
+  invokeBlas<D>(tile::internal::herk_o, uplo, op_a, alpha, a, beta, c);
 
   std::stringstream s;
   s << "HERK: " << uplo << ", " << op_a;

--- a/test/unit/test_blas_tile/test_trmm.h
+++ b/test/unit/test_blas_tile/test_trmm.h
@@ -53,7 +53,7 @@ void testTrmm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, c
   auto a = createTile<CT, D>(el_op_a, size_a, lda, op);
   auto b = createTile<T, D>(el_b, size_b, ldb);
 
-  invokeBlas<D>(tile::trmm_o, side, uplo, op, diag, alpha, a, b);
+  invokeBlas<D>(tile::internal::trmm_o, side, uplo, op, diag, alpha, a, b);
 
   std::stringstream s;
   s << "TRMM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n

--- a/test/unit/test_blas_tile/test_trsm.h
+++ b/test/unit/test_blas_tile/test_trsm.h
@@ -53,7 +53,7 @@ void testTrsm(const blas::Side side, const blas::Uplo uplo, const blas::Op op, c
   auto a = createTile<CT, D>(el_op_a, size_a, lda, op);
   auto b = createTile<T, D>(el_b, size_b, ldb);
 
-  invokeBlas<D>(tile::trsm_o, side, uplo, op, diag, alpha, a, b);
+  invokeBlas<D>(tile::internal::trsm_o, side, uplo, op, diag, alpha, a, b);
 
   std::stringstream s;
   s << "TRSM: " << side << ", " << uplo << ", " << op << ", " << diag << ", m = " << m << ", n = " << n

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -222,7 +222,7 @@ TYPED_TEST(TileOperationsTestMC, Lacpy) {
   TileElementIndex out_idx(2, 3);
   Tile_t out_tile = createTile<Scalar>([](TileElementIndex) { return 2; }, TileElementSize(7, 7), 7);
 
-  tile::internal::lacpy(region, in_idx, in_tile, out_idx, out_tile);
+  tile::lacpy(region, in_idx, in_tile, out_idx, out_tile);
 
   double eps = std::numeric_limits<double>::epsilon();
 

--- a/test/unit/test_lapack_tile.cpp
+++ b/test/unit/test_lapack_tile.cpp
@@ -222,7 +222,7 @@ TYPED_TEST(TileOperationsTestMC, Lacpy) {
   TileElementIndex out_idx(2, 3);
   Tile_t out_tile = createTile<Scalar>([](TileElementIndex) { return 2; }, TileElementSize(7, 7), 7);
 
-  tile::lacpy(region, in_idx, in_tile, out_idx, out_tile);
+  tile::internal::lacpy(region, in_idx, in_tile, out_idx, out_tile);
 
   double eps = std::numeric_limits<double>::epsilon();
 
@@ -270,7 +270,7 @@ TYPED_TEST(TileOperationsTestMC, Laset) {
 
       auto tile = createTile<TypeParam>(el, TileElementSize(m, n), lda);
 
-      tile::laset<TypeParam>(mtype, alpha, beta, tile);
+      tile::internal::laset<TypeParam>(mtype, alpha, beta, tile);
       CHECK_TILE_EQ(res, tile);
     }
   }
@@ -288,7 +288,7 @@ TYPED_TEST(TileOperationsTestMC, Set0) {
 
     auto res = [](const TileElementIndex&) { return TypeUtilities<TypeParam>::element(0.0, 0.0); };
 
-    tile::set0(tile);
+    tile::internal::set0(tile);
     CHECK_TILE_EQ(res, tile);
   }
 }

--- a/test/unit/test_lapack_tile/test_hegst.h
+++ b/test/unit/test_lapack_tile/test_hegst.h
@@ -43,7 +43,7 @@ void testHegst(const int itype, const blas::Uplo uplo, const SizeType m, const S
   auto a = createTile<T, D>(el_a, size, lda);
   auto t = createTile<T, D>(el_t, size, ldb);
 
-  invokeLapack<D>(tile::hegst_o, itype, uplo, a, t);
+  invokeLapack<D>(tile::internal::hegst_o, itype, uplo, a, t);
 
   std::stringstream s;
   s << "HEGST: itype = " << itype << ", uplo = " << uplo;

--- a/test/unit/test_lapack_tile/test_lange.h
+++ b/test/unit/test_lapack_tile/test_lange.h
@@ -32,7 +32,7 @@ using dlaf::TileElementIndex;
 using dlaf::Device;
 using dlaf::matrix::Tile;
 
-using dlaf::tile::lange;
+using dlaf::tile::internal::lange;
 using dlaf::matrix::test::set;
 
 template <class T>

--- a/test/unit/test_lapack_tile/test_lantr.h
+++ b/test/unit/test_lapack_tile/test_lantr.h
@@ -31,7 +31,7 @@ using dlaf::TileElementIndex;
 using dlaf::Device;
 using dlaf::matrix::Tile;
 
-using dlaf::tile::lantr;
+using dlaf::tile::internal::lantr;
 using dlaf::matrix::test::set;
 
 template <class T>

--- a/test/unit/test_lapack_tile/test_potrf.h
+++ b/test/unit/test_lapack_tile/test_potrf.h
@@ -39,10 +39,10 @@ void testPotrf(const blas::Uplo uplo, const SizeType n, const SizeType extra_lda
   auto a = createTile<T, D>(el_a, size_a, lda);
 
   if (return_info) {
-    EXPECT_EQ(0, invokeLapackInfo<D>(tile::potrfInfo_o, uplo, a));
+    EXPECT_EQ(0, invokeLapackInfo<D>(tile::internal::potrfInfo_o, uplo, a));
   }
   else {
-    invokeLapack<D>(tile::potrf_o, uplo, a);
+    invokeLapack<D>(tile::internal::potrf_o, uplo, a);
   }
 
   std::stringstream s;
@@ -65,7 +65,7 @@ void testPotrfNonPosDef(const blas::Uplo uplo, SizeType n, SizeType extra_lda) {
 
   auto a = createTile<T, D>(el_a, size_a, lda);
 
-  auto info = invokeLapackInfo<D>(tile::potrfInfo_o, uplo, a);
+  auto info = invokeLapackInfo<D>(tile::internal::potrfInfo_o, uplo, a);
 
   std::stringstream s;
   s << "POTRF Non Positive Definite: " << uplo;


### PR DESCRIPTION
~This is not meant to be anywhere near complete. It mostly contains a bunch of TODOs and notes for myself about what needs/can be adapted where. However, I'm opening this to start exposing others to the sender/receiver interfaces, and try to collect feedback on what sort of utilities/interfaces/functionality is useful/acceptable/harmful in your opinion.~

I've changed the gemm task in one of the triangular solver implementations to use senders/receivers and it passes tests.

I see two primary benefits to using senders/receivers in DLAF:
- More flexible sender/receiver customization points should allow us to remove some of the hacks currently in place e.g. for tile lifetime management, which can with senders/receivers be managed in real customization points, rather than our ad-hoc `dataflow_finalize`.
- Potential optimizations when chaining work (I think there are actually very few, if no cases where this applies in DLAF), and potentially fewer heap allocations (although dataflow already does a decent job of this).

Short summary of the "sender adapters" that appear here:
- `template <Backend B, typename Sender> auto transform(Sender&& sender) {...}`: this is a backend-specific version of `future::then(executor, ...)`/`dataflow(executor, ...)`/`execution::transform` (the last one is from P1897). The reason it does not take an executor/scheduler/policy or similar is that the current proposals don't really talk about the kind of customization we want to do (inserting cuda streams etc.) and what is there is semantically a bit shaky/bound to change at least for this use case. The custom CUDA/MPI executors are already a bit questionable.
- `keep_future`: currently the default behaviour of a future as a sender is to get the value from the future and pass that to the continuation. `keep_future` is an alternative which passes the future itself, similar to how `future::then` takes a callable which takes a future as its argument. We might swap the default to be the `keep_future` behaviour. This functionality is mostly intended for the transition phase from futures to senders, and should not be needed in the end.
- `when_all_lift`: P1897 proposes a `when_all` that takes a pack of senders and triggers a continuation when all the input senders are done. However, it takes *only* senders, which means that if one has ready values one would have to wrap them in `execution::just` (this is equivalent to how one would have to do `dataflow(f, make_ready_future(3))` if dataflow only supported futures as arguments). It would be nice if the proposed `when_all` was a bit more flexible in this regard (including accepting void senders), and we'll follow up on that. If the standard `when_all` ends up accepting only senders, this is still a useful extension for HPX/DLAF.