### PR TITLE
Porting to HPX@1.7.0

### DIFF
--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.7.0-rc2
+ARG HPX_VERSION=1.7.0-rc3
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=ff38fed5dbe546e1a6280225b2ba5e77aed9b419
+ARG HPX_VERSION=1.7.0-rc2
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.7.0-rc3
+ARG HPX_VERSION=1.7.0
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -11,7 +11,7 @@ ENV FORCE_UNSAFE_CONFIGURE 1
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     build-essential gfortran binutils lcov \
-    git tar wget curl gpg-agent jq tzdata && \
+    git tar wget curl gpg-agent jq tzdata libasio-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=master
+ARG HPX_VERSION=ff38fed5dbe546e1a6280225b2ba5e77aed9b419
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/codecov/build.Dockerfile
+++ b/ci/docker/codecov/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.6.0
+ARG HPX_VERSION=master
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.7.0-rc2
+ARG HPX_VERSION=1.7.0-rc3
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=ff38fed5dbe546e1a6280225b2ba5e77aed9b419
+ARG HPX_VERSION=1.7.0-rc2
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.7.0-rc3
+ARG HPX_VERSION=1.7.0
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=master
+ARG HPX_VERSION=ff38fed5dbe546e1a6280225b2ba5e77aed9b419
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -13,7 +13,7 @@ ENV FORCE_UNSAFE_CONFIGURE 1
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     software-properties-common \
     build-essential \
-    git tar wget curl gpg-agent jq tzdata && \
+    git tar wget curl gpg-agent jq tzdata libasio-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/ci/docker/release/build.Dockerfile
+++ b/ci/docker/release/build.Dockerfile
@@ -80,7 +80,7 @@ RUN wget -q https://github.com/gperftools/gperftools/releases/download/gperftool
 
 # Install HPX
 ARG HPX_FORK=STEllAR-GROUP
-ARG HPX_VERSION=1.6.0
+ARG HPX_VERSION=master
 ARG HPX_WITH_CUDA=OFF
 ARG HPX_PATH=/usr/local/hpx
 RUN wget -q https://github.com/${HPX_FORK}/hpx/archive/${HPX_VERSION}.tar.gz -O hpx.tar.gz && \

--- a/include/dlaf/auxiliary/norm/mc.h
+++ b/include/dlaf/auxiliary/norm/mc.h
@@ -49,7 +49,7 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
 
   using dlaf::common::internal::vector;
   using dlaf::common::make_data;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   using dlaf::tile::lange;
   using dlaf::tile::lantr;

