### PR TITLE
Porting to pika

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ else()
   find_package(LAPACK REQUIRED)
 endif()
 
-# ----- HPX
-find_package(HPX 1.7.0 REQUIRED)
+# ----- pika
+find_package(pika 0.1.0 REQUIRED EXACT)
 
 # ----- BLASPP/LAPACKPP
 find_package(blaspp REQUIRED)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 - MPI
 - OpenMP
-- HPX
+- pika
 - BLAS/LAPACK
 - BLASPP & LAPACKPP
 
@@ -10,12 +10,12 @@
 
 ## OpenMP
 
-## HPX
+## pika
 
-HPX provides a CMake config script in `$HPX_ROOT/lib/cmake/HPX`. To make it available, the variable
-`HPX_DIR` has to be set to this path.
+pika provides a CMake config script in `$pika_ROOT/lib/cmake/pika`. To make it available, the variable
+`pika_DIR` has to be set to this path. Depending on the platform, the files may also be in `lib64` instead of `lib`.
 
-e.g. `cmake -DHPX_DIR=${HPX_ROOT}/lib/cmake/HPX ..`
+e.g. `cmake -Dpika_DIR=${PIKA_ROOT}/lib/cmake/pika ..`
 
 ## BLAS/LAPACK
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Otherwise you can download the archive of the latest `master` branch as a [zip](
 ### Dependencies
 
 - MPI
-- [HPX](https://github.com/STEllAR-GROUP/hpx)
+- [pika](https://github.com/pika-org/pika)
 - [blaspp](https://bitbucket.org/icl/blaspp/src/default/)
 - [lapackpp](https://bitbucket.org/icl/lapackpp/src/default/)
 - Intel MKL or other LAPACK implementation
@@ -37,27 +37,22 @@ Example installation:
 
 `spack install dla-future ^intel-mkl`
 
-Or you can go even further with a more detailed spec like this one, which builds dla-future in debug mode, using the clang compiler, specifying that the HPX on which it depends has to be built
-in debug mode too, with APEX instrumentation enabled, and that we want to use MPICH as MPI implementation, without fortran support (because clang does not support it).
+Or you can go even further with a more detailed spec like this one, which builds dla-future in debug mode, using the clang compiler, specifying that the pika on which it depends has to be built
+in debug mode too, and that we want to use MPICH as MPI implementation, without fortran support (because clang does not support it).
 
-`spack install dla-future %clang build_type=Debug ^hpx build_type=Debug instrumentation=apex ^mpich ~fortran`
-
-Notice that, for the package to work correctly, the HPX option `max_cpu_count` must be set accordingly to the architecture, as it represents the size of the bitmask to interface with hardware threads.
-
-`spack install dla-future ^intel-mkl ^hpx max_cpu_count=256`
+`spack install dla-future %clang build_type=Debug ^pika build_type=Debug ^mpich ~fortran`
 
 #### Build the old good way
 
 You can build all the dependencies by yourself, but you have to ensure that:
 - BLAS/LAPACK implementation is not multithreaded
-- HPX: `HPX_WITH_NETWORKING=none` + `HPX_WITH_MAX_CPU_COUNT=n` (according to number of cores in the architecture, suggested the next closest power of 2)
-- HPX and DLAF must have a compatible `CMAKE_BUILD_TYPE`: they must be built both in Debug, or with any combination of release types (Release, RelWithDebInfo or MinSizeRel)
+- pika: `PIKA_WITH_CUDA=ON` (if building for CUDA) + `PIKA_WITH_MPI`
 
 And here the main CMake options for DLAF build customization:
 
 CMake option | Values | Note
 :---|:---|:---
-`HPX_DIR` | CMAKE:PATH | Location of the HPX CMake-config file
+`pika_DIR` | CMAKE:PATH | Location of the pika CMake-config file
 `blaspp_DIR` | CMAKE:PATH | Location of the blaspp CMake-config file
 `lapackpp_DIR` | CMAKE:PATH | Location of the lapackpp CMake-config file
 `DLAF_WITH_MKL` | `{ON,OFF}` (default: `OFF`) | if blaspp/lapackpp is built with MKL
@@ -71,7 +66,7 @@ CMake option | Values | Note
 `DLAF_INSTALL_TESTS` | `{ON,OFF}` (default: `OFF`) | enable/disable installing tests
 `DLAF_MPI_PRESET` | `{plain-mpi, slurm, custom}` (default `plain-mpi`) | presets for MPI configuration for tests. See [CMake Doc](https://cmake.org/cmake/help/latest/module/FindMPI.html?highlight=mpiexec_executable#usage-of-mpiexec) for additional information
 `DLAF_TEST_RUNALL_WITH_MPIEXEC` | `{ON, OFF}` (default: `OFF`) | Use mpi runner also for non-MPI based tests
-`DLAF_HPXTEST_EXTRA_ARGS` | CMAKE:STRING | Additional HPX command-line options for tests
+`DLAF_PIKATEST_EXTRA_ARGS` | CMAKE:STRING | Additional pika command-line options for tests
 `DLAF_BUILD_DOC` | `{ON,OFF}` (default: `OFF`) | enable/disable documentation generation
 
 ### Link your program/library with DLAF

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,9 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: 522a7c8ee0d51f92aa8cd685f378d54735a5307e
+    # TODO: Change this back. The latter is on msimberg/spack.
+    # SPACK_SHA: 522a7c8ee0d51f92aa8cd685f378d54735a5307e
+    SPACK_SHA: 737f0cc1c79e8eb903e2fc2d48d02982cd392a22
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,9 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    # TODO: Change this back. The latter is on msimberg/spack.
-    # SPACK_SHA: 522a7c8ee0d51f92aa8cd685f378d54735a5307e
-    SPACK_SHA: 737f0cc1c79e8eb903e2fc2d48d02982cd392a22
+    SPACK_SHA: 5cfaead6755fecab42ce88217814fba2185aa16d
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: fff9a29401a7ac37c2d0f04fb2a144dbdea6a47d
+    SPACK_SHA: 4b52f0e4d739998b8aca49356d66fadd0b22af17
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -39,80 +39,80 @@ stages:
       - pipeline.yml
 
 # Builds a Docker image for the current commit
-#cpu release build gcc9:
-#  extends: .build_spack_common
-#  variables:
-#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-#    BASE_IMAGE: ubuntu:20.04
-#    COMPILER: gcc@9.3.0
-#    USE_MKL: "ON"
-#    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
-#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/build
-#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/deploy:$CI_COMMIT_SHA
-#    SLURM_CONSTRAINT: mc
-#    THREADS_PER_NODE: 72
-#    USE_CODECOV: "false"
-#
-#cpu release build clang10:
-#  extends: .build_spack_common
-#  variables:
-#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-#    BASE_IMAGE: ubuntu:20.04
-#    COMPILER: clang@10.0.0
-#    USE_MKL: "ON"
-#    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
-#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/build
-#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/deploy:$CI_COMMIT_SHA
-#    SLURM_CONSTRAINT: mc
-#    THREADS_PER_NODE: 72
-#    USE_CODECOV: "false"
-#
-#cpu codecov build gcc9:
-#  extends: .build_spack_common
-#  variables:
-#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-#    DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
-#    BASE_IMAGE: ubuntu:20.04
-#    COMPILER: gcc@9.3.0
-#    USE_MKL: "OFF"
-#    SPACK_ENVIRONMENT: ci/docker/cpu-debug.yaml
-#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/build
-#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/deploy:$CI_COMMIT_SHA
-#    SLURM_CONSTRAINT: mc
-#    THREADS_PER_NODE: 72
-#    USE_CODECOV: "true"
-#
-#gpu release build gcc9:
-#  extends: .build_spack_common
-#  variables:
-#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-#    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
-#    COMPILER: gcc@9.3.0
-#    USE_MKL: "ON"
-#    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
-#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/build
-#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/deploy:$CI_COMMIT_SHA
-#    SLURM_CONSTRAINT: gpu
-#    THREADS_PER_NODE: 24
-#    USE_CODECOV: "false"
-#
-#gpu release build clang10:
-#  extends: .build_spack_common
-#  variables:
-#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-#    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
-#    COMPILER: clang@10.0.0
-#    USE_MKL: "ON"
-#    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
-#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/build
-#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/deploy:$CI_COMMIT_SHA
-#    SLURM_CONSTRAINT: gpu
-#    THREADS_PER_NODE: 24
-#    USE_CODECOV: "false"
+cpu release build gcc9:
+  extends: .build_spack_common
+  variables:
+    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+    BASE_IMAGE: ubuntu:20.04
+    COMPILER: gcc@9.3.0
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/deploy:$CI_COMMIT_SHA
+    SLURM_CONSTRAINT: mc
+    THREADS_PER_NODE: 72
+    USE_CODECOV: "false"
+
+cpu release build clang10:
+  extends: .build_spack_common
+  variables:
+    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+    BASE_IMAGE: ubuntu:20.04
+    COMPILER: clang@10.0.0
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/deploy:$CI_COMMIT_SHA
+    SLURM_CONSTRAINT: mc
+    THREADS_PER_NODE: 72
+    USE_CODECOV: "false"
+
+cpu codecov build gcc9:
+  extends: .build_spack_common
+  variables:
+    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
+    BASE_IMAGE: ubuntu:20.04
+    COMPILER: gcc@9.3.0
+    USE_MKL: "OFF"
+    SPACK_ENVIRONMENT: ci/docker/cpu-debug.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/deploy:$CI_COMMIT_SHA
+    SLURM_CONSTRAINT: mc
+    THREADS_PER_NODE: 72
+    USE_CODECOV: "true"
+
+gpu release build gcc9:
+  extends: .build_spack_common
+  variables:
+    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+    COMPILER: gcc@9.3.0
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/deploy:$CI_COMMIT_SHA
+    SLURM_CONSTRAINT: gpu
+    THREADS_PER_NODE: 24
+    USE_CODECOV: "false"
+
+gpu release build clang10:
+  extends: .build_spack_common
+  variables:
+    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+    COMPILER: clang@10.0.0
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/deploy:$CI_COMMIT_SHA
+    SLURM_CONSTRAINT: gpu
+    THREADS_PER_NODE: 24
+    USE_CODECOV: "false"
 
 gpu codecov build gcc9:
   extends: .build_spack_common
@@ -150,51 +150,51 @@ notify_github_start:
   trigger:
     strategy: depend
 
-#cpu release test gcc9:
-#  extends: .run_common
-#  needs:
-#    - cpu release build gcc9
-#  trigger:
-#    include:
-#      - artifact: pipeline.yml
-#        job: cpu release build gcc9
-#
-#cpu release test clang10:
-#  extends: .run_common
-#  needs:
-#    - cpu release build clang10
-#  trigger:
-#    include:
-#      - artifact: pipeline.yml
-#        job: cpu release build clang10
-#
-#cpu codecov test gcc9:
-#  extends: .run_common
-#  needs:
-#    - cpu codecov build gcc9
-#  trigger:
-#    strategy: depend
-#    include:
-#      - artifact: pipeline.yml
-#        job: cpu codecov build gcc9
-#
-#gpu release test gcc9:
-#  extends: .run_common
-#  needs:
-#    - gpu release build gcc9
-#  trigger:
-#    include:
-#      - artifact: pipeline.yml
-#        job: gpu release build gcc9
-#
-#gpu release test clang10:
-#  extends: .run_common
-#  needs:
-#    - gpu release build clang10
-#  trigger:
-#    include:
-#      - artifact: pipeline.yml
-#        job: gpu release build clang10
+cpu release test gcc9:
+  extends: .run_common
+  needs:
+    - cpu release build gcc9
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: cpu release build gcc9
+
+cpu release test clang10:
+  extends: .run_common
+  needs:
+    - cpu release build clang10
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: cpu release build clang10
+
+cpu codecov test gcc9:
+  extends: .run_common
+  needs:
+    - cpu codecov build gcc9
+  trigger:
+    strategy: depend
+    include:
+      - artifact: pipeline.yml
+        job: cpu codecov build gcc9
+
+gpu release test gcc9:
+  extends: .run_common
+  needs:
+    - gpu release build gcc9
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: gpu release build gcc9
+
+gpu release test clang10:
+  extends: .run_common
+  needs:
+    - gpu release build clang10
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: gpu release build clang10
 
 gpu codecov test gcc9:
   extends: .run_common

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: 5cfaead6755fecab42ce88217814fba2185aa16d
+    SPACK_SHA: fff9a29401a7ac37c2d0f04fb2a144dbdea6a47d
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -39,80 +39,80 @@ stages:
       - pipeline.yml
 
 # Builds a Docker image for the current commit
-cpu release build gcc9:
-  extends: .build_spack_common
-  variables:
-    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: ubuntu:20.04
-    COMPILER: gcc@9.3.0
-    USE_MKL: "ON"
-    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/deploy:$CI_COMMIT_SHA
-    SLURM_CONSTRAINT: mc
-    THREADS_PER_NODE: 72
-    USE_CODECOV: "false"
-
-cpu release build clang10:
-  extends: .build_spack_common
-  variables:
-    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: ubuntu:20.04
-    COMPILER: clang@10.0.0
-    USE_MKL: "ON"
-    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/deploy:$CI_COMMIT_SHA
-    SLURM_CONSTRAINT: mc
-    THREADS_PER_NODE: 72
-    USE_CODECOV: "false"
-
-cpu codecov build gcc9:
-  extends: .build_spack_common
-  variables:
-    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-    DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
-    BASE_IMAGE: ubuntu:20.04
-    COMPILER: gcc@9.3.0
-    USE_MKL: "OFF"
-    SPACK_ENVIRONMENT: ci/docker/cpu-debug.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/deploy:$CI_COMMIT_SHA
-    SLURM_CONSTRAINT: mc
-    THREADS_PER_NODE: 72
-    USE_CODECOV: "true"
-
-gpu release build gcc9:
-  extends: .build_spack_common
-  variables:
-    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
-    COMPILER: gcc@9.3.0
-    USE_MKL: "ON"
-    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/deploy:$CI_COMMIT_SHA
-    SLURM_CONSTRAINT: gpu
-    THREADS_PER_NODE: 24
-    USE_CODECOV: "false"
-
-gpu release build clang10:
-  extends: .build_spack_common
-  variables:
-    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
-    COMPILER: clang@10.0.0
-    USE_MKL: "ON"
-    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/deploy:$CI_COMMIT_SHA
-    SLURM_CONSTRAINT: gpu
-    THREADS_PER_NODE: 24
-    USE_CODECOV: "false"
+#cpu release build gcc9:
+#  extends: .build_spack_common
+#  variables:
+#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+#    BASE_IMAGE: ubuntu:20.04
+#    COMPILER: gcc@9.3.0
+#    USE_MKL: "ON"
+#    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
+#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/build
+#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/deploy:$CI_COMMIT_SHA
+#    SLURM_CONSTRAINT: mc
+#    THREADS_PER_NODE: 72
+#    USE_CODECOV: "false"
+#
+#cpu release build clang10:
+#  extends: .build_spack_common
+#  variables:
+#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+#    BASE_IMAGE: ubuntu:20.04
+#    COMPILER: clang@10.0.0
+#    USE_MKL: "ON"
+#    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
+#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/build
+#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang10/deploy:$CI_COMMIT_SHA
+#    SLURM_CONSTRAINT: mc
+#    THREADS_PER_NODE: 72
+#    USE_CODECOV: "false"
+#
+#cpu codecov build gcc9:
+#  extends: .build_spack_common
+#  variables:
+#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+#    DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
+#    BASE_IMAGE: ubuntu:20.04
+#    COMPILER: gcc@9.3.0
+#    USE_MKL: "OFF"
+#    SPACK_ENVIRONMENT: ci/docker/cpu-debug.yaml
+#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/build
+#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/deploy:$CI_COMMIT_SHA
+#    SLURM_CONSTRAINT: mc
+#    THREADS_PER_NODE: 72
+#    USE_CODECOV: "true"
+#
+#gpu release build gcc9:
+#  extends: .build_spack_common
+#  variables:
+#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+#    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+#    COMPILER: gcc@9.3.0
+#    USE_MKL: "ON"
+#    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
+#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/build
+#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-gcc9/deploy:$CI_COMMIT_SHA
+#    SLURM_CONSTRAINT: gpu
+#    THREADS_PER_NODE: 24
+#    USE_CODECOV: "false"
+#
+#gpu release build clang10:
+#  extends: .build_spack_common
+#  variables:
+#    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+#    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+#    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+#    COMPILER: clang@10.0.0
+#    USE_MKL: "ON"
+#    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
+#    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/build
+#    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-gpu-clang10/deploy:$CI_COMMIT_SHA
+#    SLURM_CONSTRAINT: gpu
+#    THREADS_PER_NODE: 24
+#    USE_CODECOV: "false"
 
 gpu codecov build gcc9:
   extends: .build_spack_common
@@ -150,51 +150,51 @@ notify_github_start:
   trigger:
     strategy: depend
 
-cpu release test gcc9:
-  extends: .run_common
-  needs:
-    - cpu release build gcc9
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cpu release build gcc9
-
-cpu release test clang10:
-  extends: .run_common
-  needs:
-    - cpu release build clang10
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cpu release build clang10
-
-cpu codecov test gcc9:
-  extends: .run_common
-  needs:
-    - cpu codecov build gcc9
-  trigger:
-    strategy: depend
-    include:
-      - artifact: pipeline.yml
-        job: cpu codecov build gcc9
-
-gpu release test gcc9:
-  extends: .run_common
-  needs:
-    - gpu release build gcc9
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: gpu release build gcc9
-
-gpu release test clang10:
-  extends: .run_common
-  needs:
-    - gpu release build clang10
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: gpu release build clang10
+#cpu release test gcc9:
+#  extends: .run_common
+#  needs:
+#    - cpu release build gcc9
+#  trigger:
+#    include:
+#      - artifact: pipeline.yml
+#        job: cpu release build gcc9
+#
+#cpu release test clang10:
+#  extends: .run_common
+#  needs:
+#    - cpu release build clang10
+#  trigger:
+#    include:
+#      - artifact: pipeline.yml
+#        job: cpu release build clang10
+#
+#cpu codecov test gcc9:
+#  extends: .run_common
+#  needs:
+#    - cpu codecov build gcc9
+#  trigger:
+#    strategy: depend
+#    include:
+#      - artifact: pipeline.yml
+#        job: cpu codecov build gcc9
+#
+#gpu release test gcc9:
+#  extends: .run_common
+#  needs:
+#    - gpu release build gcc9
+#  trigger:
+#    include:
+#      - artifact: pipeline.yml
+#        job: gpu release build gcc9
+#
+#gpu release test clang10:
+#  extends: .run_common
+#  needs:
+#    - gpu release build clang10
+#  trigger:
+#    include:
+#      - artifact: pipeline.yml
+#        job: gpu release build clang10
 
 gpu codecov test gcc9:
   extends: .run_common

--- a/ci/docker/build.Dockerfile
+++ b/ci/docker/build.Dockerfile
@@ -49,8 +49,9 @@ ARG SPACK_SHA
 ENV SPACK_SHA=$SPACK_SHA
 
 # Install the specific ref of Spack provided by the user and find compilers
+# TODO: Change this back to the upstream spack repo before merging
 RUN mkdir -p /opt/spack && \
-    curl -Ls "https://api.github.com/repos/spack/spack/tarball/$SPACK_SHA" | tar --strip-components=1 -xz -C /opt/spack
+    curl -Ls "https://api.github.com/repos/msimberg/spack/tarball/$SPACK_SHA" | tar --strip-components=1 -xz -C /opt/spack
 
 # Find compilers + Add gfortran to clang specs + Define which compiler we want to use
 ARG COMPILER

--- a/ci/docker/build.Dockerfile
+++ b/ci/docker/build.Dockerfile
@@ -49,9 +49,8 @@ ARG SPACK_SHA
 ENV SPACK_SHA=$SPACK_SHA
 
 # Install the specific ref of Spack provided by the user and find compilers
-# TODO: Change this back to the upstream spack repo before merging
 RUN mkdir -p /opt/spack && \
-    curl -Ls "https://api.github.com/repos/msimberg/spack/tarball/$SPACK_SHA" | tar --strip-components=1 -xz -C /opt/spack
+    curl -Ls "https://api.github.com/repos/spack/spack/tarball/$SPACK_SHA" | tar --strip-components=1 -xz -C /opt/spack
 
 # Find compilers + Add gfortran to clang specs + Define which compiler we want to use
 ARG COMPILER

--- a/ci/docker/cpu-debug.yaml
+++ b/ci/docker/cpu-debug.yaml
@@ -14,10 +14,9 @@ spack:
       variants:
         - '~cuda'
         - '~openmp'
-    hpx:
+    pika:
       variants:
         - 'build_type=Debug'
-        - 'max_cpu_count=128'
     mpich:
       variants:
         - '~fortran'

--- a/ci/docker/cpu-release.yaml
+++ b/ci/docker/cpu-release.yaml
@@ -14,9 +14,6 @@ spack:
       variants:
         - '~cuda'
         - '~openmp'
-    hpx:
-      variants:
-        - 'max_cpu_count=128'
     mpich:
       variants:
         - '~fortran'

--- a/ci/docker/gpu-debug.yaml
+++ b/ci/docker/gpu-debug.yaml
@@ -14,10 +14,9 @@ spack:
       variants:
         - '~cuda'
         - '~openmp'
-    hpx:
+    pika:
       variants:
         - 'build_type=Debug'
-        - 'max_cpu_count=128'
     mpich:
       variants:
         - '~fortran'

--- a/ci/docker/gpu-release.yaml
+++ b/ci/docker/gpu-release.yaml
@@ -14,9 +14,6 @@ spack:
       variants:
         - '~cuda'
         - '~openmp'
-    hpx:
-      variants:
-        - 'max_cpu_count=128'
     mpich:
       variants:
         - '~fortran'

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -14,7 +14,7 @@
 #   [INCLUDE_DIRS <arguments for target_include_directories>]
 #   [LIBRARIES <arguments for target_link_libraries>]
 #   [MPIRANKS <number of rank>]
-#   [USE_MAIN {PLAIN | HPX | MPI | MPIHPX}]
+#   [USE_MAIN {PLAIN | PIKA | MPI | MPIPIKA}]
 # )
 #
 # At least one source file has to be specified, while other parameters are optional.
@@ -27,9 +27,9 @@
 #
 # USE_MAIN links to an external main function, in particular:
 #   - PLAIN: uses the classic gtest_main
-#   - HPX: uses a main that initializes HPX
+#   - PIKA: uses a main that initializes pika
 #   - MPI: uses a main that initializes MPI
-#   - MPIHPX: uses a main that initializes both HPX and MPI
+#   - MPIPIKA: uses a main that initializes both pika and MPI
 # If not specified, no external main is used and it should exist in the test source code.
 #
 # e.g.
@@ -58,21 +58,21 @@ function(DLAF_addTest test_target_name)
   endif()
 
   set(IS_AN_MPI_TEST FALSE)
-  set(IS_AN_HPX_TEST FALSE)
+  set(IS_AN_PIKA_TEST FALSE)
   if (NOT DLAF_AT_USE_MAIN)
     set(_gtest_tgt gtest)
   elseif (DLAF_AT_USE_MAIN STREQUAL PLAIN)
     set(_gtest_tgt gtest_main)
-  elseif (DLAF_AT_USE_MAIN STREQUAL HPX)
-    set(_gtest_tgt DLAF_gtest_hpx_main)
-    set(IS_AN_HPX_TEST TRUE)
+  elseif (DLAF_AT_USE_MAIN STREQUAL PIKA)
+    set(_gtest_tgt DLAF_gtest_pika_main)
+    set(IS_AN_PIKA_TEST TRUE)
   elseif (DLAF_AT_USE_MAIN STREQUAL MPI)
     set(_gtest_tgt DLAF_gtest_mpi_main)
     set(IS_AN_MPI_TEST TRUE)
-  elseif (DLAF_AT_USE_MAIN STREQUAL MPIHPX)
-    set(_gtest_tgt DLAF_gtest_mpihpx_main)
+  elseif (DLAF_AT_USE_MAIN STREQUAL MPIPIKA)
+    set(_gtest_tgt DLAF_gtest_mpipika_main)
     set(IS_AN_MPI_TEST TRUE)
-    set(IS_AN_HPX_TEST TRUE)
+    set(IS_AN_PIKA_TEST TRUE)
   else()
     message(FATAL_ERROR "USE_MAIN=${DLAF_AT_USE_MAIN} is not a supported option")
   endif()
@@ -136,19 +136,19 @@ function(DLAF_addTest test_target_name)
     set(_TEST_LABEL "RANK_1")
   endif()
 
-  if (IS_AN_HPX_TEST)
-    separate_arguments(_HPX_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_HPXTEST_EXTRA_ARGS})
+  if (IS_AN_PIKA_TEST)
+    separate_arguments(_PIKA_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_PIKATEST_EXTRA_ARGS})
 
     # APPLE platform does not support thread binding
     if (NOT APPLE)
-      list(APPEND _TEST_ARGUMENTS "--hpx:use-process-mask")
+      list(APPEND _TEST_ARGUMENTS "--pika:use-process-mask")
     endif()
 
     if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)
-      list(APPEND _TEST_ARGUMENTS "--hpx:bind=none")
+      list(APPEND _TEST_ARGUMENTS "--pika:bind=none")
     endif()
 
-    list(APPEND _TEST_ARGUMENTS ${_HPX_EXTRA_ARGS_LIST})
+    list(APPEND _TEST_ARGUMENTS ${_PIKA_EXTRA_ARGS_LIST})
   endif()
 
   ### Test executable target

--- a/cmake/template/DLAFConfig.cmake.in
+++ b/cmake/template/DLAFConfig.cmake.in
@@ -34,7 +34,7 @@ endif()
 find_dependency(blaspp PATHS @blaspp_DIR@)
 find_dependency(lapackpp PATHS @lapackpp_DIR@)
 
-# ----- HPX
-find_dependency(HPX PATHS @HPX_DIR@)
+# ----- pika
+find_dependency(pika PATHS @pika_DIR@)
 
 check_required_components(DLAF)

--- a/include/dlaf/auxiliary/norm/mc.h
+++ b/include/dlaf/auxiliary/norm/mc.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/auxiliary/norm/api.h"
 #include "dlaf/common/range2d.h"
@@ -49,7 +49,7 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
 
   using dlaf::common::internal::vector;
   using dlaf::common::make_data;
-  using hpx::unwrapping;
+  using pika::unwrapping;
 
   using dlaf::tile::internal::lange;
   using dlaf::tile::internal::lantr;
@@ -61,7 +61,7 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
   DLAF_ASSERT(square_size(matrix), matrix);
   DLAF_ASSERT(square_blocksize(matrix), matrix);
 
-  vector<hpx::future<NormT>> tiles_max;
+  vector<pika::future<NormT>> tiles_max;
   tiles_max.reserve(distribution.localNrTiles().rows() * distribution.localNrTiles().cols());
 
   // for each local tile in the (global) lower triangular matrix, create a task that finds the max element in the tile
@@ -78,7 +78,7 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
       else
         return lange(lapack::Norm::Max, tile);
     });
-    auto current_tile_max = hpx::dataflow(norm_max_f, matrix.read(tile_wrt_local));
+    auto current_tile_max = pika::dataflow(norm_max_f, matrix.read(tile_wrt_local));
 
     tiles_max.emplace_back(std::move(current_tile_max));
   }
