### PR TITLE
Pipeline fixes: non-blocking d'tor

### DIFF
--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -62,8 +62,8 @@ private:
 /// way to register to the queue. All requests are serialized and served in the same order they arrive.
 ///
 /// The mechanism for auto-releasing the resource and passing it to the next user works thanks to the
-/// internal Wrapper object. This Wrapper contains the real resource, and it will do what is needed to
-/// unlock the next user as soon as the Wrapper is destroyed.
+/// internal PromiseGuard object. This PromiseGuard contains the real resource, and it will do what is
+/// needed to unlock the next user as soon as the PromiseGuard is destroyed.
 template <class T>
 class Pipeline {
 public:
@@ -72,10 +72,10 @@ public:
     future_ = hpx::make_ready_future(std::move(object));
   }
 
-  /// On destruction it waits that all users have finished using it.
+  /// On destruction it does not wait for the queued requests for the resource and exits immediately.
   ~Pipeline() {
     if (future_.valid())
-      future_.get();
+      future_ = {};
   }
 
   /// Enqueue for the resource.

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -60,6 +60,7 @@ private:
 /// Pipeline takes ownership of a given object and manages the access to this resource by serializing
 /// calls. Anyone that requires access to the underlying resource will get an hpx::future, which is the
 /// way to register to the queue. All requests are serialized and served in the same order they arrive.
+/// On destruction it does not wait for the queued requests for the resource and exits immediately.
 ///
 /// The mechanism for auto-releasing the resource and passing it to the next user works thanks to the
 /// internal PromiseGuard object. This PromiseGuard contains the real resource, and it will do what is
@@ -70,12 +71,6 @@ public:
   /// Create a Pipeline by moving in the resource (it takes the ownership).
   Pipeline(T object) {
     future_ = hpx::make_ready_future(std::move(object));
-  }
-
-  /// On destruction it does not wait for the queued requests for the resource and exits immediately.
-  ~Pipeline() {
-    if (future_.valid())
-      future_ = {};
   }
 
   /// Enqueue for the resource.

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -87,8 +87,8 @@ public:
     hpx::lcos::local::promise<T> promise_next;
     future_ = promise_next.get_future();
 
