### PR TITLE
Panel clean state assertions

### DIFF
--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -138,7 +138,7 @@ struct Panel<axis, const T, D> {
   /// @pre start <= 1 past the panel last tile
   /// @pre end <= 1 past the panel last tile
   void setRange(GlobalTileIndex start_idx, GlobalTileIndex end_idx) noexcept {
-    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+    DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
     start_ = start_idx.get(CoordType);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start_);
@@ -161,7 +161,7 @@ struct Panel<axis, const T, D> {
   /// @pre start <= current end range of the panel
   /// @pre panel offset on construction <= start
   void setRangeStart(GlobalTileIndex start_idx) noexcept {
-    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+    DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
     start_ = start_idx.get(CoordType);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start_);
@@ -179,7 +179,7 @@ struct Panel<axis, const T, D> {
   /// @pre current end range of the panel <= end
   /// @pre end <= 1 past the panel last tile
   void setRangeEnd(GlobalTileIndex end_idx) noexcept {
-    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+    DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
     end_ = end_idx.get(CoordType);
     end_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(end_);
@@ -217,7 +217,7 @@ struct Panel<axis, const T, D> {
   /// @pre @param 0 < width <= parentDistribution().block_size().cols()
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Col == axis, int> = 0>
   void setWidth(SizeType width) noexcept {
-    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+    DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
     DLAF_ASSERT(width > 0, width);
     DLAF_ASSERT(width <= parentDistribution().blockSize().cols(), width,
                 parentDistribution().blockSize().cols());
@@ -234,7 +234,7 @@ struct Panel<axis, const T, D> {
   /// @pre @param 0 < height <= parentDistribution().block_size().rows()
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Row == axis, int> = 0>
   void setHeight(SizeType height) noexcept {
-    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+    DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
     DLAF_ASSERT(height > 0, height);
     DLAF_ASSERT(height <= parentDistribution().blockSize().rows(), height,
                 parentDistribution().blockSize().rows());

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -86,6 +86,8 @@ struct Panel<axis, const T, D> {
     DLAF_ASSERT(!isExternal(index), "already set to external", index);
     // Note assertion on index done by linearIndex method.
 
+    has_been_used_ = true;
+
 #if defined DLAF_ASSERT_MODERATE_ENABLE
     {
       const auto panel_tile_size = tileSize(index);
@@ -106,6 +108,8 @@ struct Panel<axis, const T, D> {
   /// @pre @p index must be a valid index for the current panel size
   hpx::shared_future<ConstTileType> read(const LocalTileIndex& index) {
     // Note assertion on index done by linearIndex method.
+
+    has_been_used_ = true;
 
     const SizeType internal_linear_idx = linearIndex(index);
     if (isExternal(index)) {
@@ -134,6 +138,8 @@ struct Panel<axis, const T, D> {
   /// @pre start <= 1 past the panel last tile
   /// @pre end <= 1 past the panel last tile
   void setRange(GlobalTileIndex start_idx, GlobalTileIndex end_idx) noexcept {
+    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+
     start_ = start_idx.get(CoordType);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start_);
 
@@ -155,6 +161,8 @@ struct Panel<axis, const T, D> {
   /// @pre start <= current end range of the panel
   /// @pre panel offset on construction <= start
   void setRangeStart(GlobalTileIndex start_idx) noexcept {
+    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+
     start_ = start_idx.get(CoordType);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(start_);
 
@@ -171,6 +179,8 @@ struct Panel<axis, const T, D> {
   /// @pre current end range of the panel <= end
   /// @pre end <= 1 past the panel last tile
   void setRangeEnd(GlobalTileIndex end_idx) noexcept {
+    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
+
     end_ = end_idx.get(CoordType);
     end_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<CoordType>(end_);
 
@@ -207,6 +217,7 @@ struct Panel<axis, const T, D> {
   /// @pre @param 0 < width <= parentDistribution().block_size().cols()
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Col == axis, int> = 0>
   void setWidth(SizeType width) noexcept {
+    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
     DLAF_ASSERT(width > 0, width);
     DLAF_ASSERT(width <= parentDistribution().blockSize().cols(), width,
                 parentDistribution().blockSize().cols());
@@ -223,6 +234,7 @@ struct Panel<axis, const T, D> {
   /// @pre @param 0 < height <= parentDistribution().block_size().rows()
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Row == axis, int> = 0>
   void setHeight(SizeType height) noexcept {
+    DLAF_ASSERT(!hasBeenUsed(), hasBeenUsed());
     DLAF_ASSERT(height > 0, height);
     DLAF_ASSERT(height <= parentDistribution().blockSize().rows(), height,
                 parentDistribution().blockSize().rows());
@@ -241,6 +253,7 @@ struct Panel<axis, const T, D> {
       e = {};
     internal_.clear();
     dim_ = -1;
+    has_been_used_ = false;
   }
 
 protected:
@@ -335,6 +348,10 @@ protected:
     return external_[linearIndex(idx_matrix)].valid();
   }
 
+  bool hasBeenUsed() const noexcept {
+    return has_been_used_;
+  }
+
   ///> Parent matrix which this panel is related to
   Distribution dist_matrix_;
 
@@ -351,6 +368,8 @@ protected:
   SizeType end_local_;  // local version of @p end_
   ///> It represent the width or height of the panel. Negatives means not set, i.e. block_size.
   SizeType dim_ = -1;
+
+  bool has_been_used_ = false;
 
   ///> Container for references to external tiles
   common::internal::vector<hpx::shared_future<ConstTileType>> external_;
@@ -375,6 +394,8 @@ struct Panel : public Panel<axis, const T, device> {
     // Note assertion on index done by linearIndex method.
     DLAF_ASSERT(!BaseT::isExternal(index), "read-only access on external tiles", index);
 
+    has_been_used_ = true;
+
     BaseT::internal_.insert(BaseT::linearIndex(index));
     auto tile = BaseT::data_(BaseT::fullIndex(index));
     if (dim_ < 0)
@@ -386,6 +407,7 @@ struct Panel : public Panel<axis, const T, device> {
 protected:
   using BaseT = Panel<axis, const T, device>;
   using BaseT::dim_;
+  using BaseT::has_been_used_;
   using BaseT::tileSize;
 };
 

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -123,6 +123,17 @@ Tile<T, D> createTile(ElementGetter val, const TileElementSize size, const SizeT
   return internal::CreateTile<T, D>::createAndSet(val, size, ld);
 }
 
+/// Infinite size tile with fixed value
+///
+/// Return a callable that acts like a tile that always return @p value,
+/// for any @p index given
+template <class T>
+auto fixedValueTile(T value) noexcept {
+  return [=](TileElementIndex) noexcept {
+    return value;
+  };
+}
+
 namespace internal {
 /// Checks the elements of the tile.
 ///

--- a/test/unit/communication/test_collective_async.cpp
+++ b/test/unit/communication/test_collective_async.cpp
@@ -26,6 +26,7 @@
 #include "dlaf_test/matrix/util_tile.h"
 
 using namespace dlaf;
+using namespace dlaf::matrix::test;
 
 class CollectiveTest : public ::testing::Test {
   static_assert(NUM_MPI_RANKS >= 2, "at least 2 ranks are required");
@@ -36,11 +37,6 @@ protected:
 
   comm::Communicator world = MPI_COMM_WORLD;
 };
-
-template <class T>
-auto fixedValueTile(const T value) {
-  return [value](TileElementIndex const&) { return value; };
-}
 
 template <class T, Device device>
 auto newBlockMatrixContiguous() {
@@ -72,7 +68,7 @@ void testReduceInPlace(comm::Communicator world, matrix::Matrix<T, device> matri
   common::Pipeline<comm::Communicator> chain(world);
 
   const auto root_rank = world.size() - 1;
-  const auto ex_mpi = dlaf::getMPIExecutor<Backend::MC>();
+  const auto ex_mpi = getMPIExecutor<Backend::MC>();
 
   const LocalTileIndex idx(0, 0);
 
@@ -114,7 +110,7 @@ void testAllReduceInPlace(comm::Communicator world, matrix::Matrix<T, device> ma
                           std::string test_name) {
   common::Pipeline<comm::Communicator> chain(world);
 
-  const auto ex_mpi = dlaf::getMPIExecutor<Backend::MC>();
+  const auto ex_mpi = getMPIExecutor<Backend::MC>();
 
   const LocalTileIndex idx(0, 0);
 
@@ -152,7 +148,7 @@ void testAllReduce(comm::Communicator world, matrix::Matrix<T, device> matA,
   common::Pipeline<comm::Communicator> chain(world);
 
   const auto root_rank = world.size() - 1;
-  const auto ex_mpi = dlaf::getMPIExecutor<Backend::MC>();
+  const auto ex_mpi = getMPIExecutor<Backend::MC>();
 
   const LocalTileIndex idx(0, 0);
   matrix::Matrix<T, device>& mat_in = root_rank % 2 == 0 ? matA : matB;

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -252,6 +252,8 @@ void testSet0(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
 
     for (const auto& idx : panel.iteratorLocal())
       CHECK_TILE_EQ(null_tile, panel.read(idx).get());
+
+    panel.reset();
   }
 }
 


### PR DESCRIPTION
In the current proposal, panel methods can be split in two categories:
- setup: `setRange`, `setRangeStart`, `setRangeEnd`, `setWidth`/`setHeight`
- usage: `setTile`, `read`, `operator ()`

The rationale behind this division is that functions from the first group can be called exclusively just after construction or after a `reset()`, while the others have no restrictions (regarding this).

With this PR, we are going to enforce the above property.

Main points of this PR:
- Add panel member functions property enforcement with `DLAF_ASSERT` (do we want to make it MODERATE? @rasolca)
- Fix panel test that was not respecting the panel property (+ refactoring)
- minor: add `fixedValueTile` helper function for tests
