### PR TITLE
minor: conflict with newer version of umpire

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -25,8 +25,13 @@ class DlaFuture(CMakePackage, CudaPackage):
     depends_on("mpi")
     depends_on("blaspp")
     depends_on("lapackpp")
+
     depends_on("umpire~examples")
     depends_on("umpire+cuda~shared", when="+cuda")
+
+    # https://github.com/eth-cscs/DLA-Future/issues/420
+    conflicts("umpire@6:")
+
     depends_on("hpx cxxstd=14 networking=none +async_mpi")
     depends_on("hpx@1.7.0:")
     depends_on("hpx +cuda", when="+cuda")


### PR DESCRIPTION
As reported in #420 current master does not work with newer versions of Umpire.

This conflict will be removed as soon as we will remove the usage of deprecated things in Umpire API.

**NOTE**
At the time of writing spack package for `umpire@5` suffers of a problem that has been already fixed (https://github.com/spack/spack/pull/25484) and it will be merged (hopefully) soon in `develop` (https://github.com/spack/spack/pull/25788).