### PR TITLE
ExtraBuffers: a tool for increasing parallelization

### DIFF
--- a/include/dlaf/matrix/extra_buffers.h
+++ b/include/dlaf/matrix/extra_buffers.h
@@ -11,10 +11,12 @@
 #pragma once
 
 #include <blas.hh>
+#include <hpx/futures/future.hpp>
 #include <hpx/include/util.hpp>
 
 #include "dlaf/common/index2d.h"
 #include "dlaf/matrix/matrix.h"
+#include "dlaf/matrix/tile.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
 
@@ -22,26 +24,35 @@ namespace dlaf {
 namespace matrix {
 
 template <class T>
-struct ExtraBuffers {
-  ExtraBuffers(Matrix<T, Device::CPU>& mat, SizeType num_extra_buffers)
-      : num_extra_buffers_(num_extra_buffers), base_(mat),
-        extra_(LocalElementSize(mat.blockSize().rows() * num_extra_buffers, mat.blockSize().cols()),
-               mat.blockSize()) {
-    DLAF_ASSERT(mat.nrTiles().rows() == 1, mat.nrTiles());
-    DLAF_ASSERT(mat.nrTiles().cols() == 1, mat.nrTiles());
+class ExtraBuffers {
+  using tile_t = matrix::Tile<T, Device::CPU>;
+  using promise_t = hpx::lcos::local::promise<tile_t>;
+  using future_t = hpx::lcos::future<tile_t>;
+
+public:
+  // TODO check if there is a way to get blocksize info from the tile without asking to the user
+  ExtraBuffers(hpx::future<tile_t> tile, SizeType num_extra_buffers, TileElementSize tile_size)
+      : num_extra_buffers_(num_extra_buffers), orig_base_tile_(std::move(tile)),
+        extra_(LocalElementSize(tile_size.rows() * num_extra_buffers, tile_size.cols()), tile_size) {
     clear();
+    setup();
   }
 
-  auto get_buffer(const SizeType index) {
+  ~ExtraBuffers() {
+    DLAF_ASSERT(not orig_base_tile_.valid(),
+                "extra buffer must be reduced to release the original tile");
+  }
+
+  future_t get_buffer(const SizeType index) {
     const SizeType idx = num_extra_buffers_ != 0 ? index % (num_extra_buffers_ + 1) : 0;
     if (idx == 0)
-      return base_(LocalTileIndex(0, 0));
+      return get_base();
     else
       return extra_(LocalTileIndex(idx - 1, 0));
   }
 
-  void reduce() {
-    using hpx::util::unwrapping;
+  future_t reduce() {
+    using hpx::unwrapping;
     using hpx::util::annotated_function;
 
     for (const auto& idx_buffer : iterate_range2d(extra_.nrTiles()))
@@ -55,17 +66,60 @@ struct ExtraBuffers {
                         // clang-format on
                       }
                     }),
-                    base_(LocalTileIndex(0, 0)), extra_.read(idx_buffer));
+                    get_base(), extra_.read(idx_buffer));
+    return unlock_base();
   }
 
+  // TODO clear also base one
   void clear() {
     dlaf::matrix::util::set(extra_, [](...) { return 0; });
   }
 
-  const SizeType num_extra_buffers_;
-  Matrix<T, Device::CPU>& base_;
-  Matrix<T, Device::CPU> extra_;
-};
+  // TODO this may be useful for extrabuffers re-usage
+  // void set_base() {
+  //  // TODO check tile size
+  //  // unlock previous one, if set
+  //  // setup again
+  //}
 
+protected:
+  void setup() {
+    promise_t p;
+    base_tile_ = p.get_future();
+
+    orig_base_tile_ =
+        orig_base_tile_.then(hpx::launch::sync,
+                             hpx::unwrapping([p = std::move(p)](auto original_tile) mutable {
+                               auto memory_view_copy = original_tile.memory_view_;
+                               tile_t tile(original_tile.size_, std::move(memory_view_copy),
+                                           original_tile.ld_);
+                               tile.setPromise(std::move(p));
+                               // TODO exceptions: if I don't set promise values, I don't have to manage excpetions
+                               return std::move(original_tile);
+                             }));
+  }
+
+  future_t get_base() {
+    promise_t p;
+    future_t f = p.get_future();
+    std::swap(f, base_tile_);
+    return f.then(hpx::launch::sync, hpx::unwrapping([p = std::move(p)](auto tile) mutable {
+                    tile.setPromise(std::move(p));
+                    return std::move(tile);
+                  }));
+  }
+
+  future_t unlock_base() {
+    DLAF_ASSERT(orig_base_tile_.valid(), "");
+    return hpx::dataflow(hpx::unwrapping([](auto tile, auto) { return std::move(tile); }), std::move(orig_base_tile_),
+        std::move(base_tile_));
+  }
+
+  const SizeType num_extra_buffers_;
+  future_t orig_base_tile_;
+  Matrix<T, Device::CPU> extra_;
+
+  future_t base_tile_;
+};
 }
 }