--- a/include/dlaf/auxiliary/norm/mc.h
+++ b/include/dlaf/auxiliary/norm/mc.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/auxiliary/norm/api.h"
 #include "dlaf/common/range2d.h"

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 namespace dlaf {
 namespace common {

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -87,11 +87,10 @@ public:
     hpx::lcos::local::promise<T> promise_next;
     future_ = promise_next.get_future();
 
-    return before_last.then(hpx::launch::sync,
-                            hpx::util::unwrapping(
-                                [promise_next = std::move(promise_next)](T&& object) mutable {
-                                  return PromiseGuard<T>{std::move(object), std::move(promise_next)};
-                                }));
+    return before_last.then(hpx::launch::sync, hpx::unwrapping([promise_next = std::move(promise_next)](
+                                                                   T&& object) mutable {
+                              return PromiseGuard<T>{std::move(object), std::move(promise_next)};
+                            }));
   }
 
 private:

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -24,8 +24,8 @@ template <class T>
 class PromiseGuard {
 public:
   /// Create a wrapper.
-  /// @param object	the resource to wrap (the wrapper becomes the owner of the resource),
-  /// @param next	the promise that has to be set on destruction.
+  /// @param object the resource to wrap (the wrapper becomes the owner of the resource),
+  /// @param next the promise that has to be set on destruction.
   PromiseGuard(T object, hpx::lcos::local::promise<T> next)
       : object_(std::move(object)), promise_(std::move(next)) {}
 

--- a/include/dlaf/communication/broadcast_panel.h
+++ b/include/dlaf/communication/broadcast_panel.h
@@ -53,7 +53,7 @@ void broadcast(const comm::Executor& ex, comm::IndexT_MPI rank_root,
                matrix::Panel<axis, T, device>& panel,
                common::Pipeline<comm::Communicator>& serial_comm) {
   using hpx::dataflow;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   constexpr auto comm_coord = axis;
 
@@ -106,7 +106,7 @@ void broadcast(const comm::Executor& ex, comm::IndexT_MPI rank_root,
                common::Pipeline<comm::Communicator>& row_task_chain,
                common::Pipeline<comm::Communicator>& col_task_chain) {
   using hpx::dataflow;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   constexpr Coord axisT = orthogonal(axis);
 

--- a/include/dlaf/communication/executor.h
+++ b/include/dlaf/communication/executor.h
@@ -18,11 +18,11 @@
 #include <utility>
 
 #include <hpx/async_mpi/mpi_future.hpp>
-#include <hpx/datastructures/tuple.hpp>
-#include <hpx/execution.hpp>
-#include <hpx/functional.hpp>
-#include <hpx/future.hpp>
-#include <hpx/mutex.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/functional.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/mutex.hpp>
+#include <hpx/local/tuple.hpp>
 #include <hpx/type_support/unused.hpp>
 
 #include <mpi.h>

--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -13,7 +13,7 @@
 #include <mutex>
 
 #include <mpi.h>
-#include <hpx/mutex.hpp>
+#include <hpx/local/mutex.hpp>
 
 #include "dlaf/communication/error.h"
 

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -14,6 +14,8 @@
 
 #include <mpi.h>
 
+#include <hpx/local/unwrap.hpp>
+
 #include "dlaf/common/callable_object.h"
 #include "dlaf/common/contiguous_buffer_holder.h"
 #include "dlaf/common/pipeline.h"
@@ -65,7 +67,7 @@ void scheduleAllReduce(const comm::Executor& ex,
                        hpx::shared_future<matrix::Tile<const T, Device::CPU>> tile_in,
                        hpx::future<matrix::Tile<T, Device::CPU>> tile_out) {
   using hpx::dataflow;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   using common::internal::ContiguousBufferHolder;
   using common::internal::copyBack_o;
@@ -107,7 +109,7 @@ hpx::future<matrix::Tile<T, Device::CPU>> scheduleAllReduceInPlace(
     const comm::Executor& ex, hpx::future<common::PromiseGuard<comm::Communicator>> pcomm,
     MPI_Op reduce_op, hpx::future<matrix::Tile<T, Device::CPU>> tile) {
   using hpx::dataflow;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   using common::internal::copyBack_o;
   using common::internal::makeItContiguous_o;

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -14,6 +14,8 @@
 
 #include <mpi.h>
 
+#include <hpx/local/unwrap.hpp>
+
 #include "dlaf/common/assert.h"
 #include "dlaf/common/callable_object.h"
 #include "dlaf/common/data.h"
@@ -86,10 +88,10 @@ struct scheduleRecvBcastImpl {
     auto tile_shared = tile.share();
     auto tile_size =
         hpx::dataflow(hpx::launch::sync,
-                      hpx::util::unwrapping([](matrix::Tile<T, D> const& tile) { return tile.size(); }),
+                      hpx::unwrapping([](matrix::Tile<T, D> const& tile) { return tile.size(); }),
                       tile_shared);
     auto comm_tile =
-        hpx::dataflow(ex, hpx::util::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
+        hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
                       tile_size, root_rank, std::move(pcomm));
     hpx::dataflow(dlaf::getCopyExecutor<CommunicationDevice<D>::value, D>(),
                   matrix::unwrapExtendTiles(matrix::copy_o), std::move(comm_tile),
@@ -105,7 +107,7 @@ struct scheduleRecvBcastImpl<D, D> {
   template <class T>
   static void call(const comm::Executor& ex, hpx::future<matrix::Tile<T, D>> tile,
                    comm::IndexT_MPI root_rank, hpx::future<common::PromiseGuard<Communicator>> pcomm) {
-    hpx::dataflow(ex, hpx::util::unwrapping(recvBcast_o), std::move(tile), root_rank, std::move(pcomm));
+    hpx::dataflow(ex, hpx::unwrapping(recvBcast_o), std::move(tile), root_rank, std::move(pcomm));
   }
 };
 
@@ -122,7 +124,7 @@ hpx::future<matrix::Tile<const T, D>> scheduleRecvBcastAlloc(
     const comm::Executor& ex, TileElementSize tile_size, comm::IndexT_MPI root_rank,
     hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
   return internal::handleRecvTile<D>(
-      hpx::dataflow(ex, hpx::util::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
+      hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
                     tile_size, root_rank, std::move(pcomm)));
 }
 }

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -90,9 +90,8 @@ struct scheduleRecvBcastImpl {
         hpx::dataflow(hpx::launch::sync,
                       hpx::unwrapping([](matrix::Tile<T, D> const& tile) { return tile.size(); }),
                       tile_shared);
-    auto comm_tile =
-        hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
-                      tile_size, root_rank, std::move(pcomm));
+    auto comm_tile = hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
+                                   tile_size, root_rank, std::move(pcomm));
     hpx::dataflow(dlaf::getCopyExecutor<CommunicationDevice<D>::value, D>(),
                   matrix::unwrapExtendTiles(matrix::copy_o), std::move(comm_tile),
                   std::move(tile_shared));
@@ -124,8 +123,8 @@ hpx::future<matrix::Tile<const T, D>> scheduleRecvBcastAlloc(
     const comm::Executor& ex, TileElementSize tile_size, comm::IndexT_MPI root_rank,
     hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
   return internal::handleRecvTile<D>(
-      hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
-                    tile_size, root_rank, std::move(pcomm)));
+      hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>), tile_size,
+                    root_rank, std::move(pcomm)));
 }
 }
 }

