### PR TITLE
algo: triangular solver LLT (distributed) [adaptations for GPU]

### DIFF
--- a/include/dlaf/blas/tile.h
+++ b/include/dlaf/blas/tile.h
@@ -102,6 +102,12 @@ namespace internal {
     }                                                           \
   }
 
+DLAF_DECLARE_CUBLAS_OP(Axpy);
+DLAF_DEFINE_CUBLAS_OP(Axpy, float, Saxpy);
+DLAF_DEFINE_CUBLAS_OP(Axpy, double, Daxpy);
+DLAF_DEFINE_CUBLAS_OP(Axpy, std::complex<float>, Caxpy);
+DLAF_DEFINE_CUBLAS_OP(Axpy, std::complex<double>, Zaxpy);
+
 DLAF_DECLARE_CUBLAS_OP(Gemm);
 DLAF_DEFINE_CUBLAS_OP(Gemm, float, Sgemm);
 DLAF_DEFINE_CUBLAS_OP(Gemm, double, Dgemm);

--- a/include/dlaf/common/contiguous_buffer_holder.h
+++ b/include/dlaf/common/contiguous_buffer_holder.h
@@ -56,7 +56,7 @@ DLAF_MAKE_CALLABLE_OBJECT(makeItContiguous);
 /// It returns @p tile, ensuring that if the given @p bag owns a temporary buffer, it copies data from
 /// this latter one to @p tile before returning it. Otherwise it is a no-op.
 template <class T>
-auto copyBack(matrix::Tile<T, Device::CPU> const& tile, ContiguousBufferHolder<T> bag) {
+auto copyBack(const matrix::Tile<T, Device::CPU>& tile, ContiguousBufferHolder<T> bag) {
   auto buffer_used = std::move(bag.buffer);
   if (buffer_used)
     common::copy(buffer_used, common::make_data(tile));

--- a/include/dlaf/common/contiguous_buffer_holder.h
+++ b/include/dlaf/common/contiguous_buffer_holder.h
@@ -56,11 +56,10 @@ DLAF_MAKE_CALLABLE_OBJECT(makeItContiguous);
 /// It returns @p tile, ensuring that if the given @p bag owns a temporary buffer, it copies data from
 /// this latter one to @p tile before returning it. Otherwise it is a no-op.
 template <class T>
-auto copyBack(matrix::Tile<T, Device::CPU> tile, ContiguousBufferHolder<T> bag) {
+auto copyBack(matrix::Tile<T, Device::CPU> const& tile, ContiguousBufferHolder<T> bag) {
   auto buffer_used = std::move(bag.buffer);
   if (buffer_used)
     common::copy(buffer_used, common::make_data(tile));
-  return tile;
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(copyBack);

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -138,7 +138,9 @@ hpx::future<matrix::Tile<T, Device::CPU>> scheduleAllReduceInPlace(
   cont_buf = dataflow(ex, unwrapping(internal::allReduceInPlace_o), std::move(pcomm), reduce_op,
                       std::move(cont_buf));
 
-  return dataflow(ex_copy, unwrapping(copyBack_o), std::move(tile), std::move(cont_buf));
+  auto wrapped =
+      dataflow(ex_copy, matrix::unwrapExtendTiles(copyBack_o), std::move(tile), std::move(cont_buf));
+  return hpx::get<0>(hpx::split_future(std::move(wrapped)));
 }
 }
 }

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -140,7 +140,7 @@ hpx::future<matrix::Tile<T, Device::CPU>> scheduleAllReduceInPlace(
 
   auto wrapped =
       dataflow(ex_copy, matrix::unwrapExtendTiles(copyBack_o), std::move(tile), std::move(cont_buf));
-  return hpx::get<0>(hpx::split_future(std::move(wrapped)));
+  return getUnwrapReturnValue(std::move(wrapped));
 }
 }
 }

--- a/include/dlaf/communication/kernels/reduce.h
+++ b/include/dlaf/communication/kernels/reduce.h
@@ -91,7 +91,7 @@ void scheduleReduceRecvInPlace(const comm::Executor& ex,
 
   auto res = dataflow(ex_copy, unwrapping(copyBack_o), tile_cpu, std::move(cont_buf));
 
-  matrix::copyIfNeeded(tile_cpu, tile_orig, res);
+  matrix::copyIfNeeded(tile_cpu, tile_orig, std::move(res));
 }
 
 template <class T, Device D>