--- a/include/dlaf/matrix/extra_buffers.h
+++ b/include/dlaf/matrix/extra_buffers.h
@@ -23,7 +23,7 @@ namespace matrix {
 
 template <class T>
 struct ExtraBuffers {
-  ExtraBuffers(Matrix<T, Device::CPU>& mat, std::size_t num_extra_buffers)
+  ExtraBuffers(Matrix<T, Device::CPU>& mat, SizeType num_extra_buffers)
       : num_extra_buffers_(num_extra_buffers), base_(mat),
         extra_(LocalElementSize(mat.blockSize().rows() * num_extra_buffers, mat.blockSize().cols()),
                mat.blockSize()) {
@@ -33,7 +33,7 @@ struct ExtraBuffers {
   }
 
   auto get_buffer(const SizeType index) {
-    const auto idx = num_extra_buffers_ != 0 ? index % num_extra_buffers_ : 0;
+    const SizeType idx = num_extra_buffers_ != 0 ? index % (num_extra_buffers_ + 1) : 0;
     if (idx == 0)
       return base_(LocalTileIndex(0, 0));
     else
@@ -62,7 +62,7 @@ struct ExtraBuffers {
     dlaf::matrix::util::set(extra_, [](...) { return 0; });
   }
 
-  std::size_t num_extra_buffers_;
+  const SizeType num_extra_buffers_;
   Matrix<T, Device::CPU>& base_;
   Matrix<T, Device::CPU> extra_;
 };

--- a/include/dlaf/matrix/extra_buffers.h
+++ b/include/dlaf/matrix/extra_buffers.h
@@ -1,0 +1,71 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <blas.hh>
+#include <hpx/include/util.hpp>
+
+#include "dlaf/common/index2d.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/types.h"
+#include "dlaf/util_matrix.h"
+
+namespace dlaf {
+namespace matrix {
+
+template <class T>
+struct ExtraBuffers {
+  ExtraBuffers(Matrix<T, Device::CPU>& mat, std::size_t num_extra_buffers)
+      : num_extra_buffers_(num_extra_buffers), base_(mat),
+        extra_(LocalElementSize(mat.blockSize().rows() * num_extra_buffers, mat.blockSize().cols()),
+               mat.blockSize()) {
+    DLAF_ASSERT(mat.nrTiles().rows() == 1, mat.nrTiles());
+    DLAF_ASSERT(mat.nrTiles().cols() == 1, mat.nrTiles());
+    clear();
+  }
+
+  auto get_buffer(const SizeType index) {
+    const auto idx = num_extra_buffers_ != 0 ? index % num_extra_buffers_ : 0;
+    if (idx == 0)
+      return base_(LocalTileIndex(0, 0));
+    else
+      return extra_(LocalTileIndex(idx - 1, 0));
+  }
+
+  void reduce() {
+    using hpx::util::unwrapping;
+    using hpx::util::annotated_function;
+
+    for (const auto& idx_buffer : iterate_range2d(extra_.nrTiles()))
+      hpx::dataflow(unwrapping([](auto&& tile_result, auto&& tile_extra) {
+                      for (SizeType j = 0; j < tile_result.size().cols(); ++j) {
+                        // clang-format off
+                        blas::axpy(
+                            tile_result.size().rows(), 1,
+                            tile_extra.ptr({0, j}), 1,
+                            tile_result.ptr({0, j}), 1);
+                        // clang-format on
+                      }
+                    }),
+                    base_(LocalTileIndex(0, 0)), extra_.read(idx_buffer));
+  }
+
+  void clear() {
+    dlaf::matrix::util::set(extra_, [](...) { return 0; });
+  }
+
+  std::size_t num_extra_buffers_;
+  Matrix<T, Device::CPU>& base_;
+  Matrix<T, Device::CPU> extra_;
+};
+
+}
+}

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -42,6 +42,9 @@ struct SubTileSpec {
 };
 
 // forward declarations
+template <class T>
+class ExtraBuffers;
+
 template <class T, Device device>
 class Tile;
 
@@ -246,6 +249,7 @@ class Tile : public Tile<const T, device> {
   using promise_t = hpx::lcos::local::promise<PT>;
 
   friend ConstTileType;
+  friend ExtraBuffers<T>;
   friend hpx::future<Tile<T, device>> internal::createSubTile<>(
       const hpx::shared_future<Tile<T, device>>& tile, const SubTileSpec& spec);
   friend hpx::shared_future<Tile<T, device>> internal::splitTileInsertFutureInChain<>(

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -80,3 +80,9 @@ DLAF_addTest(test_panel
   USE_MAIN MPIHPX
   MPIRANKS 6
 )
+
+DLAF_addTest(test_extra_buffers
+  SOURCES test_extra_buffers.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN HPX
+)

--- a/test/unit/matrix/test_extra_buffers.cpp
+++ b/test/unit/matrix/test_extra_buffers.cpp
@@ -34,11 +34,12 @@ TYPED_TEST_SUITE(ExtraBuffersTest, MatrixElementTypes);
 TYPED_TEST(ExtraBuffersTest, AccessBuffers) {
   using TypeUtils = TypeUtilities<TypeParam>;
 
-  Matrix<TypeParam, Device::CPU> matrix({1, 1}, {1, 1});
+  const TileElementSize blocksize(1, 1);
+  Matrix<TypeParam, Device::CPU> matrix({1, 1}, blocksize);
   matrix::test::set(matrix, [](auto&&) { return TypeUtils::element(1, 0); });
 
   const SizeType tot_buffers = 10;
-  ExtraBuffers<TypeParam> buffers(matrix, tot_buffers - 1);
+  ExtraBuffers<TypeParam> buffers(matrix(LocalTileIndex{0, 0}), tot_buffers - 1, blocksize);
 
   for (auto i = 0; i < tot_buffers; ++i) {
     buffers.get_buffer(i).then(hpx::unwrapping([i](const auto& tile) {
@@ -47,23 +48,57 @@ TYPED_TEST(ExtraBuffersTest, AccessBuffers) {
   }
 
   for (auto i = 0; i < tot_buffers; ++i) {
-    auto value_func = [i, tot_buffers](const TileElementIndex&) {
+    auto value_func = [i /*, tot_buffers*/](const TileElementIndex&) {
       return TypeUtils::element((i % tot_buffers), 0);
     };
     CHECK_TILE_EQ(std::move(value_func), buffers.get_buffer(i).get());
   }
+
+  buffers.reduce();
 }
 
-TYPED_TEST(ExtraBuffersTest, Basic) {
-  Matrix<TypeParam, Device::CPU> matrix({1, 1}, {1, 1});
-  matrix::test::set(matrix, [](auto&&){ return 1; });
+TYPED_TEST(ExtraBuffersTest, BasicUsage) {
+  const TileElementSize blocksize(1, 1);
+  Matrix<TypeParam, Device::CPU> matrix({1, 1}, blocksize);
+  matrix::test::set(matrix, [](auto&&) { return 1; });
 
-  ExtraBuffers<TypeParam> buffers(matrix, 2);
+  ExtraBuffers<TypeParam> buffers(matrix(LocalTileIndex{0, 0}), 2, blocksize);
 
   matrix::test::set(buffers.get_buffer(1).get(), [](auto&&) { return 3; });
   matrix::test::set(buffers.get_buffer(2).get(), [](auto&&) { return 5; });
 
   buffers.reduce();
 
-  CHECK_MATRIX_EQ([](const GlobalElementIndex&) { return TypeUtilities<TypeParam>::element(9, 0); }, matrix);
+  CHECK_MATRIX_EQ([](const GlobalElementIndex&) { return TypeUtilities<TypeParam>::element(9, 0); },
+                  matrix);
+}
+
+TYPED_TEST(ExtraBuffersTest, FutureOrder) {
+  using hpx::unwrapping;
+  using TypeUtils = TypeUtilities<TypeParam>;
+
+  const TileElementSize blocksize(1, 1);
+  Matrix<TypeParam, Device::CPU> matrix({1, 1}, blocksize);
+  matrix::test::set(matrix, [](auto&&) { return 1; });
+
+  ExtraBuffers<TypeParam> buffers(matrix(LocalTileIndex{0, 0}), 2, blocksize);
+
+  matrix.read(LocalTileIndex{0, 0}).then(unwrapping([](auto&& tile) {
+    EXPECT_EQ(TypeUtils::element(4, 0), tile({0, 0}));
+  }));
+
+  buffers.get_buffer(0).then(unwrapping([](auto tile) { tile({0, 0}) += TypeUtils::element(1, 0); }));
+  buffers.get_buffer(0).then(unwrapping([](auto tile) { tile({0, 0}) *= TypeUtils::element(2, 0); }));
+
+  matrix(LocalTileIndex(0, 0)).then(unwrapping([](auto tile) {
+    tile({0, 0}) = TypeUtils::element(13, 0);
+  }));
+
+  auto f = matrix.read(LocalTileIndex{0, 0}).then(unwrapping([](auto&& tile) {
+    EXPECT_EQ(TypeUtils::element(13, 0), tile({0, 0}));
+  }));
+
+  buffers.reduce();
+
+  f.get();
 }

--- a/test/unit/matrix/test_extra_buffers.cpp
+++ b/test/unit/matrix/test_extra_buffers.cpp
@@ -1,0 +1,44 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/matrix/extra_buffers.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dlaf/matrix/matrix.h"
+
+#include "dlaf_test/util_types.h"
+#include "dlaf_test/matrix/util_matrix.h"
+
+using namespace dlaf;
+using namespace dlaf::test;
+using namespace dlaf::matrix;
+using namespace testing;
+
+template <typename Type>
+class ExtraBuffersTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE(ExtraBuffersTest, MatrixElementTypes);
+
+TYPED_TEST(ExtraBuffersTest, Basic) {
+  Matrix<TypeParam, Device::CPU> matrix({1, 1}, {1, 1});
+  matrix::test::set(matrix, [](auto&&){ return 1; });
+
+  ExtraBuffers<TypeParam> buffers(matrix, 2);
+
+  matrix::test::set(buffers.get_buffer(1).get(), [](auto&&) { return 3; });
+  matrix::test::set(buffers.get_buffer(2).get(), [](auto&&) { return 5; });
+
+  buffers.reduce();
+
+  CHECK_MATRIX_EQ([](const GlobalElementIndex&) { return TypeUtilities<TypeParam>::element(9, 0); }, matrix);
+}


### PR DESCRIPTION
The idea behind this is quite simple, these are the main points:
- it allocates a finite set of tiles, as extra buffers, in addition to a "base" tile given by the user;
- these tiles can be accessed with a modulo index, so that you can re-use them in a transparent way
- at the end, e.g. when a parallel computation has been performed putting partial results in these tiles, all the tiles can be reduced

At the moment of writing it is just a very basic proposal that targets a specific use-case I have in reduction to band algorithm (#270), so there is margin to be improved.