--- a/include/dlaf/communication/kernels/reduce.h
+++ b/include/dlaf/communication/kernels/reduce.h
@@ -14,6 +14,8 @@
 
 #include <mpi.h>
 
+#include <hpx/local/unwrap.hpp>
+
 #include "dlaf/common/callable_object.h"
 #include "dlaf/common/contiguous_buffer_holder.h"
 #include "dlaf/common/data.h"
@@ -63,7 +65,7 @@ void scheduleReduceRecvInPlace(const comm::Executor& ex,
                                hpx::future<common::PromiseGuard<comm::Communicator>> pcomm,
                                MPI_Op reduce_op, hpx::future<matrix::Tile<T, Device::CPU>> tile) {
   using hpx::dataflow;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   using common::internal::copyBack_o;
   using common::internal::makeItContiguous_o;
@@ -97,7 +99,7 @@ void scheduleReduceSend(const comm::Executor& ex, comm::IndexT_MPI rank_root,
                         hpx::future<common::PromiseGuard<comm::Communicator>> pcomm, MPI_Op reduce_op,
                         hpx::shared_future<matrix::Tile<const T, Device::CPU>> tile) {
   using hpx::dataflow;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   using common::internal::makeItContiguous_o;
   using matrix::unwrapExtendTiles;

--- a/include/dlaf/cublas/executor.h
+++ b/include/dlaf/cublas/executor.h
@@ -21,13 +21,13 @@
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 
-#include <hpx/execution.hpp>
-#include <hpx/functional.hpp>
-#include <hpx/future.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/functional.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/mutex.hpp>
+#include <hpx/local/tuple.hpp>
+#include <hpx/local/type_traits.hpp>
 #include <hpx/modules/async_cuda.hpp>
-#include <hpx/mutex.hpp>
-#include <hpx/tuple.hpp>
-#include <hpx/type_traits.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/error.h"

--- a/include/dlaf/cuda/executor.h
+++ b/include/dlaf/cuda/executor.h
@@ -20,11 +20,11 @@
 
 #include <cuda_runtime.h>
 
-#include <hpx/execution.hpp>
-#include <hpx/functional.hpp>
-#include <hpx/future.hpp>
-#include <hpx/include/util.hpp>
-#include <hpx/tuple.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/functional.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/tuple.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cuda/error.h"

--- a/include/dlaf/cusolver/executor.h
+++ b/include/dlaf/cusolver/executor.h
@@ -21,13 +21,13 @@
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
 
-#include <hpx/execution.hpp>
-#include <hpx/functional.hpp>
-#include <hpx/future.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/functional.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/mutex.hpp>
+#include <hpx/local/tuple.hpp>
+#include <hpx/local/type_traits.hpp>
 #include <hpx/modules/async_cuda.hpp>
-#include <hpx/mutex.hpp>
-#include <hpx/tuple.hpp>
-#include <hpx/type_traits.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/executor.h"

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -9,9 +9,9 @@
 //
 #pragma once
 
-#include <hpx/execution.hpp>
 #include <hpx/include/resource_partitioner.hpp>
-#include <hpx/thread.hpp>
+#include <hpx/local/execution.hpp>
+#include <hpx/local/thread.hpp>
 
 #ifdef DLAF_WITH_CUDA
 #include <hpx/modules/async_cuda.hpp>

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/factorization/qr/t_factor_mc.h
+++ b/include/dlaf/factorization/qr/t_factor_mc.h
@@ -133,15 +133,8 @@ hpx::future<matrix::Tile<T, Device::CPU>> gemvColumnT(
       }
 
       if (!va_size.isEmpty()) {
-        // clang-format off
-        blas::gemv(blas::Layout::ColMajor,
-            blas::Op::ConjTrans,
-            va_size.rows(), va_size.cols(),
-            -tau,
-            vi.ptr(va_start), vi.ld(),
-            vi.ptr(vb_start), 1,
-            1, t.ptr(t_start), 1);
-        // clang-format on
+        blas::gemv(blas::Layout::ColMajor, blas::Op::ConjTrans, va_size.rows(), va_size.cols(), -tau,
+                   vi.ptr(va_start), vi.ld(), vi.ptr(vb_start), 1, 1, t.ptr(t_start), 1);
       }
     }
     return std::move(t);
@@ -156,13 +149,8 @@ hpx::future<matrix::Tile<T, Device::CPU>> trmvUpdateColumn(
   // Update each column (in order) t = T . t
   // remember that T is upper triangular, so it is possible to use TRMV
   auto trmv_func = hpx::unwrapping([](auto&& tile_t, TileElementIndex t_start, TileElementSize t_size) {
-    // clang-format off
-        blas::trmv(blas::Layout::ColMajor,
-            blas::Uplo::Upper, blas::Op::NoTrans, blas::Diag::NonUnit,
-            t_size.rows(),
-            tile_t.ptr(), tile_t.ld(),
-            tile_t.ptr(t_start), 1);
-    // clang-format on
+    blas::trmv(blas::Layout::ColMajor, blas::Uplo::Upper, blas::Op::NoTrans, blas::Diag::NonUnit,
+               t_size.rows(), tile_t.ptr(), tile_t.ld(), tile_t.ptr(t_start), 1);
 
     return std::move(tile_t);
   });

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/executors.h"
 #include "dlaf/matrix/copy_tile.h"

--- a/include/dlaf/matrix/internal/tile_future_manager.h
+++ b/include/dlaf/matrix/internal/tile_future_manager.h
@@ -8,7 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <hpx/hpx.hpp>
+#include <hpx/local/future.hpp>
+
 #include "dlaf/matrix/tile.h"
 
 namespace dlaf {

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -9,6 +9,9 @@
 //
 #pragma once
 
+#include <hpx/local/future.hp:p>
+#include <hpx/local/unwrap.hp:p>
+
 #include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
 #include "dlaf/common/pipeline.h"
@@ -86,7 +89,7 @@ struct Panel<axis, const T, D> {
 #if defined DLAF_ASSERT_MODERATE_ENABLE
     {
       const auto panel_tile_size = tileSize(index);
-      new_tile_fut.then(hpx::launch::sync, hpx::util::unwrapping([panel_tile_size](const auto& tile) {
+      new_tile_fut.then(hpx::launch::sync, hpx::unwrapping([panel_tile_size](const auto& tile) {
                           DLAF_ASSERT_MODERATE(panel_tile_size == tile.size(), panel_tile_size,
                                                tile.size());
                         }));

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/local/future.hp:p>
-#include <hpx/local/unwrap.hp:p>
+#include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -332,9 +332,6 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
   using namespace triangular_lln;
   using hpx::unwrapping;
 
-  using common::internal::vector;
-  using ConstTileType = typename Matrix<T, device>::ConstTileType;
-
   auto executor_hp = dlaf::getHpExecutor<backend>();
   auto executor_np = dlaf::getNpExecutor<backend>();
   auto executor_mpi = dlaf::getMPIExecutor<backend>();

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -330,6 +330,10 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lln;
+  using hpx::unwrapping;
+
+  using common::internal::vector;
+  using ConstTileType = typename Matrix<T, device>::ConstTileType;
 
   auto executor_hp = dlaf::getHpExecutor<backend>();
   auto executor_np = dlaf::getNpExecutor<backend>();

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -330,7 +330,6 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lln;
-  using hpx::unwrapping;
 
   auto executor_hp = dlaf::getHpExecutor<backend>();
   auto executor_np = dlaf::getNpExecutor<backend>();

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -19,8 +19,8 @@ constexpr double M_PI = 3.141592;
 #endif
 
 #include <blas.hh>
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/blas/enum_output.h"
 #include "dlaf/common/assert.h"

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -146,7 +146,7 @@ void set(Matrix<T, Device::CPU>& matrix, const ElementGetter& el_f) {
   for (auto tile_wrt_local : iterate_range2d(dist.localNrTiles())) {
     GlobalTileIndex tile_wrt_global = dist.globalTileIndex(tile_wrt_local);
     auto tl_index = dist.globalElementIndex(tile_wrt_global, {0, 0});
-    auto set_f = hpx::util::unwrapping([tl_index, el_f = el_f](auto&& tile) {
+    auto set_f = hpx::unwrapping([tl_index, el_f = el_f](auto&& tile) {
       for (auto el_idx_l : iterate_range2d(tile.size())) {
         GlobalElementIndex el_idx_g(el_idx_l.row() + tl_index.row(), el_idx_l.col() + tl_index.col());
         tile(el_idx_l) = el_f(el_idx_g);
@@ -173,7 +173,7 @@ void set_random(Matrix<T, Device::CPU>& matrix) {
     GlobalTileIndex tile_wrt_global = dist.globalTileIndex(tile_wrt_local);
     auto tl_index = dist.globalElementIndex(tile_wrt_global, {0, 0});
     auto seed = tl_index.col() + tl_index.row() * matrix.size().cols();
-    auto rnd_f = hpx::util::unwrapping([seed](auto&& tile) {
+    auto rnd_f = hpx::unwrapping([seed](auto&& tile) {
       internal::getter_random<T> random_value(seed);
       for (auto el_idx : iterate_range2d(tile.size())) {
         tile(el_idx) = random_value();
@@ -272,7 +272,7 @@ void set_random_hermitian_with_offset(Matrix<T, Device::CPU>& matrix, const Size
     else
       seed = tl_index.row() + tl_index.col() * matrix.size().rows();
 
-    auto set_hp_f = hpx::util::unwrapping([=](auto&& tile) {
+    auto set_hp_f = hpx::unwrapping([=](auto&& tile) {
       internal::getter_random<T> random_value(seed);
       if (tile_wrt_global.row() == tile_wrt_global.col())
         internal::set_diagonal_tile(tile, random_value, offset_value);

--- a/include/dlaf/util_tile.h
+++ b/include/dlaf/util_tile.h
@@ -19,8 +19,8 @@ constexpr double M_PI = 3.141592;
 #endif
 
 #include <blas.hh>
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -34,7 +34,7 @@
 
 namespace {
 
-using hpx::util::unwrapping;
+using hpx::unwrapping;
 
 using dlaf::Device;
 using dlaf::Coord;

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -12,8 +12,11 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <hpx/include/resource_partitioner.hpp>
 #include <hpx/init.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/runtime.hpp>
+#include <hpx/local/unwrap.hpp>
+#include <hpx/program_options.hpp>
 
 #include "dlaf/auxiliary/norm.h"
 #include "dlaf/blas/tile.h"

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -45,7 +45,7 @@ int hpx_main(int argc, char* argv[]) {
     return &alpha;
   });
 
-  hpx::future<cublasStatus_t> f1 = hpx::dataflow(exec, hpx::util::unwrapping(cublasDaxpy), n, alpha_f,
+  hpx::future<cublasStatus_t> f1 = hpx::dataflow(exec, hpx::unwrapping(cublasDaxpy), n, alpha_f,
                                                  x.data().get(), incx, y.data().get(), incy);
 
   hpx::future<void> f2 = f1.then([&y](hpx::future<cublasStatus_t> s) {

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -14,11 +14,11 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include <hpx/future.hpp>
-#include <hpx/include/util.hpp>
 #include <hpx/init.hpp>
+#include <hpx/local/future.hpp>
+#include <hpx/local/thread.hpp>
+#include <hpx/local/unwrap.hpp>
 #include <hpx/modules/async_cuda.hpp>
-#include <hpx/thread.hpp>
 
 #include "dlaf/executors.h"
 #include "dlaf/init.h"

--- a/misc/example/test.cpp
+++ b/misc/example/test.cpp
@@ -58,28 +58,27 @@ void foo() {
 
   // execute some operation on matrix B asynchronously.
   MatrixRW<int> mb1 = mb.block();
-  hpx::async(
-      [mb1 = std::move(mb1)]() mutable { hpx::dataflow(hpx::util::unwrapping(work0), mb1(0), 1); });
+  hpx::async([mb1 = std::move(mb1)]() mutable { hpx::dataflow(hpx::unwrapping(work0), mb1(0), 1); });
 
   // execute some operation on matrix A asynchronously. B is constant (read-only).
   MatrixRW<int> ma1 = ma.block();
   MatrixRead<int> mb2 = mb.block_read();
   hpx::async([ma1 = std::move(ma1), mb2 = std::move(mb2), &HP]() mutable {
     for (std::size_t i = 1; i < 4; ++i) {
-      hpx::dataflow(hpx::util::unwrapping(work2<>), ma1(0), ma1.read(i), 100 + i);
+      hpx::dataflow(hpx::unwrapping(work2<>), ma1(0), ma1.read(i), 100 + i);
     }
-    { hpx::dataflow(hpx::util::unwrapping(work2<>), ma1(2), ma1.read(3), 200); }
+    { hpx::dataflow(hpx::unwrapping(work2<>), ma1(2), ma1.read(3), 200); }
     for (std::size_t i = 0; i < 4; ++i) {
-      hpx::dataflow(hpx::util::unwrapping(work2<>), ma1(i), mb2.read(i), 300 + i);
-      hpx::dataflow(HP, hpx::util::unwrapping(work), ma1(1), i * 100, 400 + i);
+      hpx::dataflow(hpx::unwrapping(work2<>), ma1(i), mb2.read(i), 300 + i);
+      hpx::dataflow(HP, hpx::unwrapping(work), ma1(1), i * 100, 400 + i);
     }
   });
 
   // execute some work on A and B.
   for (std::size_t i = 0; i < 4; ++i) {
-    hpx::dataflow(hpx::util::unwrapping(work), mb(i), -1, 1000 + i);
-    hpx::dataflow(hpx::util::unwrapping(work2<false>), ma(i), mb.read(i), 2000 + i);
-    hpx::dataflow(hpx::util::unwrapping(work), ma(3), i * 10000, 3000 + i);
+    hpx::dataflow(hpx::unwrapping(work), mb(i), -1, 1000 + i);
+    hpx::dataflow(hpx::unwrapping(work2<false>), ma(i), mb.read(i), 2000 + i);
+    hpx::dataflow(hpx::unwrapping(work), ma(3), i * 10000, 3000 + i);
   }
 
   // print the value of A and B.

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -41,8 +41,8 @@
 
 #include <gtest/gtest.h>
 
-#include <hpx/include/resource_partitioner.hpp>
 #include <hpx/init.hpp>
+#include <hpx/program_options.hpp>
 
 #include <dlaf/init.h>
 

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -13,7 +13,7 @@
 #include <limits>
 
 #include <gtest/gtest.h>
-#include <hpx/include/util.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/lapack/enum_output.h"

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -88,7 +88,7 @@ void modify_element(Matrix<T, Device::CPU>& matrix, GlobalElementIndex index, co
     return;
 
   const TileElementIndex index_wrt_local = distribution.tileElementIndex(index);
-  matrix(tile_index).then(hpx::util::unwrapping([value, index_wrt_local](auto&& tile) {
+  matrix(tile_index).then(hpx::unwrapping([value, index_wrt_local](auto&& tile) {
     tile(index_wrt_local) = value;
   }));
 }

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -24,7 +24,7 @@ TEST(Pipeline, Basic) {
   auto checkpoint0 = serial();
   auto checkpoint1 =
       checkpoint0.then(hpx::launch::sync,
-                       hpx::util::unwrapping([](auto&& wrapper) { return std::move(wrapper); }));
+                       hpx::unwrapping([](auto&& wrapper) { return std::move(wrapper); }));
 
   auto guard0 = serial();
   auto guard1 = serial();

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -12,8 +12,8 @@
 
 #include <gtest/gtest.h>
 
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 using namespace dlaf;
 using dlaf::common::Pipeline;

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -54,7 +54,7 @@ std::vector<config_t> test_params{
 template <class TypeParam, Coord panel_axis>
 void testBroadcast(comm::Executor& executor_mpi, const config_t& cfg, comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   constexpr Coord coord1D = orthogonal(panel_axis);
 
@@ -118,7 +118,7 @@ template <class TypeParam, Coord PANEL_SRC_AXIS>
 void testBrodcastTranspose(comm::Executor& executor_mpi, const config_t& cfg,
                            comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
   const auto rank = dist.rankIndex().get(PANEL_SRC_AXIS);

--- a/test/unit/communication/test_comm_executor.cpp
+++ b/test/unit/communication/test_comm_executor.cpp
@@ -59,8 +59,8 @@ TEST(Bcast, Dataflow) {
   std::vector<double> buf(static_cast<std::size_t>(size), val);
 
   // Tests the handling of futures in a dataflow
-  hpx::dataflow(ex, hpx::util::unwrapping(MPI_Ibcast), buf.data(), hpx::make_ready_future<int>(size),
-                dtype, root_rank, comm, hpx::make_ready_future<void>())
+  hpx::dataflow(ex, hpx::unwrapping(MPI_Ibcast), buf.data(), hpx::make_ready_future<int>(size), dtype,
+                root_rank, comm, hpx::make_ready_future<void>())
       .get();
 
   std::vector<double> expected_buf(static_cast<std::size_t>(size), 4.2);

--- a/test/unit/communication/test_comm_matrix.cpp
+++ b/test/unit/communication/test_comm_matrix.cpp
@@ -35,12 +35,12 @@ TEST(BcastMatrixTest, DataflowFuture) {
     dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
     mat(index).get()({sz - 1, 0}) = 1.;
     hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat(index), ccomm());
-    hpx::dataflow(hpx::util::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
+    hpx::dataflow(hpx::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
     EXPECT_EQ(2., mat(index).get()({sz - 1, 0}));
   }
   else {
     std::this_thread::sleep_for(50ms);
-    auto tile_f = hpx::dataflow(ex, hpx::util::unwrapping(comm::recvBcastAlloc<double, Device::CPU>),
+    auto tile_f = hpx::dataflow(ex, hpx::unwrapping(comm::recvBcastAlloc<double, Device::CPU>),
                                 TileElementSize{sz, 1}, root, ccomm());
     EXPECT_EQ(1., tile_f.get()({sz - 1, 0}));
   }
@@ -61,12 +61,12 @@ TEST(BcastMatrixTest, DataflowSharedFuture) {
     dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
     mat(index).get()({sz - 1, 0}) = 1.;
     hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat.read(index), ccomm());
-    hpx::dataflow(hpx::util::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
+    hpx::dataflow(hpx::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
     EXPECT_EQ(2., mat(index).get()({sz - 1, 0}));
   }
   else {
     std::this_thread::sleep_for(50ms);
-    auto tile_f = hpx::dataflow(ex, hpx::util::unwrapping(comm::recvBcastAlloc<double, Device::CPU>),
+    auto tile_f = hpx::dataflow(ex, hpx::unwrapping(comm::recvBcastAlloc<double, Device::CPU>),
                                 TileElementSize{sz, 1}, root, ccomm());
     EXPECT_EQ(1., tile_f.get()({sz - 1, 0}));
   }

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <hpx/include/util.hpp>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/util_matrix.h"

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -35,7 +35,7 @@ using namespace dlaf::comm;
 using namespace dlaf::test;
 using namespace testing;
 
-using hpx::util::unwrapping;
+using hpx::unwrapping;
 
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);

--- a/test/unit/matrix/test_matrix_output.cpp
+++ b/test/unit/matrix/test_matrix_output.cpp
@@ -15,8 +15,6 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/include/util.hpp>
-#include <hpx/local/future.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -60,7 +60,7 @@ std::vector<config_t> test_params{
 
 TYPED_TEST(PanelTest, AssignToConstRef) {
   using namespace dlaf;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   for (auto& comm_grid : this->commGrids()) {
     for (const auto& cfg : test_params) {
@@ -121,7 +121,7 @@ TYPED_TEST(PanelTest, IteratorRow) {
 template <class TypeParam, Coord panel_axis>
 void testAccess(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
 
@@ -154,7 +154,7 @@ TYPED_TEST(PanelTest, AccessTileRow) {
 template <class TypeParam, Coord panel_axis>
 void testExternalTile(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::util::unwrapping;
+  using hpx::unwrapping;
 
   constexpr Coord coord1D = orthogonal(panel_axis);
 

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -13,8 +13,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <hpx/future.hpp>
-#include <hpx/include/parallel_executors.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator.h"

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <hpx/local/future.hpp>
+#include <hpx/local/unwrap.hpp>
 
 #include "dlaf/matrix/index.h"
 #include "dlaf/memory/memory_view.h"
@@ -363,7 +364,7 @@ auto createTileChain() {
 
   hpx::future<Tile<T, D>> tile_f =
       tmp_tile_f.then(hpx::launch::sync,
-                      hpx::util::unwrapping([p = std::move(next_tile_p)](auto tile) mutable {
+                      hpx::unwrapping([p = std::move(next_tile_p)](auto tile) mutable {
                         tile.setPromise(std::move(p));
                         return Tile<T, D>(std::move(tile));
                       }));


### PR DESCRIPTION
HPX 1.7.0 is not yet released, but we are likely going to need it (e.g. https://github.com/STEllAR-GROUP/hpx/pull/5387)

Here I'll try to keep a report of what is going to change, so that everyone can update their own PRs in the near future.

- `hpx::util::unwrapping` and `hpx::util::unwrap` now are directly under the `hpx::` namespace