-    return before_last.then(hpx::launch::sync, hpx::unwrapping([promise_next = std::move(promise_next)](
-                                                                   T&& object) mutable {
+    return before_last.then(hpx::launch::sync,
+                            hpx::unwrapping([promise_next = std::move(promise_next)](T object) mutable {
                               return PromiseGuard<T>{std::move(object), std::move(promise_next)};
                             }));
   }

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -32,10 +32,10 @@ namespace comm {
 namespace internal {
 
 template <class T>
-auto allReduce(common::PromiseGuard<comm::Communicator> const& pcomm, MPI_Op reduce_op,
+auto allReduce(const common::PromiseGuard<comm::Communicator>& pcomm, MPI_Op reduce_op,
                common::internal::ContiguousBufferHolder<const T> cont_buf_in,
                common::internal::ContiguousBufferHolder<T> cont_buf_out,
-               matrix::Tile<const T, Device::CPU> const&, MPI_Request* req) {
+               const matrix::Tile<const T, Device::CPU>&, MPI_Request* req) {
   auto& comm = pcomm.ref();
   auto msg_in = comm::make_message(cont_buf_in.descriptor);
   auto msg_out = comm::make_message(cont_buf_out.descriptor);
@@ -48,7 +48,7 @@ auto allReduce(common::PromiseGuard<comm::Communicator> const& pcomm, MPI_Op red
 DLAF_MAKE_CALLABLE_OBJECT(allReduce);
 
 template <class T>
-auto allReduceInPlace(common::PromiseGuard<comm::Communicator> const& pcomm, MPI_Op reduce_op,
+auto allReduceInPlace(const common::PromiseGuard<comm::Communicator>& pcomm, MPI_Op reduce_op,
                       common::internal::ContiguousBufferHolder<T> cont_buf, MPI_Request* req) {
   auto& comm = pcomm.ref();
   auto msg = comm::make_message(cont_buf.descriptor);

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -32,7 +32,7 @@ namespace comm {
 namespace internal {
 
 template <class T>
-auto allReduce(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
+auto allReduce(common::PromiseGuard<comm::Communicator> const& pcomm, MPI_Op reduce_op,
                common::internal::ContiguousBufferHolder<const T> cont_buf_in,
                common::internal::ContiguousBufferHolder<T> cont_buf_out,
                matrix::Tile<const T, Device::CPU> const&, MPI_Request* req) {
@@ -48,7 +48,7 @@ auto allReduce(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
 DLAF_MAKE_CALLABLE_OBJECT(allReduce);
 
 template <class T>
-auto allReduceInPlace(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
+auto allReduceInPlace(common::PromiseGuard<comm::Communicator> const& pcomm, MPI_Op reduce_op,
                       common::internal::ContiguousBufferHolder<T> cont_buf, MPI_Request* req) {
   auto& comm = pcomm.ref();
   auto msg = comm::make_message(cont_buf.descriptor);

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -87,7 +87,7 @@ struct ScheduleRecvBcast {
                    comm::IndexT_MPI root_rank, hpx::future<common::PromiseGuard<Communicator>> pcomm) {
     using hpx::dataflow;
     using matrix::duplicateIfNeeded;
-    using matrix::copy_o;
+    using matrix::internal::copy_o;
 
     // Note:
     //
@@ -104,7 +104,8 @@ struct ScheduleRecvBcast {
     tile_cpu = std::move(hpx::get<0>(hpx::split_future(
         ScheduleRecvBcast<T>::call(ex, std::move(tile_cpu), root_rank, std::move(pcomm)))));
 
-    dataflow(getCopyExecutor<Device::GPU, Device::CPU>(), unwrapExtendTiles(copy_o), tile_cpu, tile_gpu);
+    dataflow(getCopyExecutor<Device::GPU, Device::CPU>(), matrix::unwrapExtendTiles(copy_o), tile_cpu,
+             tile_gpu);
   }
 };
 

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -29,102 +29,41 @@
 namespace dlaf {
 namespace comm {
 
-// Non-blocking sender broadcast
 template <class T, Device D>
-void sendBcast(matrix::Tile<const T, D> const& tile, common::PromiseGuard<Communicator> pcomm,
+void sendBcast(matrix::Tile<const T, D> const& tile, common::PromiseGuard<Communicator> const& pcomm,
                MPI_Request* req) {
+  const auto& comm = pcomm.ref();
   auto msg = comm::make_message(common::make_data(tile));
-  DLAF_MPI_CALL(MPI_Ibcast(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), pcomm.ref().rank(),
-                           pcomm.ref(), req));
+  DLAF_MPI_CALL(
+      MPI_Ibcast(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), comm.rank(), comm, req));
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(sendBcast);
 
-// Non-blocking receiver broadcast
 template <class T, Device D>
-matrix::Tile<T, D> recvBcast(matrix::Tile<T, D> tile, comm::IndexT_MPI root_rank,
-                             common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
+void recvBcast(matrix::Tile<T, D> const& tile, comm::IndexT_MPI root_rank,
+               common::PromiseGuard<Communicator> const& pcomm, MPI_Request* req) {
   auto msg = comm::make_message(common::make_data(tile));
   DLAF_MPI_CALL(MPI_Ibcast(msg.data(), msg.count(), msg.mpi_type(), root_rank, pcomm.ref(), req));
-  return tile;
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(recvBcast);
 
-// Non-blocking receiver broadcast (with Alloc)
-template <class T, Device D>
-matrix::Tile<const T, D> recvBcastAlloc(TileElementSize tile_size, comm::IndexT_MPI root_rank,
-                                        common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
-  using Tile_t = matrix::Tile<T, D>;
-  using ConstTile_t = matrix::Tile<const T, D>;
-  using MemView_t = memory::MemoryView<T, D>;
-
-  MemView_t mem_view(tile_size.rows() * tile_size.cols());
-  Tile_t tile(tile_size, std::move(mem_view), tile_size.rows());
-
-  auto msg = comm::make_message(common::make_data(tile));
-  DLAF_MPI_CALL(MPI_Ibcast(msg.data(), msg.count(), msg.mpi_type(), root_rank, pcomm.ref(), req));
-  return ConstTile_t(std::move(tile));
-}
-
 template <class T, Device D, template <class> class Future>
 void scheduleSendBcast(const comm::Executor& ex, Future<matrix::Tile<const T, D>> tile,
-                       hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
-  hpx::dataflow(ex, matrix::unwrapExtendTiles(sendBcast_o), internal::prepareSendTile(std::move(tile)),
-                std::move(pcomm));
+                       hpx::future<common::PromiseGuard<Communicator>> pcomm) {
+  using matrix::unwrapExtendTiles;
+  using internal::prepareSendTile;
+  hpx::dataflow(ex, unwrapExtendTiles(sendBcast_o), prepareSendTile(std::move(tile)), std::move(pcomm));
 }
-
-// This implements scheduleRecvBcast for when the device of the given tile and
-// the communication device are different. In that case we make use of
-// recvBcastAlloc, which will allocate a tile on the correct device for
-// communication, receive the data, and return the tile. When communication is
-// ready, we copy the data from the tile on the communication device to the tile
-// passed into scheduleRecvBcast.
-template <Device D, Device CommunicationD>
-struct scheduleRecvBcastImpl {
-  template <class T>
-  static void call(const comm::Executor& ex, hpx::future<matrix::Tile<T, D>> tile,
-                   comm::IndexT_MPI root_rank, hpx::future<common::PromiseGuard<Communicator>> pcomm) {
-    auto tile_shared = tile.share();
-    auto tile_size =
-        hpx::dataflow(hpx::launch::sync,
-                      hpx::unwrapping([](matrix::Tile<T, D> const& tile) { return tile.size(); }),
-                      tile_shared);
-    auto comm_tile = hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>),
-                                   tile_size, root_rank, std::move(pcomm));
-    hpx::dataflow(dlaf::getCopyExecutor<CommunicationDevice<D>::value, D>(),
-                  matrix::unwrapExtendTiles(matrix::internal::copy_o), std::move(comm_tile),
-                  std::move(tile_shared));
-  }
-};
-
-// This specialization is used when the communication device and the device used
-// for the input tile are the same. In this case we don't need to do anything
-// special and just launch a task that receives into the given tile.
-template <Device D>
-struct scheduleRecvBcastImpl<D, D> {
-  template <class T>
-  static void call(const comm::Executor& ex, hpx::future<matrix::Tile<T, D>> tile,
-                   comm::IndexT_MPI root_rank, hpx::future<common::PromiseGuard<Communicator>> pcomm) {
-    hpx::dataflow(ex, hpx::unwrapping(recvBcast_o), std::move(tile), root_rank, std::move(pcomm));
-  }
-};
 
 template <class T, Device D>
 void scheduleRecvBcast(const comm::Executor& ex, hpx::future<matrix::Tile<T, D>> tile,
                        comm::IndexT_MPI root_rank,
                        hpx::future<common::PromiseGuard<Communicator>> pcomm) {
-  scheduleRecvBcastImpl<D, CommunicationDevice<D>::value>::call(ex, std::move(tile), root_rank,
-                                                                std::move(pcomm));
+  using matrix::unwrapExtendTiles;
+  hpx::dataflow(ex, unwrapExtendTiles(recvBcast_o), std::move(tile), root_rank, std::move(pcomm));
 }
 
-template <class T, Device D>
-hpx::future<matrix::Tile<const T, D>> scheduleRecvBcastAlloc(
-    const comm::Executor& ex, TileElementSize tile_size, comm::IndexT_MPI root_rank,
-    hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
-  return internal::handleRecvTile<D>(
-      hpx::dataflow(ex, hpx::unwrapping(recvBcastAlloc<T, CommunicationDevice<D>::value>), tile_size,
-                    root_rank, std::move(pcomm)));
-}
 }
 }

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -89,6 +89,15 @@ struct ScheduleRecvBcast {
     using matrix::duplicateIfNeeded;
     using matrix::copy_o;
 
+    // Note:
+    //
+    // TILE_GPU -+-> duplicateIfNeeded<CPU> ---> TILE_CPU ---> recvBcast ---> TILE_CPU -+-> copy
+    //           |                                                                      |
+    //           +----------------------------------------------------------------------+
+    //
+    // Actually `duplicateIfNeeded` always makes a copy, because it is always needed since this
+    // is the specialization for GPU input and MPI withuot CUDA_RDMA requires CPU memory.
+
     auto tile_gpu = tile.share();
     auto tile_cpu = duplicateIfNeeded<Device::CPU>(tile_gpu);
 

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -30,7 +30,7 @@ namespace dlaf {
 namespace comm {
 
 template <class T, Device D>
-void sendBcast(matrix::Tile<const T, D> const& tile, common::PromiseGuard<Communicator> const& pcomm,
+void sendBcast(const matrix::Tile<const T, D>& tile, const common::PromiseGuard<Communicator>& pcomm,
                MPI_Request* req) {
   const auto& comm = pcomm.ref();
   auto msg = comm::make_message(common::make_data(tile));
@@ -41,8 +41,8 @@ void sendBcast(matrix::Tile<const T, D> const& tile, common::PromiseGuard<Commun
 DLAF_MAKE_CALLABLE_OBJECT(sendBcast);
 
 template <class T, Device D>
-void recvBcast(matrix::Tile<T, D> const& tile, comm::IndexT_MPI root_rank,
-               common::PromiseGuard<Communicator> const& pcomm, MPI_Request* req) {
+void recvBcast(const matrix::Tile<T, D>& tile, comm::IndexT_MPI root_rank,
+               const common::PromiseGuard<Communicator>& pcomm, MPI_Request* req) {
   auto msg = comm::make_message(common::make_data(tile));
   DLAF_MPI_CALL(MPI_Ibcast(msg.data(), msg.count(), msg.mpi_type(), root_rank, pcomm.ref(), req));
 }

--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -191,8 +191,8 @@ void BackTransformation<Backend::MC, Device::CPU, T>::call_FC(
 
   // Set up MPI
   auto executor_mpi = dlaf::getMPIExecutor<Backend::MC>();
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
 
   auto dist_v = mat_v.distribution();
   auto dist_c = mat_c.distribution();

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -22,7 +22,6 @@
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/executor.h"
-#include "dlaf/communication/kernels.h"
 #include "dlaf/eigensolver/gen_to_std/api.h"
 #include "dlaf/executors.h"
 #include "dlaf/lapack/tile.h"

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -275,8 +275,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -546,8 +546,8 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -795,8 +795,8 @@ std::vector<hpx::shared_future<common::internal::vector<T>>> ReductionToBand<
   const auto ex_mpi = getMPIExecutor<Backend::MC>();
 
   common::Pipeline<comm::Communicator> mpi_col_chain_panel(grid.colCommunicator().clone());
-  common::Pipeline<comm::Communicator> mpi_row_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_chain(grid.colCommunicator().clone());
 
   const auto& dist = mat_a.distribution();
   const comm::Index2D rank = dist.rankIndex();

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -169,8 +169,8 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -311,8 +311,8 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -25,8 +25,6 @@
 #include "dlaf/types.h"
 #include "dlaf/util_math.h"
 
-#include "dlaf/common/pipeline.h"
-
 namespace dlaf {
 /// Exception used to notify a continuation task that an exception has been thrown in a dependency task.
 ///
@@ -504,18 +502,8 @@ struct UnwrapFuture {
 template <typename T, Device D>
 struct UnwrapFuture<hpx::future<Tile<T, D>>> {
   template <typename U>
-  static auto call(U&& u) {
-    auto t = u.get();
-    return t;
-  }
-};
-
-template <typename T>
-struct UnwrapFuture<hpx::future<dlaf::common::PromiseGuard<T>>> {
-  template <typename U>
-  static auto call(U&& u) {
-    auto t = u.get();
-    return t;
+  static auto call(U u) {
+    return u.get();
   }
 };
 

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -25,6 +25,8 @@
 #include "dlaf/types.h"
 #include "dlaf/util_math.h"
 
+#include "dlaf/common/pipeline.h"
+
 namespace dlaf {
 /// Exception used to notify a continuation task that an exception has been thrown in a dependency task.
 ///
@@ -501,6 +503,17 @@ struct UnwrapFuture {
 
 template <typename T, Device D>
 struct UnwrapFuture<hpx::future<Tile<T, D>>> {
+  template <typename U>
+  static auto call(U&& u) {
+    auto t = u.get();
+    return t;
+  }
+};
+
+template <class> struct dummy;
+
+template <typename T>
+struct UnwrapFuture<hpx::future<dlaf::common::PromiseGuard<T>>> {
   template <typename U>
   static auto call(U&& u) {
     auto t = u.get();

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -510,8 +510,6 @@ struct UnwrapFuture<hpx::future<Tile<T, D>>> {
   }
 };
 
-template <class> struct dummy;
-
 template <typename T>
 struct UnwrapFuture<hpx::future<dlaf::common::PromiseGuard<T>>> {
   template <typename U>

--- a/include/dlaf/multiplication/triangular/impl.h
+++ b/include/dlaf/multiplication/triangular/impl.h
@@ -389,8 +389,8 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -473,8 +473,8 @@ void Triangular<backend, device, T>::call_LUN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -556,8 +556,8 @@ void Triangular<backend, device, T>::call_RLN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -640,8 +640,8 @@ void Triangular<backend, device, T>::call_RUN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -436,8 +436,8 @@ void Triangular<backend, device, T>::call_LLN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -614,8 +614,8 @@ void Triangular<backend, device, T>::call_LUN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -707,8 +707,8 @@ void Triangular<backend, device, T>::call_RLN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 
@@ -800,8 +800,8 @@ void Triangular<backend, device, T>::call_RUN(comm::CommunicatorGrid grid, blas:
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
   // Set up MPI executor pipelines
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -529,8 +529,8 @@ void Triangular<backend, D, T>::call_LLT(comm::CommunicatorGrid grid, blas::Op o
 
   auto executor_mpi = dlaf::getMPIExecutor<backend>();
 
-  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator());
-  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator());
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
   const comm::Index2D this_rank = grid.rank();
 

--- a/test/unit/communication/test_comm_matrix.cpp
+++ b/test/unit/communication/test_comm_matrix.cpp
@@ -30,19 +30,18 @@ TEST(BcastMatrixTest, DataflowFuture) {
   int root = 0;
   int sz = 10000;
 
+  LocalTileIndex index(0, 0);
+  dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
   if (comm.rank() == root) {
-    LocalTileIndex index(0, 0);
-    dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
     mat(index).get()({sz - 1, 0}) = 1.;
     hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat(index), ccomm());
     hpx::dataflow(hpx::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
-    EXPECT_EQ(2., mat(index).get()({sz - 1, 0}));
+    EXPECT_EQ(2., mat.read(index).get()({sz - 1, 0}));
   }
   else {
     std::this_thread::sleep_for(50ms);
-    auto tile_f = hpx::dataflow(ex, hpx::unwrapping(comm::recvBcastAlloc<double, Device::CPU>),
-                                TileElementSize{sz, 1}, root, ccomm());
-    EXPECT_EQ(1., tile_f.get()({sz - 1, 0}));
+    hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::recvBcast_o), mat(index), root, ccomm());
+    EXPECT_EQ(1., mat.read(index).get()({sz - 1, 0}));
   }
 }
 
@@ -56,18 +55,17 @@ TEST(BcastMatrixTest, DataflowSharedFuture) {
   int root = 0;
   int sz = 10000;
 
+  LocalTileIndex index(0, 0);
+  dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
   if (comm.rank() == root) {
-    LocalTileIndex index(0, 0);
-    dlaf::Matrix<double, Device::CPU> mat({sz, 1}, {sz, 1});
     mat(index).get()({sz - 1, 0}) = 1.;
     hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::sendBcast_o), mat.read(index), ccomm());
     hpx::dataflow(hpx::unwrapping([sz](auto tile) { tile({sz - 1, 0}) = 2.; }), mat(index));
-    EXPECT_EQ(2., mat(index).get()({sz - 1, 0}));
+    EXPECT_EQ(2., mat.read(index).get()({sz - 1, 0}));
   }
   else {
     std::this_thread::sleep_for(50ms);
-    auto tile_f = hpx::dataflow(ex, hpx::unwrapping(comm::recvBcastAlloc<double, Device::CPU>),
-                                TileElementSize{sz, 1}, root, ccomm());
-    EXPECT_EQ(1., tile_f.get()({sz - 1, 0}));
+    hpx::dataflow(ex, matrix::unwrapExtendTiles(comm::recvBcast_o), mat(index), root, ccomm());
+    EXPECT_EQ(1., mat.read(index).get()({sz - 1, 0}));
   }
 }

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -12,7 +12,11 @@
 #include <functional>
 #include <sstream>
 #include <tuple>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <hpx/include/threadmanager.hpp>
+#include <hpx/runtime.hpp>
+
 #include "dlaf/common/index2d.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/copy.h"
@@ -255,6 +259,7 @@ TYPED_TEST(BackTransformationEigenSolverTestMC, CorrectnessDistributed) {
     for (auto sz : sizes) {
       std::tie(m, n, mb, nb) = sz;
       testBacktransformationEigenv<TypeParam>(comm_grid, m, n, mb, nb);
+      hpx::threads::get_thread_manager().wait();
     }
   }
 }

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 
 #include <gtest/gtest.h>
+#include <hpx/runtime.hpp>
 #include <hpx/include/threadmanager.hpp>
 #include <lapack/util.hh>
 

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -13,8 +13,8 @@
 #include <cmath>
 
 #include <gtest/gtest.h>
-#include <hpx/runtime.hpp>
 #include <hpx/include/threadmanager.hpp>
+#include <hpx/runtime.hpp>
 #include <lapack/util.hh>
 
 #include "dlaf/common/index2d.h"

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 
 #include <gtest/gtest.h>
+#include <hpx/include/threadmanager.hpp>
 #include <lapack/util.hh>
 
 #include "dlaf/common/index2d.h"
@@ -356,6 +357,7 @@ TYPED_TEST(ReductionToBandTestMC, CorrectnessDistributed) {
       copy(reference, matrix_a);
 
       auto local_taus = eigensolver::reductionToBand<Backend::MC>(comm_grid, matrix_a);
+      hpx::threads::get_thread_manager().wait();
 
       checkUpperPartUnchanged(reference, matrix_a);
 

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -11,7 +11,11 @@
 
 #include <functional>
 #include <tuple>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <hpx/runtime.hpp>
+#include <hpx/include/threadmanager.hpp>
+
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/matrix_mirror.h"
@@ -137,7 +141,7 @@ TYPED_TEST(EigensolverGenToStdTestMC, CorrectnessDistributed) {
       for (auto sz : sizes) {
         std::tie(m, mb) = sz;
         testGenToStdEigensolver<TypeParam, Backend::MC, Device::CPU>(comm_grid, uplo, m, mb);
-        hpx::resource::get_thread_pool("default").wait();
+        hpx::threads::get_thread_manager().wait();
       }
     }
   }
@@ -163,7 +167,7 @@ TYPED_TEST(EigensolverGenToStdTestGPU, CorrectnessDistributed) {
       for (auto sz : sizes) {
         std::tie(m, mb) = sz;
         testGenToStdEigensolver<TypeParam, Backend::GPU, Device::GPU>(comm_grid, uplo, m, mb);
-        hpx::resource::get_thread_pool("default").wait();
+        hpx::threads::get_thread_manager().wait();
       }
     }
   }

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/runtime.hpp>
 #include <hpx/include/threadmanager.hpp>
+#include <hpx/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -137,6 +137,7 @@ TYPED_TEST(EigensolverGenToStdTestMC, CorrectnessDistributed) {
       for (auto sz : sizes) {
         std::tie(m, mb) = sz;
         testGenToStdEigensolver<TypeParam, Backend::MC, Device::CPU>(comm_grid, uplo, m, mb);
+        hpx::resource::get_thread_pool("default").wait();
       }
     }
   }
@@ -162,6 +163,7 @@ TYPED_TEST(EigensolverGenToStdTestGPU, CorrectnessDistributed) {
       for (auto sz : sizes) {
         std::tie(m, mb) = sz;
         testGenToStdEigensolver<TypeParam, Backend::GPU, Device::GPU>(comm_grid, uplo, m, mb);
+        hpx::resource::get_thread_pool("default").wait();
       }
     }
   }

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/runtime.hpp>
 #include <hpx/include/threadmanager.hpp>
+#include <hpx/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -11,7 +11,11 @@
 
 #include <functional>
 #include <tuple>
-#include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <hpx/runtime.hpp>
+#include <hpx/include/threadmanager.hpp>
+
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/matrix_mirror.h"
@@ -126,6 +130,7 @@ TYPED_TEST(CholeskyTestMC, CorrectnessDistributed) {
       for (auto sz : sizes) {
         std::tie(m, mb) = sz;
         testCholesky<TypeParam, Backend::MC, Device::CPU>(comm_grid, uplo, m, mb);
+        hpx::threads::get_thread_manager().wait();
       }
     }
   }
@@ -151,6 +156,7 @@ TYPED_TEST(CholeskyTestGPU, CorrectnessDistributed) {
       for (auto sz : sizes) {
         std::tie(m, mb) = sz;
         testCholesky<TypeParam, Backend::GPU, Device::GPU>(comm_grid, uplo, m, mb);
+        hpx::threads::get_thread_manager().wait();
       }
     }
   }

--- a/test/unit/multiplication/test_multiplication_triangular.cpp
+++ b/test/unit/multiplication/test_multiplication_triangular.cpp
@@ -13,6 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
+#include <hpx/include/threadmanager.hpp>
+#include <hpx/runtime.hpp>
 
 #include "dlaf/blas/tile.h"
 #include "dlaf/communication/communicator_grid.h"
@@ -179,6 +181,7 @@ TYPED_TEST(TriangularMultiplicationTestMC, CorrectnessDistributed) {
               testTriangularMultiplication<TypeParam, Backend::MC, Device::CPU>(comm_grid, side, uplo,
                                                                                 op, diag, alpha, m, n,
                                                                                 mb, nb);
+              hpx::threads::get_thread_manager().wait();
             }
           }
         }
@@ -221,6 +224,7 @@ TYPED_TEST(TriangularMultiplicationTestGPU, CorrectnessDistributed) {
               testTriangularMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, side, uplo,
                                                                                  op, diag, alpha, m, n,
                                                                                  mb, nb);
+              hpx::threads::get_thread_manager().wait();
             }
           }
         }

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -13,8 +13,8 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <hpx/runtime.hpp>
 #include <hpx/include/threadmanager.hpp>
+#include <hpx/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -12,9 +12,10 @@
 #include <functional>
 #include <tuple>
 
+#include <gtest/gtest.h>
+#include <hpx/runtime.hpp>
 #include <hpx/include/threadmanager.hpp>
 
-#include "gtest/gtest.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/matrix_mirror.h"

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -11,6 +11,9 @@
 
 #include <functional>
 #include <tuple>
+
+#include <hpx/include/threadmanager.hpp>
+
 #include "gtest/gtest.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
@@ -189,6 +192,7 @@ TYPED_TEST(TriangularSolverTestMC, CorrectnessDistributed) {
               TypeParam alpha = TypeUtilities<TypeParam>::element(-1.2, .7);
               testTriangularSolver<TypeParam, Backend::MC, Device::CPU>(comm_grid, side, uplo, op, diag,
                                                                         alpha, m, n, mb, nb);
+              hpx::threads::get_thread_manager().wait();
             }
           }
         }
@@ -235,6 +239,7 @@ TYPED_TEST(TriangularSolverTestGPU, CorrectnessDistributed) {
 
               testTriangularSolver<TypeParam, Backend::GPU, Device::GPU>(comm_grid, side, uplo, op, diag,
                                                                          alpha, m, n, mb, nb);
+              hpx::threads::get_thread_manager().wait();
             }
           }
         }


### PR DESCRIPTION
Close #417

(I write here for future reference what we found out with @rasolca)

Removing the blocking call from the `Pipeline` d'tor exposed two main problems:
- ~Resource management with `PromiseGuard`. For instance with `PromiseGuard<Communicator>` used with asynchronous communications, it suffered of the same problem of Tiles, i.e. it has to be kept alive till the completion of the operation and not just for the posting of the operation.~
  EDIT: this is not true, indeed the Communicator has to be kept just for the posting of the operation, not until its completion. Otherwise we end up serializing communications, completely missing the point of asynchronous MPI.
- Shared communicators: it is something we knew, but it shown up in a subtle way. Using the same communicator for multiple algorithms, may end up in mixed/crossed communications resulting in undefined/strange behaviours (e.g. in the case I was debugging it was an "MPI Invalid Communicator"). This happened in `test_gen_to_std` https://github.com/eth-cscs/DLA-Future/blob/41ded01d1f1311a24a80e6ec86c7415df6c7bda4/test/unit/eigensolver/test_gen_to_std.cpp#L135-L142 where the same algorithm is executed sequentially on exactly the same `CommunicatorGrid`. The problem was raised in case one of the rank was able to start the 2nd configuration before other ranks were able to finish the 1st one (e.g. a rank that does not have any tile to work on), so communications for the 2nd were posted mixed up with the 1st one.

Both these problems will need a better management and we can think of redesigning a bit how it works, this is somehow a temporary solution.

CHANGES:
- Pipeline d'tor does not block anymore
- Due to previous point, algorithm call is not "blocking" anymore. This resulted in a deadlock condition in an edge case which has been workaround with by all HPX tasks (see https://github.com/eth-cscs/DLA-Future/pull/423#issuecomment-958735416)
- ~Extend `matrix::unwrapExtendTiles` to extend lifetime also for `PromiseGuard` (and adapt asynchronous communication kernels accordingly)~
- Clone communicators got from `CommunicatorGrid`s inside each algorithm (see https://github.com/eth-cscs/DLA-Future/pull/423#issuecomment-958716222)
- Remove unused `recvBcastAlloc` (and adapt `test_comm_matrix` that was using it)

~Even if this solution is temporary, IMHO it may be worth improving the naming of `unwrapExtendTiles`, e.g. since at this point we are extending the concept of lifetime extension not just to tiles.~

