### PR TITLE
integration of change for Panel API: use Index instead of Size for range specification

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -267,8 +267,8 @@ Index2D<IndexT, TAG> indexFromOrigin(const Size2D<IndexT, TAG>& size) noexcept {
 }
 
 template <class IndexT, class TAG>
-Size2D<IndexT, TAG> sizeFromOrigin(const Index2D<IndexT, TAG>& size) noexcept {
-  return {size.row(), size.col()};
+Size2D<IndexT, TAG> sizeFromOrigin(const Index2D<IndexT, TAG>& index) noexcept {
+  return {index.row(), index.col()};
 }
 
 /// Compute coords of the @p index -th cell in a row-major ordered 2D grid with size @p dims.

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -134,6 +134,10 @@ protected:
 
 }
 
+// forward declaration due to the cross dependency between Index2D and Size2D
+template <typename IndexT, class Tag>
+class Index2D;
+
 /// A strong-type for 2D sizes.
 ///
 /// @tparam IndexT type for row and column coordinates,
@@ -144,6 +148,10 @@ class Size2D : public internal::basic_coords<IndexT> {
 
 public:
   using BaseT::basic_coords;
+
+  explicit operator Index2D<IndexT, Tag>() const noexcept {
+    return {rows(), cols()};
+  }
 
   IndexT rows() const noexcept {
     return BaseT::row_;

--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -134,10 +134,6 @@ protected:
 
 }
 
-// forward declaration due to the cross dependency between Index2D and Size2D
-template <typename IndexT, class Tag>
-class Index2D;
-
 /// A strong-type for 2D sizes.
 ///
 /// @tparam IndexT type for row and column coordinates,
@@ -148,10 +144,6 @@ class Size2D : public internal::basic_coords<IndexT> {
 
 public:
   using BaseT::basic_coords;
-
-  explicit operator Index2D<IndexT, Tag>() const noexcept {
-    return {rows(), cols()};
-  }
 
   IndexT rows() const noexcept {
     return BaseT::row_;
@@ -267,6 +259,16 @@ template <class Coords2DType, std::enable_if_t<internal::is_coord<Coords2DType>:
 Coords2DType transposed(Coords2DType coords) {
   coords.transpose();
   return coords;
+}
+
+template <class IndexT, class TAG>
+Index2D<IndexT, TAG> indexFromOrigin(const Size2D<IndexT, TAG>& size) noexcept {
+  return {size.rows(), size.cols()};
+}
+
+template <class IndexT, class TAG>
+Size2D<IndexT, TAG> sizeFromOrigin(const Index2D<IndexT, TAG>& size) noexcept {
+  return {size.row(), size.col()};
 }
 
 /// Compute coords of the @p index -th cell in a row-major ordered 2D grid with size @p dims.

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -179,7 +179,7 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
       panelT.reset();
     }
 
-    panelT.setRange({kt, kt}, GlobalTileIndex(distr.nrTiles()));
+    panelT.setRange({kt, kt}, indexFromOrigin(distr.nrTiles()));
 
     broadcast(executor_mpi, kk_rank.col(), panel, panelT, mpi_row_task_chain, mpi_col_task_chain);
 

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -179,7 +179,7 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
       panelT.reset();
     }
 
-    panelT.setRange({kt, kt}, distr.nrTiles());
+    panelT.setRange({kt, kt}, GlobalTileIndex(distr.nrTiles()));
 
     broadcast(executor_mpi, kk_rank.col(), panel, panelT, mpi_row_task_chain, mpi_col_task_chain);
 

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -248,7 +248,7 @@ protected:
 
     bias_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start.get(CoordType));
 
