### PR TITLE
algo: backtransform tridiagonal -> band (local) with subblocks (where band is a submultiple of blocksize)

### DIFF
--- a/include/dlaf/eigensolver/backtransformation.h
+++ b/include/dlaf/eigensolver/backtransformation.h
@@ -51,7 +51,8 @@ void backTransformation(Matrix<T, device>& mat_c, Matrix<const T, device>& mat_v
 
 // TODO DOC
 template <Backend backend, Device device, class T>
-void backTransformationT2B(matrix::Matrix<T, device>& mat_e, matrix::Matrix<const T, device>& mat_v,
+void backTransformationT2B(SizeType band_size, matrix::Matrix<T, device>& mat_e,
+                           matrix::Matrix<const T, device>& mat_v,
                            matrix::Matrix<const T, device>& mat_taus) {
   // TODO check conditions
   DLAF_ASSERT(matrix::local_matrix(mat_e), mat_e);
@@ -63,9 +64,11 @@ void backTransformationT2B(matrix::Matrix<T, device>& mat_e, matrix::Matrix<cons
   DLAF_ASSERT(matrix::equal_size(mat_v, mat_taus), mat_v, mat_taus);
   DLAF_ASSERT(matrix::equal_blocksize(mat_v, mat_taus), mat_v, mat_taus);
 
+  DLAF_ASSERT(mat_v.blockSize().rows() % band_size == 0, mat_v.blockSize(), band_size);
+
   // TODO check taus with respect to v
 
-  internal::BackTransformationT2B<backend, device, T>::call(mat_e, mat_v, mat_taus);
+  internal::BackTransformationT2B<backend, device, T>::call(band_size, mat_e, mat_v, mat_taus);
 }
 }
 }

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -24,6 +24,10 @@ add_executable(miniapp_reduction_to_band miniapp_reduction_to_band.cpp)
 target_link_libraries(miniapp_reduction_to_band PRIVATE DLAF)
 target_add_warnings(miniapp_reduction_to_band)
 
+add_executable(miniapp_backtransform_t2b miniapp_backtransform_t2b.cpp)
+target_link_libraries(miniapp_backtransform_t2b PRIVATE DLAF)
+target_add_warnings(miniapp_backtransform_t2b)
+
 if(DLAF_WITH_CUDA)
   add_executable(miniapp_cublas miniapp_cublas.cpp)
   target_link_libraries(miniapp_cublas PRIVATE DLAF)


### PR DESCRIPTION
TODO:
- [ ] Decide if we want to keep this and #407 implementations separated for some reason
- [ ] Identify major problems with profiler (e.g. check workspace usage if can be improved to remove internal dependencies)
- [ ] Code cleanup