### PR TITLE
Added methods to resize Panel

### DIFF
--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -249,12 +249,7 @@ protected:
     const auto size_coord = dist_matrix_.tileSize(panel_index).get<CoordType>();
     const auto size_axis = dim_ < 0 ? dist_matrix_.blockSize().get<axis>() : dim_;
 
-    switch (axis) {
-      case Coord::Col:
-        return {size_coord, size_axis};
-      case Coord::Row:
-        return {size_axis, size_coord};
-    }
+    return {axis, size_axis, size_coord};
   }
 
   static LocalElementSize computePanelSize(LocalElementSize size, TileElementSize blocksize,

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -79,13 +79,13 @@ struct Panel<axis, const T, D> {
   ///
   /// @pre @p index must be a valid index for the current panel size
   void setTile(const LocalTileIndex& index, hpx::shared_future<ConstTileType> new_tile_fut) {
-    DLAF_ASSERT(index.isIn(dist_matrix_.localNrTiles()), index, dist_matrix_.localNrTiles());
     DLAF_ASSERT(internal_.count(linearIndex(index)) == 0, "internal tile have been already used", index);
     DLAF_ASSERT(!isExternal(index), "already set to external", index);
+    // Note assertion on index done by linearIndex method.
 
 #if defined DLAF_ASSERT_MODERATE_ENABLE
     {
-      const auto panel_tile_size = dist_matrix_.tileSize(dist_matrix_.globalTileIndex(index));
+      const auto panel_tile_size = tileSize(index);
       new_tile_fut.then(hpx::launch::sync, hpx::util::unwrapping([panel_tile_size](const auto& tile) {
                           DLAF_ASSERT_MODERATE(panel_tile_size == tile.size(), panel_tile_size,
                                                tile.size());
@@ -100,9 +100,9 @@ struct Panel<axis, const T, D> {
   ///
   /// This method is very similar to the one available in dlaf::Matrix.
   ///
-  /// @p index is in the coordinate system of the matrix which this panel is related to
+  /// @pre @p index must be a valid index for the current panel size
   hpx::shared_future<ConstTileType> read(const LocalTileIndex& index) {
-    DLAF_ASSERT_HEAVY(index.isIn(dist_matrix_.localNrTiles()), index, dist_matrix_.localNrTiles());
+    // Note assertion on index done by linearIndex method.
 
     const SizeType internal_linear_idx = linearIndex(index);
     if (isExternal(index)) {
@@ -110,7 +110,12 @@ struct Panel<axis, const T, D> {
     }
     else {
       internal_.insert(internal_linear_idx);
-      return data_.read(fullIndex(index));
+      auto tile = data_.read(fullIndex(index));
+
+      if (dim_ < 0)
+        return std::move(tile);
+      else
+        return splitTile(tile, {{0, 0}, tileSize(index)});
     }
   }
 
@@ -190,18 +195,68 @@ struct Panel<axis, const T, D> {
     return end_local_;
   }
 
+  /// Set the width of the col panel.
+  ///
+  /// By default the width of the panel is parentDistribution().block_size().cols().
+  /// This method allows to reduce this value.
+  ///
+  /// @pre this can be called as first operation after range setting.
+  /// @pre @param 0 < width <= parentDistribution().block_size().cols()
+  template <Coord A = axis, std::enable_if_t<A == axis && Coord::Col == axis, int> = 0>
+  void setWidth(SizeType width) noexcept {
+    DLAF_ASSERT(width > 0, width);
+    DLAF_ASSERT(width <= parentDistribution().blockSize().cols(), width,
+                parentDistribution().blockSize().cols());
+
+    dim_ = width;
+  }
+
+  /// Set the height of the row panel.
+  ///
+  /// By default the  oghtf the panel is parentDistribution().block_size().rows().
+  /// This method allows to reduce this value.
+  ///
+  /// @pre this can be called as first operation after range setting.
+  /// @pre @param 0 < height <= parentDistribution().block_size().rows()
+  template <Coord A = axis, std::enable_if_t<A == axis && Coord::Row == axis, int> = 0>
+  void setHeight(SizeType height) noexcept {
+    DLAF_ASSERT(height > 0, height);
+    DLAF_ASSERT(height <= parentDistribution().blockSize().rows(), height,
+                parentDistribution().blockSize().rows());
+
+    dim_ = height;
+  }
+
   /// Reset the internal usage status of the panel.
   ///
   /// In particular:
   /// - usage status of each tile is reset
   /// - external tiles references are dropped and internal ones are set back
+  /// - The width (Col Panel) or the height (Row panel) are reset.
   void reset() noexcept {
     for (auto& e : external_)
       e = {};
     internal_.clear();
+    dim_ = -1;
   }
 
 protected:
+  TileElementSize tileSize(const LocalTileIndex& index) {
+    // Transform to global panel index.
+    const auto panel_coord = dist_matrix_.globalTileFromLocalTile<CoordType>(index.get<CoordType>());
+    const GlobalTileIndex panel_index(CoordType, panel_coord);
+
+    const auto size_coord = dist_matrix_.tileSize(panel_index).get<CoordType>();
+    const auto size_axis = dim_ < 0 ? dist_matrix_.blockSize().get<axis>() : dim_;
+
+    switch (axis) {
+      case Coord::Col:
+        return {size_coord, size_axis};
+      case Coord::Row:
+        return {size_axis, size_coord};
+    }
+  }
+
   static LocalElementSize computePanelSize(LocalElementSize size, TileElementSize blocksize,
                                            LocalTileIndex start) {
     const auto mb = blocksize.rows();
@@ -259,7 +314,6 @@ protected:
   /// Given a matrix index, compute the internal linear index
   SizeType linearIndex(const LocalTileIndex& index) const noexcept {
     const auto idx = index.get(CoordType);
-
     DLAF_ASSERT_MODERATE(idx >= rangeStartLocal(), idx, rangeStartLocal());
 
     return idx - bias_;
@@ -273,9 +327,6 @@ protected:
   /// will always be 0 (and relatively for a Panel<Row>)
   LocalTileIndex fullIndex(LocalTileIndex index) const {
     index = LocalTileIndex(CoordType, linearIndex(index));
-
-    DLAF_ASSERT_HEAVY(index.isIn(LocalTileSize(CoordType, rangeEndLocal(), 1)), index,
-                      LocalTileSize(CoordType, rangeEndLocal(), 1));
 
     return index;
   }
@@ -299,6 +350,8 @@ protected:
   ///> It represents the last tile which this panel gives access to
   SizeType end_;
   SizeType end_local_;  // local version of @p end_
+  ///> It represent the width or height of the panel. Negatives means not set, i.e. block_size.
+  SizeType dim_ = -1;
 
   ///> Container for references to external tiles
   common::internal::vector<hpx::shared_future<ConstTileType>> external_;
@@ -320,14 +373,21 @@ struct Panel : public Panel<axis, const T, device> {
   ///
   /// @pre index must point to a tile which is internally managed by the panel
   hpx::future<TileType> operator()(const LocalTileIndex& index) {
+    // Note assertion on index done by linearIndex method.
     DLAF_ASSERT(!BaseT::isExternal(index), "read-only access on external tiles", index);
 
     BaseT::internal_.insert(BaseT::linearIndex(index));
-    return BaseT::data_(BaseT::fullIndex(index));
+    auto tile = BaseT::data_(BaseT::fullIndex(index));
+    if (dim_ < 0)
+      return std::move(tile);
+    else
+      return splitTile(tile, {{0, 0}, tileSize(index)});
   }
 
 protected:
   using BaseT = Panel<axis, const T, device>;
+  using BaseT::dim_;
+  using BaseT::tileSize;
 };
 
 }

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -113,7 +113,7 @@ struct Panel<axis, const T, D> {
       auto tile = data_.read(fullIndex(index));
 
       if (dim_ < 0)
-        return std::move(tile);
+        return tile;
       else
         return splitTile(tile, {{0, 0}, tileSize(index)});
     }
@@ -379,7 +379,7 @@ struct Panel : public Panel<axis, const T, device> {
     BaseT::internal_.insert(BaseT::linearIndex(index));
     auto tile = BaseT::data_(BaseT::fullIndex(index));
     if (dim_ < 0)
-      return std::move(tile);
+      return tile;
     else
       return splitTile(tile, {{0, 0}, tileSize(index)});
   }

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -213,7 +213,7 @@ struct Panel<axis, const T, D> {
 
   /// Set the height of the row panel.
   ///
-  /// By default the  oghtf the panel is parentDistribution().block_size().rows().
+  /// By default the height of the panel is parentDistribution().block_size().rows().
   /// This method allows to reduce this value.
   ///
   /// @pre this can be called as first operation after range setting.

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -335,10 +335,8 @@ void checkPanelTileSize(SizeType dim, Panel<panel_axis, T, D>& panel) {
     auto dim_perp = dist.blockSize().get<coord>();
     if (dist.globalTileFromLocalTile<coord>(i) == dist.nrTiles().get<coord>() - 1)
       dim_perp = dist.size().get<coord>() % dist.blockSize().get<coord>();
-    const auto tile_size = [](auto dim, auto dim_perp) -> TileElementSize {
-      if (panel_axis == Coord::Row)
-        return {dim, dim_perp};
-      return {dim_perp, dim};
+    const auto tile_size = [](auto dim, auto dim_perp) {
+      return TileElementSize(panel_axis, dim, dim_perp);
     }(dim, dim_perp);
 
     EXPECT_EQ(tile_size, panel(LocalTileIndex{coord, i}).get().size());


### PR DESCRIPTION
Added setWidth method to Panel<Col> and setHeight method to Panel<Row>
Improved tile size checking when setTile method is used.

Note:
- [x] Depends on #389 for subtiling
- [x] Depends on #382 for test correctness (Asserts fail on broadcast transposed as last tile of the transposed panel has not the correct size)