-    setRange(start, GlobalTileIndex(dist_matrix_.nrTiles()));
+    setRange(start, indexFromOrigin(dist_matrix_.nrTiles()));
 
     external_.resize(data_.nrTiles().get(CoordType));
 

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -125,7 +125,7 @@ struct Panel<axis, const T, D> {
   /// @pre panel offset on construction <= end
   /// @pre start <= 1 past the panel last tile
   /// @pre end <= 1 past the panel last tile
-  void setRange(GlobalTileSize start_idx, GlobalTileSize end_idx) noexcept {
+  void setRange(GlobalTileIndex start_idx, GlobalTileIndex end_idx) noexcept {
     start_ = start_idx.get(CoordType);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start_);
 
@@ -146,7 +146,7 @@ struct Panel<axis, const T, D> {
   /// @pre (just the index relevant for the axis of the panel)
   /// @pre start <= current end range of the panel
   /// @pre panel offset on construction <= start
-  void setRangeStart(GlobalTileSize start_idx) noexcept {
+  void setRangeStart(GlobalTileIndex start_idx) noexcept {
     start_ = start_idx.get(CoordType);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start_);
 
@@ -162,7 +162,7 @@ struct Panel<axis, const T, D> {
   /// @pre (just the index relevant for the axis of the panel)
   /// @pre current end range of the panel <= end
   /// @pre end <= 1 past the panel last tile
-  void setRangeEnd(GlobalTileSize end_idx) noexcept {
+  void setRangeEnd(GlobalTileIndex end_idx) noexcept {
     end_ = end_idx.get(CoordType);
     end_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(end_);
 
@@ -203,7 +203,7 @@ struct Panel<axis, const T, D> {
 
 protected:
   static LocalElementSize computePanelSize(LocalElementSize size, TileElementSize blocksize,
-                                           LocalTileSize start) {
+                                           LocalTileIndex start) {
     const auto mb = blocksize.rows();
     const auto nb = blocksize.cols();
 
@@ -222,10 +222,10 @@ protected:
   ///
   /// It allocates just the memory needed for the part of matrix used, so
   /// starting from @p start
-  static Matrix<T, D> setupInternalMatrix(const Distribution& dist, const GlobalTileSize start) {
+  static Matrix<T, D> setupInternalMatrix(const Distribution& dist, const GlobalTileIndex start) {
     constexpr auto CT = CoordType;
 
-    const LocalTileSize start_loc(CT, dist.template nextLocalTileFromGlobalTile<CT>(start.get(CT)));
+    const LocalTileIndex start_loc(CT, dist.template nextLocalTileFromGlobalTile<CT>(start.get(CT)));
     const auto panel_size = computePanelSize(dist.localSize(), dist.blockSize(), start_loc);
 
     Distribution dist_internal{panel_size, dist.blockSize()};
@@ -242,13 +242,13 @@ protected:
   /// e.g. a 4x5 matrix with an offset 2x1 will have either:
   /// - a Panel<Col> 2x1
   /// - or a Panel<Row> 4x1
-  Panel(matrix::Distribution dist_matrix, GlobalTileSize start)
+  Panel(matrix::Distribution dist_matrix, GlobalTileIndex start)
       : dist_matrix_(dist_matrix), data_(setupInternalMatrix(dist_matrix, start)) {
     DLAF_ASSERT_HEAVY(data_.nrTiles().get(axis) == 1, data_.nrTiles());
 
     bias_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start.get(CoordType));
 
-    setRange(start, dist_matrix_.nrTiles());
+    setRange(start, GlobalTileIndex(dist_matrix_.nrTiles()));
 
     external_.resize(data_.nrTiles().get(CoordType));
 
@@ -311,7 +311,7 @@ struct Panel : public Panel<axis, const T, device> {
   using TileType = Tile<T, device>;
   using ConstTileType = Tile<const T, device>;
 
-  explicit Panel(matrix::Distribution distribution, GlobalTileSize start = {0, 0})
+  explicit Panel(matrix::Distribution distribution, GlobalTileIndex start = {0, 0})
       : Panel<axis, const T, device>(std::move(distribution), std::move(start)) {}
 
   /// Access tile at specified index in readwrite mode

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -43,7 +43,7 @@ TYPED_TEST_SUITE(PanelBcastTest, MatrixElementTypes);
 struct config_t {
   const GlobalElementSize sz;
   const TileElementSize blocksz;
-  const GlobalTileSize offset;
+  const GlobalTileIndex offset;
 };
 
 std::vector<config_t> test_params{

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -285,7 +285,7 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
   }
 
   // Shrink from both ends
-  panel.setRangeEnd(GlobalTileIndex(dist.nrTiles()));
+  panel.setRangeEnd(indexFromOrigin(dist.nrTiles()));
 
   for (SizeType head = cfg.offset.get<coord1D>(), tail = dist.nrTiles().get(coord1D); head <= tail;
        ++head, --tail) {

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -50,7 +50,7 @@ TYPED_TEST_SUITE(PanelTest, MatrixElementTypes);
 struct config_t {
   const GlobalElementSize sz;
   const TileElementSize blocksz;
-  const GlobalTileSize offset;
+  const GlobalTileIndex offset;
 };
 
 std::vector<config_t> test_params{
@@ -236,7 +236,7 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
 
   // Shrink from head
   for (SizeType head = cfg.offset.get<coord1D>(); head <= dist.nrTiles().get(coord1D); ++head) {
-    panel.setRangeStart(GlobalTileSize(coord1D, head));
+    panel.setRangeStart(GlobalTileIndex(coord1D, head));
 
     const auto head_loc = dist.template nextLocalTileFromGlobalTile<coord1D>(head);
     const auto tail_loc = dist.localNrTiles().get(coord1D);
@@ -262,7 +262,7 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
   panel.setRangeStart(cfg.offset);
 
   for (SizeType tail = dist.nrTiles().get(coord1D); cfg.offset.get<coord1D>() <= tail; --tail) {
-    panel.setRangeEnd(GlobalTileSize(coord1D, tail));
+    panel.setRangeEnd(GlobalTileIndex(coord1D, tail));
 
     const auto head_loc = dist.template nextLocalTileFromGlobalTile<coord1D>(cfg.offset.get<coord1D>());
     const auto tail_loc = dist.template nextLocalTileFromGlobalTile<coord1D>(tail);
@@ -285,11 +285,11 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
   }
 
   // Shrink from both ends
-  panel.setRangeEnd(dist.nrTiles());
+  panel.setRangeEnd(GlobalTileIndex(dist.nrTiles()));
 
   for (SizeType head = cfg.offset.get<coord1D>(), tail = dist.nrTiles().get(coord1D); head <= tail;
        ++head, --tail) {
-    panel.setRange(GlobalTileSize(coord1D, head), GlobalTileSize(coord1D, tail));
+    panel.setRange(GlobalTileIndex(coord1D, head), GlobalTileIndex(coord1D, tail));
 
     const auto head_loc = dist.template nextLocalTileFromGlobalTile<coord1D>(head);
     const auto tail_loc = dist.template nextLocalTileFromGlobalTile<coord1D>(tail);


### PR DESCRIPTION
As per discussion with @rasolca, here a small proposal (if this will be accepted it will become part of #384).

The main points:
- Panel now accepts Index2D instead of Size2D for ranges (both in c'tor and in setRange functions)
- a new cast operator has been added that allows to convert from Size2D to Index2D if EXPLICITLY requested

About the latter point, I opted for that because the end component of the setRange requires to specify the first index outside the range, and this is often identified by the size of the matrix. Not really the nicest thing, but it is quite handy in the code and it should not be too harmful for the Index/Size semantic separation.

Look forward to your comments and suggestions.