### PR TITLE
bug fix backtransformation

### DIFF
--- a/include/dlaf/eigensolver/backtransformation/mc.h
+++ b/include/dlaf/eigensolver/backtransformation/mc.h
@@ -91,8 +91,11 @@ void BackTransformation<Backend::MC, Device::CPU, T>::call_FC(
   if (m <= 1 || n == 0)
     return;
 
-  // Note: "- 1" added to deal with size 1 reflector.
+  // Note: "-1" added to deal with size 1 reflector.
   const SizeType total_nr_reflector = mat_v.size().rows() - mb - 1;
+
+  if (total_nr_reflector == 0)
+    return;
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<matrix::Panel<Coord::Col, T, Device::CPU>> panelsV(n_workspaces,
@@ -206,8 +209,11 @@ void BackTransformation<Backend::MC, Device::CPU, T>::call_FC(
   if (m <= 1 || n == 0)
     return;
 
-  // Note: "- 1" added to deal with size 1 reflector.
+  // Note: "-1" added to deal with size 1 reflector.
   const SizeType total_nr_reflector = mat_v.size().cols() - mb - 1;
+
+  if (total_nr_reflector == 0)
+    return;
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<matrix::Panel<Coord::Col, T, Device::CPU>> panelsV(n_workspaces, dist_v);

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -57,10 +57,11 @@ GlobalElementSize globalTestSize(const LocalElementSize& size) {
 const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> sizes =
     // m, n, mb, nb
     {
-        {3, 0, 1, 1}, {0, 5, 2, 3},                                  // m, n = 0
-        {2, 2, 3, 3}, {3, 4, 6, 7},                                  // m < mb
-        {3, 3, 1, 1}, {4, 4, 2, 2},  {12, 2, 4, 4}, {24, 36, 6, 6},  // mb = nb
-        {5, 8, 3, 2}, {8, 27, 3, 4}, {15, 34, 4, 6}                  // mb != nb
+        {3, 0, 1, 1}, {0, 5, 2, 3},                                   // m, n = 0
+        {2, 2, 3, 3}, {3, 4, 6, 7},                                   // m < mb
+        {3, 3, 1, 1}, {4, 4, 2, 2},  {12, 2, 4, 4},  {24, 36, 6, 6},  // mb = nb
+        {5, 8, 3, 2}, {8, 27, 3, 4}, {15, 34, 4, 6},                  // mb != nb
+        {3, 3, 2, 2}, {3, 27, 2, 4}                                   // m = mb + 1
 };
 
 template <class T>


### PR DESCRIPTION
Missing quick return with zero reflectors (i.e. `m == mb + 1`).