### PR TITLE
Fix Range2D iterators

### DIFF
--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -72,7 +72,9 @@ struct IteratorRange2D {
   }
 
   reference operator[](difference_type n) const noexcept {
-    return computeIndex2D(n);
+    auto it = *this;
+    it += n;
+    return *it;
   }
 
   IteratorRange2D& operator++() noexcept {
@@ -80,7 +82,7 @@ struct IteratorRange2D {
     return *this;
   }
 
-  IteratorRange2D& operator++(int) noexcept {
+  IteratorRange2D operator++(int) noexcept {
     auto tmp = *this;
     operator++();
     return tmp;
@@ -91,18 +93,20 @@ struct IteratorRange2D {
     return *this;
   }
 
-  IteratorRange2D& operator--(int) noexcept {
+  IteratorRange2D operator--(int) noexcept {
     auto tmp = *this;
     operator--();
     return tmp;
   }
 
   IteratorRange2D& operator+=(difference_type n) noexcept {
-    return i_ += n, *this;
+    current_ = (i_ += n, computeIndex2D(i_));
+    return *this;
   }
 
   IteratorRange2D& operator-=(difference_type n) noexcept {
-    return i_ -= n, *this;
+    current_ = (i_ -= n, computeIndex2D(i_));
+    return *this;
   }
 
   friend IteratorRange2D operator+(IteratorRange2D a, difference_type n) noexcept {

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -60,7 +60,7 @@ struct IteratorRange2D {
 
   IteratorRange2D(value_type begin, IndexT ld, SizeType i)
       : begin_(begin), i_(i), ld_(std::max(ld, IndexT(1))) {
-    current_ = computeIndex2D(i_);
+    updateIndex2D();
   }
 
   reference operator*() const noexcept {
@@ -78,7 +78,8 @@ struct IteratorRange2D {
   }
 
   IteratorRange2D& operator++() noexcept {
-    current_ = computeIndex2D(++i_);
+    ++i_;
+    updateIndex2D();
     return *this;
   }
 
@@ -89,7 +90,8 @@ struct IteratorRange2D {
   }
 
   IteratorRange2D& operator--() noexcept {
-    current_ = computeIndex2D(--i_);
+    --i_;
+    updateIndex2D();
     return *this;
   }
 
@@ -100,12 +102,14 @@ struct IteratorRange2D {
   }
 
   IteratorRange2D& operator+=(difference_type n) noexcept {
-    current_ = computeIndex2D(i_ += n);
+    i_ += n;
+    updateIndex2D();
     return *this;
   }
 
   IteratorRange2D& operator-=(difference_type n) noexcept {
-    current_ = computeIndex2D(i_ -= n);
+    i_ -= n;
+    updateIndex2D();
     return *this;
   }
 
@@ -150,8 +154,9 @@ struct IteratorRange2D {
   }
 
 protected:
-  value_type computeIndex2D(difference_type n) {
-    return {begin_.row() + static_cast<IndexT>(n % ld_), begin_.col() + static_cast<IndexT>(n / ld_)};
+  void updateIndex2D() {
+    current_ = {begin_.row() + static_cast<IndexT>(i_ % ld_),
+                begin_.col() + static_cast<IndexT>(i_ / ld_)};
   }
 
   value_type current_;

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -71,7 +71,7 @@ struct IteratorRange2D {
     return &current_;
   }
 
-  reference operator[](difference_type n) const noexcept {
+  value_type operator[](difference_type n) const noexcept {
     auto it = *this;
     it += n;
     return *it;

--- a/include/dlaf/common/range2d.h
+++ b/include/dlaf/common/range2d.h
@@ -78,7 +78,7 @@ struct IteratorRange2D {
   }
 
   IteratorRange2D& operator++() noexcept {
-    current_ = (++i_, computeIndex2D(i_));
+    current_ = computeIndex2D(++i_);
     return *this;
   }
 
@@ -89,7 +89,7 @@ struct IteratorRange2D {
   }
 
   IteratorRange2D& operator--() noexcept {
-    current_ = (--i_, computeIndex2D(i_));
+    current_ = computeIndex2D(--i_);
     return *this;
   }
 
@@ -100,12 +100,12 @@ struct IteratorRange2D {
   }
 
   IteratorRange2D& operator+=(difference_type n) noexcept {
-    current_ = (i_ += n, computeIndex2D(i_));
+    current_ = computeIndex2D(i_ += n);
     return *this;
   }
 
   IteratorRange2D& operator-=(difference_type n) noexcept {
-    current_ = (i_ -= n, computeIndex2D(i_));
+    current_ = computeIndex2D(i_ -= n);
     return *this;
   }
 

--- a/test/unit/common/test_range2d.cpp
+++ b/test/unit/common/test_range2d.cpp
@@ -114,6 +114,15 @@ TEST(DoubleArgEmptyRange2D, Size2D) {
   ::test_double_arg_empty(Size(0, 0));
 }
 
+/// This is a very trivial test fixture that creates the following range2D
+///
+/// +---------+--------+---------+
+/// | (1, 1)B | (1, 2) | (1, 3)E |
+/// | (2, 1)  | (2, 2) |         |
+/// | (3, 1)  | (3, 2) |         |
+/// +---------+--------+---------+
+///
+/// {(1, 1) == range.begin(), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2), (1, 3) == range.end()}
 struct IteratorTest : public ::testing::Test {
   using range2D_t = decltype(iterate_range2d(::Index{0, 0}, ::Size{0, 0}));
 

--- a/test/unit/common/test_range2d.cpp
+++ b/test/unit/common/test_range2d.cpp
@@ -128,26 +128,26 @@ TEST_F(IteratorTest, IndexAccess) {
 
 TEST_F(IteratorTest, IncrementPrefix) {
   auto it = range.begin();
-  auto it2 = ++it;
+  const auto it2 = ++it;
   EXPECT_EQ(*it, *it2);
 }
 
 TEST_F(IteratorTest, IncrementPostfix) {
   auto it = range.begin();
-  auto it2 = it++;
+  const auto it2 = it++;
   EXPECT_EQ(range.begin(), it2);
   EXPECT_EQ(::Index(2, 1), *it);
 }
 
 TEST_F(IteratorTest, DecrementPrefix) {
   auto it = range.end();
-  auto it2 = --it;
+  const auto it2 = --it;
   EXPECT_EQ(it, it2);
 }
 
 TEST_F(IteratorTest, DecrementPostfix) {
   auto it = range.end();
-  auto it2 = it--;
+  const auto it2 = it--;
   EXPECT_EQ(range.end(), it2);
   EXPECT_EQ(::Index(3, 2), *it);
 }
@@ -159,9 +159,10 @@ TEST_F(IteratorTest, Addition) {
 
 TEST_F(IteratorTest, AdditionAssigment) {
   auto it = range.begin();
-  auto it2 = it;
+  const auto it2 = it;
   it += 2;
-  EXPECT_EQ(*(++(++it2)), *it);
+  EXPECT_EQ(it2, range.begin());
+  EXPECT_EQ(::Index(3, 1), *it);
 }
 
 TEST_F(IteratorTest, Subtraction) {
@@ -171,9 +172,10 @@ TEST_F(IteratorTest, Subtraction) {
 
 TEST_F(IteratorTest, SubtractionAssignment) {
   auto it = range.end();
-  auto it2 = it;
+  const auto it2 = it;
   it -= 2;
-  EXPECT_EQ(*(--(--it2)), *it);
+  EXPECT_EQ(it2, range.end());
+  EXPECT_EQ(::Index(2, 2), *it);
 }
 
 TEST_F(IteratorTest, DeltaIterators) {

--- a/test/unit/common/test_range2d.cpp
+++ b/test/unit/common/test_range2d.cpp
@@ -113,3 +113,68 @@ TEST(DoubleArgEmptyRange2D, Index2D) {
 TEST(DoubleArgEmptyRange2D, Size2D) {
   ::test_double_arg_empty(Size(0, 0));
 }
+
+struct IteratorTest : public ::testing::Test {
+  using range2D_t = decltype(iterate_range2d(::Index{0, 0}, ::Size{0, 0}));
+
+  const range2D_t range = iterate_range2d(::Index{1, 1}, ::Size{3, 2});
+};
+
+TEST_F(IteratorTest, IndexAccess) {
+  dlaf::SizeType i = 0;
+  for (auto it = range.begin(); it != range.end(); ++it, ++i)
+    EXPECT_EQ(*it, range.begin()[i]);
+}
+
+TEST_F(IteratorTest, IncrementPrefix) {
+  auto it = range.begin();
+  auto it2 = ++it;
+  EXPECT_EQ(*it, *it2);
+}
+
+TEST_F(IteratorTest, IncrementPostfix) {
+  auto it = range.begin();
+  auto it2 = it++;
+  EXPECT_NE(*it, *it2);
+}
+
+TEST_F(IteratorTest, DecrementPrefix) {
+  auto it = range.end();
+  auto it2 = --it;
+  EXPECT_EQ(*it, *it2);
+}
+
+TEST_F(IteratorTest, DecrementPostfix) {
+  auto it = range.end();
+  auto it2 = it--;
+  EXPECT_NE(*it, *it2);
+}
+
+TEST_F(IteratorTest, Addition) {
+  const auto it = range.begin();
+  EXPECT_EQ(::Index(1, 2), *(it + 3));
+}
+
+TEST_F(IteratorTest, AdditionAssigment) {
+  auto it = range.begin();
+  auto it2 = it;
+  it += 2;
+  EXPECT_EQ(*(++(++it2)), *it);
+}
+
+TEST_F(IteratorTest, Subtraction) {
+  const auto it = range.end();
+  EXPECT_EQ(::Index(1, 2), *(it - 3));
+}
+
+TEST_F(IteratorTest, SubtractionAssignment) {
+  auto it = range.end();
+  auto it2 = it;
+  it -= 2;
+  EXPECT_EQ(*(--(--it2)), *it);
+}
+
+TEST_F(IteratorTest, DeltaIterators) {
+  const dlaf::SizeType delta = range.end() - range.begin();
+  EXPECT_EQ(6, delta);
+}

--- a/test/unit/common/test_range2d.cpp
+++ b/test/unit/common/test_range2d.cpp
@@ -135,19 +135,21 @@ TEST_F(IteratorTest, IncrementPrefix) {
 TEST_F(IteratorTest, IncrementPostfix) {
   auto it = range.begin();
   auto it2 = it++;
-  EXPECT_NE(*it, *it2);
+  EXPECT_EQ(range.begin(), it2);
+  EXPECT_EQ(::Index(2, 1), *it);
 }
 
 TEST_F(IteratorTest, DecrementPrefix) {
   auto it = range.end();
   auto it2 = --it;
-  EXPECT_EQ(*it, *it2);
+  EXPECT_EQ(it, it2);
 }
 
 TEST_F(IteratorTest, DecrementPostfix) {
   auto it = range.end();
   auto it2 = it--;
-  EXPECT_NE(*it, *it2);
+  EXPECT_EQ(range.end(), it2);
+  EXPECT_EQ(::Index(3, 2), *it);
 }
 
 TEST_F(IteratorTest, Addition) {


### PR DESCRIPTION
The iterator had a few major problems, which I addressed when using `std::prev` which was not working properly (it was not computing the previous iterator and it was just returning exactly the same one).

At the time of writing I added few very basic tests that I used to debug the problems, together with the fixes to the bugs I found out.

Look forward to your comments.