### PR TITLE
Python scripts: plot customization

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -29,9 +29,9 @@ def _gen_nodes_plot(
         title:          title of the plot
         df:             the pandas.DataFrame with the data for the plot
         combine_mb:     bool indicates if different mb has to be included in the same plot
-        filts:          [regex] for matching benchmark names to filter from the plot
-        replaces:       [(regex_replace_rule, newtext)] to apply to benchmark names for the legend
-        styles:         [(regex, dict())] where dict() contains kwargs valid for the plot
+        filts:          list of regex for selecting benchmark names to plot
+        replaces:       list of (regex_replace_rule, newtext) to apply to benchmark names for the legend
+        styles:         list of (regex, dict()) where dict() contains kwargs valid for the plot
         subplot_args:   kwargs to pass to pyplot.subplots
         fill_area:      switch on/off the min-max area on plots
     """

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -11,7 +11,7 @@ from parse import parse
 
 sns.set_theme()
 
-# plt_type : ppn | time
+
 def _gen_nodes_plot(
     plt_type,
     title,
@@ -23,7 +23,18 @@ def _gen_nodes_plot(
     subplot_args=None,
     fill_area=True,
 ):
-
+    """
+    Args:
+        plt_type:       ppn | time
+        title:          title of the plot
+        df:             the pandas.DataFrame with the data for the plot
+        combine_mb:     group also by mb sizes
+        filts:          [regex] for matching benchmark names to filter from the plot
+        replaces:       [(regex_replace_rule, newtext)] to apply to benchmark names for the legend
+        styles:         [(regex, dict())] where dict() contains kwargs valid for the plot
+        subplot_args:   kwargs to pass to pyplot.subplots
+        fill_area:      switch on/off the min-max area on plots
+    """
     if subplot_args is None:
         subplot_args = dict()
     fig, ax = plt.subplots(**subplot_args)
@@ -321,7 +332,6 @@ def gen_chol_plots(
                 ax.set_xscale("log", base=2)
 
 
-# customize_* functions should accept fig and ax as parameters
 def gen_chol_plots_weak(
     df,
     weak_rt_approx,
@@ -332,6 +342,11 @@ def gen_chol_plots_weak(
     customize_time=None,
     **proxy_args,
 ):
+    """
+    Args:
+        customize_ppn:  function accepting the two arguments fig and ax for ppn plot customization
+        customize_time: function accepting the two arguments fig and ax for time plot customization
+    """
     df = df.assign(
         weak_rt=[
             int(round(x[0] / math.sqrt(x[1]) / weak_rt_approx)) * weak_rt_approx
@@ -380,10 +395,14 @@ def gen_chol_plots_weak(
             ax.set_yscale("log", base=10)
 
 
-# customize_* functions should accept fig and ax as parameters
 def gen_trsm_plots(
     df, logx=False, filename_suffix=None, customize_ppn=None, customize_time=None, **proxy_args,
 ):
+    """
+    Args:
+        customize_ppn:  function accepting the two arguments fig and ax for ppn plot customization
+        customize_time: function accepting the two arguments fig and ax for time plot customization
+    """
     for (m, n, mb), grp_data in df.groupby(["matrix_rows", "matrix_cols", "block_rows"]):
         title = f"TRSM: matrix_size = {m} x {n}, block_size = {mb} x {mb}"
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -12,10 +12,19 @@ from parse import parse
 sns.set_theme()
 
 # plt_type : ppn | time
-def _gen_nodes_plot(plt_type, title, df, combine_mb=False,
-        filts=None, replaces=None, styles=None, subplot_args=None):
+def _gen_nodes_plot(
+    plt_type,
+    title,
+    df,
+    combine_mb=False,
+    filts=None,
+    replaces=None,
+    styles=None,
+    subplot_args=None,
+):
 
-    if subplot_args is None: subplot_args = dict()
+    if subplot_args is None:
+        subplot_args = dict()
     fig, ax = plt.subplots(**subplot_args)
 
     if combine_mb:
@@ -44,16 +53,16 @@ def _gen_nodes_plot(plt_type, title, df, combine_mb=False,
 
         # setup style applying each config in order as they appear in the list
         # i.e. the last overwrites the first (in case of regex match)
-        bench_style = dict(linestyle='-', marker='.') # default style
+        bench_style = dict(linestyle="-", marker=".")  # default style
         if styles != None:
             for (bench_regex, style) in styles:
-                if re.search(bench_regex, bench_name): 
+                if re.search(bench_regex, bench_name):
                     bench_style |= style
 
         # benchmark name update happens just before plotting
 
         # remove routine prefix
-        bench_name = bench_name[bench_name.find("_") + 1:]
+        bench_name = bench_name[bench_name.find("_") + 1 :]
 
         # benchmark name replacement as specified by the user
         if replaces != None:
@@ -65,7 +74,7 @@ def _gen_nodes_plot(plt_type, title, df, combine_mb=False,
             lib_data[f"{plt_type}_mean"],
             label=bench_name,
             **bench_style,
-            )[0].get_color()
+        )[0].get_color()
         ax.fill_between(
             lib_data["nodes"],
             lib_data[f"{plt_type}_min"],
@@ -84,8 +93,8 @@ def _gen_nodes_plot(plt_type, title, df, combine_mb=False,
         nodes = df["nodes"].sort_values().unique()
         ax.set_xticks(nodes)
         ax.set_xticklabels([f"{x:d}" for x in nodes])
-        
-        ax.grid(axis='y', linewidth=0.5, alpha=0.5)
+
+        ax.grid(axis="y", linewidth=0.5, alpha=0.5)
 
     return fig, ax
 
@@ -111,11 +120,12 @@ class NodePlotWriter:
 
     See `_gen_nodes_plot` for details about parameters.
     """
+
     def __init__(self, filename, plt_type, title, df, **gen_plot_args):
         self.filename = filename
 
         self.fig, self.ax = _gen_nodes_plot(plt_type, title, df, **gen_plot_args)
-                   
+
     def __enter__(self):
         return (self.fig, self.ax)
 
@@ -182,9 +192,7 @@ def _parse_line_based(fout, bench_name, nodes):
         ]
         pstr_res = "[****] TIME(s) {time:g} : dtrsm PxQ= {grid_rows:d} {grid_cols:d} NB= {block_rows:d} N= {:d} : {perf:g} gflops"
     elif bench_name.startswith("chol_scalapack"):
