### PR TITLE
Enable warnings in object libraries

### DIFF
--- a/cmake/DLAF_AddTargetWarnings.cmake
+++ b/cmake/DLAF_AddTargetWarnings.cmake
@@ -24,6 +24,7 @@ macro(target_add_warnings target_name)
       -Wextra
       -Wnon-virtual-dtor
       -Wunused
+      -Wunused-local-typedefs
       -Woverloaded-virtual
       -Wdangling-else
       -Wswitch-enum

--- a/cmake/DLAF_AddTargetWarnings.cmake
+++ b/cmake/DLAF_AddTargetWarnings.cmake
@@ -17,38 +17,39 @@ macro(target_add_warnings target_name)
 
   set(IS_COMPILER_CLANG $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
   set(IS_COMPILER_GCC $<CXX_COMPILER_ID:GNU>)
+  set(IS_CUDA_NVCC $<COMPILE_LANG_AND_ID:CUDA,NVIDIA>)
 
   target_compile_options(${target_name}
     PRIVATE
-      -Wall
-      -Wextra
-      -Wnon-virtual-dtor
-      -Wunused
-      -Wunused-local-typedefs
-      -Woverloaded-virtual
-      -Wdangling-else
-      -Wswitch-enum
-      # Conversions
-      $<${IS_COMPILER_GCC}:
-        -Wsign-conversion
-        -Wfloat-conversion>
-      $<${IS_COMPILER_CLANG}:
-        -Wbitfield-enum-conversion
-        -Wbool-conversion
-        -Wconstant-conversion
-        -Wenum-conversion
-        -Wfloat-conversion
-        -Wint-conversion
-        -Wliteral-conversion
-        -Wnon-literal-null-conversion
-        -Wnull-conversion
-        -Wshorten-64-to-32
-        -Wsign-conversion
-        -Wstring-conversion>
-      -pedantic-errors
+        -Wall
+        -Wextra
+        -Wnon-virtual-dtor
+        -Wunused
+        -Wunused-local-typedefs
+        -Woverloaded-virtual
+        -Wdangling-else
+        -Wswitch-enum
+        # Conversions
+        $<${IS_COMPILER_GCC}:
+          -Wsign-conversion
+          -Wfloat-conversion>
+        $<${IS_COMPILER_CLANG}:
+          -Wbitfield-enum-conversion
+          -Wbool-conversion
+          -Wconstant-conversion
+          -Wenum-conversion
+          -Wfloat-conversion
+          -Wint-conversion
+          -Wliteral-conversion
+          -Wnon-literal-null-conversion
+          -Wnull-conversion
+          -Wshorten-64-to-32
+          -Wsign-conversion
+          -Wstring-conversion>
 
-      # googletest macro problem
-      # must specify at least one argument for '...' parameter of variadic macro
-      $<${IS_COMPILER_CLANG}:-Wno-gnu-zero-variadic-macro-arguments>
+        $<$<NOT:${IS_CUDA_NVCC}>:-pedantic-errors>
+        # googletest macro problem
+        # must specify at least one argument for '...' parameter of variadic macro
+        $<${IS_COMPILER_CLANG}:-Wno-gnu-zero-variadic-macro-arguments>
     )
 endmacro()

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -110,7 +110,8 @@ T computeReflector(const comm::IndexT_MPI rank_v0, comm::Communicator& communica
   // (e.g. norm, y, tau) just on the root rank and then having to broadcast them (i.e. additional
   // communication).
   comm::sync::allReduceInPlace(communicator, MPI_SUM,
-                               common::make_data(x0_and_squares.data(), x0_and_squares.size()));
+                               common::make_data(x0_and_squares.data(),
+                                                 to_SizeType(x0_and_squares.size())));
 
   const T norm = std::sqrt(x0_and_squares[1]);
   const T x0 = x0_and_squares[0];
@@ -151,7 +152,7 @@ void updateTrailingPanelWithReflector(comm::IndexT_MPI rank_v0, comm::Communicat
   if (!(pt_cols > 0))
     return;
 
-  std::vector<T> w(pt_cols, 0);
+  std::vector<T> w(to_sizet(pt_cols), 0);
 
   const bool is_head_rank = rank_v0 == communicator.rank();
 
@@ -530,7 +531,7 @@ std::vector<hpx::shared_future<common::internal::vector<T>>> ReductionToBand<
 
   const SizeType nblocks = dist.nrTiles().cols() - 1;
   std::vector<hpx::shared_future<common::internal::vector<T>>> taus;
-  taus.reserve(nblocks);
+  taus.reserve(to_sizet(nblocks));
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<PanelT<Coord::Col, T>> panels_v(n_workspaces, dist);

--- a/include/dlaf/matrix/matrix.tpp
+++ b/include/dlaf/matrix/matrix.tpp
@@ -29,7 +29,7 @@ Matrix<T, device>::Matrix(Distribution distribution) : Matrix<const T, device>(s
 
   auto layout = colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 
-  std::size_t memory_size = layout.minMemSize();
+  SizeType memory_size = layout.minMemSize();
   memory::MemoryView<ElementType, device> mem(memory_size);
 
   setUpTiles(mem, layout);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,10 +106,12 @@ add_library(dlaf.core
 )
 target_compile_options(dlaf.core PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
 target_link_libraries(dlaf.core PUBLIC dlaf.prop)
+target_add_warnings(dlaf.core)
 
 # Define DLAF's auxiliary library
 add_library(dlaf.auxiliary OBJECT auxiliary/norm/mc.cpp)
 target_link_libraries(dlaf.auxiliary PUBLIC dlaf.prop)
+target_add_warnings(dlaf.auxiliary)
 
 # Define DLAF's eigensolver library
 add_library(dlaf.eigensolver OBJECT
@@ -118,18 +120,21 @@ add_library(dlaf.eigensolver OBJECT
   $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/gen_to_std/gpu.cpp>
   eigensolver/reduction_to_band/mc.cpp)
 target_link_libraries(dlaf.eigensolver PUBLIC dlaf.prop)
+target_add_warnings(dlaf.eigensolver)
 
 # Define DLAF's factorization library
 add_library(dlaf.factorization OBJECT
   factorization/cholesky/mc.cpp
   $<$<BOOL:${DLAF_WITH_CUDA}>:factorization/cholesky/gpu.cpp>)
 target_link_libraries(dlaf.factorization PUBLIC dlaf.prop)
+target_add_warnings(dlaf.factorization)
 
 # Define DLAF's solver library
 add_library(dlaf.solver OBJECT
   solver/triangular/mc.cpp
   $<$<BOOL:${DLAF_WITH_CUDA}>:solver/triangular/gpu.cpp>)
 target_link_libraries(dlaf.solver PUBLIC dlaf.prop)
+target_add_warnings(dlaf.solver)
 
 # Define DLAF's complete library
 add_library(DLAF

--- a/src/memory/memory_chunk.cpp
+++ b/src/memory/memory_chunk.cpp
@@ -44,6 +44,8 @@ void initializeUmpireHostAllocator(std::size_t initial_bytes) {
 
     initialized = true;
   }
+#else
+  (void) initial_bytes;
 #endif
 }
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(DLAF_gtest_hpx_main
     dlaf.core
     HPX::hpx
 )
+target_add_warnings(DLAF_gtest_hpx_main)
 
 add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp gtest_mpi_listener.cpp)
 target_link_libraries(DLAF_gtest_mpi_main
@@ -24,6 +25,7 @@ target_link_libraries(DLAF_gtest_mpi_main
   PRIVATE
     MPI::MPI_CXX
 )
+target_add_warnings(DLAF_gtest_mpi_main)
 
 add_library(DLAF_gtest_mpihpx_main STATIC gtest_mpihpx_main.cpp gtest_mpi_listener.cpp)
 target_link_libraries(DLAF_gtest_mpihpx_main
@@ -34,3 +36,4 @@ target_link_libraries(DLAF_gtest_mpihpx_main
     MPI::MPI_CXX
     HPX::hpx
 )
+target_add_warnings(DLAF_gtest_mpihpx_main)

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -81,7 +81,9 @@ void MPIListener::OnTestEnd(const ::testing::TestInfo& test_info) {
 
       if (rank == 0) {
         number_of_results = last_test_part_results_.size();
-        get_result = [this](int index) { return last_test_part_results_[index]; };
+        get_result = [this](int index) {
+          return last_test_part_results_[static_cast<std::size_t>(index)];
+        };
       }
       else {
         MPI_Recv(&number_of_results, 1, MPI_INT, rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
@@ -131,14 +133,15 @@ bool MPIListener::isMasterRank() const {
 void MPIListener::OnTestEndAllRanks(const ::testing::TestInfo& test_info) const {
   bool is_local_passed = test_info.result()->Passed();
 
-  bool all_tests_passed[world_size_];
-  MPI_Gather(&is_local_passed, 1, MPI_BYTE, isMasterRank() ? &all_tests_passed : nullptr, 1, MPI_BYTE, 0,
-             MPI_COMM_WORLD);
+  auto all_tests_passed = std::make_unique<bool[]>(static_cast<std::size_t>(world_size_));
+  MPI_Gather(&is_local_passed, 1, MPI_BYTE, isMasterRank() ? all_tests_passed.get() : nullptr, 1,
+             MPI_BYTE, 0, MPI_COMM_WORLD);
 
   if (!isMasterRank())
     return;
 
-  auto how_many_ranks_failed = std::count(all_tests_passed, all_tests_passed + world_size_, false);
+  auto how_many_ranks_failed =
+      std::count(all_tests_passed.get(), all_tests_passed.get() + world_size_, false);
 
   // exploit this to make the master rank fail if any rank failed
   // as a side-effect it calls OnTestPartResult, but since it just collects error messages,
@@ -166,9 +169,10 @@ std::string mpi_receive_string(int from_rank) {
   int message_length;
   MPI_Get_count(&status, MPI_CHAR, &message_length);
 
-  char message_buffer[message_length];
-  MPI_Recv(message_buffer, message_length, MPI_CHAR, from_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  std::vector<char> message_buffer(static_cast<std::size_t>(message_length));
+  MPI_Recv(message_buffer.data(), message_length, MPI_CHAR, from_rank, 0, MPI_COMM_WORLD,
+           MPI_STATUS_IGNORE);
 
-  return message_buffer;
+  return message_buffer.data();
 }
 }


### PR DESCRIPTION
Only opening now as a reminder for myself to come back to this; I have not compiled this to check how many of these there are. Inspired by https://github.com/eth-cscs/DLA-Future/pull/388#discussion_r671014072.

Additionally, we should strongly consider setting `-Wall`, with possible exceptions through `-Wno-x` but that may be a bigger task (I don't know, did someone already try it? How bad was it?).