### PR TITLE
Remove pointer to promise by variant in Tile.

### DIFF
--- a/include/dlaf/matrix/internal/tile_future_manager.h
+++ b/include/dlaf/matrix/internal/tile_future_manager.h
@@ -29,7 +29,7 @@ hpx::future<ReturnTileType> setPromiseTileFuture(
     std::exception_ptr current_exception_ptr;
 
     try {
-      return ReturnTileType(std::move(NonConstTileType(std::move(fut.get())).setPromise(std::move(p))));
+      return ReturnTileType(std::move(NonConstTileType(fut.get()).setPromise(std::move(p))));
     }
     catch (...) {
       current_exception_ptr = std::current_exception();

--- a/include/dlaf/matrix/internal/tile_future_manager.h
+++ b/include/dlaf/matrix/internal/tile_future_manager.h
@@ -17,15 +17,19 @@ namespace matrix {
 namespace internal {
 
 // Attach the promise to the tile included in old_future with a continuation and returns a new future to it.
-template <class ReturnTileType, class TileType>
-hpx::future<ReturnTileType> setPromiseTileFuture(hpx::future<TileType> old_future,
-                                                 hpx::lcos::local::promise<TileType> p) noexcept {
+template <class ReturnTileType>
+hpx::future<ReturnTileType> setPromiseTileFuture(
+    hpx::future<typename ReturnTileType::TileDataType> old_future,
+    hpx::lcos::local::promise<typename ReturnTileType::TileDataType> p) noexcept {
+  using TileDataType = typename ReturnTileType::TileDataType;
+  using NonConstTileType = typename ReturnTileType::TileType;
+
   DLAF_ASSERT_HEAVY(old_future.valid(), "");
-  return old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileType>&& fut) mutable {
+  return old_future.then(hpx::launch::sync, [p = std::move(p)](hpx::future<TileDataType>&& fut) mutable {
     std::exception_ptr current_exception_ptr;
 
     try {
-      return ReturnTileType(std::move(fut.get().setPromise(std::move(p))));
+      return ReturnTileType(std::move(NonConstTileType(std::move(fut.get())).setPromise(std::move(p))));
     }
     catch (...) {
       current_exception_ptr = std::current_exception();
@@ -41,10 +45,13 @@ hpx::future<ReturnTileType> setPromiseTileFuture(hpx::future<TileType> old_futur
 
 // Returns a future<ReturnTileType> setting a new promise p to the tile contained in tile_future.
 // tile_future is then updated with the new internal state future (which value is set by p).
-template <class ReturnTileType, class TileType>
-hpx::future<ReturnTileType> getTileFuture(hpx::future<TileType>& tile_future) noexcept {
-  hpx::future<TileType> old_future = std::move(tile_future);
-  hpx::lcos::local::promise<TileType> p;
+template <class ReturnTileType>
+hpx::future<ReturnTileType> getTileFuture(
+    hpx::future<typename ReturnTileType::TileDataType>& tile_future) noexcept {
+  using TileDataType = typename ReturnTileType::TileDataType;
+
+  hpx::future<TileDataType> old_future = std::move(tile_future);
+  hpx::lcos::local::promise<TileDataType> p;
   tile_future = p.get_future();
   return setPromiseTileFuture<ReturnTileType>(std::move(old_future), std::move(p));
 }
@@ -56,10 +63,11 @@ class TileFutureManager {
 public:
   using TileType = Tile<T, device>;
   using ConstTileType = Tile<const T, device>;
+  using TileDataType = internal::TileData<T, device>;
 
   TileFutureManager() {}
 
-  TileFutureManager(TileType tile) : tile_future_(hpx::make_ready_future(std::move(tile))) {}
+  TileFutureManager(TileDataType tile) : tile_future_(hpx::make_ready_future(std::move(tile))) {}
 
   hpx::shared_future<ConstTileType> getReadTileSharedFuture() noexcept {
     if (!tile_shared_future_.valid()) {
@@ -85,7 +93,7 @@ public:
 
 protected:
   // The future of the tile with no promise set.
-  hpx::future<TileType> tile_future_;
+  hpx::future<TileDataType> tile_future_;
 
   // If valid, a copy of the shared future of the tile,
   // which has the promise set to the promise for tile_future_.

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -59,6 +59,7 @@ public:
   using ElementType = T;
   using TileType = Tile<ElementType, device>;
   using ConstTileType = Tile<const ElementType, device>;
+  using TileDataType = internal::TileData<const ElementType, device>;
   friend Matrix<const ElementType, device>;
 
   /// Create a non distributed matrix of size @p size and block size @p block_size.
@@ -151,6 +152,7 @@ public:
   using ElementType = T;
   using TileType = Tile<ElementType, device>;
   using ConstTileType = Tile<const ElementType, device>;
+  using TileDataType = internal::TileData<ElementType, device>;
   friend Matrix<ElementType, device>;
 
   Matrix(const LayoutInfo& layout, ElementType* ptr);

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -68,8 +68,8 @@ void Matrix<const T, device>::setUpTiles(const memory::MemoryView<ElementType, d
       LocalTileIndex ind(i, j);
       TileElementSize tile_size = layout.tileSize(ind);
       tile_managers_.emplace_back(
-          TileType(tile_size, MemView(mem, layout.tileOffset(ind), layout.minTileMemSize(tile_size)),
-                   layout.ldTile()));
+          TileDataType(tile_size, MemView(mem, layout.tileOffset(ind), layout.minTileMemSize(tile_size)),
+                       layout.ldTile()));
     }
   }
 }

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -386,7 +386,7 @@ hpx::shared_future<Tile<T, D>> splitTileInsertFutureInChain(hpx::future<Tile<T, 
   // 2. Break the dependency chain inserting PN and storing P2 or SF(P2):  F1(PN)  FN()  F2(P3)
   auto swap_promise = [promise = std::move(p)](auto tile) mutable {
     // The dep_tracker cannot be a const Tile (can happen only for const Tiles).
-    DLAF_ASSERT_HEAVY(!std::holds_alternative < hpx::shared_future<Tile<const T, D>>(tile.dep_tracker_),
+    DLAF_ASSERT_HEAVY((!std::holds_alternative<hpx::shared_future<Tile<const T, D>>>(tile.dep_tracker_)),
                       "Internal Dependency Error");
 
     auto dep_tracker = std::move(tile.dep_tracker_);

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -290,7 +290,7 @@ TYPED_TEST(TileTest, PromiseToFuture) {
   }
 
   ASSERT_EQ(true, tile_future.is_ready());
-  TileType tile2{std::move(tile_future.get())};
+  TileType tile2{tile_future.get()};
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile2));
 
   auto ptr = [&memory_view](const TileElementIndex& index) { return memory_view(elIndex(index, ld)); };
@@ -321,7 +321,7 @@ TYPED_TEST(TileTest, PromiseToFutureConst) {
   }
 
   ASSERT_EQ(true, tile_future.is_ready());
-  TileType tile2{std::move(tile_future.get())};
+  TileType tile2{tile_future.get()};
   EXPECT_EQ(TileSizes(size, ld), getSizes(tile2));
 
   auto ptr = [&memory_view](const TileElementIndex& index) { return memory_view(elIndex(index, ld)); };
@@ -472,7 +472,7 @@ void testSubtileConst(std::string name, TileElementSize size, SizeType ld, const
   checkReadyAndDependencyChain(tile_ptr, subtiles, full_specs, last_dep, next_tile_f);
 
   // Check next tile in the dependency chain
-  checkFullTile(tile_ptr, Tile<T, D>{std::move(next_tile_f.get())}, size);
+  checkFullTile(tile_ptr, Tile<T, D>{next_tile_f.get()}, size);
 }
 
 template <class T, Device D>
@@ -505,7 +505,7 @@ void testSubtilesConst(std::string name, TileElementSize size, SizeType ld,
   tile_p.set_value(std::move(tile));
 
   checkReadyAndDependencyChain(tile_ptr, subtiles, specs, last_dep, next_tile_f);
-  checkFullTile(tile_ptr, Tile<T, D>{std::move(next_tile_f.get())}, size);
+  checkFullTile(tile_ptr, Tile<T, D>{next_tile_f.get()}, size);
 }
 
 template <class T, Device D>


### PR DESCRIPTION
As the tile promise is optional within a Tile the member was declared as a unique ptr (`std::optional` was not available in C++14). Subtiles added two extra shared futures and therefore `std::variant` became the better option as only one of object can be present at a given time.

However an object cannot contain a `optional/variant` of an object of its type, therefore a small refactoring was needed. 

Note: After this small refactoring, I think that an analysis about which part of the Tile API should be public (mainly dependency tracking part) has to be made.