### PR TITLE
Fix SubTile asserts

### DIFF
--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -246,8 +246,8 @@ protected:
     const auto panel_coord = dist_matrix_.globalTileFromLocalTile<CoordType>(index.get<CoordType>());
     const GlobalTileIndex panel_index(CoordType, panel_coord);
 
-    const auto size_coord = dist_matrix_.tileSize(panel_index).get<CoordType>();
-    const auto size_axis = dim_ < 0 ? dist_matrix_.blockSize().get<axis>() : dim_;
+    const auto size_coord = dist_matrix_.tileSize(panel_index).template get<CoordType>();
+    const auto size_axis = dim_ < 0 ? dist_matrix_.blockSize().template get<axis>() : dim_;
 
     return {axis, size_axis, size_coord};
   }


### PR DESCRIPTION
The Tile c'tor used for subtiles had ASSERTs checking for the correctness of parameters, but being inside the body of the c'tor they were not executed in case the call to the parent constructor failed (e.g. MemoryView realizes that a given configuration does not fit).