@@ -86,7 +86,7 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
   // than it is necessary to reduce max values from all ranks into a single max value for the matrix
 
   // TODO unwrapping can be skipped for optimization reasons
-  NormT local_max_value = hpx::dataflow(unwrapping([](const auto&& values) {
+  NormT local_max_value = pika::dataflow(unwrapping([](const auto&& values) {
                                           if (values.size() == 0)
                                             return std::numeric_limits<NormT>::min();
                                           return *std::max_element(values.begin(), values.end());

--- a/include/dlaf/auxiliary/norm/mc.h
+++ b/include/dlaf/auxiliary/norm/mc.h
@@ -87,11 +87,11 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
 
   // TODO unwrapping can be skipped for optimization reasons
   NormT local_max_value = pika::dataflow(unwrapping([](const auto&& values) {
-                                          if (values.size() == 0)
-                                            return std::numeric_limits<NormT>::min();
-                                          return *std::max_element(values.begin(), values.end());
-                                        }),
-                                        tiles_max)
+                                           if (values.size() == 0)
+                                             return std::numeric_limits<NormT>::min();
+                                           return *std::max_element(values.begin(), values.end());
+                                         }),
+                                         tiles_max)
                               .get();
   NormT max_value;
   dlaf::comm::sync::reduce(comm_grid.rankFullCommunicator(rank), comm_grid.fullCommunicator(), MPI_MAX,

--- a/include/dlaf/blas/tile.h
+++ b/include/dlaf/blas/tile.h
@@ -45,7 +45,7 @@ void gemm(const blas::Op op_a, const blas::Op op_b, const T alpha, const Tile<co
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto gemm(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload gemm
@@ -67,7 +67,7 @@ void hemm(const blas::Side side, const blas::Uplo uplo, const T alpha, const Til
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto hemm(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload hemm
@@ -89,7 +89,7 @@ void her2k(const blas::Uplo uplo, const blas::Op op, const T alpha, const Tile<c
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto her2k(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload her2k
@@ -111,7 +111,7 @@ void herk(const blas::Uplo uplo, const blas::Op op, const BaseType<T> alpha, con
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto herk(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload herk
@@ -134,7 +134,7 @@ void trmm(const dlaf::internal::Policy<B>& policy, const blas::Side side, const 
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto trmm(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload trmm
@@ -157,7 +157,7 @@ void trsm(const dlaf::internal::Policy<B>& policy, const blas::Side side, const 
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto trsm(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload trsm

--- a/include/dlaf/blas/tile_extensions.h
+++ b/include/dlaf/blas/tile_extensions.h
@@ -42,7 +42,7 @@ void add(T alpha, const matrix::Tile<const T, D>& tile_b, const matrix::Tile<T, 
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto add(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload add

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -53,7 +53,7 @@ public:
   };
 
 private:
-  T object_;                              /// the object owned by the wrapper.
+  T object_;                               /// the object owned by the wrapper.
   pika::lcos::local::promise<T> promise_;  /// the shared state that will unlock the next user.
 };
 

--- a/include/dlaf/communication/broadcast_panel.h
+++ b/include/dlaf/communication/broadcast_panel.h
@@ -12,7 +12,7 @@
 
 /// @file
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/communication/message.h"
 #include "dlaf/executors.h"
@@ -53,8 +53,8 @@ template <class T, Device device, Coord axis, class = std::enable_if_t<!std::is_
 void broadcast(const comm::Executor& ex, comm::IndexT_MPI rank_root,
                matrix::Panel<axis, T, device>& panel,
                common::Pipeline<comm::Communicator>& serial_comm) {
-  using hpx::dataflow;
-  using hpx::unwrapping;
+  using pika::dataflow;
+  using pika::unwrapping;
 
   constexpr auto comm_coord = axis;
 
@@ -106,8 +106,8 @@ void broadcast(const comm::Executor& ex, comm::IndexT_MPI rank_root,
                matrix::Panel<axis, T, device>& panel, matrix::Panel<orthogonal(axis), T, device>& panelT,
                common::Pipeline<comm::Communicator>& row_task_chain,
                common::Pipeline<comm::Communicator>& col_task_chain) {
-  using hpx::dataflow;
-  using hpx::unwrapping;
+  using pika::dataflow;
+  using pika::unwrapping;
 
   constexpr Coord axisT = orthogonal(axis);
 

--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -13,7 +13,7 @@
 #include <mutex>
 
 #include <mpi.h>
-#include <hpx/local/mutex.hpp>
+#include <pika/mutex.hpp>
 
 #include "dlaf/communication/error.h"
 
@@ -44,15 +44,15 @@ inline bool mpi_serialized() noexcept {
 
 /// Serializes the MPI call if `MPI_THREAD_SERIALIZED` is used.
 ///
-/// Note: HPX mutex is used instead of std::mutex to avoid stalling the HPX scheduler as the function may
-///       be called from a HPX thread/task.
-/// Note: This function should only be called after HPX has been initialized, otherwise the HPX mutex may
+/// Note: pika mutex is used instead of std::mutex to avoid stalling the pika scheduler as the function may
+///       be called from a pika thread/task.
+/// Note: This function should only be called after pika has been initialized, otherwise the pika mutex may
 ///       error out.
 template <class F, class... Ts>
 void mpi_invoke(F f, Ts... ts) noexcept {
   if (mpi_serialized()) {
-    static hpx::lcos::local::mutex mt;
-    std::lock_guard<hpx::lcos::local::mutex> lk(mt);
+    static pika::lcos::local::mutex mt;
+    std::lock_guard<pika::lcos::local::mutex> lk(mt);
     DLAF_MPI_CALL(f(ts...));
   }
   else {

--- a/include/dlaf/communication/kernels/reduce.h
+++ b/include/dlaf/communication/kernels/reduce.h
@@ -18,7 +18,7 @@
 
 #include <mpi.h>
 
-#include <hpx/local/unwrap.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/common/callable_object.h"
 #include "dlaf/common/contiguous_buffer_holder.h"
@@ -66,8 +66,8 @@ DLAF_MAKE_CALLABLE_OBJECT(reduceSend);
 
 template <class T, Device D>
 void scheduleReduceRecvInPlace(const comm::Executor& ex,
-                               hpx::future<common::PromiseGuard<comm::Communicator>> pcomm,
-                               MPI_Op reduce_op, hpx::future<matrix::Tile<T, D>> tile) {
+                               pika::future<common::PromiseGuard<comm::Communicator>> pcomm,
+                               MPI_Op reduce_op, pika::future<matrix::Tile<T, D>> tile) {
   // Note:
   //
   // GPU  -> duplicateIfNeeded ---------------------> cCPU -> MPI -------------> copyIfNeeded --> GPU
@@ -76,8 +76,8 @@ void scheduleReduceRecvInPlace(const comm::Executor& ex,
   //
   // where: cCPU = contiguous CPU
 
-  using hpx::dataflow;
-  using hpx::unwrapping;
+  using pika::dataflow;
+  using pika::unwrapping;
 
   using common::internal::copyBack_o;
   using common::internal::makeItContiguous_o;
@@ -96,8 +96,8 @@ void scheduleReduceRecvInPlace(const comm::Executor& ex,
   // TILE_CPU ----> duplicateIfNeeded<CPU> ----> TILE_CPU (no-op)
   // TILE_GPU ----> duplicateIfNeeded<CPU> ----> TILE_CPU
 
-  hpx::shared_future<Tile<T, D>> tile_orig = tile.share();
-  hpx::shared_future<Tile<T, Device::CPU>> tile_cpu = duplicateIfNeeded<Device::CPU>(tile_orig);
+  pika::shared_future<Tile<T, D>> tile_orig = tile.share();
+  pika::shared_future<Tile<T, Device::CPU>> tile_cpu = duplicateIfNeeded<Device::CPU>(tile_orig);
 
   // Note:
   //
@@ -127,10 +127,10 @@ void scheduleReduceRecvInPlace(const comm::Executor& ex,
 
 template <class T, Device D, template <class> class Future>
 void scheduleReduceSend(const comm::Executor& ex, comm::IndexT_MPI rank_root,
-                        hpx::future<common::PromiseGuard<comm::Communicator>> pcomm, MPI_Op reduce_op,
+                        pika::future<common::PromiseGuard<comm::Communicator>> pcomm, MPI_Op reduce_op,
                         Future<matrix::Tile<T, D>> tile) {
-  using hpx::dataflow;
-  using hpx::unwrapping;
+  using pika::dataflow;
+  using pika::unwrapping;
 
   using common::internal::makeItContiguous_o;
   using matrix::Tile;
@@ -146,7 +146,7 @@ void scheduleReduceSend(const comm::Executor& ex, comm::IndexT_MPI rank_root,
   //
   // TILE_CPU ----> duplicateIfNeeded<CPU> ----> TILE_CPU (no-op)
   // TILE_GPU ----> duplicateIfNeeded<CPU> ----> TILE_CPU
-  hpx::shared_future<Tile<const T, Device::CPU>> tile_cpu =
+  pika::shared_future<Tile<const T, Device::CPU>> tile_cpu =
       duplicateIfNeeded<Device::CPU>(std::move(tile));
 
   // Note:

--- a/include/dlaf/communication/rdma.h
+++ b/include/dlaf/communication/rdma.h
@@ -12,7 +12,7 @@
 
 /// @file
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/communication/message.h"
 #include "dlaf/executors.h"
@@ -47,7 +47,7 @@ namespace internal {
 /// Duplicates the tile to CPU memory if CUDA RDMA is not enabled for MPI.
 /// Returns the tile unmodified otherwise.
 template <Device D, typename T>
-auto prepareSendTile(hpx::shared_future<matrix::Tile<const T, D>> tile) {
+auto prepareSendTile(pika::shared_future<matrix::Tile<const T, D>> tile) {
   return matrix::duplicateIfNeeded<CommunicationDevice_v<D>>(std::move(tile));
 }
 
@@ -57,7 +57,7 @@ auto prepareSendTile(hpx::shared_future<matrix::Tile<const T, D>> tile) {
 /// the CPU. This helper duplicates to the GPU if the first template parameter
 /// is a GPU device. The first template parameter must be given.
 template <Device D, typename T>
-auto handleRecvTile(hpx::future<matrix::Tile<T, CommunicationDevice_v<D>>> tile) {
+auto handleRecvTile(pika::future<matrix::Tile<T, CommunicationDevice_v<D>>> tile) {
   return matrix::duplicateIfNeeded<D>(std::move(tile));
 }
 }

--- a/include/dlaf/communication/sync/broadcast.h
+++ b/include/dlaf/communication/sync/broadcast.h
@@ -12,7 +12,7 @@
 
 /// @file
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/common/callable_object.h"

--- a/include/dlaf/cublas/executor.h
+++ b/include/dlaf/cublas/executor.h
@@ -21,13 +21,13 @@
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/functional.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/mutex.hpp>
-#include <hpx/local/tuple.hpp>
-#include <hpx/local/type_traits.hpp>
-#include <hpx/modules/async_cuda.hpp>
+#include <pika/execution.hpp>
+#include <pika/functional.hpp>
+#include <pika/future.hpp>
+#include <pika/mutex.hpp>
+#include <pika/tuple.hpp>
+#include <pika/type_traits.hpp>
+#include <pika/modules/async_cuda.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/error.h"
@@ -47,20 +47,20 @@ struct isAsyncCublasCallableImpl : std::false_type {
 
 template <typename F, typename... Ts>
 struct isAsyncCublasCallableImpl<true, F, Ts...> : std::true_type {
-  using return_type = hpx::future<typename hpx::invoke_result<F, cublasHandle_t&, Ts...>::type>;
+  using return_type = pika::future<typename pika::invoke_result<F, cublasHandle_t&, Ts...>::type>;
 };
 
 template <typename F, typename... Ts>
 struct isAsyncCublasCallable
-    : isAsyncCublasCallableImpl<hpx::is_invocable_v<F, cublasHandle_t&, Ts...>, F, Ts...> {};
+    : isAsyncCublasCallableImpl<pika::is_invocable_v<F, cublasHandle_t&, Ts...>, F, Ts...> {};
 
 template <typename F, typename... Ts>
 inline constexpr bool isAsyncCublasCallable_v = isAsyncCublasCallable<F, Ts...>::value;
 
 template <typename F, typename Futures>
 struct isDataflowCublasCallable
-    : hpx::is_invocable<hpx::util::functional::invoke_fused, F,
-                        decltype(hpx::tuple_cat(hpx::tie(std::declval<cublasHandle_t&>()),
+    : pika::is_invocable<pika::util::functional::invoke_fused, F,
+                        decltype(pika::tuple_cat(pika::tie(std::declval<cublasHandle_t&>()),
                                                 std::declval<Futures>()))> {};
 template <typename F, typename Futures>
 inline constexpr bool isDataflowCublasCallable_v = isDataflowCublasCallable<F, Futures>::value;
@@ -102,40 +102,40 @@ public:
   async_execute(F&& f, Ts&&... ts) {
     cudaStream_t stream = stream_pool_.getNextStream();
     cublasHandle_t handle = handle_pool_.getNextHandle(stream);
-    auto r = hpx::invoke(std::forward<F>(f), handle, std::forward<Ts>(ts)...);
-    hpx::future<void> fut = hpx::cuda::experimental::detail::get_future_with_event(stream);
+    auto r = pika::invoke(std::forward<F>(f), handle, std::forward<Ts>(ts)...);
+    pika::future<void> fut = pika::cuda::experimental::detail::get_future_with_event(stream);
 
     // The handle and stream pools are captured by value to ensure that the
     // streams live at least until the event has completed.
-    return fut.then(hpx::launch::sync,
+    return fut.then(pika::launch::sync,
                     [r = std::move(r), stream_pool = stream_pool_,
-                     handle_pool = handle_pool_](hpx::future<void>&&) mutable { return std::move(r); });
+                     handle_pool = handle_pool_](pika::future<void>&&) mutable { return std::move(r); });
   }
 
   template <class Frame, class F, class Futures>
   std::enable_if_t<internal::isDataflowCublasCallable_v<F, Futures>> dataflow_finalize(
       Frame&& frame, F&& f, Futures&& futures) {
     // Ensure the dataflow frame stays alive long enough.
-    hpx::intrusive_ptr<typename std::remove_pointer<typename std::decay<Frame>::type>::type> frame_p(
+    pika::intrusive_ptr<typename std::remove_pointer<typename std::decay<Frame>::type>::type> frame_p(
         frame);
 
     cudaStream_t stream = stream_pool_.getNextStream();
     cublasHandle_t handle = handle_pool_.getNextHandle(stream);
-    auto r = hpx::invoke_fused(std::forward<F>(f),
-                               hpx::tuple_cat(hpx::tie(handle), std::forward<Futures>(futures)));
-    hpx::future<void> fut = hpx::cuda::experimental::detail::get_future_with_event(stream);
+    auto r = pika::invoke_fused(std::forward<F>(f),
+                               pika::tuple_cat(pika::tie(handle), std::forward<Futures>(futures)));
+    pika::future<void> fut = pika::cuda::experimental::detail::get_future_with_event(stream);
 
     // The handle and stream pools are captured by value to ensure that the
     // streams live at least until the event has completed.
-    fut.then(hpx::launch::sync, [r = std::move(r), frame_p = std::move(frame_p),
+    fut.then(pika::launch::sync, [r = std::move(r), frame_p = std::move(frame_p),
                                  stream_pool = stream_pool_, handle_pool = handle_pool_](
-                                    hpx::future<void>&&) mutable { frame_p->set_data(std::move(r)); });
+                                    pika::future<void>&&) mutable { frame_p->set_data(std::move(r)); });
   }
 };
 }
 }
 
-namespace hpx {
+namespace pika {
 namespace parallel {
 namespace execution {
 template <>

--- a/include/dlaf/cublas/executor.h
+++ b/include/dlaf/cublas/executor.h
@@ -24,10 +24,10 @@
 #include <pika/execution.hpp>
 #include <pika/functional.hpp>
 #include <pika/future.hpp>
+#include <pika/modules/async_cuda.hpp>
 #include <pika/mutex.hpp>
 #include <pika/tuple.hpp>
 #include <pika/type_traits.hpp>
-#include <pika/modules/async_cuda.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/error.h"
@@ -60,8 +60,8 @@ inline constexpr bool isAsyncCublasCallable_v = isAsyncCublasCallable<F, Ts...>:
 template <typename F, typename Futures>
 struct isDataflowCublasCallable
     : pika::is_invocable<pika::util::functional::invoke_fused, F,
-                        decltype(pika::tuple_cat(pika::tie(std::declval<cublasHandle_t&>()),
-                                                std::declval<Futures>()))> {};
+                         decltype(pika::tuple_cat(pika::tie(std::declval<cublasHandle_t&>()),
+                                                  std::declval<Futures>()))> {};
 template <typename F, typename Futures>
 inline constexpr bool isDataflowCublasCallable_v = isDataflowCublasCallable<F, Futures>::value;
 }
@@ -122,14 +122,14 @@ public:
     cudaStream_t stream = stream_pool_.getNextStream();
     cublasHandle_t handle = handle_pool_.getNextHandle(stream);
     auto r = pika::invoke_fused(std::forward<F>(f),
-                               pika::tuple_cat(pika::tie(handle), std::forward<Futures>(futures)));
+                                pika::tuple_cat(pika::tie(handle), std::forward<Futures>(futures)));
     pika::future<void> fut = pika::cuda::experimental::detail::get_future_with_event(stream);
 
     // The handle and stream pools are captured by value to ensure that the
     // streams live at least until the event has completed.
     fut.then(pika::launch::sync, [r = std::move(r), frame_p = std::move(frame_p),
-                                 stream_pool = stream_pool_, handle_pool = handle_pool_](
-                                    pika::future<void>&&) mutable { frame_p->set_data(std::move(r)); });
+                                  stream_pool = stream_pool_, handle_pool = handle_pool_](
+                                     pika::future<void>&&) mutable { frame_p->set_data(std::move(r)); });
   }
 };
 }

--- a/include/dlaf/cublas/handle_pool.h
+++ b/include/dlaf/cublas/handle_pool.h
@@ -22,7 +22,7 @@
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 
-#include <hpx/local/runtime.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/error.h"
@@ -34,7 +34,7 @@ namespace cublas {
 namespace internal {
 class HandlePoolImpl {
   int device_;
-  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
+  std::size_t num_worker_threads_ = pika::get_num_worker_threads();
   std::vector<cublasHandle_t> handles_;
   cublasPointerMode_t ptr_mode_;
 
@@ -60,7 +60,7 @@ public:
   }
 
   cublasHandle_t getNextHandle(cudaStream_t stream) {
-    cublasHandle_t handle = handles_[hpx::get_worker_thread_num()];
+    cublasHandle_t handle = handles_[pika::get_worker_thread_num()];
     DLAF_CUDA_CALL(cudaSetDevice(device_));
     DLAF_CUBLAS_CALL(cublasSetStream(handle, stream));
     DLAF_CUBLAS_CALL(cublasSetPointerMode(handle, ptr_mode_));
@@ -77,7 +77,7 @@ public:
 /// same underlying cuBLAS handles, last reference destroys the references).
 /// Allows access to cuBLAS handles associated with a particular stream. The
 /// user must ensure that the handle pool and the stream use the same device.
-/// Each HPX worker thread is assigned thread local cuBLAS handle.
+/// Each pika worker thread is assigned thread local cuBLAS handle.
 class HandlePool {
   std::shared_ptr<internal::HandlePoolImpl> handles_ptr_;
 

--- a/include/dlaf/cuda/executor.h
+++ b/include/dlaf/cuda/executor.h
@@ -66,7 +66,7 @@ public:
     // The stream pool is captured by value to ensure that the streams live at
     // least until the event has completed.
     return fut.then(pika::launch::sync, [r = std::move(r), stream_pool = stream_pool_](
-                                           pika::future<void>&&) mutable { return std::move(r); });
+                                            pika::future<void>&&) mutable { return std::move(r); });
   }
 
   template <class Frame, class F, class Futures>
@@ -77,7 +77,7 @@ public:
 
     cudaStream_t stream = stream_pool_.getNextStream();
     auto r = pika::invoke_fused(std::forward<F>(f),
-                               pika::tuple_cat(std::forward<Futures>(futures), pika::tie(stream)));
+                                pika::tuple_cat(std::forward<Futures>(futures), pika::tie(stream)));
     pika::future<void> fut = pika::cuda::experimental::detail::get_future_with_event(stream);
 
     // The stream pool is captured by value to ensure that the streams live at

--- a/include/dlaf/cusolver/executor.h
+++ b/include/dlaf/cusolver/executor.h
@@ -21,13 +21,13 @@
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/functional.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/mutex.hpp>
-#include <hpx/local/tuple.hpp>
-#include <hpx/local/type_traits.hpp>
-#include <hpx/modules/async_cuda.hpp>
+#include <pika/execution.hpp>
+#include <pika/functional.hpp>
+#include <pika/future.hpp>
+#include <pika/mutex.hpp>
+#include <pika/tuple.hpp>
+#include <pika/type_traits.hpp>
+#include <pika/modules/async_cuda.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cublas/executor.h"
@@ -47,20 +47,20 @@ struct isAsyncCusolverCallableImpl : std::false_type {
 
 template <typename F, typename... Ts>
 struct isAsyncCusolverCallableImpl<true, F, Ts...> : std::true_type {
-  using return_type = hpx::future<typename hpx::invoke_result<F, cusolverDnHandle_t&, Ts...>::type>;
+  using return_type = pika::future<typename pika::invoke_result<F, cusolverDnHandle_t&, Ts...>::type>;
 };
 
 template <typename F, typename... Ts>
 struct isAsyncCusolverCallable
-    : isAsyncCusolverCallableImpl<hpx::is_invocable_v<F, cusolverDnHandle_t&, Ts...>, F, Ts...> {};
+    : isAsyncCusolverCallableImpl<pika::is_invocable_v<F, cusolverDnHandle_t&, Ts...>, F, Ts...> {};
 
 template <typename F, typename... Ts>
 inline constexpr bool isAsyncCusolverCallable_v = isAsyncCusolverCallable<F, Ts...>::value;
 
 template <typename F, typename Futures>
 struct isDataflowCusolverCallable
-    : hpx::is_invocable<hpx::util::functional::invoke_fused, F,
-                        decltype(hpx::tuple_cat(hpx::tie(std::declval<cusolverDnHandle_t&>()),
+    : pika::is_invocable<pika::util::functional::invoke_fused, F,
+                        decltype(pika::tuple_cat(pika::tie(std::declval<cusolverDnHandle_t&>()),
                                                 std::declval<Futures>()))> {};
 
 template <typename F, typename Futures>
@@ -103,34 +103,34 @@ public:
   async_execute(F&& f, Ts&&... ts) {
     cudaStream_t stream = stream_pool_.getNextStream();
     cusolverDnHandle_t handle = handle_pool_.getNextHandle(stream);
-    auto r = hpx::invoke(std::forward<F>(f), handle, std::forward<Ts>(ts)...);
-    hpx::future<void> fut = hpx::cuda::experimental::detail::get_future_with_event(stream);
+    auto r = pika::invoke(std::forward<F>(f), handle, std::forward<Ts>(ts)...);
+    pika::future<void> fut = pika::cuda::experimental::detail::get_future_with_event(stream);
 
     // The handle and stream pools are captured by value to ensure that the
     // streams live at least until the event has completed.
-    return fut.then(hpx::launch::sync,
+    return fut.then(pika::launch::sync,
                     [r = std::move(r), stream_pool = stream_pool_,
-                     handle_pool = handle_pool_](hpx::future<void>&&) mutable { return std::move(r); });
+                     handle_pool = handle_pool_](pika::future<void>&&) mutable { return std::move(r); });
   }
 
   template <class Frame, class F, class Futures>
   std::enable_if_t<internal::isDataflowCusolverCallable_v<F, Futures>> dataflow_finalize(
       Frame&& frame, F&& f, Futures&& futures) {
     // Ensure the dataflow frame stays alive long enough.
-    hpx::intrusive_ptr<typename std::remove_pointer<typename std::decay<Frame>::type>::type> frame_p(
+    pika::intrusive_ptr<typename std::remove_pointer<typename std::decay<Frame>::type>::type> frame_p(
         frame);
 
     cudaStream_t stream = stream_pool_.getNextStream();
     cusolverDnHandle_t handle = handle_pool_.getNextHandle(stream);
-    auto r = hpx::invoke_fused(std::forward<F>(f),
-                               hpx::tuple_cat(hpx::tie(handle), std::forward<Futures>(futures)));
-    hpx::future<void> fut = hpx::cuda::experimental::detail::get_future_with_event(stream);
+    auto r = pika::invoke_fused(std::forward<F>(f),
+                               pika::tuple_cat(pika::tie(handle), std::forward<Futures>(futures)));
+    pika::future<void> fut = pika::cuda::experimental::detail::get_future_with_event(stream);
 
     // The handle and stream pools are captured by value to ensure that the
     // streams live at least until the event has completed.
-    fut.then(hpx::launch::sync, [r = std::move(r), frame_p = std::move(frame_p),
+    fut.then(pika::launch::sync, [r = std::move(r), frame_p = std::move(frame_p),
                                  stream_pool = stream_pool_, handle_pool = handle_pool_](
-                                    hpx::future<void>&&) mutable { frame_p->set_data(std::move(r)); });
+                                    pika::future<void>&&) mutable { frame_p->set_data(std::move(r)); });
   }
 
   template <typename F, typename... Ts>
@@ -150,7 +150,7 @@ public:
 }
 }
 
-namespace hpx {
+namespace pika {
 namespace parallel {
 namespace execution {
 template <>

--- a/include/dlaf/cusolver/handle_pool.h
+++ b/include/dlaf/cusolver/handle_pool.h
@@ -22,7 +22,7 @@
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
 
-#include <hpx/local/runtime.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/cuda/error.h"
@@ -33,7 +33,7 @@ namespace cusolver {
 namespace internal {
 class HandlePoolImpl {
   int device_;
-  std::size_t num_worker_threads_ = hpx::get_num_worker_threads();
+  std::size_t num_worker_threads_ = pika::get_num_worker_threads();
   std::vector<cusolverDnHandle_t> handles_;
 
 public:
@@ -57,7 +57,7 @@ public:
   }
 
   cusolverDnHandle_t getNextHandle(cudaStream_t stream) {
-    cusolverDnHandle_t handle = handles_[hpx::get_worker_thread_num()];
+    cusolverDnHandle_t handle = handles_[pika::get_worker_thread_num()];
     DLAF_CUDA_CALL(cudaSetDevice(device_));
     DLAF_CUSOLVER_CALL(cusolverDnSetStream(handle, stream));
     return handle;
@@ -73,7 +73,7 @@ public:
 /// same underlying cuSOLVER handles, last reference destroys the handles).
 /// Allows access to cuSOLVER handles associated with a particular stream. The
 /// user must ensure that the handle pool and the stream use the same device.
-/// Each HPX worker thread is assigned thread local cuSOLVER handle.
+/// Each pika worker thread is assigned thread local cuSOLVER handle.
 class HandlePool {
   std::shared_ptr<internal::HandlePoolImpl> handles_ptr_;
 

--- a/include/dlaf/eigensolver/backtransformation.h
+++ b/include/dlaf/eigensolver/backtransformation.h
@@ -35,7 +35,7 @@ namespace eigensolver {
 /// @pre mat_v is not distributed.
 template <Backend backend, Device device, class T>
 void backTransformation(Matrix<T, device>& mat_c, Matrix<const T, device>& mat_v,
-                        common::internal::vector<hpx::shared_future<common::internal::vector<T>>> taus) {
+                        common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus) {
   DLAF_ASSERT(matrix::local_matrix(mat_c), mat_c);
   DLAF_ASSERT(matrix::local_matrix(mat_v), mat_v);
   DLAF_ASSERT(square_size(mat_v), mat_v);
@@ -67,7 +67,7 @@ void backTransformation(Matrix<T, device>& mat_c, Matrix<const T, device>& mat_v
 template <Backend backend, Device device, class T>
 void backTransformation(comm::CommunicatorGrid grid, Matrix<T, device>& mat_c,
                         Matrix<const T, device>& mat_v,
-                        common::internal::vector<hpx::shared_future<common::internal::vector<T>>> taus) {
+                        common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_c, grid), mat_c, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_v, grid), mat_v, grid);
   DLAF_ASSERT(square_size(mat_v), mat_v);

--- a/include/dlaf/eigensolver/band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/mc.h
@@ -299,7 +299,7 @@ struct BandToTridiag<Backend::MC, Device::CPU, T> {
           deps.push_back(sf);
         }
         sf = pika::dataflow(executor_hp, unwrapping(copy_offdiag), k * nb,
-                           mat_a.read(GlobalTileIndex{k + 1, k}), sf);
+                            mat_a.read(GlobalTileIndex{k + 1, k}), sf);
         deps.push_back(sf);
       }
       else {
@@ -342,7 +342,7 @@ struct BandToTridiag<Backend::MC, Device::CPU, T> {
         const auto tile_index = sweep / nb;
         const auto start = tile_index * nb;
         pika::dataflow(executor_hp, unwrapping(copy_tridiag_task), start, std::min(nb, size - start),
-                      std::min(nb, size - 1 - start), mat_trid(GlobalTileIndex{0, tile_index}), dep);
+                       std::min(nb, size - 1 - start), mat_trid(GlobalTileIndex{0, tile_index}), dep);
       }
     };
 
@@ -362,7 +362,7 @@ struct BandToTridiag<Backend::MC, Device::CPU, T> {
         const GlobalElementIndex index_v((sweep / b + step) * b, sweep);
 
         pika::dataflow(pika::launch::sync, unwrapping(store_tau_v), w_pipeline(),
-                      mat_v(dist_v.globalTileIndex(index_v)), dist_v.tileElementIndex(index_v));
+                       mat_v(dist_v.globalTileIndex(index_v)), dist_v.tileElementIndex(index_v));
         deps[step] = pika::dataflow(executor_hp, unwrapping(cont_sweep), w_pipeline(), deps[dep_index]);
       }
 

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -9,9 +9,9 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/execution.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/common/index2d.h"
@@ -38,26 +38,26 @@ namespace internal {
 
 namespace gentostd_l {
 template <Backend backend, class AKKSender, class LKKSender>
-void hegstDiagTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LKKSender&& l_kk) {
+void hegstDiagTile(pika::threads::thread_priority priority, AKKSender&& a_kk, LKKSender&& l_kk) {
   dlaf::internal::whenAllLift(1, blas::Uplo::Lower, std::forward<AKKSender>(a_kk),
                               std::forward<LKKSender>(l_kk)) |
       dlaf::tile::hegst(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LKKSender, class AIKSender>
-void trsmPanelTile(hpx::threads::thread_priority priority, LKKSender&& l_kk, AIKSender&& a_ik) {
+void trsmPanelTile(pika::threads::thread_priority priority, LKKSender&& l_kk, AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LKKSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::ConjTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LKKSender>(l_kk),
                               std::forward<AIKSender>(a_ik)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AKKSender, class LIKSender, class AIKSender>
-void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIKSender&& l_ik,
+void hemmPanelTile(pika::threads::thread_priority priority, AKKSender&& a_kk, LIKSender&& l_ik,
                    AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<AKKSender>;
 
@@ -65,11 +65,11 @@ void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIK
                               std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::hemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AJKSender, class LJKSender, class AKKSender>
-void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a_jk, LJKSender&& l_jk,
+void her2kTrailingDiagTile(pika::threads::thread_priority priority, AJKSender&& a_jk, LJKSender&& l_jk,
                            AKKSender&& a_kk) {
   using ElementType = dlaf::internal::SenderElementType<AJKSender>;
 
@@ -77,11 +77,11 @@ void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a
                               std::forward<AJKSender>(a_jk), std::forward<LJKSender>(l_jk),
                               BaseType<ElementType>(1.0), std::forward<AKKSender>(a_kk)) |
       dlaf::tile::her2k(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class MatIKSender, class MatJKSender, class AIJSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&& mat_ik,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, MatIKSender&& mat_ik,
                             MatJKSender&& mat_jk, AIJSender a_ij) {
   using ElementType = dlaf::internal::SenderElementType<MatIKSender>;
 
@@ -89,22 +89,22 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&
                               std::forward<MatIKSender>(mat_ik), std::forward<MatJKSender>(mat_jk),
                               ElementType(1.0), std::forward<AIJSender>(a_ij)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LJJSender, class AJKSender>
-void trsmPanelUpdateTile(hpx::threads::thread_priority priority, LJJSender&& l_jj, AJKSender a_jk) {
+void trsmPanelUpdateTile(pika::threads::thread_priority priority, LJJSender&& l_jj, AJKSender a_jk) {
   using ElementType = dlaf::internal::SenderElementType<LJJSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LJJSender>(l_jj),
                               std::forward<AJKSender>(a_jk)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LIJSender, class AJKSender, class AIKSender>
-void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_ij, AJKSender&& a_jk,
+void gemmPanelUpdateTile(pika::threads::thread_priority priority, LIJSender&& l_ij, AJKSender&& a_jk,
                          AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LIJSender>;
 
@@ -112,32 +112,32 @@ void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_i
                               std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace gentostd_u {
 template <Backend backend, class AKKSender, class LKKSender>
-void hegstDiagTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LKKSender&& l_kk) {
+void hegstDiagTile(pika::threads::thread_priority priority, AKKSender&& a_kk, LKKSender&& l_kk) {
   dlaf::internal::whenAllLift(1, blas::Uplo::Upper, std::forward<AKKSender>(a_kk),
                               std::forward<LKKSender>(l_kk)) |
       dlaf::tile::hegst(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LKKSender, class AIKSender>
-void trsmPanelTile(hpx::threads::thread_priority priority, LKKSender&& l_kk, AIKSender&& a_ik) {
+void trsmPanelTile(pika::threads::thread_priority priority, LKKSender&& l_kk, AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LKKSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::ConjTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LKKSender>(l_kk),
                               std::forward<AIKSender>(a_ik)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AKKSender, class LIKSender, class AIKSender>
-void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIKSender&& l_ik,
+void hemmPanelTile(pika::threads::thread_priority priority, AKKSender&& a_kk, LIKSender&& l_ik,
                    AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<AKKSender>;
 
@@ -145,11 +145,11 @@ void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIK
                               std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::hemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AJKSender, class LJKSender, class AKKSender>
-void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a_jk, LJKSender&& l_jk,
+void her2kTrailingDiagTile(pika::threads::thread_priority priority, AJKSender&& a_jk, LJKSender&& l_jk,
                            AKKSender&& a_kk) {
   using ElementType = dlaf::internal::SenderElementType<AJKSender>;
 
@@ -157,11 +157,11 @@ void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a
                               std::forward<AJKSender>(a_jk), std::forward<LJKSender>(l_jk),
                               BaseType<ElementType>(1.0), std::forward<AKKSender>(a_kk)) |
       dlaf::tile::her2k(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class MatIKSender, class MatJKSender, class AIJSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&& mat_ik,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, MatIKSender&& mat_ik,
                             MatJKSender&& mat_jk, AIJSender a_ij) {
   using ElementType = dlaf::internal::SenderElementType<MatIKSender>;
 
@@ -169,22 +169,22 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&
                               std::forward<MatIKSender>(mat_ik), std::forward<MatJKSender>(mat_jk),
                               ElementType(1.0), std::forward<AIJSender>(a_ij)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LJJSender, class AJKSender>
-void trsmPanelUpdateTile(hpx::threads::thread_priority priority, LJJSender&& l_jj, AJKSender a_jk) {
+void trsmPanelUpdateTile(pika::threads::thread_priority priority, LJJSender&& l_jj, AJKSender a_jk) {
   using ElementType = dlaf::internal::SenderElementType<LJJSender>;
 
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LJJSender>(l_jj),
                               std::forward<AJKSender>(a_jk)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LIJSender, class AJKSender, class AIKSender>
-void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_ij, AJKSender&& a_jk,
+void gemmPanelUpdateTile(pika::threads::thread_priority priority, LIJSender&& l_ij, AJKSender&& a_jk,
                          AIKSender&& a_ik) {
   using ElementType = dlaf::internal::SenderElementType<LIJSender>;
 
@@ -192,7 +192,7 @@ void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_i
                               std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
@@ -201,7 +201,7 @@ void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_i
 template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_L(Matrix<T, device>& mat_a, Matrix<T, device>& mat_l) {
   using namespace gentostd_l;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -270,7 +270,7 @@ template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a,
                                           Matrix<T, device>& mat_l) {
   using namespace gentostd_l;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -377,7 +377,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 
     a_panel.setRangeStart(at);
 
-    hpx::shared_future<matrix::Tile<const T, device>> a_diag;
+    pika::shared_future<matrix::Tile<const T, device>> a_diag;
     if (kk_rank.col() == this_rank.col()) {
       // Note:
       // [a,l]_panelT shrinked to a single tile for temporarly storing and communicating the diagonal
@@ -462,7 +462,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Row, i_local);
         const LocalTileIndex ik(i_local, distr.localTileFromGlobalTile<Coord::Col>(k));
 
-        hemmPanelTile<backend>(thread_priority::high, hpx::execution::experimental::keep_future(a_diag),
+        hemmPanelTile<backend>(thread_priority::high, pika::execution::experimental::keep_future(a_diag),
                                mat_l.read_sender(ik), mat_a.readwrite_sender(ik));
       }
     }
@@ -472,7 +472,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_U(Matrix<T, device>& mat_a, Matrix<T, device>& mat_u) {
   using namespace gentostd_u;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -541,7 +541,7 @@ template <Backend backend, Device device, class T>
 void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a,
                                           Matrix<T, device>& mat_u) {
   using namespace gentostd_u;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -649,7 +649,7 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
 
     a_panel.setRangeStart(at);
 
-    hpx::shared_future<matrix::Tile<const T, device>> a_diag;
+    pika::shared_future<matrix::Tile<const T, device>> a_diag;
     if (kk_rank.row() == this_rank.row()) {
       // Note:
       // [a,u]_panelT shrinked to a single tile for temporarly storing and communicating the diagonal
@@ -734,7 +734,7 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
         const LocalTileIndex local_idx(Coord::Col, j_local);
         const LocalTileIndex ki(distr.localTileFromGlobalTile<Coord::Row>(k), j_local);
 
-        hemmPanelTile<backend>(thread_priority::high, hpx::execution::experimental::keep_future(a_diag),
+        hemmPanelTile<backend>(thread_priority::high, pika::execution::experimental::keep_future(a_diag),
                                mat_u.read_sender(ki), mat_a.readwrite_sender(ki));
       }
     }

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -42,7 +42,7 @@ void hegstDiagTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LKK
   dlaf::internal::whenAllLift(1, blas::Uplo::Lower, std::forward<AKKSender>(a_kk),
                               std::forward<LKKSender>(l_kk)) |
       dlaf::tile::hegst(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LKKSender, class AIKSender>
@@ -53,7 +53,7 @@ void trsmPanelTile(hpx::threads::thread_priority priority, LKKSender&& l_kk, AIK
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LKKSender>(l_kk),
                               std::forward<AIKSender>(a_ik)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AKKSender, class LIKSender, class AIKSender>
@@ -65,7 +65,7 @@ void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIK
                               std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::hemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AJKSender, class LJKSender, class AKKSender>
@@ -77,7 +77,7 @@ void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a
                               std::forward<AJKSender>(a_jk), std::forward<LJKSender>(l_jk),
                               BaseType<ElementType>(1.0), std::forward<AKKSender>(a_kk)) |
       dlaf::tile::her2k(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class MatIKSender, class MatJKSender, class AIJSender>
@@ -89,7 +89,7 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&
                               std::forward<MatIKSender>(mat_ik), std::forward<MatJKSender>(mat_jk),
                               ElementType(1.0), std::forward<AIJSender>(a_ij)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LJJSender, class AJKSender>
@@ -100,7 +100,7 @@ void trsmPanelUpdateTile(hpx::threads::thread_priority priority, LJJSender&& l_j
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LJJSender>(l_jj),
                               std::forward<AJKSender>(a_jk)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LIJSender, class AJKSender, class AIKSender>
@@ -112,7 +112,7 @@ void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_i
                               std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -122,7 +122,7 @@ void hegstDiagTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LKK
   dlaf::internal::whenAllLift(1, blas::Uplo::Upper, std::forward<AKKSender>(a_kk),
                               std::forward<LKKSender>(l_kk)) |
       dlaf::tile::hegst(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LKKSender, class AIKSender>
@@ -133,7 +133,7 @@ void trsmPanelTile(hpx::threads::thread_priority priority, LKKSender&& l_kk, AIK
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LKKSender>(l_kk),
                               std::forward<AIKSender>(a_ik)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AKKSender, class LIKSender, class AIKSender>
@@ -145,7 +145,7 @@ void hemmPanelTile(hpx::threads::thread_priority priority, AKKSender&& a_kk, LIK
                               std::forward<AKKSender>(a_kk), std::forward<LIKSender>(l_ik),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::hemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class AJKSender, class LJKSender, class AKKSender>
@@ -157,7 +157,7 @@ void her2kTrailingDiagTile(hpx::threads::thread_priority priority, AJKSender&& a
                               std::forward<AJKSender>(a_jk), std::forward<LJKSender>(l_jk),
                               BaseType<ElementType>(1.0), std::forward<AKKSender>(a_kk)) |
       dlaf::tile::her2k(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class MatIKSender, class MatJKSender, class AIJSender>
@@ -169,7 +169,7 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, MatIKSender&
                               std::forward<MatIKSender>(mat_ik), std::forward<MatJKSender>(mat_jk),
                               ElementType(1.0), std::forward<AIJSender>(a_ij)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LJJSender, class AJKSender>
@@ -180,7 +180,7 @@ void trsmPanelUpdateTile(hpx::threads::thread_priority priority, LJJSender&& l_j
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<LJJSender>(l_jj),
                               std::forward<AJKSender>(a_jk)) |
       dlaf::tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class LIJSender, class AJKSender, class AIKSender>
@@ -192,7 +192,7 @@ void gemmPanelUpdateTile(hpx::threads::thread_priority priority, LIJSender&& l_i
                               std::forward<LIJSender>(l_ij), std::forward<AJKSender>(a_jk),
                               ElementType(1.0), std::forward<AIKSender>(a_ik)) |
       dlaf::tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::detach();
+      hpx::execution::experimental::start_detached();
 }
 }
 

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -31,7 +31,7 @@ namespace eigensolver {
 /// @pre mat_a has a square block size
 /// @pre mat_a is a local matrix
 template <Backend backend, Device device, class T>
-std::vector<hpx::shared_future<common::internal::vector<T>>> reductionToBand(Matrix<T, device>& mat_a) {
+std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(Matrix<T, device>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
 
@@ -76,7 +76,7 @@ std::vector<hpx::shared_future<common::internal::vector<T>>> reductionToBand(Mat
 /// @pre mat_a has a square block size
 /// @pre mat_a is distributed according to @p grid
 template <Backend backend, Device device, class T>
-std::vector<hpx::shared_future<common::internal::vector<T>>> reductionToBand(comm::CommunicatorGrid grid,
+std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(comm::CommunicatorGrid grid,
                                                                              Matrix<T, device>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -76,8 +76,8 @@ std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(Ma
 /// @pre mat_a has a square block size
 /// @pre mat_a is distributed according to @p grid
 template <Backend backend, Device device, class T>
-std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(comm::CommunicatorGrid grid,
-                                                                             Matrix<T, device>& mat_a) {
+std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(
+    comm::CommunicatorGrid grid, Matrix<T, device>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::equal_process_grid(mat_a, grid), mat_a, grid);

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -46,7 +46,8 @@ namespace internal {
 
 template <class T>
 struct ReductionToBand<Backend::MC, Device::CPU, T> {
-  static std::vector<pika::shared_future<common::internal::vector<T>>> call(Matrix<T, Device::CPU>& mat_a);
+  static std::vector<pika::shared_future<common::internal::vector<T>>> call(
+      Matrix<T, Device::CPU>& mat_a);
   static std::vector<pika::shared_future<common::internal::vector<T>>> call(
       comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& mat_a);
 };
@@ -217,7 +218,7 @@ template <class Executor, class T>
 void hemmDiag(const Executor& ex, pika::shared_future<TileT<const T>> tile_a,
               pika::shared_future<TileT<const T>> tile_w, pika::future<TileT<T>> tile_x) {
   pika::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::hemm_o), blas::Side::Left,
-                blas::Uplo::Lower, T(1), std::move(tile_a), std::move(tile_w), T(1), std::move(tile_x));
+                 blas::Uplo::Lower, T(1), std::move(tile_a), std::move(tile_w), T(1), std::move(tile_x));
 }
 
 // X += op(A) * W
@@ -225,7 +226,7 @@ template <class Executor, class T>
 void hemmOffDiag(const Executor& ex, blas::Op op, pika::shared_future<TileT<const T>> tile_a,
                  pika::shared_future<TileT<const T>> tile_w, pika::future<TileT<T>> tile_x) {
   pika::dataflow(ex, matrix::unwrapExtendTiles(tile::internal::gemm_o), op, blas::Op::NoTrans, T(1),
-                std::move(tile_a), std::move(tile_w), T(1), std::move(tile_x));
+                 std::move(tile_a), std::move(tile_w), T(1), std::move(tile_x));
 }
 
 template <class Executor, class T>
@@ -357,7 +358,7 @@ void gemmUpdateX(PanelT<Coord::Col, T>& x, ConstMatrixT<T>& w2, MatrixLikeT& v) 
   // GEMM X = X - 0.5 . V . W2
   for (const auto& index_i : v.iteratorLocal())
     pika::dataflow(ex, unwrapExtendTiles(gemm_o), blas::Op::NoTrans, blas::Op::NoTrans, T(-0.5),
-                  v.read(index_i), w2.read(LocalTileIndex(0, 0)), T(1), x(index_i));
+                   v.read(index_i), w2.read(LocalTileIndex(0, 0)), T(1), x(index_i));
 }
 
 template <class T>
@@ -426,7 +427,7 @@ void gemmComputeW2(MatrixT<T>& w2, ConstPanelT<Coord::Col, T>& w, ConstPanelT<Co
   // GEMM W2 = W* . X
   for (const auto& index_tile : w.iteratorLocal())
     pika::dataflow(ex, unwrapExtendTiles(gemm_o), blas::Op::ConjTrans, blas::Op::NoTrans, T(1),
-                  w.read(index_tile), x.read(index_tile), T(1), w2(LocalTileIndex(0, 0)));
+                   w.read(index_tile), x.read(index_tile), T(1), w2(LocalTileIndex(0, 0)));
 }
 
 template <class T>
@@ -532,7 +533,7 @@ pika::shared_future<common::internal::vector<T>> computePanelReflectors(
   auto panel_tiles = pika::when_all(matrix::select(mat_a, ai_panel_range));
 
   return pika::dataflow(getHpExecutor<Backend::MC>(), std::move(panel_task), std::move(panel_tiles),
-                       mpi_col_chain_panel, std::move(trigger));
+                        mpi_col_chain_panel, std::move(trigger));
 }
 
 template <class T>

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -9,12 +9,12 @@
 //
 #pragma once
 
-#include <hpx/include/resource_partitioner.hpp>
-#include <hpx/local/execution.hpp>
-#include <hpx/local/thread.hpp>
+#include <pika/execution.hpp>
+#include <pika/modules/resource_partitioner.hpp>
+#include <pika/thread.hpp>
 
 #ifdef DLAF_WITH_CUDA
-#include <hpx/modules/async_cuda.hpp>
+#include <pika/modules/async_cuda.hpp>
 #endif
 
 #include <dlaf/communication/executor.h>
@@ -31,8 +31,8 @@ namespace internal {
 template <Device S, Device D>
 struct GetCopyExecutor {
   static auto call() {
-    return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default"),
-                                             hpx::threads::thread_priority::normal};
+    return pika::execution::parallel_executor{&pika::resource::get_thread_pool("default"),
+                                              pika::threads::thread_priority::normal};
   }
 };
 
@@ -74,8 +74,8 @@ auto getMPIExecutor() {
 /// @tparam B backend with which the executor should be used.
 template <Backend B>
 auto getNpExecutor() {
-  return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default"),
-                                           hpx::threads::thread_priority::normal};
+  return pika::execution::parallel_executor{&pika::resource::get_thread_pool("default"),
+                                            pika::threads::thread_priority::normal};
 }
 
 #ifdef DLAF_WITH_CUDA
@@ -92,8 +92,8 @@ inline auto getNpExecutor<Backend::GPU>() {
 /// @tparam B backend with which the executor should be used.
 template <Backend B>
 auto getHpExecutor() {
-  return hpx::execution::parallel_executor{&hpx::resource::get_thread_pool("default"),
-                                           hpx::threads::thread_priority::high};
+  return pika::execution::parallel_executor{&pika::resource::get_thread_pool("default"),
+                                            pika::threads::thread_priority::high};
 }
 
 #ifdef DLAF_WITH_CUDA

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -40,7 +40,8 @@ namespace cholesky_l {
 template <Backend backend, class MatrixTileSender>
 void potrfDiagTile(hpx::threads::thread_priority priority, MatrixTileSender&& matrix_tile) {
   dlaf::internal::whenAllLift(blas::Uplo::Lower, std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::potrf(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::potrf(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class KKTileSender, class MatrixTileSender>
@@ -51,7 +52,8 @@ void trsmPanelTile(hpx::threads::thread_priority priority, KKTileSender&& kk_til
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::ConjTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<KKTileSender>(kk_tile),
                               std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class MatrixTileSender>
@@ -62,7 +64,8 @@ void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSende
   dlaf::internal::whenAllLift(blas::Uplo::Lower, blas::Op::NoTrans, BaseElementType(-1.0),
                               std::forward<PanelTileSender>(panel_tile), BaseElementType(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::herk(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::herk(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class ColPanelSender, class MatrixTileSender>
@@ -74,7 +77,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSen
                               std::forward<PanelTileSender>(panel_tile),
                               std::forward<ColPanelSender>(col_panel), ElementType(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -82,7 +86,8 @@ namespace cholesky_u {
 template <Backend backend, class MatrixTileSender>
 void potrfDiagTile(hpx::threads::thread_priority priority, MatrixTileSender&& matrix_tile) {
   dlaf::internal::whenAllLift(blas::Uplo::Upper, std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::potrf(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::potrf(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class KKTileSender, class MatrixTileSender>
@@ -93,7 +98,8 @@ void trsmPanelTile(hpx::threads::thread_priority priority, KKTileSender&& kk_til
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::ConjTrans,
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<KKTileSender>(kk_tile),
                               std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class MatrixTileSender>
@@ -104,7 +110,8 @@ void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSende
   dlaf::internal::whenAllLift(blas::Uplo::Upper, blas::Op::ConjTrans, base_element_type(-1.0),
                               std::forward<PanelTileSender>(panel_tile), base_element_type(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::herk(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::herk(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class ColPanelSender, class MatrixTileSender>
@@ -116,7 +123,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSen
                               std::forward<PanelTileSender>(panel_tile),
                               std::forward<ColPanelSender>(col_panel), ElementType(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/common/index2d.h"
@@ -38,14 +38,14 @@ namespace internal {
 
 namespace cholesky_l {
 template <Backend backend, class MatrixTileSender>
-void potrfDiagTile(hpx::threads::thread_priority priority, MatrixTileSender&& matrix_tile) {
+void potrfDiagTile(pika::threads::thread_priority priority, MatrixTileSender&& matrix_tile) {
   dlaf::internal::whenAllLift(blas::Uplo::Lower, std::forward<MatrixTileSender>(matrix_tile)) |
       tile::potrf(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class KKTileSender, class MatrixTileSender>
-void trsmPanelTile(hpx::threads::thread_priority priority, KKTileSender&& kk_tile,
+void trsmPanelTile(pika::threads::thread_priority priority, KKTileSender&& kk_tile,
                    MatrixTileSender&& matrix_tile) {
   using ElementType = dlaf::internal::SenderElementType<KKTileSender>;
 
@@ -53,11 +53,11 @@ void trsmPanelTile(hpx::threads::thread_priority priority, KKTileSender&& kk_til
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<KKTileSender>(kk_tile),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class MatrixTileSender>
-void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSender&& panel_tile,
+void herkTrailingDiagTile(pika::threads::thread_priority priority, PanelTileSender&& panel_tile,
                           MatrixTileSender&& matrix_tile) {
   using BaseElementType = BaseType<dlaf::internal::SenderElementType<PanelTileSender>>;
 
@@ -65,11 +65,11 @@ void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSende
                               std::forward<PanelTileSender>(panel_tile), BaseElementType(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::herk(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class ColPanelSender, class MatrixTileSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSender&& panel_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, PanelTileSender&& panel_tile,
                             ColPanelSender&& col_panel, MatrixTileSender&& matrix_tile) {
   using ElementType = dlaf::internal::SenderElementType<PanelTileSender>;
 
@@ -78,20 +78,20 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSen
                               std::forward<ColPanelSender>(col_panel), ElementType(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace cholesky_u {
 template <Backend backend, class MatrixTileSender>
-void potrfDiagTile(hpx::threads::thread_priority priority, MatrixTileSender&& matrix_tile) {
+void potrfDiagTile(pika::threads::thread_priority priority, MatrixTileSender&& matrix_tile) {
   dlaf::internal::whenAllLift(blas::Uplo::Upper, std::forward<MatrixTileSender>(matrix_tile)) |
       tile::potrf(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class KKTileSender, class MatrixTileSender>
-void trsmPanelTile(hpx::threads::thread_priority priority, KKTileSender&& kk_tile,
+void trsmPanelTile(pika::threads::thread_priority priority, KKTileSender&& kk_tile,
                    MatrixTileSender&& matrix_tile) {
   using ElementType = dlaf::internal::SenderElementType<KKTileSender>;
 
@@ -99,11 +99,11 @@ void trsmPanelTile(hpx::threads::thread_priority priority, KKTileSender&& kk_til
                               blas::Diag::NonUnit, ElementType(1.0), std::forward<KKTileSender>(kk_tile),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class MatrixTileSender>
-void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSender&& panel_tile,
+void herkTrailingDiagTile(pika::threads::thread_priority priority, PanelTileSender&& panel_tile,
                           MatrixTileSender&& matrix_tile) {
   using base_element_type = BaseType<dlaf::internal::SenderElementType<PanelTileSender>>;
 
@@ -111,11 +111,11 @@ void herkTrailingDiagTile(hpx::threads::thread_priority priority, PanelTileSende
                               std::forward<PanelTileSender>(panel_tile), base_element_type(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::herk(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class PanelTileSender, class ColPanelSender, class MatrixTileSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSender&& panel_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, PanelTileSender&& panel_tile,
                             ColPanelSender&& col_panel, MatrixTileSender&& matrix_tile) {
   using ElementType = dlaf::internal::SenderElementType<PanelTileSender>;
 
@@ -124,7 +124,7 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSen
                               std::forward<ColPanelSender>(col_panel), ElementType(1.0),
                               std::forward<MatrixTileSender>(matrix_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
@@ -132,7 +132,7 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, PanelTileSen
 template <Backend backend, Device device, class T>
 void Cholesky<backend, device, T>::call_L(Matrix<T, device>& mat_a) {
   using namespace cholesky_l;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -172,7 +172,7 @@ void Cholesky<backend, device, T>::call_L(Matrix<T, device>& mat_a) {
 template <Backend backend, Device device, class T>
 void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a) {
   using namespace cholesky_l;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -280,7 +280,7 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 template <Backend backend, Device device, class T>
 void Cholesky<backend, device, T>::call_U(Matrix<T, device>& mat_a) {
   using namespace cholesky_u;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   // Number of tile (rows = cols)
   SizeType nrtile = mat_a.nrTiles().cols();
@@ -314,7 +314,7 @@ void Cholesky<backend, device, T>::call_U(Matrix<T, device>& mat_a) {
 template <Backend backend, Device device, class T>
 void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T, device>& mat_a) {
   using namespace cholesky_u;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 

--- a/include/dlaf/factorization/qr.h
+++ b/include/dlaf/factorization/qr.h
@@ -25,8 +25,8 @@ namespace internal {
 // SIAM Journal on Scientific and Statistical Computing. 10. 10.1137/0910005.
 template <Backend backend, Device device, class T>
 void computeTFactor(const SizeType k, Matrix<const T, device>& v, const GlobalTileIndex v_start,
-                    hpx::shared_future<common::internal::vector<T>> taus,
-                    hpx::future<matrix::Tile<T, device>> t) {
+                    pika::shared_future<common::internal::vector<T>> taus,
+                    pika::future<matrix::Tile<T, device>> t) {
   QR_Tfactor<backend, device, T>::call(k, v, v_start, taus, std::move(t));
 }
 
@@ -38,8 +38,8 @@ void computeTFactor(const SizeType k, Matrix<const T, device>& v, const GlobalTi
 // SIAM Journal on Scientific and Statistical Computing. 10. 10.1137/0910005.
 template <Backend backend, Device device, class T>
 void computeTFactor(const SizeType k, Matrix<const T, device>& v, const GlobalTileIndex v_start,
-                    hpx::shared_future<common::internal::vector<T>> taus,
-                    hpx::future<matrix::Tile<T, device>> t,
+                    pika::shared_future<common::internal::vector<T>> taus,
+                    pika::future<matrix::Tile<T, device>> t,
                     common::Pipeline<comm::Communicator>& mpi_col_task_chain) {
   QR_Tfactor<backend, device, T>::call(k, v, v_start, taus, std::move(t), mpi_col_task_chain);
 }

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -11,11 +11,11 @@
 
 #include <iostream>
 
-#include <hpx/include/resource_partitioner.hpp>
-#include <hpx/program_options.hpp>
+#include <pika/modules/resource_partitioner.hpp>
+#include <pika/program_options.hpp>
 
 #ifdef DLAF_WITH_CUDA
-#include <hpx/modules/async_cuda.hpp>
+#include <pika/modules/async_cuda.hpp>
 #endif
 
 #include <dlaf/communication/mech.h>
@@ -54,12 +54,12 @@ cusolver::HandlePool getCusolverHandlePool();
 }
 
 /// Returns the DLA-Future command-line options description.
-hpx::program_options::options_description getOptionsDescription();
+pika::program_options::options_description getOptionsDescription();
 
 /// Initialize DLA-Future.
 ///
 /// Should be called once before every dlaf::finalize call. This overload can
-/// be used when the application is using hpx::program_options for its own
+/// be used when the application is using pika::program_options for its own
 /// command-line parsing needs. The user is responsible for ensuring that
 /// DLA-Future command-line options are parsed. The DLA-Future options can be
 /// retrieved with dlaf::getOptionsDescription.
@@ -67,7 +67,7 @@ hpx::program_options::options_description getOptionsDescription();
 /// @param vm parsed command-line options as provided by the application entry point.
 /// @param user_cfg user-provided default configuration. Takes precedence over
 /// DLA-Future defaults.
-void initialize(hpx::program_options::variables_map const& vm, configuration const& user_cfg = {});
+void initialize(pika::program_options::variables_map const& vm, configuration const& user_cfg = {});
 
 /// Initialize DLA-Future.
 ///
@@ -88,11 +88,11 @@ void finalize();
 ///
 /// Calls dlaf::initialize on construction and dlaf::finalize on destruction.
 struct [[nodiscard]] ScopedInitializer {
-  ScopedInitializer(hpx::program_options::variables_map const& vm, configuration const& user_cfg = {});
+  ScopedInitializer(pika::program_options::variables_map const& vm, configuration const& user_cfg = {});
   ScopedInitializer(int argc, const char* const argv[], configuration const& user_cfg = {});
   ~ScopedInitializer();
 
-  ScopedInitializer(ScopedInitializer &&) = delete;
+  ScopedInitializer(ScopedInitializer&&) = delete;
   ScopedInitializer(ScopedInitializer const&) = delete;
   ScopedInitializer& operator=(ScopedInitializer&&) = delete;
   ScopedInitializer& operator=(ScopedInitializer const&) = delete;
@@ -101,6 +101,6 @@ struct [[nodiscard]] ScopedInitializer {
 /// Initialize the MPI pool.
 ///
 ///
-void initResourcePartitionerHandler(hpx::resource::partitioner& rp,
-                                    hpx::program_options::variables_map const& vm);
+void initResourcePartitionerHandler(pika::resource::partitioner& rp,
+                                    pika::program_options::variables_map const& vm);
 }

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -92,7 +92,7 @@ struct [[nodiscard]] ScopedInitializer {
   ScopedInitializer(int argc, const char* const argv[], configuration const& user_cfg = {});
   ~ScopedInitializer();
 
-  ScopedInitializer(ScopedInitializer&&) = delete;
+  ScopedInitializer(ScopedInitializer &&) = delete;
   ScopedInitializer(ScopedInitializer const&) = delete;
   ScopedInitializer& operator=(ScopedInitializer&&) = delete;
   ScopedInitializer& operator=(ScopedInitializer const&) = delete;

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -14,7 +14,7 @@
 
 #include <lapack.hh>
 // LAPACKPP includes complex.h which defines the macro I.
-// This breaks HPX.
+// This breaks pika.
 #ifdef I
 #undef I
 #endif
@@ -22,7 +22,7 @@
 #ifdef DLAF_WITH_CUDA
 #include <cusolverDn.h>
 
-#include <hpx/modules/async_cuda.hpp>
+#include <pika/modules/async_cuda.hpp>
 #endif
 
 #include "dlaf/common/assert.h"
@@ -99,7 +99,7 @@ dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p, const lapack::Norm n
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload lange
@@ -127,7 +127,7 @@ dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p, const lapack::Norm n
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload lantr
@@ -149,7 +149,7 @@ void laset(const dlaf::internal::Policy<B>& p, const lapack::MatrixType type, T 
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 void laset(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload laset
@@ -170,7 +170,7 @@ void set0(const dlaf::internal::Policy<B>& p, const Tile<T, Device::CPU>& tile);
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 void set0(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload set0
@@ -203,7 +203,7 @@ void hegst(const dlaf::internal::Policy<B>&, const int itype, const blas::Uplo u
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto hegst(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload hegst
@@ -227,7 +227,7 @@ auto potrfInfo(const dlaf::internal::Policy<B>&, const blas::Uplo uplo, const Ti
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto potrfInfo(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload potrfInfo
@@ -252,7 +252,7 @@ void potrf(const dlaf::internal::Policy<B>& p, const blas::Uplo uplo, const Tile
 /// This overload takes a policy argument and a sender which must send all required arguments for the
 /// algorithm. Returns a sender which signals a connected receiver when the algorithm is done.
 template <Backend B, typename Sender,
-          typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>
+          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 auto potrf(const dlaf::internal::Policy<B>& p, Sender&& s);
 
 /// \overload potrf
@@ -390,8 +390,8 @@ void assertExtendInfo(F assertFunc, cusolverDnHandle_t handle, CusolverInfo<T>&&
   DLAF_CUSOLVER_CALL(cusolverDnGetStream(handle, &stream));
   assertFunc(stream, info.info());
   // Extend info scope to the end of the kernel execution
-  hpx::cuda::experimental::detail::get_future_with_event(stream)  //
-      .then(hpx::launch::sync, [info = std::move(info)](hpx::future<void>&&) {});
+  pika::cuda::experimental::detail::get_future_with_event(stream)  //
+      .then(pika::launch::sync, [info = std::move(info)](pika::future<void>&&) {});
 }
 }
 

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/execution.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/executors.h"
 #include "dlaf/matrix/copy_tile.h"
@@ -37,11 +37,11 @@ void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
   const SizeType local_tile_rows = distribution.localNrTiles().rows();
   const SizeType local_tile_cols = distribution.localNrTiles().cols();
 
-  namespace ex = hpx::execution::experimental;
+  namespace ex = pika::execution::experimental;
 
   for (SizeType j = 0; j < local_tile_cols; ++j) {
     for (SizeType i = 0; i < local_tile_rows; ++i) {
-      hpx::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
+      pika::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
                     unwrapExtendTiles(dlaf::matrix::internal::copy_o), source.read(LocalTileIndex(i, j)),
                     dest(LocalTileIndex(i, j)));
     }

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <hpx/local/execution.hpp>
 #include <hpx/local/future.hpp>
 #include <hpx/local/unwrap.hpp>
 

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -42,8 +42,8 @@ void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
   for (SizeType j = 0; j < local_tile_cols; ++j) {
     for (SizeType i = 0; i < local_tile_rows; ++i) {
       pika::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
-                    unwrapExtendTiles(dlaf::matrix::internal::copy_o), source.read(LocalTileIndex(i, j)),
-                    dest(LocalTileIndex(i, j)));
+                     unwrapExtendTiles(dlaf::matrix::internal::copy_o),
+                     source.read(LocalTileIndex(i, j)), dest(LocalTileIndex(i, j)));
     }
   }
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -196,29 +196,29 @@ struct Duplicate {
 ///
 /// When Destination and Source are the same, returns the input tile unmodified.
 template <Device Destination, typename T, Device Source>
-auto duplicateIfNeeded(hpx::future<Tile<T, Source>> tile) {
+auto duplicateIfNeeded(pika::future<Tile<T, Source>> tile) {
   if constexpr (Source == Destination) {
     return tile;
   }
   else {
-    return hpx::execution::experimental::make_future(
+    return pika::execution::experimental::make_future(
         dlaf::internal::transform(dlaf::internal::Policy<internal::CopyBackend_v<Source, Destination>>(
-                                      hpx::threads::thread_priority::normal),
+                                      pika::threads::thread_priority::normal),
                                   dlaf::matrix::Duplicate<Destination>{}, std::move(tile)));
   }
 }
 
 template <Device Destination, typename T, Device Source>
-auto duplicateIfNeeded(hpx::shared_future<Tile<T, Source>> tile) {
+auto duplicateIfNeeded(pika::shared_future<Tile<T, Source>> tile) {
   if constexpr (Source == Destination) {
     return tile;
   }
   else {
-    return hpx::execution::experimental::make_future(
+    return pika::execution::experimental::make_future(
         dlaf::internal::transform(dlaf::internal::Policy<internal::CopyBackend_v<Source, Destination>>(
-                                      hpx::threads::thread_priority::normal),
+                                      pika::threads::thread_priority::normal),
                                   dlaf::matrix::Duplicate<Destination>{},
-                                  hpx::execution::experimental::keep_future(std::move(tile))));
+                                  pika::execution::experimental::keep_future(std::move(tile))));
   }
 }
 
@@ -229,9 +229,9 @@ auto duplicateIfNeeded(hpx::shared_future<Tile<T, Source>> tile) {
 template <Device Destination, class T, Device Source, class U, template <class> class FutureD,
           template <class> class FutureS>
 void copyIfNeeded(FutureS<Tile<U, Source>> tile_from, FutureD<Tile<T, Destination>> tile_to,
-                  hpx::future<void> wait_for_me = hpx::make_ready_future<void>()) {
+                  pika::future<void> wait_for_me = pika::make_ready_future<void>()) {
   if constexpr (Destination != Source)
-    hpx::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
+    pika::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
                   matrix::unwrapExtendTiles(internal::copy_o), wait_for_me, std::move(tile_from),
                   std::move(tile_to));
 }

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -232,8 +232,8 @@ void copyIfNeeded(FutureS<Tile<U, Source>> tile_from, FutureD<Tile<T, Destinatio
                   pika::future<void> wait_for_me = pika::make_ready_future<void>()) {
   if constexpr (Destination != Source)
     pika::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
-                  matrix::unwrapExtendTiles(internal::copy_o), wait_for_me, std::move(tile_from),
-                  std::move(tile_to));
+                   matrix::unwrapExtendTiles(internal::copy_o), wait_for_me, std::move(tile_from),
+                   std::move(tile_to));
 }
 }
 }

--- a/include/dlaf/matrix/internal/tile_future_manager.h
+++ b/include/dlaf/matrix/internal/tile_future_manager.h
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/matrix/tile.h"
 
@@ -18,14 +18,14 @@ namespace internal {
 
 // Attach the promise to the tile included in old_future with a continuation and returns a new future to it.
 template <class ReturnTileType>
-hpx::future<ReturnTileType> setPromiseTileFuture(
-    hpx::future<typename ReturnTileType::TileDataType> old_future,
-    hpx::lcos::local::promise<typename ReturnTileType::TileDataType> p) noexcept {
+pika::future<ReturnTileType> setPromiseTileFuture(
+    pika::future<typename ReturnTileType::TileDataType> old_future,
+    pika::lcos::local::promise<typename ReturnTileType::TileDataType> p) noexcept {
   using TileDataType = typename ReturnTileType::TileDataType;
   using NonConstTileType = typename ReturnTileType::TileType;
 
   DLAF_ASSERT_HEAVY(old_future.valid(), "");
-  return old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileDataType>&& fut) mutable {
+  return old_future.then(pika::launch::sync, [p = std::move(p)](pika::future<TileDataType>&& fut) mutable {
     std::exception_ptr current_exception_ptr;
 
     try {
@@ -46,12 +46,12 @@ hpx::future<ReturnTileType> setPromiseTileFuture(
 // Returns a future<ReturnTileType> setting a new promise p to the tile contained in tile_future.
 // tile_future is then updated with the new internal state future (which value is set by p).
 template <class ReturnTileType>
-hpx::future<ReturnTileType> getTileFuture(
-    hpx::future<typename ReturnTileType::TileDataType>& tile_future) noexcept {
+pika::future<ReturnTileType> getTileFuture(
+    pika::future<typename ReturnTileType::TileDataType>& tile_future) noexcept {
   using TileDataType = typename ReturnTileType::TileDataType;
 
-  hpx::future<TileDataType> old_future = std::move(tile_future);
-  hpx::lcos::local::promise<TileDataType> p;
+  pika::future<TileDataType> old_future = std::move(tile_future);
+  pika::lcos::local::promise<TileDataType> p;
   tile_future = p.get_future();
   return setPromiseTileFuture<ReturnTileType>(std::move(old_future), std::move(p));
 }
@@ -67,16 +67,16 @@ public:
 
   TileFutureManager() {}
 
-  TileFutureManager(TileDataType tile) : tile_future_(hpx::make_ready_future(std::move(tile))) {}
+  TileFutureManager(TileDataType tile) : tile_future_(pika::make_ready_future(std::move(tile))) {}
 
-  hpx::shared_future<ConstTileType> getReadTileSharedFuture() noexcept {
+  pika::shared_future<ConstTileType> getReadTileSharedFuture() noexcept {
     if (!tile_shared_future_.valid()) {
       tile_shared_future_ = getTileFuture<ConstTileType>(tile_future_);
     }
     return tile_shared_future_;
   }
 
-  hpx::future<TileType> getRWTileFuture() noexcept {
+  pika::future<TileType> getRWTileFuture() noexcept {
     tile_shared_future_ = {};
     return getTileFuture<TileType>(tile_future_);
   }
@@ -93,11 +93,11 @@ public:
 
 protected:
   // The future of the tile with no promise set.
-  hpx::future<TileDataType> tile_future_;
+  pika::future<TileDataType> tile_future_;
 
   // If valid, a copy of the shared future of the tile,
   // which has the promise set to the promise for tile_future_.
-  hpx::shared_future<ConstTileType> tile_shared_future_;
+  pika::shared_future<ConstTileType> tile_shared_future_;
 };
 
 }

--- a/include/dlaf/matrix/internal/tile_future_manager.h
+++ b/include/dlaf/matrix/internal/tile_future_manager.h
@@ -25,7 +25,8 @@ pika::future<ReturnTileType> setPromiseTileFuture(
   using NonConstTileType = typename ReturnTileType::TileType;
 
   DLAF_ASSERT_HEAVY(old_future.valid(), "");
-  return old_future.then(pika::launch::sync, [p = std::move(p)](pika::future<TileDataType>&& fut) mutable {
+  return old_future.then(pika::launch::sync, [p = std::move(p)](
+                                                 pika::future<TileDataType>&& fut) mutable {
     std::exception_ptr current_exception_ptr;
 
     try {

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -13,7 +13,7 @@
 #include <exception>
 #include <vector>
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
@@ -118,14 +118,14 @@ public:
   ///
   /// See misc/synchronization.md for the synchronization details.
   /// @pre index.isIn(distribution().localNrTiles()).
-  hpx::future<TileType> operator()(const LocalTileIndex& index) noexcept;
+  pika::future<TileType> operator()(const LocalTileIndex& index) noexcept;
 
   /// Returns a future of the Tile with global index @p index.
   ///
   /// See misc/synchronization.md for the synchronization details.
   /// @pre the global tile is stored in the current process,
   /// @pre index.isIn(globalNrTiles()).
-  hpx::future<TileType> operator()(const GlobalTileIndex& index) {
+  pika::future<TileType> operator()(const GlobalTileIndex& index) {
     return operator()(this->distribution().localTileIndex(index));
   }
 
@@ -175,21 +175,21 @@ public:
   ///
   /// See misc/synchronization.md for the synchronization details.
   /// @pre index.isIn(distribution().localNrTiles()).
-  hpx::shared_future<ConstTileType> read(const LocalTileIndex& index) noexcept;
+  pika::shared_future<ConstTileType> read(const LocalTileIndex& index) noexcept;
 
   /// Returns a read-only shared_future of the Tile with global index @p index.
   ///
   /// See misc/synchronization.md for the synchronization details.
   /// @pre the global tile is stored in the current process,
   /// @pre index.isIn(globalNrTiles()).
-  hpx::shared_future<ConstTileType> read(const GlobalTileIndex& index) {
+  pika::shared_future<ConstTileType> read(const GlobalTileIndex& index) {
     return read(distribution().localTileIndex(index));
   }
 
   auto read_sender(const LocalTileIndex& index) noexcept {
     // We want to explicitly deal with the shared_future, not the const& to the
     // value.
-    return hpx::execution::experimental::keep_future(read(index));
+    return pika::execution::experimental::keep_future(read(index));
   }
 
   auto read_sender(const GlobalTileIndex& index) {
@@ -381,7 +381,7 @@ Matrix<T, device> createMatrixFromTile(const GlobalElementSize& size, const Tile
 ///
 /// @pre @p range must be a valid range for @p matrix
 template <class MatrixLike>
-std::vector<hpx::shared_future<typename MatrixLike::ConstTileType>> selectRead(
+std::vector<pika::shared_future<typename MatrixLike::ConstTileType>> selectRead(
     MatrixLike& matrix, common::IterableRange2D<SizeType, LocalTile_TAG> range) {
   return internal::selectGeneric([&](auto index) { return matrix.read(index); }, range);
 }
@@ -390,7 +390,7 @@ std::vector<hpx::shared_future<typename MatrixLike::ConstTileType>> selectRead(
 ///
 /// @pre @p range must be a valid range for @p matrix
 template <class MatrixLike>
-std::vector<hpx::future<typename MatrixLike::TileType>> select(
+std::vector<pika::future<typename MatrixLike::TileType>> select(
     MatrixLike& matrix, common::IterableRange2D<SizeType, LocalTile_TAG> range) {
   return internal::selectGeneric([&](auto index) { return matrix(index); }, range);
 }

--- a/include/dlaf/matrix/matrix.tpp
+++ b/include/dlaf/matrix/matrix.tpp
@@ -58,7 +58,7 @@ Matrix<T, device>::Matrix(const LayoutInfo& layout, ElementType* ptr)
     : Matrix<const T, device>(layout, ptr) {}
 
 template <class T, Device device>
-hpx::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex& index) noexcept {
+pika::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex& index) noexcept {
   const auto i = tileLinearIndex(index);
   return tile_managers_[i].getRWTileFuture();
 }

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -32,7 +32,7 @@ Matrix<const T, device>::Matrix(Distribution distribution, const matrix::LayoutI
 }
 
 template <class T, Device device>
-hpx::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
+pika::shared_future<Tile<const T, device>> Matrix<const T, device>::read(
     const LocalTileIndex& index) noexcept {
   const auto i = tileLinearIndex(index);
   return tile_managers_[i].getReadTileSharedFuture();
@@ -50,7 +50,7 @@ void Matrix<const T, device>::waitLocalTiles() noexcept {
   };
 
   const auto range_local = common::iterate_range2d(distribution().localNrTiles());
-  hpx::wait_all(internal::selectGeneric(readwrite_f, range_local));
+  pika::wait_all(internal::selectGeneric(readwrite_f, range_local));
 }
 
 template <class T, Device device>

--- a/include/dlaf/matrix/matrix_view.h
+++ b/include/dlaf/matrix/matrix_view.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include <blas.hh>
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
@@ -51,7 +51,7 @@ public:
   /// TODO: Sync details.
   ///
   /// @pre index.isIn(distribution().localNrTiles()).
-  hpx::shared_future<ConstTileType> read(const LocalTileIndex& index) noexcept;
+  pika::shared_future<ConstTileType> read(const LocalTileIndex& index) noexcept;
 
   /// Returns a read-only shared_future of the Tile with global index @p index.
   ///
@@ -59,7 +59,7 @@ public:
   ///
   /// @pre index.isIn(globalNrTiles()),
   /// @pre global tile stored in current process.
-  hpx::shared_future<ConstTileType> read(const GlobalTileIndex& index) noexcept {
+  pika::shared_future<ConstTileType> read(const GlobalTileIndex& index) noexcept {
     return read(distribution().localTileIndex(index));
   }
 
@@ -84,7 +84,7 @@ private:
             std::enable_if_t<std::is_same_v<T, std::remove_const_t<T2>>, int> = 0>
   void setUpTiles(MatrixType<T2, device>& matrix) noexcept;
 
-  std::vector<hpx::shared_future<ConstTileType>> tile_shared_futures_;
+  std::vector<pika::shared_future<ConstTileType>> tile_shared_futures_;
 };
 
 template <template <class, Device> class MatrixType, class T, Device device>

--- a/include/dlaf/matrix/matrix_view_const.tpp
+++ b/include/dlaf/matrix/matrix_view_const.tpp
@@ -24,7 +24,7 @@ MatrixView<const T, device>::MatrixView(blas::Uplo uplo, MatrixType<T2, device>&
 }
 
 template <class T, Device device>
-hpx::shared_future<Tile<const T, device>> MatrixView<const T, device>::read(
+pika::shared_future<Tile<const T, device>> MatrixView<const T, device>::read(
     const LocalTileIndex& index) noexcept {
   const auto i = tileLinearIndex(index);
   return tile_shared_futures_[i];

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
@@ -81,7 +81,7 @@ struct Panel<axis, const T, D> {
   /// - has not been already set to an external tile
   ///
   /// @pre @p index must be a valid index for the current panel size
-  void setTile(const LocalTileIndex& index, hpx::shared_future<ConstTileType> new_tile_fut) {
+  void setTile(const LocalTileIndex& index, pika::shared_future<ConstTileType> new_tile_fut) {
     DLAF_ASSERT(internal_.count(linearIndex(index)) == 0, "internal tile have been already used", index);
     DLAF_ASSERT(!isExternal(index), "already set to external", index);
     // Note assertion on index done by linearIndex method.
@@ -91,7 +91,7 @@ struct Panel<axis, const T, D> {
 #if defined DLAF_ASSERT_MODERATE_ENABLE
     {
       const auto panel_tile_size = tileSize(index);
-      new_tile_fut.then(hpx::launch::sync, hpx::unwrapping([panel_tile_size](const auto& tile) {
+      new_tile_fut.then(pika::launch::sync, pika::unwrapping([panel_tile_size](const auto& tile) {
                           DLAF_ASSERT_MODERATE(panel_tile_size == tile.size(), panel_tile_size,
                                                tile.size());
                         }));
@@ -106,7 +106,7 @@ struct Panel<axis, const T, D> {
   /// This method is very similar to the one available in dlaf::Matrix.
   ///
   /// @pre @p index must be a valid index for the current panel size
-  hpx::shared_future<ConstTileType> read(const LocalTileIndex& index) {
+  pika::shared_future<ConstTileType> read(const LocalTileIndex& index) {
     // Note assertion on index done by linearIndex method.
 
     has_been_used_ = true;
@@ -127,7 +127,7 @@ struct Panel<axis, const T, D> {
   }
 
   auto read_sender(const LocalTileIndex& index) {
-    return hpx::execution::experimental::keep_future(read(index));
+    return pika::execution::experimental::keep_future(read(index));
   }
 
   /// Set the panel to enable access to the range of tiles [start, end)
@@ -376,7 +376,7 @@ protected:
   bool has_been_used_ = false;
 
   ///> Container for references to external tiles
-  common::internal::vector<hpx::shared_future<ConstTileType>> external_;
+  common::internal::vector<pika::shared_future<ConstTileType>> external_;
   ///> Keep track of usage status of internal tiles (accessed or not)
   std::set<SizeType> internal_;
 };
@@ -394,7 +394,7 @@ struct Panel : public Panel<axis, const T, device> {
   /// It is possible to access just internal tiles in RW mode.
   ///
   /// @pre index must point to a tile which is internally managed by the panel
-  hpx::future<TileType> operator()(const LocalTileIndex& index) {
+  pika::future<TileType> operator()(const LocalTileIndex& index) {
     // Note assertion on index done by linearIndex method.
     DLAF_ASSERT(!BaseT::isExternal(index), "read-only access on external tiles", index);
 

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -129,7 +129,7 @@ pika::shared_future<Tile<T, D>> splitTileInsertFutureInChain(pika::future<Tile<T
 
 template <class T, Device D>
 pika::future<Tile<T, D>> createSubTile(const pika::shared_future<Tile<T, D>>& tile,
-                                      const SubTileSpec& spec);
+                                       const SubTileSpec& spec);
 }
 
 /// The Tile object aims to provide an effective way to access the memory as a two dimensional
@@ -361,7 +361,7 @@ auto create_data(const Tile<T, device>& tile) {
 namespace internal {
 template <class T, Device D>
 pika::future<Tile<T, D>> createSubTile(const pika::shared_future<Tile<T, D>>& tile,
-                                      const SubTileSpec& spec) {
+                                       const SubTileSpec& spec) {
   return pika::dataflow(
       pika::launch::sync, [](auto tile, auto spec) { return Tile<T, D>(tile, spec); }, tile, spec);
 }
@@ -394,7 +394,8 @@ pika::shared_future<Tile<T, D>> splitTileInsertFutureInChain(pika::future<Tile<T
 
     return pika::make_tuple(std::move(tile), std::move(dep_tracker));
   };
-  auto tmp = pika::split_future(tile.then(pika::launch::sync, pika::unwrapping(std::move(swap_promise))));
+  auto tmp =
+      pika::split_future(tile.then(pika::launch::sync, pika::unwrapping(std::move(swap_promise))));
   // old_tile = F1(PN) and will be used to create the subtiles
   pika::shared_future<TileType> old_tile = std::move(pika::get<0>(tmp));
   // 3. Set P2 or SF(P2) into FN to restore the chain:  F1(PN)  FN(*) ...
@@ -405,7 +406,7 @@ pika::shared_future<Tile<T, D>> splitTileInsertFutureInChain(pika::future<Tile<T
   };
   // tile = FN(*) (out argument) can be used to access the full tile after the subtiles tasks completed.
   tile = pika::dataflow(pika::launch::sync, pika::unwrapping(set_promise_or_shfuture), tmp_tile,
-                       std::move(pika::get<1>(tmp)));
+                        std::move(pika::get<1>(tmp)));
 
   return old_tile;
 }
@@ -418,7 +419,7 @@ pika::shared_future<Tile<T, D>> splitTileInsertFutureInChain(pika::future<Tile<T
 /// and the returned subtile go out of scope.
 template <class T, Device D>
 pika::shared_future<Tile<const T, D>> splitTile(const pika::shared_future<Tile<const T, D>>& tile,
-                                               const SubTileSpec& spec) {
+                                                const SubTileSpec& spec) {
   return internal::createSubTile(tile, spec);
 }
 
@@ -463,7 +464,7 @@ pika::future<Tile<T, D>> splitTile(pika::future<Tile<T, D>>& tile, const SubTile
 ///      (i.e. two different subtile cannot access the same element).
 template <class T, Device D>
 std::vector<pika::future<Tile<T, D>>> splitTileDisjoint(pika::future<Tile<T, D>>& tile,
-                                                       const std::vector<SubTileSpec>& specs) {
+                                                        const std::vector<SubTileSpec>& specs) {
   if (specs.size() == 0)
     return {};
 

--- a/include/dlaf/multiplication/triangular/impl.h
+++ b/include/dlaf/multiplication/triangular/impl.h
@@ -42,7 +42,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -50,7 +51,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASe
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -60,7 +62,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -68,7 +71,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -78,7 +82,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -86,7 +91,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASe
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -96,7 +102,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -104,7 +111,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -114,7 +122,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -122,7 +131,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASe
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -132,7 +142,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -140,7 +151,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -150,7 +162,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -158,7 +171,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASe
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -168,7 +182,8 @@ void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trmm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trmm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -176,7 +191,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 

--- a/include/dlaf/multiplication/triangular/impl.h
+++ b/include/dlaf/multiplication/triangular/impl.h
@@ -9,9 +9,9 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/thread.hpp>
+#include <pika/execution.hpp>
+#include <pika/future.hpp>
+#include <pika/thread.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/common/index2d.h"
@@ -38,161 +38,161 @@ namespace internal {
 
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T alpha, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_llt {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T alpha,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T alpha,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_lun {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T alpha, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_lut {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T alpha,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T alpha,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_rln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T alpha, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_rlt {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T alpha,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T alpha,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_run {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T alpha, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T alpha, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_rut {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T alpha,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T alpha,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, alpha, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
@@ -200,7 +200,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_lln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -225,7 +225,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_llt;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -250,7 +250,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LUN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_lun;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -275,7 +275,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LUT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lut;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -300,7 +300,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RLN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_rln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -325,7 +325,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RLT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_rlt;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -350,7 +350,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RUN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_run;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -375,7 +375,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RUT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_rut;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -400,7 +400,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -484,7 +484,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LUN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lun;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -567,7 +567,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_rln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -651,7 +651,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RUN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_run;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 

--- a/include/dlaf/multiplication/triangular/impl.h
+++ b/include/dlaf/multiplication/triangular/impl.h
@@ -38,8 +38,8 @@ namespace internal {
 
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
@@ -78,8 +78,8 @@ void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op
 
 namespace triangular_lun {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
@@ -118,8 +118,8 @@ void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op
 
 namespace triangular_rln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |
@@ -158,8 +158,8 @@ void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op
 
 namespace triangular_run {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trmmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trmm(dlaf::internal::Policy<backend>(priority)) |

--- a/include/dlaf/sender/lift_non_sender.h
+++ b/include/dlaf/sender/lift_non_sender.h
@@ -9,7 +9,7 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
+#include <pika/execution.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -19,11 +19,11 @@ namespace internal {
 /// Makes a sender out of the input, if it is not already a sender.
 template <typename S>
 decltype(auto) liftNonSender(S&& s) {
-  if constexpr (hpx::execution::experimental::is_sender_v<S>) {
+  if constexpr (pika::execution::experimental::is_sender_v<S>) {
     return std::forward<S>(s);
   }
   else {
-    return hpx::execution::experimental::just(std::forward<S>(s));
+    return pika::execution::experimental::just(std::forward<S>(s));
   }
 }
 }

--- a/include/dlaf/sender/make_sender_algorithm_overloads.h
+++ b/include/dlaf/sender/make_sender_algorithm_overloads.h
@@ -12,7 +12,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <hpx/local/execution.hpp>
+#include <pika/execution.hpp>
 
 #include "dlaf/sender/partial_transform.h"
 #include "dlaf/sender/policy.h"
@@ -32,7 +32,7 @@
 ///    does the required synchronization before returning in cases when the callable is not blocking.
 #define DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(fname, callable)                                   \
   template <Backend B, typename Sender,                                                         \
-            typename = std::enable_if_t<hpx::execution::experimental::is_sender_v<Sender>>>     \
+            typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>     \
   auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                   \
     return dlaf::internal::transform<B>(p, callable, std::forward<Sender>(s));                  \
   }                                                                                             \
@@ -44,7 +44,7 @@
                                                                                                 \
   template <Backend B, typename T1, typename T2, typename... Ts>                                \
   void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                 \
-    hpx::execution::experimental::sync_wait(                                                    \
-        fname(p, hpx::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
+    pika::execution::experimental::sync_wait(                                                    \
+        fname(p, pika::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
                                                     std::forward<Ts>(ts)...)));                 \
   }

--- a/include/dlaf/sender/make_sender_algorithm_overloads.h
+++ b/include/dlaf/sender/make_sender_algorithm_overloads.h
@@ -30,21 +30,21 @@
 /// 3. One that takes a policy and the arguments required by the callable. This is almost equivalent to
 ///    calling the callable directly with the required arguments, with the difference that this overload
 ///    does the required synchronization before returning in cases when the callable is not blocking.
-#define DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(fname, callable)                                   \
-  template <Backend B, typename Sender,                                                         \
+#define DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(fname, callable)                                    \
+  template <Backend B, typename Sender,                                                          \
             typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>     \
-  auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                   \
-    return dlaf::internal::transform<B>(p, callable, std::forward<Sender>(s));                  \
-  }                                                                                             \
-                                                                                                \
-  template <Backend B>                                                                          \
-  auto fname(const dlaf::internal::Policy<B> p) {                                               \
-    return dlaf::internal::PartialTransform{p, callable};                                       \
-  }                                                                                             \
-                                                                                                \
-  template <Backend B, typename T1, typename T2, typename... Ts>                                \
-  void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                 \
+  auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                    \
+    return dlaf::internal::transform<B>(p, callable, std::forward<Sender>(s));                   \
+  }                                                                                              \
+                                                                                                 \
+  template <Backend B>                                                                           \
+  auto fname(const dlaf::internal::Policy<B> p) {                                                \
+    return dlaf::internal::PartialTransform{p, callable};                                        \
+  }                                                                                              \
+                                                                                                 \
+  template <Backend B, typename T1, typename T2, typename... Ts>                                 \
+  void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                  \
     pika::execution::experimental::sync_wait(                                                    \
         fname(p, pika::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
-                                                    std::forward<Ts>(ts)...)));                 \
+                                                     std::forward<Ts>(ts)...)));                 \
   }

--- a/include/dlaf/sender/partial_transform.h
+++ b/include/dlaf/sender/partial_transform.h
@@ -9,7 +9,7 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
+#include <pika/execution.hpp>
 
 #include <type_traits>
 #include <utility>

--- a/include/dlaf/sender/policy.h
+++ b/include/dlaf/sender/policy.h
@@ -9,7 +9,7 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
+#include <pika/execution.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -21,17 +21,17 @@ namespace internal {
 template <Backend B>
 class Policy {
 private:
-  const hpx::threads::thread_priority priority_ = hpx::threads::thread_priority::normal;
+  const pika::threads::thread_priority priority_ = pika::threads::thread_priority::normal;
 
 public:
   Policy() = default;
-  explicit Policy(hpx::threads::thread_priority priority) : priority_(priority) {}
+  explicit Policy(pika::threads::thread_priority priority) : priority_(priority) {}
   Policy(Policy&&) = default;
   Policy(Policy const&) = default;
   Policy& operator=(Policy&&) = default;
   Policy& operator=(Policy const&) = default;
 
-  hpx::threads::thread_priority priority() const noexcept {
+  pika::threads::thread_priority priority() const noexcept {
     return priority_;
   }
 };

--- a/include/dlaf/sender/traits.h
+++ b/include/dlaf/sender/traits.h
@@ -9,8 +9,8 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
+#include <pika/execution.hpp>
+#include <pika/future.hpp>
 
 namespace dlaf::internal {
 template <typename...>
@@ -27,19 +27,19 @@ struct SenderSingleValueTypeImpl<TypeList<TypeList<T>>> {
 // We are only interested in the types wrapped by future and shared_future since
 // we will internally unwrap them.
 template <typename T>
-struct SenderSingleValueTypeImpl<TypeList<TypeList<hpx::future<T>>>> {
+struct SenderSingleValueTypeImpl<TypeList<TypeList<pika::future<T>>>> {
   using type = T;
 };
 
 template <typename T>
-struct SenderSingleValueTypeImpl<TypeList<TypeList<hpx::shared_future<T>>>> {
+struct SenderSingleValueTypeImpl<TypeList<TypeList<pika::shared_future<T>>>> {
   using type = T;
 };
 
 // The type sent by Sender, if Sender sends exactly one type.
 template <typename Sender>
 using SenderSingleValueType =
-    typename SenderSingleValueTypeImpl<typename hpx::execution::experimental::sender_traits<
+    typename SenderSingleValueTypeImpl<typename pika::execution::experimental::sender_traits<
         Sender>::template value_types<TypeList, TypeList>>::type;
 
 // The type of an embedded ElementType in the value_types of Sender, if it

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -44,7 +44,7 @@ struct Transform<Backend::MC> {
   static auto call(const Policy<Backend::MC> policy, S&& s, F&& f) {
     namespace ex = hpx::execution::experimental;
     return ex::then(ex::transfer(std::forward<S>(s),
-                           ex::with_priority(ex::thread_pool_scheduler{}, policy.priority())),
+                                 ex::with_priority(ex::thread_pool_scheduler{}, policy.priority())),
                     hpx::unwrapping(std::forward<F>(f)));
   }
 };

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -52,9 +52,9 @@ struct Transform<Backend::MC> {
   template <typename S, typename F>
   static auto call(const Policy<Backend::MC> policy, S&& s, F&& f) {
     namespace ex = hpx::execution::experimental;
-    return ex::transform(ex::on(std::forward<S>(s),
-                                ex::with_priority(ex::thread_pool_scheduler{}, policy.priority())),
-                         hpx::unwrapping(std::forward<F>(f)));
+    return ex::then(ex::on(std::forward<S>(s),
+                           ex::with_priority(ex::thread_pool_scheduler{}, policy.priority())),
+                    hpx::unwrapping(std::forward<F>(f)));
   }
 };
 
@@ -245,7 +245,7 @@ template <Backend B, typename F, typename... Ts>
 /// when_all sender of the lifted senders.
 template <Backend B, typename F, typename... Ts>
 void transformLiftDetach(const Policy<B> policy, F&& f, Ts&&... ts) {
-  hpx::execution::experimental::detach(
+  hpx::execution::experimental::start_detached(
       transformLift<B>(policy, std::forward<F>(f), std::forward<Ts>(ts)...));
 }
 }

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -43,7 +43,7 @@ struct Transform<Backend::MC> {
   template <typename S, typename F>
   static auto call(const Policy<Backend::MC> policy, S&& s, F&& f) {
     namespace ex = hpx::execution::experimental;
-    return ex::then(ex::on(std::forward<S>(s),
+    return ex::then(ex::transfer(std::forward<S>(s),
                            ex::with_priority(ex::thread_pool_scheduler{}, policy.priority())),
                     hpx::unwrapping(std::forward<F>(f)));
   }

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -194,13 +194,13 @@ struct Transform<Backend::GPU> {
     template <typename R>
     friend auto tag_invoke(pika::execution::experimental::connect_t, GPUTransformSender&& s, R&& r) {
       return pika::execution::experimental::connect(std::move(s.s),
-                                                   GPUTransformReceiver<R>{std::move(s.stream_pool),
-                                                                           std::move(
-                                                                               s.cublas_handle_pool),
-                                                                           std::move(
-                                                                               s.cusolver_handle_pool),
-                                                                           std::forward<R>(r),
-                                                                           std::move(s.f)});
+                                                    GPUTransformReceiver<R>{std::move(s.stream_pool),
+                                                                            std::move(
+                                                                                s.cublas_handle_pool),
+                                                                            std::move(
+                                                                                s.cusolver_handle_pool),
+                                                                            std::forward<R>(r),
+                                                                            std::move(s.f)});
     }
   };
 

--- a/include/dlaf/sender/when_all_lift.h
+++ b/include/dlaf/sender/when_all_lift.h
@@ -12,7 +12,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <hpx/local/execution.hpp>
+#include <pika/execution.hpp>
 
 #include "dlaf/sender/lift_non_sender.h"
 
@@ -22,7 +22,7 @@ namespace internal {
 /// non-senders are first turned into senders using just.
 template <typename... Ts>
 auto whenAllLift(Ts&&... ts) {
-  return hpx::execution::experimental::when_all(liftNonSender<Ts>(std::forward<Ts>(ts))...);
+  return pika::execution::experimental::when_all(liftNonSender<Ts>(std::forward<Ts>(ts))...);
 }
 }
 }

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -609,7 +609,7 @@ void Triangular<backend, D, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op o
 
         dlaf::internal::whenAllLift(T(-1), b_panel.read_sender(kj), mat_b.readwrite_sender(kj)) |
             tile::add(dlaf::internal::Policy<backend>(priority)) |
-            hpx::execution::experimental::detach();
+            hpx::execution::experimental::start_detached();
 
         trsmBPanelTile<backend>(priority, op, diag, alpha, a_panel.read_sender(kk_offset),
                                 mat_b.readwrite_sender(kj));

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -9,9 +9,9 @@
 //
 #pragma once
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
-#include <hpx/local/thread.hpp>
+#include <pika/execution.hpp>
+#include <pika/future.hpp>
+#include <pika/thread.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/blas/tile_extensions.h"
@@ -39,161 +39,161 @@ namespace solver {
 namespace internal {
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T beta, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_llt {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T beta,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T beta,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_lun {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T beta, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_lut {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T beta,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T beta,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_rln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T beta, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_rlt {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T beta,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T beta,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_run {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASender&& a_tile,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, T beta, ASender&& a_tile,
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
 namespace triangular_rut {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Op op, blas::Diag diag, T alpha,
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
-void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op, T beta,
+void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op, T beta,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
       tile::gemm(dlaf::internal::Policy<backend>(priority)) |
-      hpx::execution::experimental::start_detached();
+      pika::execution::experimental::start_detached();
 }
 }
 
@@ -201,7 +201,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_lln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -232,7 +232,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_llt;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -263,7 +263,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LUN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_lun;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -292,7 +292,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LUT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lut;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -323,7 +323,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RLN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_rln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -353,7 +353,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RLT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_rlt;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -384,7 +384,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RUN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
                                               Matrix<T, device>& mat_b) {
   using namespace triangular_run;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -414,7 +414,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RUT(blas::Op op, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_rut;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   SizeType m = mat_b.nrTiles().rows();
   SizeType n = mat_b.nrTiles().cols();
@@ -445,7 +445,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   using common::internal::vector;
 
@@ -541,7 +541,7 @@ template <Backend backend, Device D, class T>
 void Triangular<backend, D, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op op, blas::Diag diag,
                                          T alpha, Matrix<const T, D>& mat_a, Matrix<T, D>& mat_b) {
   using namespace triangular_llt;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -609,7 +609,7 @@ void Triangular<backend, D, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op o
 
         dlaf::internal::whenAllLift(T(-1), b_panel.read_sender(kj), mat_b.readwrite_sender(kj)) |
             tile::add(dlaf::internal::Policy<backend>(priority)) |
-            hpx::execution::experimental::start_detached();
+            pika::execution::experimental::start_detached();
 
         trsmBPanelTile<backend>(priority, op, diag, alpha, a_panel.read_sender(kk_offset),
                                 mat_b.readwrite_sender(kj));
@@ -625,7 +625,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_LUN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_lun;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -718,7 +718,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RLN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_rln;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
@@ -811,7 +811,7 @@ template <Backend backend, Device device, class T>
 void Triangular<backend, device, T>::call_RUN(comm::CommunicatorGrid grid, blas::Diag diag, T alpha,
                                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   using namespace triangular_run;
-  using hpx::threads::thread_priority;
+  using pika::threads::thread_priority;
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -43,7 +43,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -51,7 +52,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -61,7 +63,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -69,7 +72,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -79,7 +83,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -87,7 +92,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -97,7 +103,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -105,7 +112,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(op, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -115,7 +123,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -123,7 +132,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -133,7 +143,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -141,7 +152,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -151,7 +163,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Diag diag, T a
                     OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -159,7 +172,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, T beta, ASen
                             BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 
@@ -169,7 +183,8 @@ void trsmBPanelTile(hpx::threads::thread_priority priority, blas::Op op, blas::D
                     InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, op, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
-      tile::trsm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::trsm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 
 template <Backend backend, class T, typename ASender, typename BSender, typename CSender>
@@ -177,7 +192,8 @@ void gemmTrailingMatrixTile(hpx::threads::thread_priority priority, blas::Op op,
                             ASender&& a_tile, BSender&& b_tile, CSender&& c_tile) {
   dlaf::internal::whenAllLift(blas::Op::NoTrans, op, beta, std::forward<ASender>(a_tile),
                               std::forward<BSender>(b_tile), T(1.0), std::forward<CSender>(c_tile)) |
-      tile::gemm(dlaf::internal::Policy<backend>(priority)) | hpx::execution::experimental::detach();
+      tile::gemm(dlaf::internal::Policy<backend>(priority)) |
+      hpx::execution::experimental::start_detached();
 }
 }
 

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -39,8 +39,8 @@ namespace solver {
 namespace internal {
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
@@ -79,8 +79,8 @@ void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op
 
 namespace triangular_lun {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Left, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
@@ -119,8 +119,8 @@ void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op
 
 namespace triangular_rln {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Lower, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |
@@ -159,8 +159,8 @@ void gemmTrailingMatrixTile(pika::threads::thread_priority priority, blas::Op op
 
 namespace triangular_run {
 template <Backend backend, class T, typename InSender, typename OutSender>
-void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha, InSender&& in_tile,
-                    OutSender&& out_tile) {
+void trsmBPanelTile(pika::threads::thread_priority priority, blas::Diag diag, T alpha,
+                    InSender&& in_tile, OutSender&& out_tile) {
   dlaf::internal::whenAllLift(blas::Side::Right, blas::Uplo::Upper, blas::Op::NoTrans, diag, alpha,
                               std::forward<InSender>(in_tile), std::forward<OutSender>(out_tile)) |
       tile::trsm(dlaf::internal::Policy<backend>(priority)) |

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -140,20 +140,20 @@ public:
 template <Backend backend, class T, Device D>
 void set0(hpx::threads::thread_priority priority, Matrix<T, D>& matrix) {
   using dlaf::internal::Policy;
-  using hpx::execution::experimental::detach;
+  using hpx::execution::experimental::start_detached;
 
   for (const auto& idx : iterate_range2d(matrix.distribution().localNrTiles()))
-    matrix.readwrite_sender(idx) | tile::set0(Policy<backend>(priority)) | detach();
+    matrix.readwrite_sender(idx) | tile::set0(Policy<backend>(priority)) | start_detached();
 }
 
 /// Sets all the elements of all the tiles in the active range to zero
 template <Backend backend, class T, Coord axis, Device D>
 void set0(hpx::threads::thread_priority priority, Panel<axis, T, D>& panel) {
   using dlaf::internal::Policy;
-  using hpx::execution::experimental::detach;
+  using hpx::execution::experimental::start_detached;
 
   for (const auto& tile_idx : panel.iteratorLocal())
-    panel.readwrite_sender(tile_idx) | tile::set0(Policy<backend>(priority)) | detach();
+    panel.readwrite_sender(tile_idx) | tile::set0(Policy<backend>(priority)) | start_detached();
 }
 
 /// Set the elements of the matrix.

--- a/include/dlaf/util_tile.h
+++ b/include/dlaf/util_tile.h
@@ -19,8 +19,8 @@ constexpr double M_PI = 3.141592;
 #endif
 
 #include <blas.hh>
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 
 add_library(DLAF_miniapp INTERFACE)
-target_link_libraries(DLAF_miniapp INTERFACE DLAF HPX::hpx)
+target_link_libraries(DLAF_miniapp INTERFACE DLAF pika::pika)
 target_include_directories(DLAF_miniapp
   INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/miniapp/include/dlaf/miniapp/options.h
+++ b/miniapp/include/dlaf/miniapp/options.h
@@ -19,7 +19,7 @@
 
 #include <blas.hh>
 
-#include <hpx/program_options.hpp>
+#include <pika/program_options.hpp>
 
 #include <dlaf/common/assert.h>
 #include <dlaf/common/format_short.h>
@@ -206,7 +206,7 @@ struct MiniappOptions {
   int64_t nwarmups;
   CheckIterFreq do_check;
 
-  MiniappOptions(const hpx::program_options::variables_map& vm)
+  MiniappOptions(const pika::program_options::variables_map& vm)
       : backend(parseBackend(vm["backend"].as<std::string>())),
         type(parseElementType<support_real, support_complex>(vm["type"].as<std::string>())),
         grid_rows(vm["grid-rows"].as<int>()), grid_cols(vm["grid-cols"].as<int>()),
@@ -224,61 +224,61 @@ struct MiniappOptions {
   MiniappOptions& operator=(const MiniappOptions&) = default;
 };
 
-inline hpx::program_options::options_description getMiniappOptionsDescription() {
-  hpx::program_options::options_description desc("DLA-Future miniapp options");
+inline pika::program_options::options_description getMiniappOptionsDescription() {
+  pika::program_options::options_description desc("DLA-Future miniapp options");
 
   desc.add_options()(
-      "backend", hpx::program_options::value<std::string>()->default_value("default"),
+      "backend", pika::program_options::value<std::string>()->default_value("default"),
       "Backend to use ('default' ('gpu' if available, otherwise 'mc'), 'mc', 'gpu' (if available))");
   desc.add_options()(
-      "type", hpx::program_options::value<std::string>()->default_value("d"),
+      "type", pika::program_options::value<std::string>()->default_value("d"),
       "Element type to use ('s' (float), 'd' (double), 'c' (std::complex<single>), 'z' (std::complex<double>))");
-  desc.add_options()("grid-rows", hpx::program_options::value<int>()->default_value(1),
+  desc.add_options()("grid-rows", pika::program_options::value<int>()->default_value(1),
                      "Number of row processes in the 2D communicator");
-  desc.add_options()("grid-cols", hpx::program_options::value<int>()->default_value(1),
+  desc.add_options()("grid-cols", pika::program_options::value<int>()->default_value(1),
                      "Number of column processes in the 2D communicator");
-  desc.add_options()("nruns", hpx::program_options::value<int64_t>()->default_value(1),
+  desc.add_options()("nruns", pika::program_options::value<int64_t>()->default_value(1),
                      "Number of runs");
-  desc.add_options()("nwarmups", hpx::program_options::value<int64_t>()->default_value(1),
+  desc.add_options()("nwarmups", pika::program_options::value<int64_t>()->default_value(1),
                      "Number of warmup runs");
-  desc.add_options()("check-result", hpx::program_options::value<std::string>()->default_value("none"),
+  desc.add_options()("check-result", pika::program_options::value<std::string>()->default_value("none"),
                      "Enable result checking ('none', 'all', 'last')");
 
   return desc;
 }
 
-inline void addLayoutOption(hpx::program_options::options_description& desc,
+inline void addLayoutOption(pika::program_options::options_description& desc,
                             const blas::Layout def = blas::Layout::ColMajor) {
   desc.add_options()("layout",
-                     hpx::program_options::value<std::string>()->default_value({blas::layout2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::layout2char(def)}),
                      "'C' (ColMajor), 'R' (RowMajor)");
 }
 
-inline void addOpOption(hpx::program_options::options_description& desc,
+inline void addOpOption(pika::program_options::options_description& desc,
                         const blas::Op def = blas::Op::NoTrans) {
   desc.add_options()("op",
-                     hpx::program_options::value<std::string>()->default_value({blas::op2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::op2char(def)}),
                      "'N' (NoTrans), 'T' (Trans), 'C' (ConjTrans)");
 }
 
-inline void addUploOption(hpx::program_options::options_description& desc,
+inline void addUploOption(pika::program_options::options_description& desc,
                           const blas::Uplo def = blas::Uplo::Lower) {
   desc.add_options()("uplo",
-                     hpx::program_options::value<std::string>()->default_value({blas::uplo2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::uplo2char(def)}),
                      "'L' (Lower), 'U' (Upper), 'G' (General)");
 }
 
-inline void addDiagOption(hpx::program_options::options_description& desc,
+inline void addDiagOption(pika::program_options::options_description& desc,
                           const blas::Diag def = blas::Diag::NonUnit) {
   desc.add_options()("diag",
-                     hpx::program_options::value<std::string>()->default_value({blas::diag2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::diag2char(def)}),
                      "'N' (NonUnit), 'U' (Unit)");
 }
 
-inline void addSideOption(hpx::program_options::options_description& desc,
+inline void addSideOption(pika::program_options::options_description& desc,
                           const blas::Side def = blas::Side::Left) {
   desc.add_options()("side",
-                     hpx::program_options::value<std::string>()->default_value({blas::side2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::side2char(def)}),
                      "'L' (Left), 'R' (Right)");
 }
 }

--- a/miniapp/include/dlaf/miniapp/options.h
+++ b/miniapp/include/dlaf/miniapp/options.h
@@ -250,7 +250,8 @@ inline pika::program_options::options_description getMiniappOptionsDescription()
 inline void addLayoutOption(pika::program_options::options_description& desc,
                             const blas::Layout def = blas::Layout::ColMajor) {
   desc.add_options()("layout",
-                     pika::program_options::value<std::string>()->default_value({blas::layout2char(def)}),
+                     pika::program_options::value<std::string>()->default_value(
+                         {blas::layout2char(def)}),
                      "'C' (ColMajor), 'R' (RowMajor)");
 }
 

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -344,7 +344,7 @@ void cholesky_diff(Matrix<T, Device::CPU>& A, Matrix<T, Device::CPU>& L, Communi
                                     j_loc == 0 ? T(0.0) : T(1.0),
                                     partial_result.readwrite_sender(LocalTileIndex{i_loc, 0})) |
             dlaf::tile::gemm(dlaf::internal::Policy<dlaf::Backend::MC>()) |
-            hpx::execution::experimental::detach();
+            hpx::execution::experimental::start_detached();
       }
     }
 

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -12,11 +12,11 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <pika/init.hpp>
 #include <pika/future.hpp>
+#include <pika/init.hpp>
+#include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 #include <pika/unwrap.hpp>
-#include <pika/program_options.hpp>
 
 #include "dlaf/auxiliary/norm.h"
 #include "dlaf/blas/tile.h"

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -14,11 +14,11 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include <pika/init.hpp>
 #include <pika/future.hpp>
+#include <pika/init.hpp>
+#include <pika/modules/async_cuda.hpp>
 #include <pika/thread.hpp>
 #include <pika/unwrap.hpp>
-#include <pika/modules/async_cuda.hpp>
 
 #include "dlaf/executors.h"
 #include "dlaf/init.h"
@@ -47,7 +47,7 @@ int pika_main(int argc, char* argv[]) {
     });
 
     pika::future<cublasStatus_t> f1 = pika::dataflow(exec, pika::unwrapping(cublasDaxpy), n, alpha_f,
-                                                   x.data().get(), incx, y.data().get(), incy);
+                                                     x.data().get(), incx, y.data().get(), incy);
 
     pika::future<void> f2 = f1.then([&y](pika::future<cublasStatus_t> s) {
       DLAF_CUBLAS_CALL(s.get());

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -9,10 +9,11 @@
 //
 
 #include <iostream>
-
-#include <hpx/hpx.hpp>
-#include <hpx/hpx_init.hpp>
 #include <limits>
+
+#include <pika/init.hpp>
+#include <pika/program_options.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/common/format_short.h"
 #include "dlaf/common/index2d.h"
@@ -38,7 +39,7 @@ struct Options
   SizeType m;
   SizeType mb;
 
-  Options(const hpx::program_options::variables_map& vm)
+  Options(const pika::program_options::variables_map& vm)
       : MiniappOptions(vm), m(vm["matrix-size"].as<SizeType>()), mb(vm["block-size"].as<SizeType>()) {
     DLAF_ASSERT(m > 0, m);
     DLAF_ASSERT(mb > 0, mb);
@@ -124,7 +125,7 @@ struct reductionToBandMiniapp {
                   << " " << elapsed_time << "s"
                   << " " << gigaflops << "GFlop/s"
                   << " " << dlaf::internal::FormatShort{opts.type} << " " << matrix.size() << " "
-                  << matrix.blockSize() << " " << comm_grid.size() << " " << hpx::get_os_thread_count()
+                  << matrix.blockSize() << " " << comm_grid.size() << " " << pika::get_os_thread_count()
                   << " " << backend << std::endl;
 
       // TODO (optional) run test
@@ -132,7 +133,7 @@ struct reductionToBandMiniapp {
   }
 };
 
-int hpx_main(hpx::program_options::variables_map& vm) {
+int pika_main(pika::program_options::variables_map& vm) {
   {
     dlaf::ScopedInitializer init(vm);
     const Options opts(vm);
@@ -140,7 +141,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
     dlaf::miniapp::dispatchMiniapp<reductionToBandMiniapp>(opts);
   }
 
-  return hpx::finalize();
+  return pika::finalize();
 }
 
 int main(int argc, char** argv) {
@@ -149,8 +150,8 @@ int main(int argc, char** argv) {
   dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
 
   // options
-  using namespace hpx::program_options;
-  options_description desc_commandline("Usage: " HPX_APPLICATION_STRING " [options]");
+  using namespace pika::program_options;
+  options_description desc_commandline("Usage: miniapp_reduction_to_band [options]");
   desc_commandline.add(dlaf::miniapp::getMiniappOptionsDescription());
   desc_commandline.add(dlaf::getOptionsDescription());
 
@@ -161,8 +162,8 @@ int main(int argc, char** argv) {
   ;
   // clang-format on
 
-  hpx::init_params p;
+  pika::init_params p;
   p.desc_cmdline = desc_commandline;
   p.rp_callback = dlaf::initResourcePartitionerHandler;
-  return hpx::init(argc, argv, p);
+  return pika::init(pika_main, argc, argv, p);
 }

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -13,9 +13,9 @@
 #include <type_traits>
 
 #include <mpi.h>
-#include <hpx/init.hpp>
-#include <hpx/program_options.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/init.hpp>
+#include <pika/program_options.hpp>
+#include <pika/runtime.hpp>
 
 #include <blas/util.hh>
 
@@ -64,7 +64,7 @@ struct Options
   blas::Op op;
   blas::Diag diag;
 
-  Options(const hpx::program_options::variables_map& vm)
+  Options(const pika::program_options::variables_map& vm)
       : MiniappOptions(vm), m(vm["m"].as<SizeType>()), n(vm["n"].as<SizeType>()),
         mb(vm["mb"].as<SizeType>()), nb(vm["nb"].as<SizeType>()),
         side(dlaf::miniapp::parseSide(vm["side"].as<std::string>())),
@@ -158,7 +158,7 @@ struct triangularSolverMiniapp {
                   << dlaf::internal::FormatShort{opts.side} << dlaf::internal::FormatShort{opts.uplo}
                   << dlaf::internal::FormatShort{opts.op} << dlaf::internal::FormatShort{opts.diag}
                   << " " << bh.size() << " " << bh.blockSize() << " " << comm_grid.size() << " "
-                  << hpx::get_os_thread_count() << " " << backend << std::endl;
+                  << pika::get_os_thread_count() << " " << backend << std::endl;
       }
 
       b.copyTargetToSource();
@@ -177,7 +177,7 @@ struct triangularSolverMiniapp {
   }
 };
 
-int hpx_main(hpx::program_options::variables_map& vm) {
+int pika_main(pika::program_options::variables_map& vm) {
   {
     dlaf::ScopedInitializer init(vm);
     const Options opts(vm);
@@ -185,14 +185,14 @@ int hpx_main(hpx::program_options::variables_map& vm) {
     dlaf::miniapp::dispatchMiniapp<triangularSolverMiniapp>(opts);
   }
 
-  return hpx::finalize();
+  return pika::finalize();
 }
 
 int main(int argc, char** argv) {
   dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
 
   // options
-  using namespace hpx::program_options;
+  using namespace pika::program_options;
   options_description desc_commandline(
       "Benchmark computation of solution for A . X = 2 . B, "
       "where A is a non-unit lower triangular matrix, and B is an m by n matrix\n\n"
@@ -213,10 +213,10 @@ int main(int argc, char** argv) {
   dlaf::miniapp::addOpOption(desc_commandline);
   dlaf::miniapp::addDiagOption(desc_commandline);
 
-  hpx::init_params p;
+  pika::init_params p;
   p.desc_cmdline = desc_commandline;
   p.rp_callback = dlaf::initResourcePartitionerHandler;
-  return hpx::init(argc, argv, p);
+  return pika::init(pika_main, argc, argv, p);
 }
 
 namespace {

--- a/misc/cuda.md
+++ b/misc/cuda.md
@@ -1,7 +1,7 @@
 # CUDA/cuBLAS executors
 
 The current cuBLAS executor implementation lives in DLA-Future. This will be
-upstreamed to HPX once stable.
+upstreamed to pika once stable.
 
 There are four main design considerations for the cuBLAS executors:
 
@@ -12,9 +12,9 @@ There are four main design considerations for the cuBLAS executors:
 
 ## Synchronization
 
-The executor currently relies on an experimental customization point in the HPX
-dataflow implementation to improve integration with hpx::dataflow. It uses
-HPX's new internal polling mechanism to check for completion of kernels. After
+The executor currently relies on an experimental customization point in the pika
+dataflow implementation to improve integration with pika::dataflow. It uses
+pika's new internal polling mechanism to check for completion of kernels. After
 submitting a kernel for execution on the GPU, the executor registers an event
 with the scheduler, which then polls for completion between executing tasks.
 
@@ -38,14 +38,14 @@ There are two approaches that can be used here. The first is to simply make
 cuBLAS wrapper functions blocking until the operation is complete. The second
 is to return the tiles from the wrapper functions to ensure that they live
 until the future representing the operation is released. The initial
-implementation uses the second approach to avoid unnecessary yielding of HPX
+implementation uses the second approach to avoid unnecessary yielding of pika
 tasks. However, the overheads from either approach are unlikely to be high
 compared to CUDA latencies.
 
 ## Stream and handle management
 
-The current implementation uses a pool of multiple CUDA streams per HPX worker
-thread and a pool of a single cuBLAS handle per HPX worker thread. This avoids
+The current implementation uses a pool of multiple CUDA streams per pika worker
+thread and a pool of a single cuBLAS handle per pika worker thread. This avoids
 having to take locks to access the streams and handles and thus improves
 performance noticeably.
 

--- a/misc/example/CMakelists.txt
+++ b/misc/example/CMakelists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(test CXX)
 
-find_package(HPX)
+find_package(pika)
 
-add_hpx_executable(test SOURCES test.cpp)
+add_executable(test test.cpp)
+target_link_libraries(test pika::pika)

--- a/misc/example/m.h
+++ b/misc/example/m.h
@@ -78,9 +78,10 @@ public:
       pika::future<Type> fut = std::move(f_[i]);
       pika::lcos::local::promise<Type> p;
       f_[i] = p.get_future();
-      s_[i] = std::move(fut.then(pika::launch::sync, [p = std::move(p)](pika::future<Type>&& fut) mutable {
-        return ConstType(std::move(fut.get().setPromise(std::move(p))));
-      }));
+      s_[i] =
+          std::move(fut.then(pika::launch::sync, [p = std::move(p)](pika::future<Type>&& fut) mutable {
+            return ConstType(std::move(fut.get().setPromise(std::move(p))));
+          }));
     }
     return s_[i];
   }

--- a/misc/example/out.h
+++ b/misc/example/out.h
@@ -1,13 +1,13 @@
 #include <chrono>
 #include <sstream>
 
-#include <hpx/hpx.hpp>
+#include <pika/runtime.hpp>
 
 std::string out(const char* s, int i, int j, int index) {
   std::stringstream ss;
   std::time_t t = std::time(nullptr);
   std::tm tm = *std::localtime(&t);
-  ss << std::put_time(&tm, "%T: ") << "t" << hpx::get_worker_thread_num() << " T" << index << " " << s
+  ss << std::put_time(&tm, "%T: ") << "t" << pika::get_worker_thread_num() << " T" << index << " " << s
      << " " << i << " " << j << std::endl;
   return ss.str();
 }
@@ -16,7 +16,7 @@ std::string out(const char* s, const char* r, int index) {
   std::stringstream ss;
   std::time_t t = std::time(nullptr);
   std::tm tm = *std::localtime(&t);
-  ss << std::put_time(&tm, "%T: ") << "t" << hpx::get_worker_thread_num() << " T" << index << " " << r
+  ss << std::put_time(&tm, "%T: ") << "t" << pika::get_worker_thread_num() << " T" << index << " " << r
      << " " << s << std::endl;
   return ss.str();
 }

--- a/misc/example/test.cpp
+++ b/misc/example/test.cpp
@@ -45,14 +45,14 @@ void foo() {
   std::array<int, 4> a = {0, 1, 2, 3};
   std::array<int, 4> b = {0, 1, 2, 3};
   std::array<pika::future<Type>, 4> fa = {pika::make_ready_future<Type>(&a[0]),
-                                         pika::make_ready_future<Type>(&a[1]),
-                                         pika::make_ready_future<Type>(&a[2]),
-                                         pika::make_ready_future<Type>(&a[3])};
+                                          pika::make_ready_future<Type>(&a[1]),
+                                          pika::make_ready_future<Type>(&a[2]),
+                                          pika::make_ready_future<Type>(&a[3])};
 
   std::array<pika::future<Type>, 4> fb = {pika::make_ready_future<Type>(&b[0]),
-                                         pika::make_ready_future<Type>(&b[1]),
-                                         pika::make_ready_future<Type>(&b[2]),
-                                         pika::make_ready_future<Type>(&b[3])};
+                                          pika::make_ready_future<Type>(&b[1]),
+                                          pika::make_ready_future<Type>(&b[2]),
+                                          pika::make_ready_future<Type>(&b[3])};
 
   Matrix<int> ma(std::move(fa));
   Matrix<int> mb(std::move(fb));

--- a/misc/synchronization.md
+++ b/misc/synchronization.md
@@ -14,8 +14,8 @@ The matrix object (`dlaf::matrix::Matrix`) is the object which manages the setup
 the correct dependencies of the tasks which involve any of its tiles.
 
 Matrix tiles (`dlaf::matrix::Tile`) can be accessed using two matrix methods.
-- `operator()` returns a `hpx::future` of a tile containing the requested tile,
-- `read()` returns a copy of a `hpx::shared_future` of a tile with constant elements representing
+- `operator()` returns a `pika::future` of a tile containing the requested tile,
+- `read()` returns a copy of a `pika::shared_future` of a tile with constant elements representing
   the tile (allows only read operations on tile elements).
 
 Successive calls to `read()` with the same tile index return a copy of the same `shared_future`
@@ -36,9 +36,9 @@ however they cannot be compiled since they are simplified to improve readability
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, m({0, 0}));  // Depends on Task1.
-  hpx::dataflow(Task3, m({0, 1}));  // Different tile. No dependency on Task1 nor on Task2.
+  pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, m({0, 0}));  // Depends on Task1.
+  pika::dataflow(Task3, m({0, 1}));  // Different tile. No dependency on Task1 nor on Task2.
 
 // Resulting dependency graph:
 // Task1 - Task2
@@ -49,12 +49,12 @@ however they cannot be compiled since they are simplified to improve readability
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, m({0, 1}));                  // Different tile.
-  hpx::dataflow(Task3, m.read({0, 0}), m({1, 1}));  // Depends on Task1.
-  hpx::dataflow(Task4, m.read({0, 0}), m({0, 1}));  // Depends on Task1 and Task2. No dependency on Task3 (both only read Tile {0, 0})
-  hpx::dataflow(Task5, m({0, 0}));                  // Depends on Task3 and Task4.
-  hpx::dataflow(Task6, m.read({0, 0}));             // Depends on Task5.
+  pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, m({0, 1}));                  // Different tile.
+  pika::dataflow(Task3, m.read({0, 0}), m({1, 1}));  // Depends on Task1.
+  pika::dataflow(Task4, m.read({0, 0}), m({0, 1}));  // Depends on Task1 and Task2. No dependency on Task3 (both only read Tile {0, 0})
+  pika::dataflow(Task5, m({0, 0}));                  // Depends on Task3 and Task4.
+  pika::dataflow(Task6, m.read({0, 0}));             // Depends on Task5.
 
 // Resulting dependency graph:
 // Task1 - Task3 - Task 5 - Task6
@@ -117,18 +117,18 @@ however they cannot be compiled since they are simplified to improve readability
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, m({0, 0}));  // Depends on Task1.
-  hpx::dataflow(Task3, m({0, 1}));  // Different tile. No dependency on Task1 or Task2.
+  pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, m({0, 0}));  // Depends on Task1.
+  pika::dataflow(Task3, m({0, 1}));  // Different tile. No dependency on Task1 or Task2.
 
   {
     MatrixView mv(UpLo::General, m);
-    hpx::dataflow(Task4, mv({0, 0}));  // Depends on Task2.
-    hpx::dataflow(Task5, mv({0, 1}));  // Depends on Task3.
+    pika::dataflow(Task4, mv({0, 0}));  // Depends on Task2.
+    pika::dataflow(Task5, mv({0, 1}));  // Depends on Task3.
   }
 
-  hpx::dataflow(Task6, m({0, 0}));  // Depends on Task4.
-  hpx::dataflow(Task7, m({0, 1}));  // Depends on Task5.
+  pika::dataflow(Task6, m({0, 0}));  // Depends on Task4.
+  pika::dataflow(Task7, m({0, 1}));  // Depends on Task5.
 
 // Resulting dependency graph:
 // Task1 - Task2 - Task4 ~ Task6
@@ -141,16 +141,16 @@ however they cannot be compiled since they are simplified to improve readability
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, m({0, 0}));  // Depends on Task1.
-  hpx::dataflow(Task3, m({0, 1}));  // Different tile. No dependency on Task1 or Task2.
+  pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, m({0, 0}));  // Depends on Task1.
+  pika::dataflow(Task3, m({0, 1}));  // Different tile. No dependency on Task1 or Task2.
 
   MatrixView mv(UpLo::General, m);
 
-  hpx::dataflow(Task4, m({0, 0}));   // Depends on done notification and Task6
-  hpx::dataflow(Task5, m({0, 1}));   // Depends on done notification and Task7
-  hpx::dataflow(Task6, mv({0, 0}));  // Depends on Task2.
-  hpx::dataflow(Task7, mv({0, 1}));  // Depends on Task3.
+  pika::dataflow(Task4, m({0, 0}));   // Depends on done notification and Task6
+  pika::dataflow(Task5, m({0, 1}));   // Depends on done notification and Task7
+  pika::dataflow(Task6, mv({0, 0}));  // Depends on Task2.
+  pika::dataflow(Task7, mv({0, 1}));  // Depends on Task3.
 
   mv.done({0, 0});
   mv.done({0, 1});
@@ -166,23 +166,23 @@ however they cannot be compiled since they are simplified to improve readability
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, m.read({0, 0}));  // Depends on Task1
+  pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, m.read({0, 0}));  // Depends on Task1
 
   MatrixView mv(UpLo::General, m);
 
-  hpx::dataflow(Task3, m.read({0, 0}));   // Depends on doneWrite notification and Task5
-  hpx::dataflow(Task4, mv.read({0, 0}));  // Depends on Task2.
-  hpx::dataflow(Task5, mv({0, 0}));       // Depends on Task2 and Task4.
+  pika::dataflow(Task3, m.read({0, 0}));   // Depends on doneWrite notification and Task5
+  pika::dataflow(Task4, mv.read({0, 0}));  // Depends on Task2.
+  pika::dataflow(Task5, mv({0, 0}));       // Depends on Task2 and Task4.
 
   mv.doneWrite({0, 0});
 
-  hpx::dataflow(Task6, mv.read({0, 0}));  // Depends on Task5.
+  pika::dataflow(Task6, mv.read({0, 0}));  // Depends on Task5.
 
   mv.done({0, 0});
 
-  hpx::dataflow(Task7, m.read({0, 0}));  // Depends on doneWrite notification and Task5
-  hpx::dataflow(Task8, m({0, 0}));       // Depends on done notification and Task3,6,7
+  pika::dataflow(Task7, m.read({0, 0}));  // Depends on doneWrite notification and Task5
+  pika::dataflow(Task8, m({0, 0}));       // Depends on done notification and Task3,6,7
 
 // Resulting dependency graph:
 // Task1 - Task2 - Task5 -  Task6 -= Task8
@@ -214,7 +214,7 @@ however they cannot be compiled since they are simplified to improve readability
 
 - Example 1: Returning Tiles.
 ```cpp
-Tile&& Task1(hpx::future<Tile>&& future) {
+Tile&& Task1(pika::future<Tile>&& future) {
   auto tile = future.get();
   // Do some work
 
@@ -223,17 +223,17 @@ Tile&& Task1(hpx::future<Tile>&& future) {
 
   Matrix m;
 
-  auto future1 = hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, m.read({0, 0}));  // Depends on Task3 (The Tile used in Task1 is still available in future1).
+  auto future1 = pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, m.read({0, 0}));  // Depends on Task3 (The Tile used in Task1 is still available in future1).
 
-  hpx::dataflow(Task3, future1);  // Depends on Task1.
+  pika::dataflow(Task3, future1);  // Depends on Task1.
 
 // Resulting dependency graph:
 // Task1 - Task3 - Task2
 ```
 - Example 2: Deadlock returning Tiles.
 ```cpp
-Tile&& Task1(hpx::future<Tile>&& future) {
+Tile&& Task1(pika::future<Tile>&& future) {
   auto tile = future.get();
   // Do some work
 
@@ -242,8 +242,8 @@ Tile&& Task1(hpx::future<Tile>&& future) {
 
   Matrix m;
 
-  auto future1 = hpx::dataflow(Task1, m({0, 0}));
-  hpx::dataflow(Task2, future1, m.read({0, 0}));
+  auto future1 = pika::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task2, future1, m.read({0, 0}));
   // DEADLOCK:
   // This task depends on Task1 (via future1), and on the destruction of the Tile in future1 (read()).
   // The scope of the Tile in future1 is extended to the end of Task2, and therefore the execution
@@ -251,7 +251,7 @@ Tile&& Task1(hpx::future<Tile>&& future) {
 ```
 - Example 3: Deadlock returning Tiles (2).
 ```cpp
-Tile&& Task1(hpx::future<Tile>&& future) {
+Tile&& Task1(pika::future<Tile>&& future) {
   auto tile = future.get();
   // Do some work
 
@@ -260,23 +260,23 @@ Tile&& Task1(hpx::future<Tile>&& future) {
 
   Matrix m;
 
-  auto future1 = hpx::dataflow(Task1, m({0, 0}));
-  auto future2 = hpx::dataflow(Task2, m.read({0, 0}));  // Depends on Task3 (The Tile used in Task1 is still available in future1).
+  auto future1 = pika::dataflow(Task1, m({0, 0}));
+  auto future2 = pika::dataflow(Task2, m.read({0, 0}));  // Depends on Task3 (The Tile used in Task1 is still available in future1).
 
   future2.get();  // DEADLOCK! Task2 is not ready yet, and cannot get ready because the destructor of the Tile in future1 will not be called.
 
-  hpx::dataflow(Task3, future1);  // Depends on Task1.
+  pika::dataflow(Task3, future1);  // Depends on Task1.
 ```
 - Example 4: Deadlock shared future scope.
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task1, m({0, 0}));
   auto shared_future = matrix.read({0, 0});
-  hpx::dataflow(Task2, shared_future);   // Depends on Task1.
-  hpx::dataflow(Task3, m.read({0, 0}));  // Depends on Task1.
+  pika::dataflow(Task2, shared_future);   // Depends on Task1.
+  pika::dataflow(Task3, m.read({0, 0}));  // Depends on Task1.
 
-  auto future4 = hpx::dataflow(Task4, m({0, 0}));  // Depends on Task2 and Task3.
+  auto future4 = pika::dataflow(Task4, m({0, 0}));  // Depends on Task2 and Task3.
 
   future4.get();  // DEADLOCK! Task4 is not ready yet, and cannot get ready because the destructor of the Tile in shared_future will not be called.
 ```
@@ -284,15 +284,15 @@ Tile&& Task1(hpx::future<Tile>&& future) {
 ```cpp
   Matrix m;
 
-  hpx::dataflow(Task1, m({0, 0}));
+  pika::dataflow(Task1, m({0, 0}));
 
   {
   auto shared_future = matrix.read({0, 0});
-  hpx::dataflow(Task2, shared_future);   // Depends on Task1.
-  hpx::dataflow(Task3, m.read({0, 0}));  // Depends on Task1.
+  pika::dataflow(Task2, shared_future);   // Depends on Task1.
+  pika::dataflow(Task3, m.read({0, 0}));  // Depends on Task1.
   }  // shared_future goes out of scope here.
 
-  auto future4 = hpx::dataflow(Task4, m({0, 0}));  // Depends on Task2 and Task3.
+  auto future4 = pika::dataflow(Task4, m({0, 0}));  // Depends on Task2 and Task3.
 
   future4.get();  // Task4 may not be ready yet, but it will get ready after the completion of Task4.
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ rm -rf CMakeCache.txt CMakeFiles
 export CC=<FIXME: path to C compiler>
 export CXX=<FIXME: path to C++ compiler>
 export MKLROOT=<FIXME: path to the root installation directory of MKL>
-HPX_DIR=<FIXME: path to the root installation directory of HPX>
+pika_DIR=<FIXME: path to the root installation directory of pika>
 blaspp_DIR=<FIXME: path to the root installation directory of BLASPP>
 lapackpp_DIR=<FIXME: path to the root installation directory of LAPACKPP>
 

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -159,7 +159,7 @@ def chol(
     if lib.startswith("dlaf"):
         env += " OMP_NUM_THREADS=1"
         app = f"{build_dir}/miniapp/miniapp_cholesky"
-        opts = f"--matrix-size {m_sz} --block-size {mb_sz} --grid-rows {grid_rows} --grid-cols {grid_cols} --nruns {nruns} --hpx:use-process-mask {extra_flags}"
+        opts = f"--matrix-size {m_sz} --block-size {mb_sz} --grid-rows {grid_rows} --grid-cols {grid_cols} --nruns {nruns} --pika:use-process-mask {extra_flags}"
     elif lib == "slate":
         env += f" OMP_NUM_THREADS={cores_per_rank}"
         app = f"{build_dir}/test/tester"
@@ -212,7 +212,7 @@ def trsm(
     if lib.startswith("dlaf"):
         env += " OMP_NUM_THREADS=1"
         app = f"{build_dir}/miniapp/miniapp_triangular_solver"
-        opts = f"--m {m_sz} --n {n_sz} --mb {mb_sz} --nb {mb_sz} --grid-rows {gr} --grid-cols {gc} --nruns {nruns} --hpx:use-process-mask {extra_flags}"
+        opts = f"--m {m_sz} --n {n_sz} --mb {mb_sz} --nb {mb_sz} --grid-rows {gr} --grid-cols {gc} --nruns {nruns} --pika:use-process-mask {extra_flags}"
     elif lib == "slate":
         env += f" OMP_NUM_THREADS={cores_per_rank}"
         app = f"{build_dir}/test/tester"
@@ -258,7 +258,7 @@ def gen2std(
     if lib.startswith("dlaf"):
         env += " OMP_NUM_THREADS=1"
         app = f"{build_dir}/miniapp/miniapp_gen_to_std"
-        opts = f"--matrix-size {m_sz} --block-size {mb_sz} --grid-rows {grid_rows} --grid-cols {grid_cols} --nruns {nruns} --hpx:use-process-mask {extra_flags}"
+        opts = f"--matrix-size {m_sz} --block-size {mb_sz} --grid-rows {grid_rows} --grid-cols {grid_cols} --nruns {nruns} --pika:use-process-mask {extra_flags}"
     elif lib == "slate":
         env += f" OMP_NUM_THREADS={cores_per_rank}"
         app = f"{build_dir}/test/tester"

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -35,13 +35,13 @@ class DlaFuture(CMakePackage, CudaPackage):
     # https://github.com/eth-cscs/DLA-Future/issues/420
     conflicts("umpire@6:")
 
-    depends_on("hpx cxxstd=17 networking=none +async_mpi")
-    depends_on("hpx@1.8.0:")
-    depends_on("hpx +cuda", when="+cuda")
+    depends_on("pika cxxstd=17 +mpi")
+    depends_on("pika@main")
+    depends_on("pika +cuda", when="+cuda")
 
-    depends_on("hpx build_type=Debug", when="build_type=Debug")
-    depends_on("hpx build_type=Release", when="build_type=Release")
-    depends_on("hpx build_type=RelWithDebInfo", when="build_type=RelWithDebInfo")
+    depends_on("pika build_type=Debug", when="build_type=Debug")
+    depends_on("pika build_type=Release", when="build_type=Release")
+    depends_on("pika build_type=RelWithDebInfo", when="build_type=RelWithDebInfo")
 
     def cmake_args(self):
         spec = self.spec

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -36,7 +36,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("hpx cxxstd=17 networking=none +async_mpi")
-    depends_on("hpx@1.7.0:")
+    depends_on("hpx@1.8.0:")
     depends_on("hpx +cuda", when="+cuda")
 
     depends_on("hpx build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -36,7 +36,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@main")
+    depends_on("pika@0.1.0")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(dlaf.prop
   INTERFACE
     MPI::MPI_CXX
     LAPACK::LAPACK
-    HPX::hpx
+    pika::pika
     lapackpp
     blaspp
     umpire

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <hpx/async_mpi/mpi_future.hpp>
+#include <pika/async_mpi/mpi_future.hpp>
 
 #include <dlaf/common/assert.h>
 #include <dlaf/communication/error.h>
@@ -57,7 +57,7 @@ struct Init<Backend::MC> {
     memory::internal::initializeUmpireHostAllocator(cfg.umpire_host_memory_pool_initial_bytes);
     // TODO: Consider disabling polling in finalize()
     if (cfg.mpi_mech == comm::MPIMech::Polling) {
-      hpx::mpi::experimental::init(false, cfg.mpi_pool);
+      pika::mpi::experimental::init(false, cfg.mpi_pool);
     }
   }
 
@@ -72,7 +72,7 @@ static std::unique_ptr<cuda::StreamPool> np_stream_pool{nullptr};
 void initializeNpCudaStreamPool(int device, std::size_t num_streams_per_thread) {
   DLAF_ASSERT(!np_stream_pool, "");
   np_stream_pool = std::make_unique<cuda::StreamPool>(device, num_streams_per_thread,
-                                                      hpx::threads::thread_priority::normal);
+                                                      pika::threads::thread_priority::normal);
 }
 
 void finalizeNpCudaStreamPool() {
@@ -90,7 +90,7 @@ static std::unique_ptr<cuda::StreamPool> hp_stream_pool{nullptr};
 void initializeHpCudaStreamPool(int device, std::size_t num_streams_per_thread) {
   DLAF_ASSERT(!hp_stream_pool, "");
   hp_stream_pool = std::make_unique<cuda::StreamPool>(device, num_streams_per_thread,
-                                                      hpx::threads::thread_priority::high);
+                                                      pika::threads::thread_priority::high);
 }
 
 void finalizeHpCudaStreamPool() {
@@ -146,7 +146,7 @@ struct Init<Backend::GPU> {
     initializeHpCudaStreamPool(device, cfg.num_hp_cuda_streams_per_thread);
     initializeCublasHandlePool();
     initializeCusolverHandlePool();
-    hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool("default"));
+    pika::cuda::experimental::detail::register_polling(pika::resource::get_thread_pool("default"));
   }
 
   static void finalize() {
@@ -191,20 +191,20 @@ struct parseFromString<comm::MPIMech> {
 
 template <class T>
 struct parseFromCommandLine {
-  static T call(hpx::program_options::variables_map const& vm, const std::string& cmd_val) {
+  static T call(pika::program_options::variables_map const& vm, const std::string& cmd_val) {
     return vm[cmd_val].as<T>();
   }
 };
 
 template <>
 struct parseFromCommandLine<comm::MPIMech> {
-  static comm::MPIMech call(hpx::program_options::variables_map const& vm, const std::string& cmd_val) {
+  static comm::MPIMech call(pika::program_options::variables_map const& vm, const std::string& cmd_val) {
     return parseFromString<comm::MPIMech>::call(vm[cmd_val].as<std::string>());
   }
 };
 
 template <class T>
-void updateConfigurationValue(hpx::program_options::variables_map const& vm, T& var,
+void updateConfigurationValue(pika::program_options::variables_map const& vm, T& var,
                               std::string const& env_var, std::string const& cmdline_option) {
   const std::string dlaf_env_var = "DLAF_" + env_var;
   char* env_var_value = std::getenv(dlaf_env_var.c_str());
@@ -218,7 +218,7 @@ void updateConfigurationValue(hpx::program_options::variables_map const& vm, T& 
   }
 }
 
-void updateConfiguration(hpx::program_options::variables_map const& vm, configuration& cfg) {
+void updateConfiguration(pika::program_options::variables_map const& vm, configuration& cfg) {
   updateConfigurationValue(vm, cfg.num_np_cuda_streams_per_thread, "NUM_NP_CUDA_STREAMS_PER_THREAD",
                            "num-np-cuda-streams-per-thread");
   updateConfigurationValue(vm, cfg.num_hp_cuda_streams_per_thread, "NUM_HP_CUDA_STREAMS_PER_THREAD",
@@ -230,7 +230,7 @@ void updateConfiguration(hpx::program_options::variables_map const& vm, configur
                            "UMPIRE_DEVICE_MEMORY_POOL_INITIAL_BYTES",
                            "umpire-device-memory-pool-initial-bytes");
   updateConfigurationValue(vm, cfg.mpi_mech, "MPI_MECH", "mpi-mech");
-  cfg.mpi_pool = (hpx::resource::pool_exists("mpi")) ? "mpi" : "default";
+  cfg.mpi_pool = (pika::resource::pool_exists("mpi")) ? "mpi" : "default";
 }
 
 configuration& getConfiguration() {
@@ -239,30 +239,30 @@ configuration& getConfiguration() {
 }
 }
 
-hpx::program_options::options_description getOptionsDescription() {
-  hpx::program_options::options_description desc("DLA-Future options");
+pika::program_options::options_description getOptionsDescription() {
+  pika::program_options::options_description desc("DLA-Future options");
 
   desc.add_options()("dlaf:help", "Print help message");
   desc.add_options()("dlaf:print-config", "Print the DLA-Future configuration");
-  desc.add_options()("dlaf:num-np-cuda-streams-per-thread", hpx::program_options::value<std::size_t>(),
+  desc.add_options()("dlaf:num-np-cuda-streams-per-thread", pika::program_options::value<std::size_t>(),
                      "Number of normal priority CUDA streams per worker thread");
-  desc.add_options()("dlaf:num-hp-cuda-streams-per-thread", hpx::program_options::value<std::size_t>(),
+  desc.add_options()("dlaf:num-hp-cuda-streams-per-thread", pika::program_options::value<std::size_t>(),
                      "Number of high priority CUDA streams per worker thread");
   desc.add_options()("dlaf:umpire-host-memory-pool-initial-bytes",
-                     hpx::program_options::value<std::size_t>(),
+                     pika::program_options::value<std::size_t>(),
                      "Number of bytes to preallocate for pinned host memory pool");
   desc.add_options()("dlaf:umpire-device-memory-pool-initial-bytes",
-                     hpx::program_options::value<std::size_t>(),
+                     pika::program_options::value<std::size_t>(),
                      "Number of bytes to preallocate for device memory pool");
   desc.add_options()("dlaf:mpi-mech",
-                     hpx::program_options::value<std::string>()->default_value("yielding"),
+                     pika::program_options::value<std::string>()->default_value("yielding"),
                      "MPI mechanism ('yielding', 'polling')");
-  desc.add_options()("dlaf:no-mpi-pool", hpx::program_options::bool_switch(), "Disable the MPI pool.");
+  desc.add_options()("dlaf:no-mpi-pool", pika::program_options::bool_switch(), "Disable the MPI pool.");
 
   return desc;
 }
 
-void initialize(hpx::program_options::variables_map const& vm, configuration const& user_cfg) {
+void initialize(pika::program_options::variables_map const& vm, configuration const& user_cfg) {
   bool should_exit = false;
   if (vm.count("dlaf:help") > 0) {
     should_exit = true;
@@ -294,9 +294,9 @@ void initialize(hpx::program_options::variables_map const& vm, configuration con
 void initialize(int argc, const char* const argv[], configuration const& user_cfg) {
   auto desc = getOptionsDescription();
 
-  hpx::program_options::variables_map vm;
-  hpx::program_options::store(hpx::program_options::parse_command_line(argc, argv, desc), vm);
-  hpx::program_options::notify(vm);
+  pika::program_options::variables_map vm;
+  pika::program_options::store(pika::program_options::parse_command_line(argc, argv, desc), vm);
+  pika::program_options::notify(vm);
 
   initialize(vm, user_cfg);
 }
@@ -311,7 +311,7 @@ void finalize() {
   internal::initialized() = false;
 }
 
-ScopedInitializer::ScopedInitializer(hpx::program_options::variables_map const& vm,
+ScopedInitializer::ScopedInitializer(pika::program_options::variables_map const& vm,
                                      configuration const& user_cfg) {
   initialize(vm, user_cfg);
 }
@@ -324,8 +324,8 @@ ScopedInitializer::~ScopedInitializer() {
   finalize();
 }
 
-void initResourcePartitionerHandler(hpx::resource::partitioner& rp,
-                                    hpx::program_options::variables_map const& vm) {
+void initResourcePartitionerHandler(pika::resource::partitioner& rp,
+                                    pika::program_options::variables_map const& vm) {
   // Don't create the MPI pool if the user disabled it
   if (vm["dlaf:no-mpi-pool"].as<bool>())
     return;
@@ -337,13 +337,13 @@ void initResourcePartitionerHandler(hpx::resource::partitioner& rp,
     return;
 
   // Disable idle backoff on the MPI pool
-  using hpx::threads::policies::scheduler_mode;
+  using pika::threads::policies::scheduler_mode;
   auto mode = scheduler_mode::default_mode;
   mode = scheduler_mode(mode & ~scheduler_mode::enable_idle_backoff);
 
   // Create a thread pool with a single core that we will use for all
   // communication related tasks
-  rp.create_thread_pool("mpi", hpx::resource::scheduling_policy::local_priority_fifo, mode);
+  rp.create_thread_pool("mpi", pika::resource::scheduling_policy::local_priority_fifo, mode);
   rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0], "mpi");
 }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ option(DLAF_CI_RUNNER_USES_MPIRUN "Remove mpiexec command for tests executed by 
 
 # On some machines, tests using multiple ranks + oversubscribing run
 # significantly faster when threads are not pinned.
-option(DLAF_TEST_THREAD_BINDING_ENABLED "If OFF disables HPX thread binding." ON)
+option(DLAF_TEST_THREAD_BINDING_ENABLED "If OFF disables pika thread binding." ON)
 
 # if a preset has been selected and it has been changed from previous configurations
 if (NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
@@ -62,8 +62,8 @@ if ((MPIEXEC_NUMCORE_FLAG OR MPIEXEC_NUMCORES) AND NOT (MPIEXEC_NUMCORE_FLAG AND
   message(FATAL_ERROR "MPIEXEC_NUMCORES and MPIEXEC_NUMCORE_FLAG must be either both sets or both empty.")
 endif()
 
-# ----- HPX
-set(DLAF_HPXTEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with HPX")
+# ----- pika
+set(DLAF_PIKATEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with pika")
 
 add_library(DLAF_test INTERFACE)
 

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <vector>
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "gtest/gtest.h"
 #include "dlaf/matrix/matrix.h"
@@ -29,10 +29,10 @@ namespace test {
 /// The futures are created using the matrix method operator()(const LocalTileIndex&).
 /// Note: This function is interchangeable with getFuturesUsingGlobalIndex.
 template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<hpx::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<T, device>& mat) {
+std::vector<pika::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<T, device>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<hpx::future<Tile<T, device>>> result;
+  std::vector<pika::future<Tile<T, device>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.localNrTiles().cols(); ++j) {
@@ -49,10 +49,10 @@ std::vector<hpx::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<T
 /// The futures are created using the matrix method operator()(const GlobalTileIndex&).
 /// Note: This function is interchangeable with getFuturesUsingLocalIndex.
 template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<hpx::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType<T, device>& mat) {
+std::vector<pika::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType<T, device>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<hpx::future<Tile<T, device>>> result;
+  std::vector<pika::future<Tile<T, device>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {
@@ -74,11 +74,11 @@ std::vector<hpx::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType<
 /// The futures are created using the matrix method read(const LocalTileIndex&).
 /// Note: This function is interchangeable with getSharedFuturesUsingGlobalIndex.
 template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingLocalIndex(
+std::vector<pika::shared_future<Tile<const T, device>>> getSharedFuturesUsingLocalIndex(
     MatrixType<T, device>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<hpx::shared_future<Tile<const T, device>>> result;
+  std::vector<pika::shared_future<Tile<const T, device>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.localNrTiles().cols(); ++j) {
@@ -96,11 +96,11 @@ std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingLoca
 /// The futures are created using the matrix method read(const GlobalTileIndex&).
 /// Note: This function is interchangeable with getSharedFuturesUsingLocalIndex.
 template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<hpx::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlobalIndex(
+std::vector<pika::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlobalIndex(
     MatrixType<T, device>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<hpx::shared_future<Tile<const T, device>>> result;
+  std::vector<pika::shared_future<Tile<const T, device>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -13,15 +13,15 @@ add_library(gtest_mpi_listener OBJECT gtest_mpi_listener.cpp)
 target_compile_features(gtest_mpi_listener PUBLIC cxx_std_17)
 target_link_libraries(gtest_mpi_listener PUBLIC gtest MPI::MPI_CXX)
 
-add_library(DLAF_gtest_hpx_main STATIC gtest_hpx_main.cpp)
-target_link_libraries(DLAF_gtest_hpx_main
+add_library(DLAF_gtest_pika_main STATIC gtest_pika_main.cpp)
+target_link_libraries(DLAF_gtest_pika_main
   PUBLIC
     gtest
   PRIVATE
     dlaf.core
-    HPX::hpx
+    pika::pika
 )
-target_add_warnings(DLAF_gtest_hpx_main)
+target_add_warnings(DLAF_gtest_pika_main)
 
 add_library(DLAF_gtest_mpi_main STATIC gtest_mpi_main.cpp)
 target_link_libraries(DLAF_gtest_mpi_main
@@ -32,13 +32,13 @@ target_link_libraries(DLAF_gtest_mpi_main
 )
 target_add_warnings(DLAF_gtest_mpi_main)
 
-add_library(DLAF_gtest_mpihpx_main STATIC gtest_mpihpx_main.cpp)
-target_link_libraries(DLAF_gtest_mpihpx_main
+add_library(DLAF_gtest_mpipika_main STATIC gtest_mpipika_main.cpp)
+target_link_libraries(DLAF_gtest_mpipika_main
   PUBLIC
     gtest
   PRIVATE
     dlaf.core
     gtest_mpi_listener
-    HPX::hpx
+    pika::pika
 )
-target_add_warnings(DLAF_gtest_mpihpx_main)
+target_add_warnings(DLAF_gtest_mpipika_main)

--- a/test/src/gtest_mpipika_main.cpp
+++ b/test/src/gtest_mpipika_main.cpp
@@ -41,8 +41,8 @@
 
 #include <gtest/gtest.h>
 
-#include <pika/modules/threadmanager.hpp>
 #include <pika/init.hpp>
+#include <pika/modules/threadmanager.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/test/src/gtest_pika_main.cpp
+++ b/test/src/gtest_pika_main.cpp
@@ -40,21 +40,21 @@
 #include <cstdio>
 
 #include <gtest/gtest.h>
-#include <hpx/init.hpp>
+#include <pika/init.hpp>
 
 #include <dlaf/init.h>
 
 GTEST_API_ int test_main(int argc, char** argv) {
-  std::printf("Running main() from gtest_hpx_main.cpp\n");
+  std::printf("Running main() from gtest_pika_main.cpp\n");
   auto ret = [&] {
     dlaf::ScopedInitializer init(argc, argv);
     return RUN_ALL_TESTS();
   }();
-  hpx::finalize();
+  pika::finalize();
   return ret;
 }
 
 GTEST_API_ int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  return hpx::init(test_main, argc, argv);
+  return pika::init(test_main, argc, argv);
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -23,13 +23,13 @@ DLAF_addTest(test_util_math
 DLAF_addTest(test_blas_tile
   SOURCES test_blas_tile.cpp
   LIBRARIES dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
 )
 
 DLAF_addTest(test_lapack_tile
   SOURCES test_lapack_tile.cpp
   LIBRARIES dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
 )
 
 # Generic libraries

--- a/test/unit/auxiliary/mc/CMakeLists.txt
+++ b/test/unit/auxiliary/mc/CMakeLists.txt
@@ -11,6 +11,6 @@
 DLAF_addTest(test_norm
   SOURCES test_norm.cpp
   LIBRARIES dlaf.auxiliary dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -13,7 +13,7 @@
 #include <limits>
 
 #include <gtest/gtest.h>
-#include <hpx/local/unwrap.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/lapack/enum_output.h"
@@ -88,7 +88,7 @@ void modify_element(Matrix<T, Device::CPU>& matrix, GlobalElementIndex index, co
     return;
 
   const TileElementIndex index_wrt_local = distribution.tileElementIndex(index);
-  matrix(tile_index).then(hpx::unwrapping([value, index_wrt_local](auto&& tile) {
+  matrix(tile_index).then(pika::unwrapping([value, index_wrt_local](auto&& tile) {
     tile(index_wrt_local) = value;
   }));
 }

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -31,5 +31,5 @@ DLAF_addTest(test_data_descriptor
 DLAF_addTest(test_pipeline
   SOURCES test_pipeline.cpp
   LIBRARIES dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
 )

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -14,9 +14,9 @@
 #include <chrono>
 
 #include <gtest/gtest.h>
-#include <hpx/local/future.hpp>
-#include <hpx/local/thread.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/thread.hpp>
+#include <pika/unwrap.hpp>
 
 using namespace dlaf;
 using namespace std::chrono_literals;
@@ -28,8 +28,8 @@ TEST(Pipeline, Basic) {
 
   auto checkpoint0 = serial();
   auto checkpoint1 =
-      checkpoint0.then(hpx::launch::sync,
-                       hpx::unwrapping([](auto&& wrapper) { return std::move(wrapper); }));
+      checkpoint0.then(pika::launch::sync,
+                       pika::unwrapping([](auto&& wrapper) { return std::move(wrapper); }));
 
   auto guard0 = serial();
   auto guard1 = serial();
@@ -70,16 +70,16 @@ auto try_waiting_guard = [](auto& guard) {
   const auto wait_guard = 20ms;
 
   for (int i = 0; i < 100 && !guard; ++i)
-    hpx::this_thread::sleep_for(wait_guard);
+    pika::this_thread::sleep_for(wait_guard);
 };
 
 TEST(PipelineDestructor, DestructionWithDependency) {
-  hpx::future<void> last_task;
+  pika::future<void> last_task;
 
   std::atomic<bool> is_exited_from_scope;
   {
     Pipeline<int> serial(26);
-    last_task = serial().then(hpx::launch::async, [&is_exited_from_scope](auto) {
+    last_task = serial().then(pika::launch::async, [&is_exited_from_scope](auto) {
       try_waiting_guard(is_exited_from_scope);
       EXPECT_TRUE(is_exited_from_scope);
     });

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -70,7 +70,7 @@ auto try_waiting_guard = [](auto& guard) {
   const auto wait_guard = 20ms;
 
   for (int i = 0; i < 100 && !guard; ++i)
-    pika::this_thread::sleep_for(wait_guard);
+    std::this_thread::sleep_for(wait_guard);
 };
 
 TEST(PipelineDestructor, DestructionWithDependency) {

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -61,33 +61,33 @@ DLAF_addTest(test_broadcast_matrix
   SOURCES test_broadcast_matrix.cpp
   LIBRARIES dlaf.core
   MPIRANKS 4
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
 )
 
 DLAF_addTest(test_broadcast_panel
   SOURCES test_broadcast_panel.cpp
   LIBRARIES dlaf.core
   MPIRANKS 6
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
 )
 
 DLAF_addTest(test_comm_executor
   SOURCES test_comm_executor.cpp
   LIBRARIES dlaf.core
   MPIRANKS 4
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
 )
 
 DLAF_addTest(test_comm_matrix
   SOURCES test_comm_matrix.cpp
   LIBRARIES dlaf.core
   MPIRANKS 2
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
 )
 
 DLAF_addTest(test_collective_async
   SOURCES test_collective_async.cpp
   LIBRARIES dlaf.core
   MPIRANKS 2
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
 )

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -54,7 +54,7 @@ std::vector<config_t> test_params{
 template <class TypeParam, Coord panel_axis>
 void testBroadcast(comm::Executor& executor_mpi, const config_t& cfg, comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::unwrapping;
+  using pika::unwrapping;
 
   constexpr Coord coord1D = orthogonal(panel_axis);
 
@@ -72,7 +72,7 @@ void testBroadcast(comm::Executor& executor_mpi, const config_t& cfg, comm::Comm
 
   // set all panels
   for (const auto i_w : panel.iteratorLocal())
-    hpx::dataflow(unwrapping(
+    pika::dataflow(unwrapping(
                       [rank](auto&& tile) { matrix::test::set(tile, TypeUtil::element(rank, 26)); }),
                   panel(i_w));
 
@@ -118,7 +118,7 @@ template <class TypeParam, Coord PANEL_SRC_AXIS>
 void testBrodcastTranspose(comm::Executor& executor_mpi, const config_t& cfg,
                            comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::unwrapping;
+  using pika::unwrapping;
 
   const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
   const auto rank = dist.rankIndex().get(PANEL_SRC_AXIS);
@@ -129,7 +129,7 @@ void testBrodcastTranspose(comm::Executor& executor_mpi, const config_t& cfg,
   Panel<PANEL_DST_AXIS, TypeParam, dlaf::Device::CPU> panel_dst(dist, cfg.offset);
 
   for (const auto i_w : panel_src.iteratorLocal())
-    hpx::dataflow(unwrapping(
+    pika::dataflow(unwrapping(
                       [rank](auto&& tile) { matrix::test::set(tile, TypeUtil::element(rank, 26)); }),
                   panel_src(i_w));
 

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -73,8 +73,8 @@ void testBroadcast(comm::Executor& executor_mpi, const config_t& cfg, comm::Comm
   // set all panels
   for (const auto i_w : panel.iteratorLocal())
     pika::dataflow(unwrapping(
-                      [rank](auto&& tile) { matrix::test::set(tile, TypeUtil::element(rank, 26)); }),
-                  panel(i_w));
+                       [rank](auto&& tile) { matrix::test::set(tile, TypeUtil::element(rank, 26)); }),
+                   panel(i_w));
 
   // check that all panels have been set
   for (const auto i_w : panel.iteratorLocal())
@@ -130,8 +130,8 @@ void testBrodcastTranspose(comm::Executor& executor_mpi, const config_t& cfg,
 
   for (const auto i_w : panel_src.iteratorLocal())
     pika::dataflow(unwrapping(
-                      [rank](auto&& tile) { matrix::test::set(tile, TypeUtil::element(rank, 26)); }),
-                  panel_src(i_w));
+                       [rank](auto&& tile) { matrix::test::set(tile, TypeUtil::element(rank, 26)); }),
+                   panel_src(i_w));
 
   // test it!
   common::Pipeline<comm::Communicator> row_task_chain(comm_grid.rowCommunicator());

--- a/test/unit/communication/test_comm_executor.cpp
+++ b/test/unit/communication/test_comm_executor.cpp
@@ -8,8 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include <vector>
 
@@ -33,9 +33,9 @@ void test_exec() {
   int recv_rank = (rank != 0) ? rank - 1 : nprocs - 1;
   int tag = 0;
 
-  auto send_fut = hpx::async(ex, MPI_Isend, send_buf.data(), size, dtype, send_rank, tag, comm);
-  auto recv_fut = hpx::async(ex, MPI_Irecv, recv_buf.data(), size, dtype, recv_rank, tag, comm);
-  hpx::wait_all(send_fut, recv_fut);
+  auto send_fut = pika::async(ex, MPI_Isend, send_buf.data(), size, dtype, send_rank, tag, comm);
+  auto recv_fut = pika::async(ex, MPI_Irecv, recv_buf.data(), size, dtype, recv_rank, tag, comm);
+  pika::wait_all(send_fut, recv_fut);
 
   std::vector<double> expected_recv_buf(static_cast<std::size_t>(size), recv_rank);
 
@@ -61,8 +61,8 @@ TEST(Bcast, Dataflow) {
   std::vector<double> buf(static_cast<std::size_t>(size), val);
 
   // Tests the handling of futures in a dataflow
-  hpx::dataflow(ex, hpx::unwrapping(MPI_Ibcast), buf.data(), hpx::make_ready_future<int>(size), dtype,
-                root_rank, comm, hpx::make_ready_future<void>())
+  pika::dataflow(ex, pika::unwrapping(MPI_Ibcast), buf.data(), pika::make_ready_future<int>(size), dtype,
+                root_rank, comm, pika::make_ready_future<void>())
       .get();
 
   std::vector<double> expected_buf(static_cast<std::size_t>(size), 4.2);

--- a/test/unit/communication/test_comm_executor.cpp
+++ b/test/unit/communication/test_comm_executor.cpp
@@ -62,7 +62,7 @@ TEST(Bcast, Dataflow) {
 
   // Tests the handling of futures in a dataflow
   pika::dataflow(ex, pika::unwrapping(MPI_Ibcast), buf.data(), pika::make_ready_future<int>(size), dtype,
-                root_rank, comm, pika::make_ready_future<void>())
+                 root_rank, comm, pika::make_ready_future<void>())
       .get();
 
   std::vector<double> expected_buf(static_cast<std::size_t>(size), 4.2);

--- a/test/unit/communication/test_comm_matrix.cpp
+++ b/test/unit/communication/test_comm_matrix.cpp
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include <gtest/gtest.h>
 #include <mpi.h>
@@ -34,13 +34,13 @@ TEST(BcastMatrixTest, DataflowFuture) {
   dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
   if (comm.rank() == root) {
     mat(index).get()({sz - 1, 0}) = 1.;
-    hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat(index), ccomm());
-    hpx::dataflow(hpx::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
+    pika::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat(index), ccomm());
+    pika::dataflow(pika::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
     EXPECT_EQ(2., mat.read(index).get()({sz - 1, 0}));
   }
   else {
     std::this_thread::sleep_for(50ms);
-    hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::recvBcast_o), mat(index), root, ccomm());
+    pika::dataflow(ex, matrix::unwrapExtendTiles(comm::recvBcast_o), mat(index), root, ccomm());
     EXPECT_EQ(1., mat.read(index).get()({sz - 1, 0}));
   }
 }
@@ -59,13 +59,13 @@ TEST(BcastMatrixTest, DataflowSharedFuture) {
   dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
   if (comm.rank() == root) {
     mat(index).get()({sz - 1, 0}) = 1.;
-    hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat.read(index), ccomm());
-    hpx::dataflow(hpx::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
+    pika::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat.read(index), ccomm());
+    pika::dataflow(pika::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
     EXPECT_EQ(2., mat.read(index).get()({sz - 1, 0}));
   }
   else {
     std::this_thread::sleep_for(50ms);
-    hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::recvBcast_o), mat(index), root, ccomm());
+    pika::dataflow(ex, matrix::unwrapExtendTiles(comm::recvBcast_o), mat(index), root, ccomm());
     EXPECT_EQ(1., mat.read(index).get()({sz - 1, 0}));
   }
 }

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -13,18 +13,18 @@ add_subdirectory(mc)
 DLAF_addTest(test_band_to_tridiag
   SOURCES test_band_to_tridiag.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
 )
 
 DLAF_addTest(test_bt_band_to_tridiag
   SOURCES test_bt_band_to_tridiag.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
 )
 
 DLAF_addTest(test_gen_to_std
   SOURCES test_gen_to_std.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/eigensolver/mc/CMakeLists.txt
+++ b/test/unit/eigensolver/mc/CMakeLists.txt
@@ -11,13 +11,13 @@
 DLAF_addTest(test_backtransformation
   SOURCES test_backtransformation.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_reduction_to_band
   SOURCES test_reduction_to_band.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -14,8 +14,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/include/threadmanager.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/modules/threadmanager.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/common/index2d.h"
 #include "dlaf/communication/communicator_grid.h"
@@ -113,7 +113,7 @@ void testBacktransformationEigenv(SizeType m, SizeType n, SizeType mb, SizeType 
     copy(source_tile, c.tile(ij_tile));
   }
 
-  common::internal::vector<hpx::shared_future<common::internal::vector<T>>> taus;
+  common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus;
   SizeType nr_reflectors_blocks = std::max<SizeType>(0, dlaf::util::ceilDiv(m - mb - 1, mb));
   taus.reserve(nr_reflectors_blocks);
 
@@ -140,7 +140,7 @@ void testBacktransformationEigenv(SizeType m, SizeType n, SizeType mb, SizeType 
       tausloc.push_back(tau);
       tau_tile.push_back(tau);
     }
-    taus.push_back(hpx::make_ready_future(tau_tile));
+    taus.push_back(pika::make_ready_future(tau_tile));
   }
 
   if (n != 0) {
@@ -195,7 +195,7 @@ void testBacktransformationEigenv(comm::CommunicatorGrid grid, SizeType m, SizeT
       tile::internal::laset<T>(lapack::MatrixType::Upper, 0.f, 1.f, mat_v_loc.tile(ij_tile));
   }
 
-  common::internal::vector<hpx::shared_future<common::internal::vector<T>>> taus;
+  common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus;
   SizeType nr_reflectors_blocks = std::max<SizeType>(0, dlaf::util::ceilDiv(m - mb - 1, mb));
   taus.reserve(nr_reflectors_blocks);
 
@@ -223,7 +223,7 @@ void testBacktransformationEigenv(comm::CommunicatorGrid grid, SizeType m, SizeT
       tau_tile.push_back(tau);
     }
     if (grid.rank().col() == mat_v.distribution().template rankGlobalTile<Coord::Col>(k / mb))
-      taus.push_back(hpx::make_ready_future(tau_tile));
+      taus.push_back(pika::make_ready_future(tau_tile));
   }
 
   if (n != 0) {
@@ -258,7 +258,7 @@ TYPED_TEST(BackTransformationEigenSolverTestMC, CorrectnessDistributed) {
   for (const auto& comm_grid : {this->commGrids()[0]}) {
     for (const auto& [m, n, mb, nb] : sizes) {
       testBacktransformationEigenv<TypeParam>(comm_grid, m, n, mb, nb);
-      hpx::threads::get_thread_manager().wait();
+      pika::threads::get_thread_manager().wait();
     }
   }
 }

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -13,8 +13,8 @@
 #include <cmath>
 
 #include <gtest/gtest.h>
-#include <hpx/include/threadmanager.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/modules/threadmanager.hpp>
+#include <pika/runtime.hpp>
 #include <lapack/util.hh>
 
 #include "dlaf/common/index2d.h"
@@ -163,12 +163,12 @@ void splitReflectorsAndBand(MatrixLocal<T>& mat_v, MatrixLocal<T>& mat_b, const 
 
 template <class T>
 auto allGatherTaus(const SizeType k, const SizeType chunk_size, const SizeType band_size,
-                   std::vector<hpx::shared_future<common::internal::vector<T>>> fut_local_taus) {
+                   std::vector<pika::shared_future<common::internal::vector<T>>> fut_local_taus) {
   std::vector<T> taus;
   taus.reserve(to_sizet(k));
 
-  hpx::wait_all(fut_local_taus);
-  auto local_taus = hpx::unwrap(fut_local_taus);
+  pika::wait_all(fut_local_taus);
+  auto local_taus = pika::unwrap(fut_local_taus);
 
   DLAF_ASSERT(band_size == chunk_size, band_size, chunk_size);
 
@@ -188,13 +188,13 @@ auto allGatherTaus(const SizeType k, const SizeType chunk_size, const SizeType b
 
 template <class T>
 auto allGatherTaus(const SizeType k, const SizeType chunk_size, const SizeType band_size,
-                   std::vector<hpx::shared_future<common::internal::vector<T>>> fut_local_taus,
+                   std::vector<pika::shared_future<common::internal::vector<T>>> fut_local_taus,
                    comm::CommunicatorGrid comm_grid) {
   std::vector<T> taus;
   taus.reserve(to_sizet(k));
 
-  hpx::wait_all(fut_local_taus);
-  auto local_taus = hpx::unwrap(fut_local_taus);
+  pika::wait_all(fut_local_taus);
+  auto local_taus = pika::unwrap(fut_local_taus);
 
   DLAF_ASSERT(band_size == chunk_size, band_size, chunk_size);
 
@@ -361,7 +361,7 @@ TYPED_TEST(ReductionToBandTestMC, CorrectnessDistributed) {
       copy(reference, matrix_a);
 
       auto local_taus = eigensolver::reductionToBand<Backend::MC>(comm_grid, matrix_a);
-      hpx::threads::get_thread_manager().wait();
+      pika::threads::get_thread_manager().wait();
 
       checkUpperPartUnchanged(reference, matrix_a);
 

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -13,9 +13,9 @@
 #include <cmath>
 
 #include <gtest/gtest.h>
+#include <lapack/util.hh>
 #include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
-#include <lapack/util.hh>
 
 #include "dlaf/common/index2d.h"
 #include "dlaf/common/pipeline.h"

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -91,7 +91,7 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb) {
                            (affectsTwoRows ? mat_hh.tileSize({i + 1, j}).rows() : 0);
         if (k <= 0)
           continue;
-        hpx::dataflow(hpx::unwrapping(computeTaus<T>), n, k, mat_hh(LocalTileIndex(i, j)));
+        pika::dataflow(pika::unwrapping(computeTaus<T>), n, k, mat_hh(LocalTileIndex(i, j)));
       }
     }
 

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/include/threadmanager.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/modules/threadmanager.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
@@ -131,7 +131,7 @@ TYPED_TEST(EigensolverGenToStdTestMC, CorrectnessDistributed) {
     for (const auto uplo : blas_uplos) {
       for (const auto& [m, mb] : sizes) {
         testGenToStdEigensolver<TypeParam, Backend::MC, Device::CPU>(comm_grid, uplo, m, mb);
-        hpx::threads::get_thread_manager().wait();
+        pika::threads::get_thread_manager().wait();
       }
     }
   }
@@ -151,7 +151,7 @@ TYPED_TEST(EigensolverGenToStdTestGPU, CorrectnessDistributed) {
     for (const auto uplo : blas_uplos) {
       for (const auto& [m, mb] : sizes) {
         testGenToStdEigensolver<TypeParam, Backend::GPU, Device::GPU>(comm_grid, uplo, m, mb);
-        hpx::threads::get_thread_manager().wait();
+        pika::threads::get_thread_manager().wait();
       }
     }
   }

--- a/test/unit/factorization/CMakeLists.txt
+++ b/test/unit/factorization/CMakeLists.txt
@@ -13,6 +13,6 @@ add_subdirectory(mc)
 DLAF_addTest(test_cholesky
   SOURCES test_cholesky.cpp
   LIBRARIES dlaf.factorization dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/factorization/mc/CMakeLists.txt
+++ b/test/unit/factorization/mc/CMakeLists.txt
@@ -11,6 +11,6 @@
 DLAF_addTest(test_compute_t_factor
   SOURCES test_compute_t_factor.cpp
   LIBRARIES dlaf.factorization dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -13,8 +13,7 @@
 
 #include <gtest/gtest.h>
 #include <blas.hh>
-#include <hpx/include/util.hpp>
-#include <hpx/local/future.hpp>
+#include <pika/future.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator_grid.h"
@@ -271,8 +270,8 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessLocal) {
     }
 
     auto tmp = computeHAndTFactor(k, v);
-    hpx::shared_future<dlaf::common::internal::vector<TypeParam>> taus_input =
-        hpx::make_ready_future<dlaf::common::internal::vector<TypeParam>>(std::move(std::get<0>(tmp)));
+    pika::shared_future<dlaf::common::internal::vector<TypeParam>> taus_input =
+        pika::make_ready_future<dlaf::common::internal::vector<TypeParam>>(std::move(std::get<0>(tmp)));
     auto h_expected = std::move(std::get<1>(tmp));
 
     is_orthogonal(h_expected);
@@ -356,8 +355,8 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessDistributed) {
       }();
 
       auto tmp = computeHAndTFactor(k, v);
-      hpx::shared_future<dlaf::common::internal::vector<TypeParam>> taus_input =
-          hpx::make_ready_future<dlaf::common::internal::vector<TypeParam>>(std::move(std::get<0>(tmp)));
+      pika::shared_future<dlaf::common::internal::vector<TypeParam>> taus_input =
+          pika::make_ready_future<dlaf::common::internal::vector<TypeParam>>(std::move(std::get<0>(tmp)));
       auto h_expected = std::move(std::get<1>(tmp));
 
       is_orthogonal(h_expected);

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -356,7 +356,8 @@ TYPED_TEST(ComputeTFactorTestMC, CorrectnessDistributed) {
 
       auto tmp = computeHAndTFactor(k, v);
       pika::shared_future<dlaf::common::internal::vector<TypeParam>> taus_input =
-          pika::make_ready_future<dlaf::common::internal::vector<TypeParam>>(std::move(std::get<0>(tmp)));
+          pika::make_ready_future<dlaf::common::internal::vector<TypeParam>>(
+              std::move(std::get<0>(tmp)));
       auto h_expected = std::move(std::get<1>(tmp));
 
       is_orthogonal(h_expected);

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/include/threadmanager.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/modules/threadmanager.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
@@ -118,7 +118,7 @@ TYPED_TEST(CholeskyTestMC, CorrectnessDistributed) {
     for (auto uplo : blas_uplos) {
       for (const auto& [m, mb] : sizes) {
         testCholesky<TypeParam, Backend::MC, Device::CPU>(comm_grid, uplo, m, mb);
-        hpx::threads::get_thread_manager().wait();
+        pika::threads::get_thread_manager().wait();
       }
     }
   }
@@ -138,7 +138,7 @@ TYPED_TEST(CholeskyTestGPU, CorrectnessDistributed) {
     for (auto uplo : blas_uplos) {
       for (const auto& [m, mb] : sizes) {
         testCholesky<TypeParam, Backend::GPU, Device::GPU>(comm_grid, uplo, m, mb);
-        hpx::threads::get_thread_manager().wait();
+        pika::threads::get_thread_manager().wait();
       }
     }
   }

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 
-#include <hpx/init.hpp>
+#include <pika/init.hpp>
 
 static const char* binary_name = "init_test";
 static const char* env_var_name = "DLAF_NUM_HP_CUDA_STREAMS_PER_THREAD";
@@ -140,18 +140,18 @@ int precedence_main(int, char*[]) {
     EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
   }
 
-  return hpx::finalize();
+  return pika::finalize();
 }
 
 TEST_P(InitTest, Precedence) {
   current_initializer_type = GetParam();
 
-  // The const_cast is currently necessary for hpx::init. HPX should be updated
+  // The const_cast is currently necessary for pika::init. pika should be updated
   // to take const argc/argv.
-  hpx::init(precedence_main, argc_without_option, const_cast<char**>(argv_without_option));
+  pika::init(precedence_main, argc_without_option, const_cast<char**>(argv_without_option));
 }
 
-int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
+int vm_no_command_line_option_main(pika::program_options::variables_map& vm) {
   const dlaf::configuration default_cfg;
   const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
   // Note that this test doesn't mean that the default value has to be 3. It is
@@ -210,19 +210,19 @@ int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
     EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
   }
 
-  return hpx::finalize();
+  return pika::finalize();
 }
 
 TEST_P(InitTest, VariablesMapNoCommandLineOption) {
   current_initializer_type = GetParam();
 
-  // The const_cast is currently necessary for hpx::init. HPX should be updated
+  // The const_cast is currently necessary for pika::init. pika should be updated
   // to take const argc/argv.
-  hpx::init(vm_no_command_line_option_main, argc_without_option,
+  pika::init(vm_no_command_line_option_main, argc_without_option,
             const_cast<char**>(argv_without_option));
 }
 
-int vm_command_line_option_main(hpx::program_options::variables_map& vm) {
+int vm_command_line_option_main(pika::program_options::variables_map& vm) {
   dlaf::configuration default_cfg;
   const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
 
@@ -240,16 +240,16 @@ int vm_command_line_option_main(hpx::program_options::variables_map& vm) {
     EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
   }
 
-  return hpx::finalize();
+  return pika::finalize();
 }
 
 TEST_P(InitTest, VariablesMapCommandLineOption) {
   current_initializer_type = GetParam();
 
-  hpx::program_options::options_description options("options");
+  pika::program_options::options_description options("options");
   options.add(dlaf::getOptionsDescription());
 
-  hpx::init_params p;
+  pika::init_params p;
   p.desc_cmdline = options;
 
   dlaf::configuration default_cfg;
@@ -263,12 +263,12 @@ TEST_P(InitTest, VariablesMapCommandLineOption) {
   std::string command_line_option_str =
       command_line_option_name + std::string("=") + command_line_option_val_str;
   int argc_with_option = 2;
-  // The const_cast is currently necessary for hpx::init. HPX should be updated
+  // The const_cast is currently necessary for pika::init. pika should be updated
   // to take const argc/argv.
   char* argv_with_option[] = {const_cast<char*>(binary_name),
                               const_cast<char*>(command_line_option_str.c_str())};
 
-  hpx::init(vm_command_line_option_main, argc_with_option, argv_with_option, p);
+  pika::init(vm_command_line_option_main, argc_with_option, argv_with_option, p);
 }
 
 INSTANTIATE_TEST_SUITE_P(Init, InitTest, initializer_types);

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -219,7 +219,7 @@ TEST_P(InitTest, VariablesMapNoCommandLineOption) {
   // The const_cast is currently necessary for pika::init. pika should be updated
   // to take const argc/argv.
   pika::init(vm_no_command_line_option_main, argc_without_option,
-            const_cast<char**>(argv_without_option));
+             const_cast<char**>(argv_without_option));
 }
 
 int vm_command_line_option_main(pika::program_options::variables_map& vm) {

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -11,7 +11,7 @@
 DLAF_addTest(test_tile
   SOURCES test_tile.cpp
   LIBRARIES dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
 )
 
 DLAF_addTest(test_layout_info
@@ -35,48 +35,48 @@ DLAF_addTest(test_util_distribution
 DLAF_addTest(test_matrix
   SOURCES test_matrix.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_matrix_local
   SOURCES test_matrix_local.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_matrix_mirror
   SOURCES test_matrix_mirror.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_matrix_view
   SOURCES test_matrix_view.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_util_matrix
   SOURCES test_util_matrix.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_matrix_output
   SOURCES test_matrix_output.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_panel
   SOURCES test_panel.cpp
   LIBRARIES dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <hpx/local/future.hpp>
-#include <hpx/local/unwrap.hpp>
+#include <pika/future.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/util_matrix.h"
@@ -35,7 +35,7 @@ using namespace dlaf::comm;
 using namespace dlaf::test;
 using namespace testing;
 
-using hpx::unwrapping;
+using pika::unwrapping;
 
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
@@ -1246,7 +1246,7 @@ auto try_waiting_guard = [](auto& guard) {
   const auto wait_guard = 20ms;
 
   for (int i = 0; i < 100 && !guard; ++i)
-    hpx::this_thread::sleep_for(wait_guard);
+    pika::this_thread::sleep_for(wait_guard);
 };
 
 // Create a single-element matrix
@@ -1268,14 +1268,14 @@ auto createConstMatrix(const T& data) {
 }
 
 TEST(MatrixDestructorFutures, NonConstAfterRead) {
-  hpx::future<void> last_task;
+  pika::future<void> last_task;
 
   std::atomic<bool> is_exited_from_scope{false};
   {
     auto matrix = createMatrix<TypeParam>();
 
     auto shared_future = matrix.read(LocalTileIndex(0, 0));
-    last_task = shared_future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
+    last_task = shared_future.then(pika::launch::async, [&is_exited_from_scope](auto&&) {
       try_waiting_guard(is_exited_from_scope);
       EXPECT_TRUE(is_exited_from_scope);
     });
@@ -1286,14 +1286,14 @@ TEST(MatrixDestructorFutures, NonConstAfterRead) {
 }
 
 TEST(MatrixDestructorFutures, NonConstAfterReadWrite) {
-  hpx::future<void> last_task;
+  pika::future<void> last_task;
 
   std::atomic<bool> is_exited_from_scope{false};
   {
     auto matrix = createMatrix<TypeParam>();
 
     auto future = matrix(LocalTileIndex(0, 0));
-    last_task = future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
+    last_task = future.then(pika::launch::async, [&is_exited_from_scope](auto&&) {
       try_waiting_guard(is_exited_from_scope);
       EXPECT_TRUE(is_exited_from_scope);
     });
@@ -1304,7 +1304,7 @@ TEST(MatrixDestructorFutures, NonConstAfterReadWrite) {
 }
 
 TEST(MatrixDestructorFutures, NonConstAfterRead_UserMemory) {
-  hpx::future<void> last_task;
+  pika::future<void> last_task;
 
   std::atomic<bool> is_exited_from_scope{false};
   {
@@ -1312,7 +1312,7 @@ TEST(MatrixDestructorFutures, NonConstAfterRead_UserMemory) {
     auto matrix = createMatrix<TypeParam>(data);
 
     auto shared_future = matrix.read(LocalTileIndex(0, 0));
-    last_task = shared_future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
+    last_task = shared_future.then(pika::launch::async, [&is_exited_from_scope](auto&&) {
       try_waiting_guard(is_exited_from_scope);
       EXPECT_TRUE(is_exited_from_scope);
     });
@@ -1323,7 +1323,7 @@ TEST(MatrixDestructorFutures, NonConstAfterRead_UserMemory) {
 }
 
 TEST(MatrixDestructorFutures, NonConstAfterReadWrite_UserMemory) {
-  hpx::future<void> last_task;
+  pika::future<void> last_task;
 
   std::atomic<bool> is_exited_from_scope{false};
   {
@@ -1331,7 +1331,7 @@ TEST(MatrixDestructorFutures, NonConstAfterReadWrite_UserMemory) {
     auto matrix = createMatrix<TypeParam>(data);
 
     auto future = matrix(LocalTileIndex(0, 0));
-    last_task = future.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
+    last_task = future.then(pika::launch::async, [&is_exited_from_scope](auto&&) {
       try_waiting_guard(is_exited_from_scope);
       EXPECT_TRUE(is_exited_from_scope);
     });
@@ -1342,7 +1342,7 @@ TEST(MatrixDestructorFutures, NonConstAfterReadWrite_UserMemory) {
 }
 
 TEST(MatrixDestructorFutures, ConstAfterRead_UserMemory) {
-  hpx::future<void> last_task;
+  pika::future<void> last_task;
 
   std::atomic<bool> is_exited_from_scope{false};
   {
@@ -1350,7 +1350,7 @@ TEST(MatrixDestructorFutures, ConstAfterRead_UserMemory) {
     auto matrix = createConstMatrix<TypeParam>(data);
 
     auto sf = matrix.read(LocalTileIndex(0, 0));
-    last_task = sf.then(hpx::launch::async, [&is_exited_from_scope](auto&&) {
+    last_task = sf.then(pika::launch::async, [&is_exited_from_scope](auto&&) {
       try_waiting_guard(is_exited_from_scope);
       EXPECT_TRUE(is_exited_from_scope);
     });
@@ -1392,8 +1392,8 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
 
       // start a task (if it has at least a local part...otherwise there is no tile to work on)
       if (has_local)
-        matrix.read(tile_tl).then(hpx::launch::async, [&guard](auto&&) {
-          hpx::this_thread::sleep_for(100ms);
+        matrix.read(tile_tl).then(pika::launch::async, [&guard](auto&&) {
+          pika::this_thread::sleep_for(100ms);
           guard = true;
         });
 

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -1246,7 +1246,7 @@ auto try_waiting_guard = [](auto& guard) {
   const auto wait_guard = 20ms;
 
   for (int i = 0; i < 100 && !guard; ++i)
-    pika::this_thread::sleep_for(wait_guard);
+    std::this_thread::sleep_for(wait_guard);
 };
 
 // Create a single-element matrix
@@ -1393,7 +1393,7 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
       // start a task (if it has at least a local part...otherwise there is no tile to work on)
       if (has_local)
         matrix.read(tile_tl).then(pika::launch::async, [&guard](auto&&) {
-          pika::this_thread::sleep_for(100ms);
+          std::this_thread::sleep_for(100ms);
           guard = true;
         });
 

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <hpx/local/unwrap.hpp>
+#include <pika/unwrap.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator.h"
@@ -59,7 +59,7 @@ std::vector<config_t> test_params{
 
 TYPED_TEST(PanelTest, AssignToConstRef) {
   using namespace dlaf;
-  using hpx::unwrapping;
+  using pika::unwrapping;
 
   for (auto& comm_grid : this->commGrids()) {
     for (const auto& cfg : test_params) {
@@ -120,7 +120,7 @@ TYPED_TEST(PanelTest, IteratorRow) {
 template <class TypeParam, Coord panel_axis>
 void testAccess(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::unwrapping;
+  using pika::unwrapping;
 
   const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
 
@@ -153,7 +153,7 @@ TYPED_TEST(PanelTest, AccessTileRow) {
 template <class TypeParam, Coord panel_axis>
 void testExternalTile(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
-  using hpx::unwrapping;
+  using pika::unwrapping;
 
   constexpr Coord coord1D = orthogonal(panel_axis);
 
@@ -240,7 +240,7 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
     SizeType counter = 0;
     for (SizeType k = head_loc; k < tail_loc; ++k) {
       const LocalTileIndex idx(coord1D, k);
-      hpx::dataflow(hpx::unwrapping(setTile), panel(idx), counter++);
+      pika::dataflow(pika::unwrapping(setTile), panel(idx), counter++);
       const auto& tile = panel.read(idx).get();
       SCOPED_TRACE(message);
       EXPECT_EQ(tile.size(), matrix.read(idx).get().size());

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -245,8 +245,8 @@ void testSet0(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
     panel.setRange(GlobalTileIndex(coord1D, head), GlobalTileIndex(coord1D, tail));
 
     for (const auto& idx : panel.iteratorLocal())
-      pika::dataflow(pika::unwrapping(tile::internal::laset_o), lapack::MatrixType::General, TypeParam(1),
-                    TypeParam(1), panel(idx));
+      pika::dataflow(pika::unwrapping(tile::internal::laset_o), lapack::MatrixType::General,
+                     TypeParam(1), TypeParam(1), panel(idx));
 
     matrix::util::set0<Backend::MC>(pika::threads::thread_priority::normal, panel);
 

--- a/test/unit/multiplication/CMakeLists.txt
+++ b/test/unit/multiplication/CMakeLists.txt
@@ -11,6 +11,6 @@
 DLAF_addTest(test_multiplication_triangular
   SOURCES test_multiplication_triangular.cpp
   LIBRARIES dlaf.multiplication dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/multiplication/test_multiplication_triangular.cpp
+++ b/test/unit/multiplication/test_multiplication_triangular.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/include/threadmanager.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/modules/threadmanager.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/communication/communicator_grid.h"
@@ -179,7 +179,7 @@ TYPED_TEST(TriangularMultiplicationTestMC, CorrectnessDistributed) {
               testTriangularMultiplication<TypeParam, Backend::MC, Device::CPU>(comm_grid, side, uplo,
                                                                                 op, diag, alpha, m, n,
                                                                                 mb, nb);
-              hpx::threads::get_thread_manager().wait();
+              pika::threads::get_thread_manager().wait();
             }
           }
         }
@@ -220,7 +220,7 @@ TYPED_TEST(TriangularMultiplicationTestGPU, CorrectnessDistributed) {
               testTriangularMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, side, uplo,
                                                                                  op, diag, alpha, m, n,
                                                                                  mb, nb);
-              hpx::threads::get_thread_manager().wait();
+              pika::threads::get_thread_manager().wait();
             }
           }
         }

--- a/test/unit/solver/CMakeLists.txt
+++ b/test/unit/solver/CMakeLists.txt
@@ -11,6 +11,6 @@
 DLAF_addTest(test_triangular
   SOURCES test_triangular.cpp
   LIBRARIES dlaf.solver dlaf.core
-  USE_MAIN MPIHPX
+  USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/include/threadmanager.hpp>
-#include <hpx/runtime.hpp>
+#include <pika/modules/threadmanager.hpp>
+#include <pika/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
@@ -175,7 +175,7 @@ TYPED_TEST(TriangularSolverTestMC, CorrectnessDistributed) {
               TypeParam alpha = TypeUtilities<TypeParam>::element(-1.2, .7);
               testTriangularSolver<TypeParam, Backend::MC, Device::CPU>(comm_grid, side, uplo, op, diag,
                                                                         alpha, m, n, mb, nb);
-              hpx::threads::get_thread_manager().wait();
+              pika::threads::get_thread_manager().wait();
             }
           }
         }
@@ -216,7 +216,7 @@ TYPED_TEST(TriangularSolverTestGPU, CorrectnessDistributed) {
 
               testTriangularSolver<TypeParam, Backend::GPU, Device::GPU>(comm_grid, side, uplo, op, diag,
                                                                          alpha, m, n, mb, nb);
-              hpx::threads::get_thread_manager().wait();
+              pika::threads::get_thread_manager().wait();
             }
           }
         }


### PR DESCRIPTION
This is the PR in preparation for the next HPX release.

Changelog:
- [x] Update minimum C++ standard requirement to C++17 (changed in #371 and #427)
- [x] update HPX minimum version both in CMake and spack package

TODO:
- [x] Adapt CI to use the actual release branch
- [x] Remove `tag_invoke/dispatch` compatibility macros
  https://github.com/STEllAR-GROUP/hpx/pull/5600
- [x] Use `execution::then` instead of `transform`, and `execution::start_detached` instead of `detach` (renamed)
  https://github.com/STEllAR-GROUP/hpx/pull/5644
- [x] Use `execution::transfer` instead of `on` (renamed)
  https://github.com/STEllAR-GROUP/hpx/pull/5656
- [x] CUDA and C++17 https://github.com/eth-cscs/DLA-Future/pull/422#issuecomment-960633301

Word to @msimberg for any major change (in case there are).