--- a/include/dlaf/communication/kernels/reduce.h
+++ b/include/dlaf/communication/kernels/reduce.h
@@ -48,7 +48,7 @@ DLAF_MAKE_CALLABLE_OBJECT(reduceRecvInPlace);
 template <class T, Device D>
 auto reduceSend(comm::IndexT_MPI rank_root, common::PromiseGuard<comm::Communicator> pcomm,
                 MPI_Op reduce_op, common::internal::ContiguousBufferHolder<const T> cont_buf,
-                matrix::Tile<const T, D> const&, MPI_Request* req) {
+                const matrix::Tile<const T, D>&, MPI_Request* req) {
   auto msg = comm::make_message(cont_buf.descriptor);
   auto& comm = pcomm.ref();
 

--- a/include/dlaf/communication/rdma.h
+++ b/include/dlaf/communication/rdma.h
@@ -44,7 +44,7 @@ namespace internal {
 /// Duplicates the tile to CPU memory if CUDA RDMA is not enabled for MPI.
 /// Returns the tile unmodified otherwise.
 template <Device D, typename T>
-auto prepareSendTile(hpx::shared_future<matrix::Tile<const T, D>> tile) {
+auto prepareSendTile(hpx::shared_future<matrix::Tile<T, D>> tile) {
   return matrix::duplicateIfNeeded<CommunicationDevice<D>::value>(std::move(tile));
 }
 

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -449,7 +449,7 @@ void gemmComputeW2(MatrixT<T>& w2, ConstPanelT<Coord::Col, T>& w, ConstPanelT<Co
   }
 
   if (!isW2initialized)
-    hpx::dataflow(ex, unwrapExtendTiles(tile::set0<T>), w2(LocalTileIndex(0, 0)));
+    hpx::dataflow(ex, unwrapExtendTiles(tile::set0_o), w2(LocalTileIndex(0, 0)));
 
   comm::scheduleAllReduceInPlace(ex_mpi, mpi_col_chain(), MPI_SUM, w2(LocalTileIndex(0, 0)));
 }

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -284,9 +284,19 @@ void set0(const Tile<T, Device::CPU>& tile) {
   tile::laset(lapack::MatrixType::General, static_cast<T>(0.0), static_cast<T>(0.0), tile);
 }
 
+#ifdef DLAF_WITH_CUDA
+/// Set zero all the elements of Tile @param tile.
+template <class T>
+void set0(const Tile<T, Device::GPU>& tile, cudaStream_t stream) {
+  DLAF_CUDA_CALL(cudaMemset2DAsync(tile.ptr(), tile.ld(), 0, tile.size().rows(), tile.size().cols(), stream));
+}
+#endif
+
 DLAF_MAKE_CALLABLE_OBJECT(hegst);
 DLAF_MAKE_CALLABLE_OBJECT(potrf);
 DLAF_MAKE_CALLABLE_OBJECT(potrfInfo);
+DLAF_MAKE_CALLABLE_OBJECT(laset);
+DLAF_MAKE_CALLABLE_OBJECT(set0);
 
 }
 }

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -288,7 +288,8 @@ void set0(const Tile<T, Device::CPU>& tile) {
 /// Set zero all the elements of Tile @param tile.
 template <class T>
 void set0(const Tile<T, Device::GPU>& tile, cudaStream_t stream) {
-  DLAF_CUDA_CALL(cudaMemset2DAsync(tile.ptr(), tile.ld(), 0, tile.size().rows(), tile.size().cols(), stream));
+  DLAF_CUDA_CALL(cudaMemset2DAsync(tile.ptr(), sizeof(T) * tile.ld(), 0, sizeof(T) * tile.size().rows(),
+                                   tile.size().cols(), stream));
 }
 #endif
 
@@ -297,6 +298,5 @@ DLAF_MAKE_CALLABLE_OBJECT(potrf);
 DLAF_MAKE_CALLABLE_OBJECT(potrfInfo);
 DLAF_MAKE_CALLABLE_OBJECT(laset);
 DLAF_MAKE_CALLABLE_OBJECT(set0);
-
 }
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -175,8 +175,8 @@ struct DuplicateIfNeeded<SourceDestination, SourceDestination> {
 
 template <Device Source, Device Destination>
 struct CopyIfNeeded {
-  template <class T, template <class> class Future, class... Ts>
-  static auto call(Future<Tile<T, Source>> from, Future<Tile<T, Destination>> to, Ts&&... ts) {
+  template <class T, class U, template <class> class FutureD, template <class> class FutureS, class... Ts>
+  static auto call(FutureS<Tile<U, Source>> from, FutureD<Tile<T, Destination>> to, Ts&&... ts) {
     hpx::dataflow(dlaf::getCopyExecutor<Source, Destination>(), matrix::unwrapExtendTiles(copy_o),
                   std::move(from), std::move(to), std::forward<Ts>(ts)...);
   }
@@ -184,8 +184,8 @@ struct CopyIfNeeded {
 
 template <Device D>
 struct CopyIfNeeded<D, D> {
-  template <class T, template <class> class Future, class... Ts>
-  static auto call(Future<Tile<T, D>>, Future<Tile<T, D>>, Ts&&...) {}
+  template <class T, class U, template <class> class FutureD, template <class> class FutureS, class... Ts>
+  static auto call(FutureS<Tile<U, D>>, FutureD<Tile<T, D>>, Ts&&...) {}
 };
 }
 
@@ -198,8 +198,10 @@ auto duplicateIfNeeded(Future<Tile<T, Source>> tile) {
   return internal::DuplicateIfNeeded<Destination, Source>::call(std::move(tile));
 }
 
-template <Device Destination, class T, Device Source, template <class> class Future, class... Ts>
-auto copyIfNeeded(Future<Tile<T, Source>> tile_from, Future<Tile<T, Destination>> tile_to, Ts&&... ts) {
+template <Device Destination, class T, Device Source, class U, template <class> class FutureD,
+          template <class> class FutureS, class... Ts>
+auto copyIfNeeded(FutureS<Tile<U, Source>> tile_from, FutureD<Tile<T, Destination>> tile_to,
+                  Ts&&... ts) {
   return internal::CopyIfNeeded<Source, Destination>::call(std::move(tile_from), std::move(tile_to),
                                                            std::forward<Ts>(ts)...);
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -134,11 +134,14 @@ void copy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, D
 
 DLAF_MAKE_CALLABLE_OBJECT(copy);
 
-/// Helper struct for copying a given tile to an identical tile on Destination.
+/// Helper struct for copying a given tile to a tile on Destination.
 ///
 /// Defines a call operator which allocates a tile of the same dimensions as the
 /// input tile on Destination, and then copies the input tile to the output
 /// tile.
+/// The allocated tile on Destination will be of the same size of the input one, but it will be also
+/// contiguous, i.e. whatever the input leading dimension is, the destination one will have the leading
+/// dimension equal to the number of rows.
 ///
 /// This is useful for use with dataflow, since the output tile is allocated
 /// only when the input tile is ready.

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -449,8 +449,8 @@ struct getGenericExecutor<Backend::GPU> {
 #endif
 
 template <class T>
-void tileSubtractInPlace(matrix::Tile<T, Device::CPU> const& tile_a,
-                         matrix::Tile<const T, Device::CPU> const& tile_b) {
+void tileSubtractInPlace(const matrix::Tile<T, Device::CPU>& tile_a,
+                         const matrix::Tile<const T, Device::CPU>& tile_b) {
   DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
   for (auto j = 0; j < tile_a.size().cols(); ++j)
     blas::axpy(tile_a.size().rows(), T(-1), tile_b.ptr({0, j}), 1, tile_a.ptr({0, j}), 1);
@@ -458,8 +458,8 @@ void tileSubtractInPlace(matrix::Tile<T, Device::CPU> const& tile_a,
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-void tileSubtractInPlace(cublasHandle_t handle, matrix::Tile<T, Device::GPU> const& tile_a,
-                         matrix::Tile<const T, Device::GPU> const& tile_b) {
+void tileSubtractInPlace(cublasHandle_t handle, const matrix::Tile<T, Device::GPU>& tile_a,
+                         const matrix::Tile<const T, Device::GPU>& tile_b) {
   DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
   const T alpha = -1;
   for (auto j = 0; j < tile_a.size().cols(); ++j)

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -425,10 +425,46 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
   }
 }
 
-template <Backend backend, Device device, class T>
-void Triangular<backend, device, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op op, blas::Diag diag,
-                                              T alpha, Matrix<const T, device>& mat_a,
-                                              Matrix<T, device>& mat_b) {
+template <Backend B>
+struct getGenericExecutor {
+  static auto call() {
+    return dlaf::getNpExecutor<Backend::MC>();
+  }
+};
+
+#ifdef DLAF_WITH_CUDA
+template <>
+struct getGenericExecutor<Backend::GPU> {
+  static auto call() {
+    return dlaf::cuda::Executor{dlaf::internal::getNpCudaStreamPool()};
+  }
+};
+#endif
+
+template <class T>
+void tileSubtractInPlace(matrix::Tile<T, Device::CPU> const & tile_a, matrix::Tile<const T, Device::CPU> const& tile_b) {
+  DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
+  for (auto j = 0; j < tile_a.size().cols(); ++j)
+    blas::axpy(tile_a.size().rows(), T(-1), tile_b.ptr({0, j}), 1, tile_a.ptr({0, j}), 1);
+}
+
+#ifdef DLAF_WITH_CUDA
+template <class T>
+void tileSubtractInPlace(cublasHandle_t handle, matrix::Tile<T, Device::GPU> const & tile_a, matrix::Tile<const T, Device::GPU> const& tile_b) {
+  DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
+  const T alpha = -1;
+  for (auto j = 0; j < tile_a.size().cols(); ++j)
+    tile::internal::CublasAxpy<T>::call(handle, tile_a.size().rows(), util::blasToCublasCast(&alpha),
+        util::blasToCublasCast(tile_b.ptr({0, j})), 1, util::blasToCublasCast(tile_a.ptr({0, j})), 1);
+}
+#endif
+
+DLAF_MAKE_CALLABLE_OBJECT(tileSubtractInPlace);
+
+template <Backend backend, Device D, class T>
+void Triangular<backend, D, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op op, blas::Diag diag,
+                                              T alpha, Matrix<const T, D>& mat_a,
+                                              Matrix<T, D>& mat_b) {
   constexpr auto NoTrans = blas::Op::NoTrans;
 
   auto executor_hp = dlaf::getHpExecutor<backend>();
@@ -451,8 +487,8 @@ void Triangular<backend, device, T>::call_LLT(comm::CommunicatorGrid grid, blas:
     return;
 
   constexpr std::size_t n_workspaces = 2;
-  common::RoundRobin<matrix::Panel<Coord::Col, T, device>> a_panels(n_workspaces, distr_a);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, device>> b_panels(n_workspaces, distr_b);
+  common::RoundRobin<matrix::Panel<Coord::Col, T, D>> a_panels(n_workspaces, distr_a);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> b_panels(n_workspaces, distr_b);
 
   for (SizeType k = mat_a.nrTiles().cols() - 1; k >= 0; --k) {
     const GlobalTileIndex kk{k, k};
@@ -479,7 +515,7 @@ void Triangular<backend, device, T>::call_LLT(comm::CommunicatorGrid grid, blas:
 
     const LocalTileIndex bt_offset(distr_b.nextLocalTileFromGlobalTile<Coord::Row>(kk.row() + 1), 0);
 
-    matrix::util::set0(hpx::launch::sync, b_panel);
+    matrix::util::set0(getGenericExecutor<backend>::call(), b_panel);
 
     for (SizeType j = bt_offset.col(); j < distr_b.localNrTiles().cols(); ++j) {
       for (SizeType i = bt_offset.row(); i < distr_b.localNrTiles().rows(); ++i) {
@@ -487,7 +523,7 @@ void Triangular<backend, device, T>::call_LLT(comm::CommunicatorGrid grid, blas:
 
         const T beta = T(1) / alpha;
         // TODO executor
-        hpx::dataflow(matrix::unwrapExtendTiles(tile::gemm_o), op, blas::Op::NoTrans, beta,
+        hpx::dataflow(executor_np, matrix::unwrapExtendTiles(tile::gemm_o), op, blas::Op::NoTrans, beta,
                       a_panel.read(ij), mat_b.read(ij), T(1), b_panel(ij));
       }
     }
@@ -505,16 +541,11 @@ void Triangular<backend, device, T>::call_LLT(comm::CommunicatorGrid grid, blas:
     if (this_rank.row() == rank_kk.row()) {
       for (SizeType j_loc = 0; j_loc < distr_b.localNrTiles().cols(); ++j_loc) {
         const LocalTileIndex kj(kk_offset.row(), j_loc);
-        auto tile_diff = hpx::unwrapping([](auto tile_a, const auto& tile_b) {
-          DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
-          for (auto j = 0; j < tile_a.size().cols(); ++j)
-            blas::axpy(tile_a.size().rows(), T(-1), tile_b.ptr({0, j}), 1, tile_a.ptr({0, j}), 1);
-        });
         // TODO executor
-        hpx::dataflow(tile_diff, mat_b(kj), b_panel.read(kj));
+        hpx::dataflow(executor_np, matrix::unwrapExtendTiles(tileSubtractInPlace_o), mat_b(kj), b_panel.read(kj));
 
         // TODO executor
-        hpx::dataflow(matrix::unwrapExtendTiles(tile::trsm_o), blas::Side::Left, blas::Uplo::Lower, op,
+        hpx::dataflow(executor_np, matrix::unwrapExtendTiles(tile::trsm_o), blas::Side::Left, blas::Uplo::Lower, op,
                       diag, alpha, a_panel.read(kk_offset), mat_b(kj));
       }
     }

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -425,6 +425,13 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
   }
 }
 
+/// Note:
+/// This is a workaround because the Np/Hp CUDA executors are able to execute
+/// cuSolver and cuBlas calls delegating to the respective custom executors, but they
+/// do not have as fallback the basic CUDA executor, who is is needed by the set0
+/// call.
+/// Moreover, since the algorithm is generic for both CPU and GPU, this helper allows to
+/// hide the different backends needs.
 template <Backend B>
 struct getGenericExecutor {
   static auto call() {

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -524,6 +524,7 @@ void Triangular<backend, D, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op o
 
     const LocalTileIndex bt_offset(distr_b.nextLocalTileFromGlobalTile<Coord::Row>(kk.row() + 1), 0);
 
+    // TODO np/hp executor selection in getGenericExecutor
     matrix::util::set0(getGenericExecutor<backend>::call(), b_panel);
 
     for (SizeType j = bt_offset.col(); j < distr_b.localNrTiles().cols(); ++j) {

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -140,14 +140,14 @@ public:
 template <class T, class ExecutorOrPolicy>
 void set0(ExecutorOrPolicy ex, Matrix<T, Device::CPU>& matrix) {
   for (const auto& idx : iterate_range2d(matrix.distribution().localNrTiles()))
-    matrix(idx).then(ex, hpx::unwrapping(tile::set0<T>));
+    matrix(idx).then(ex, hpx::unwrapping(tile::set0_o));
 }
 
 /// Sets all the elements of all the tiles in the active range to zero
-template <class T, Coord axis, class ExecutorOrPolicy>
-void set0(ExecutorOrPolicy ex, Panel<axis, T, Device::CPU>& panel) {
+template <class T, Coord axis, Device D, class ExecutorOrPolicy>
+void set0(ExecutorOrPolicy ex, Panel<axis, T, D>& panel) {
   for (const auto& tile_idx : panel.iteratorLocal())
-    panel(tile_idx).then(ex, hpx::unwrapping(tile::set0<T>));
+    hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::set0_o), panel(tile_idx));
 }
 
 /// Set the elements of the matrix.

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -137,10 +137,10 @@ public:
 }
 
 /// Sets all the elements of all the tiles to zero
-template <class T, class ExecutorOrPolicy>
-void set0(ExecutorOrPolicy ex, Matrix<T, Device::CPU>& matrix) {
+template <class T, Device D, class ExecutorOrPolicy>
+void set0(ExecutorOrPolicy ex, Matrix<T, D>& matrix) {
   for (const auto& idx : iterate_range2d(matrix.distribution().localNrTiles()))
-    matrix(idx).then(ex, hpx::unwrapping(tile::set0_o));
+    matrix(idx).then(ex, matrix::unwrapExtendTiles(tile::set0_o));
 }
 
 /// Sets all the elements of all the tiles in the active range to zero

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -140,7 +140,7 @@ public:
 template <class T, Device D, class ExecutorOrPolicy>
 void set0(ExecutorOrPolicy ex, Matrix<T, D>& matrix) {
   for (const auto& idx : iterate_range2d(matrix.distribution().localNrTiles()))
-    matrix(idx).then(ex, matrix::unwrapExtendTiles(tile::set0_o));
+    hpx::dataflow(ex, matrix::unwrapExtendTiles(tile::set0_o), matrix(idx));
 }
 
 /// Sets all the elements of all the tiles in the active range to zero

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -69,6 +69,7 @@ linear_system_t sampleLeftTr(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 
 int hpx_main(hpx::program_options::variables_map& vm) {
   dlaf::initialize(vm);
+  {
   options_t opts = check_options(vm);
 
   Communicator world(MPI_COMM_WORLD);
@@ -153,6 +154,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
       const T max_error = 20 * (bh.size().rows() + 1) * muladd_error;
       CHECK_MATRIX_NEAR(ref_x, bh, max_error, 0);
     }
+  }
   }
 
   dlaf::finalize();


### PR DESCRIPTION
This PR is a fork of the main #409, to which adds the needed adaptions for making it work on the GPU too.

Main adaptions:
1. Generic CPU/GPU code for `tile_a -= tile_b` operation (currently carried out column by column via `axpy`)
2. `set0` helper function for GPU
3. Generic executor for `set0`, because `cuSolver`/`cuBlas` executors currently do not dispatch to the basic CUDA one (thanks @msimberg for the support)
4. Adapt MPI async reduce machinery to GPU

In addition to these, there is also a quick workaround in the miniapp for the problem described in #411 (again, thanks @msimberg for the support).