### PR TITLE
Update to GoogleTest 1.11

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -8,6 +8,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+set(CMAKE_CXX_STANDARD 17)
+
 ### GoogleTest
 include(FetchContent)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,27 +14,9 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
-
-  # Patch for TestPartResult operator<<
-  # Fixes missing filename on exceptions causing segmentation fault
-  PATCH_COMMAND git cherry-pick -n 5395345ca4f0c596110188688ed990e0de5a181c -m 1
+  GIT_TAG        release-1.11.0
 )
+set(BUILD_GMOCK OFF CACHE INTERNAL "")
+set(INSTALL_GTEST OFF CACHE INTERNAL "")
 
-FetchContent_GetProperties(googletest)
-if (NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
-
-  # set default values for options
-  option(BUILD_GMOCK "Build GoogleTest GMock" OFF)
-  option(BUILD_GTEST "Build GoogleTest GTest" ON)
-
-  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-
-  # keep project cache clean
-  mark_as_advanced(
-    BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-    gmock_build_tests gtest_build_samples gtest_build_tests
-    gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
-  )
-endif()
+FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
Not really mandatory, but after a quick check there is no reason to not update.

- It removes the warning about a too old CMake version supported  https://github.com/google/googletest/issues/3040
- add back global `set(CMAKE_CXX_STANDARD 17)` according to https://github.com/google/googletest/blob/main/googletest/README.md#c-standard-version