-        pstr_arr = [
-          "PROBLEM PARAMETERS:"
-        ]
+        pstr_arr = ["PROBLEM PARAMETERS:"]
         pstr_res = "{time_ms:g}ms {perf:g}GFlop/s {matrix_rows:d} ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
     else:
         raise ValueError("Unknown bench_name: " + bench_name)
@@ -266,8 +274,15 @@ def calc_trsm_metrics(df):
 
 
 # customize_* functions should accept fig and ax as parameters
-def gen_chol_plots(df, logx=False, combine_mb=False, filename_suffix=None,
-        customize_ppn=None, customize_time=None, **proxy_args):
+def gen_chol_plots(
+    df,
+    logx=False,
+    combine_mb=False,
+    filename_suffix=None,
+    customize_ppn=None,
+    customize_time=None,
+    **proxy_args,
+):
     if combine_mb:
         it_space = df.groupby(["matrix_rows"])
     else:
@@ -291,20 +306,40 @@ def gen_chol_plots(df, logx=False, combine_mb=False, filename_suffix=None,
             filename_ppn += f"_{filename_suffix}"
             filename_time += f"_{filename_suffix}"
 
-        with NodePlotWriter(filename_ppn, "ppn", title, grp_data,
-                combine_mb=combine_mb, **proxy_args) as (fig, ax):
-            if customize_ppn: customize_ppn(fig, ax)
-            if logx: ax.set_xscale("log", base=2)
+        with NodePlotWriter(
+            filename_ppn, "ppn", title, grp_data, combine_mb=combine_mb, **proxy_args
+        ) as (fig, ax):
+            if customize_ppn:
+                customize_ppn(fig, ax)
+            if logx:
+                ax.set_xscale("log", base=2)
 
-        with NodePlotWriter(filename_time, "time", title, grp_data,
-                combine_mb=combine_mb, **proxy_args) as (fig, ax):
-            if customize_time: customize_time(fig, ax)
-            if logx: ax.set_xscale("log", base=2)
+        with NodePlotWriter(
+            filename_time, "time", title, grp_data, combine_mb=combine_mb, **proxy_args
+        ) as (fig, ax):
+            if customize_time:
+                customize_time(fig, ax)
+            if logx:
+                ax.set_xscale("log", base=2)
+
 
 # customize_* functions should accept fig and ax as parameters
-def gen_chol_plots_weak(df, weak_rt_approx, logx=False, combine_mb=False, filename_suffix=None,
-        customize_ppn=None, customize_time=None, **proxy_args):
-    df = df.assign(weak_rt=[int(round(x[0] / math.sqrt(x[1]) / weak_rt_approx)) * weak_rt_approx for x in zip(df['matrix_rows'], df['nodes'])])
+def gen_chol_plots_weak(
+    df,
+    weak_rt_approx,
+    logx=False,
+    combine_mb=False,
+    filename_suffix=None,
+    customize_ppn=None,
+    customize_time=None,
+    **proxy_args,
+):
+    df = df.assign(
+        weak_rt=[
+            int(round(x[0] / math.sqrt(x[1]) / weak_rt_approx)) * weak_rt_approx
+            for x in zip(df["matrix_rows"], df["nodes"])
+        ]
+    )
 
     if combine_mb:
         it_space = df.groupby(["weak_rt"])
@@ -329,22 +364,36 @@ def gen_chol_plots_weak(df, weak_rt_approx, logx=False, combine_mb=False, filena
             filename_ppn += f"_{filename_suffix}"
             filename_time += f"_{filename_suffix}"
 
-        with NodePlotWriter(filename_ppn, "ppn", title, grp_data,
-                combine_mb=combine_mb, **proxy_args) as (fig, ax):
-            if customize_ppn: customize_ppn(fig, ax)
-            if logx: ax.set_xscale("log", base=2)
+        with NodePlotWriter(
+            filename_ppn, "ppn", title, grp_data, combine_mb=combine_mb, **proxy_args
+        ) as (fig, ax):
+            if customize_ppn:
+                customize_ppn(fig, ax)
+            if logx:
+                ax.set_xscale("log", base=2)
 
-        with NodePlotWriter(filename_time, "time", title, grp_data,
-                combine_mb=combine_mb, **proxy_args) as (fig, ax):
-            if customize_time: customize_time(fig, ax)
-            if logx: ax.set_xscale("log", base=2)
+        with NodePlotWriter(
+            filename_time, "time", title, grp_data, combine_mb=combine_mb, **proxy_args
+        ) as (fig, ax):
+            if customize_time:
+                customize_time(fig, ax)
+            if logx:
+                ax.set_xscale("log", base=2)
             ax.set_yscale("log", base=10)
 
 
 # customize_* functions should accept fig and ax as parameters
-def gen_trsm_plots(df, logx=False, filename_suffix=None,
-        customize_ppn=None, customize_time=None, **proxy_args):
-    for (m, n, mb), grp_data in df.groupby(["matrix_rows", "matrix_cols", "block_rows"]):
+def gen_trsm_plots(
+    df,
+    logx=False,
+    filename_suffix=None,
+    customize_ppn=None,
+    customize_time=None,
+    **proxy_args,
+):
+    for (m, n, mb), grp_data in df.groupby(
+        ["matrix_rows", "matrix_cols", "block_rows"]
+    ):
         title = f"TRSM: matrix_size = {m} x {n}, block_size = {mb} x {mb}"
 
         filename_ppn = f"trsm_ppn_{m}_{n}_{mb}"
@@ -353,10 +402,20 @@ def gen_trsm_plots(df, logx=False, filename_suffix=None,
             filename_ppn += f"_{filename_suffix}"
             filename_time += f"_{filename_suffix}"
 
-        with NodePlotWriter("ppn", title, filename_ppn, grp_data, **proxy_args) as (fig, ax):
-            if customize_ppn: customize_ppn(fig, ax)
-            if logx: ax.set_xscale("log", base=2)
+        with NodePlotWriter("ppn", title, filename_ppn, grp_data, **proxy_args) as (
+            fig,
+            ax,
+        ):
+            if customize_ppn:
+                customize_ppn(fig, ax)
+            if logx:
+                ax.set_xscale("log", base=2)
 
-        with NodePlotWriter("time", title, filename_time, grp_data, **proxy_args) as (fig, ax):
-            if customize_time: customize_time(fig, ax)
-            if logx: ax.set_xscale("log", base=2)
+        with NodePlotWriter("time", title, filename_time, grp_data, **proxy_args) as (
+            fig,
+            ax,
+        ):
+            if customize_time:
+                customize_time(fig, ax)
+            if logx:
+                ax.set_xscale("log", base=2)

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -28,7 +28,7 @@ def _gen_nodes_plot(
         plt_type:       ppn | time
         title:          title of the plot
         df:             the pandas.DataFrame with the data for the plot
-        combine_mb:     group also by mb sizes
+        combine_mb:     bool indicates if different mb has to be included in the same plot
         filts:          [regex] for matching benchmark names to filter from the plot
         replaces:       [(regex_replace_rule, newtext)] to apply to benchmark names for the legend
         styles:         [(regex, dict())] where dict() contains kwargs valid for the plot

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -21,6 +21,7 @@ def _gen_nodes_plot(
     replaces=None,
     styles=None,
     subplot_args=None,
+    fill_area=True,
 ):
 
     if subplot_args is None:
@@ -75,13 +76,15 @@ def _gen_nodes_plot(
             label=bench_name,
             **bench_style,
         )[0].get_color()
-        ax.fill_between(
-            lib_data["nodes"],
-            lib_data[f"{plt_type}_min"],
-            lib_data[f"{plt_type}_max"],
-            alpha=0.2,
-            color=line_color,
-        )
+
+        if fill_area:
+            ax.fill_between(
+                    lib_data["nodes"],
+                    lib_data[f"{plt_type}_min"],
+                    lib_data[f"{plt_type}_max"],
+                    alpha=0.2,
+                    color=line_color,
+                    )
         plotted = True
 
     if plotted:

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -71,20 +71,17 @@ def _gen_nodes_plot(
                 bench_name = re.sub(replace[0], replace[1], bench_name)
 
         line_color = ax.plot(
-            lib_data["nodes"],
-            lib_data[f"{plt_type}_mean"],
-            label=bench_name,
-            **bench_style,
+            lib_data["nodes"], lib_data[f"{plt_type}_mean"], label=bench_name, **bench_style,
         )[0].get_color()
 
         if fill_area:
             ax.fill_between(
-                    lib_data["nodes"],
-                    lib_data[f"{plt_type}_min"],
-                    lib_data[f"{plt_type}_max"],
-                    alpha=0.2,
-                    color=line_color,
-                    )
+                lib_data["nodes"],
+                lib_data[f"{plt_type}_min"],
+                lib_data[f"{plt_type}_max"],
+                alpha=0.2,
+                color=line_color,
+            )
         plotted = True
 
     if plotted:
@@ -271,9 +268,7 @@ def calc_chol_metrics(df):
 
 
 def calc_trsm_metrics(df):
-    return _calc_metrics(
-        ["matrix_rows", "matrix_cols", "block_rows", "nodes", "bench_name"], df
-    )
+    return _calc_metrics(["matrix_rows", "matrix_cols", "block_rows", "nodes", "bench_name"], df)
 
 
 # customize_* functions should accept fig and ax as parameters
@@ -387,16 +382,9 @@ def gen_chol_plots_weak(
 
 # customize_* functions should accept fig and ax as parameters
 def gen_trsm_plots(
-    df,
-    logx=False,
-    filename_suffix=None,
-    customize_ppn=None,
-    customize_time=None,
-    **proxy_args,
+    df, logx=False, filename_suffix=None, customize_ppn=None, customize_time=None, **proxy_args,
 ):
-    for (m, n, mb), grp_data in df.groupby(
-        ["matrix_rows", "matrix_cols", "block_rows"]
-    ):
+    for (m, n, mb), grp_data in df.groupby(["matrix_rows", "matrix_cols", "block_rows"]):
         title = f"TRSM: matrix_size = {m} x {n}, block_size = {mb} x {mb}"
 
         filename_ppn = f"trsm_ppn_{m}_{n}_{mb}"


### PR DESCRIPTION
This PR slightly changes how internally plot generation works, introducing also some new features.

- `_gen_nodes_plot` now returns `(fig, ax)`. Its role is just generating plots, it does not save on file anymore;
- introduced `NodePlotWriter`, a generator that using the previous function, allow to customize the plots via returned `(fig, ax)` and on exit it writes to specified file
- existing specialized functions (e.g. `gen_chol_plots`), now accepts additional parameters `customize_ppn` and `customize_time` which are functions accepting `(fig, ax)` that are internally used (if set, they are optional), to customize the respective plots

Apart from being able to customize plots using `(fig, ax)`, other new features are that `_gen_nodes_plot` accepts:
- `subplots_args`: a dict with keywords to pass to `plt.subplots()` call (e.g. `gridspec_kw`)
- `styles`: a list with a structure similar to `filts` (i.e. `(regex, value)`), but accepting as values a dict with matplotlib styles for `plot` call (e.g. color, linewidth, ...)
- `fill_area`: enable/disable the min-max area plot

note: I gave a try to `black` for formatting the `postprocess.py` file (separate commit). let me know if you like it or not.