### PR TITLE
Upgrade to clang-format-10

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,20 +1,24 @@
 ---
-# Need clang-format version 8!
+# Need clang-format version 10!
 
 Language:        Cpp
 
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
@@ -22,6 +26,7 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
+  AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -39,9 +44,9 @@ BraceWrapping:
   SplitEmptyNamespace: false
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
-BreakInheritanceList: BeforeColon
 BreakStringLiterals: false
 ColumnLimit:     105
 CommentPragmas:  '^ IWYU pragma:'
@@ -50,24 +55,35 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat:   false
 FixNamespaceComments: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           'dlaf.*/'
     Priority:        4
+    SortPriority:    0
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
+    SortPriority:    0
   - Regex:           '^<.*\.h>'
     Priority:        1
+    SortPriority:    0
   - Regex:           '^<.*'
     Priority:        2
+    SortPriority:    0
   - Regex:           '.*'
     Priority:        3
+    SortPriority:    0
 IncludeIsMainRegex: '(test)?$'
+IncludeIsMainSourceRegex: ''
 IndentCaseLabels: true
+IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
@@ -76,6 +92,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 2500
 PenaltyBreakComment: 1500
 PenaltyBreakFirstLessLess: 500
@@ -84,10 +101,11 @@ PenaltyBreakTemplateDeclaration: 500
 PenaltyExcessCharacter: 100
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
-ReflowComments: true
+ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
@@ -95,14 +113,18 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false
-SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
 ...

--- a/.github/format.sh
+++ b/.github/format.sh
@@ -12,7 +12,7 @@ do
 
   case $FILE in
     *.cpp|*.h|*.hpp|*.tpp|*.ipp|*.cu)
-      clang-format-8 -i --style=file $FILE
+      clang-format-10 -i --style=file $FILE
       # The following is needed for regions in which clang-format is disabled.
       # Note: clang-format removes trailing spaces even in disabled regions.
       # Check if tab are present.

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install tools
         run: |
-          sudo apt-get install --no-install-recommends clang-format-8 python3
+          sudo apt-get install --no-install-recommends clang-format-10 python3
           pip3 install black==21.8b0
       - name: Checkout
         uses: actions/checkout@v2

--- a/include/dlaf/auxiliary/norm/mc.h
+++ b/include/dlaf/auxiliary/norm/mc.h
@@ -72,7 +72,7 @@ dlaf::BaseType<T> Norm<Backend::MC, Device::CPU, T>::max_L(comm::CommunicatorGri
       continue;
 
     bool is_diag = tile_wrt_global.row() == tile_wrt_global.col();
-    auto norm_max_f = unwrapping([is_diag](auto&& tile) noexcept->NormT {
+    auto norm_max_f = unwrapping([is_diag](auto&& tile) noexcept -> NormT {
       if (is_diag)
         return lantr(lapack::Norm::Max, blas::Uplo::Lower, blas::Diag::NonUnit, tile);
       else

--- a/include/dlaf/matrix/distribution.h
+++ b/include/dlaf/matrix/distribution.h
@@ -176,8 +176,8 @@ public:
   /// @pre 0 <= global_tile < nrTiles().get<rc>(),
   /// @pre 0 <= tile_element < blockSize.get<rc>().
   template <Coord rc>
-  SizeType globalElementFromGlobalTileAndTileElement(SizeType global_tile, SizeType tile_element) const
-      noexcept {
+  SizeType globalElementFromGlobalTileAndTileElement(SizeType global_tile,
+                                                     SizeType tile_element) const noexcept {
     DLAF_ASSERT_HEAVY(0 <= global_tile && global_tile < global_nr_tiles_.get<rc>(), global_tile,
                       global_nr_tiles_.get<rc>());
     DLAF_ASSERT_HEAVY(0 <= tile_element && tile_element < block_size_.get<rc>(), tile_element,
@@ -191,8 +191,8 @@ public:
   /// @pre 0 <= local_tile < localNrTiles().get<rc>(),
   /// @pre 0 <= tile_element < blockSize.get<rc>().
   template <Coord rc>
-  SizeType globalElementFromLocalTileAndTileElement(SizeType local_tile, SizeType tile_element) const
-      noexcept {
+  SizeType globalElementFromLocalTileAndTileElement(SizeType local_tile,
+                                                    SizeType tile_element) const noexcept {
     return globalElementFromGlobalTileAndTileElement<rc>(globalTileFromLocalTile<rc>(local_tile),
                                                          tile_element);
   }

--- a/include/dlaf/sender/partial_transform.h
+++ b/include/dlaf/sender/partial_transform.h
@@ -42,6 +42,6 @@ public:
 };
 
 template <Backend B, typename F>
-PartialTransform(const Policy<B> policy, F&& f)->PartialTransform<B, std::decay_t<F>>;
+PartialTransform(const Policy<B> policy, F&& f) -> PartialTransform<B, std::decay_t<F>>;
 }
 }

--- a/test/include/dlaf_test/matrix/util_tile.h
+++ b/test/include/dlaf_test/matrix/util_tile.h
@@ -129,9 +129,7 @@ Tile<T, D> createTile(ElementGetter val, const TileElementSize size, const SizeT
 /// for any @p index given
 template <class T>
 auto fixedValueTile(T value) noexcept {
-  return [=](TileElementIndex) noexcept {
-    return value;
-  };
+  return [=](TileElementIndex) noexcept { return value; };
 }
 
 namespace internal {

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -146,7 +146,7 @@ void testBacktransformationEigenv(SizeType m, SizeType n, SizeType mb, SizeType 
 
   eigensolver::backTransformation<Backend::MC>(mat_c, mat_v, taus);
 
-  auto result = [& dist = mat_c.distribution(), &mat_local = c](const GlobalElementIndex& element) {
+  auto result = [&dist = mat_c.distribution(), &mat_local = c](const GlobalElementIndex& element) {
     const auto tile_index = dist.globalTileIndex(element);
     const auto tile_element = dist.tileElementIndex(element);
     return mat_local.tile_read(tile_index)(tile_element);
@@ -229,7 +229,7 @@ void testBacktransformationEigenv(comm::CommunicatorGrid grid, SizeType m, SizeT
 
   eigensolver::backTransformation<Backend::MC>(grid, mat_c, mat_v, taus);
 
-  auto result = [& dist = mat_c.distribution(),
+  auto result = [&dist = mat_c.distribution(),
                  &mat_local = mat_c_loc](const GlobalElementIndex& element) {
     const auto tile_index = dist.globalTileIndex(element);
     const auto tile_element = dist.tileElementIndex(element);

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -283,7 +283,7 @@ auto checkResult(const SizeType k, const SizeType band_size, const SizeType bloc
   }
 
   // Eventually, check the result obtained by applying the inverse transformation equals the original matrix
-  auto result = [& dist = reference.distribution(),
+  auto result = [&dist = reference.distribution(),
                  &mat_local = mat_b](const GlobalElementIndex& element) {
     const auto tile_index = dist.globalTileIndex(element);
     const auto tile_element = dist.tileElementIndex(element);


### PR DESCRIPTION
As pointed out by @albestro clang-format-8 doesn't format c++17 code correctly.

I chose clang-format-10 as it is the newest version available in Ubuntu 20.04 (the current LTS).
