### PR TITLE
Add RAII helper for `dlaf::initialize/finalize`

### DIFF
--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -84,6 +84,20 @@ void initialize(int argc, const char* const argv[], configuration const& user_cf
 /// Should be called once after every dlaf::initialize call.
 void finalize();
 
+/// RAII helper for dlaf::initialize and dlaf::finalize.
+///
+/// Calls dlaf::initialize on construction and dlaf::finalize on destruction.
+struct [[nodiscard]] ScopedInitializer {
+  ScopedInitializer(hpx::program_options::variables_map const& vm, configuration const& user_cfg = {});
+  ScopedInitializer(int argc, const char* const argv[], configuration const& user_cfg = {});
+  ~ScopedInitializer();
+
+  ScopedInitializer(ScopedInitializer &&) = delete;
+  ScopedInitializer(ScopedInitializer const&) = delete;
+  ScopedInitializer& operator=(ScopedInitializer&&) = delete;
+  ScopedInitializer& operator=(ScopedInitializer const&) = delete;
+};
+
 /// Initialize the MPI pool.
 ///
 ///

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -24,46 +24,47 @@
 #include "dlaf/init.h"
 
 int hpx_main(int argc, char* argv[]) {
-  dlaf::initialize(argc, argv);
+  {
+    dlaf::ScopedInitializer init(argc, argv);
 
-  auto exec = dlaf::getHpExecutor<dlaf::Backend::GPU>();
+    auto exec = dlaf::getHpExecutor<dlaf::Backend::GPU>();
 
-  constexpr int n = 10000;
-  constexpr int incx = 1;
-  constexpr int incy = 1;
+    constexpr int n = 10000;
+    constexpr int incx = 1;
+    constexpr int incy = 1;
 
-  // Initialize buffers on the device
-  thrust::device_vector<double> x = thrust::host_vector<double>(n, 4.0);
-  thrust::device_vector<double> y = thrust::host_vector<double>(n, 2.0);
+    // Initialize buffers on the device
+    thrust::device_vector<double> x = thrust::host_vector<double>(n, 4.0);
+    thrust::device_vector<double> y = thrust::host_vector<double>(n, 2.0);
 
-  // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-axpy
+    // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-axpy
 
-  // NOTE: The hpx::async only serves to produce a future and check that
-  // dataflow works correctly also with future arguments.
-  hpx::future<const double*> alpha_f = hpx::async([]() {
-    static constexpr double alpha = 2.0;
-    return &alpha;
-  });
+    // NOTE: The hpx::async only serves to produce a future and check that
+    // dataflow works correctly also with future arguments.
+    hpx::future<const double*> alpha_f = hpx::async([]() {
+      static constexpr double alpha = 2.0;
+      return &alpha;
+    });
 
-  hpx::future<cublasStatus_t> f1 = hpx::dataflow(exec, hpx::unwrapping(cublasDaxpy), n, alpha_f,
-                                                 x.data().get(), incx, y.data().get(), incy);
+    hpx::future<cublasStatus_t> f1 = hpx::dataflow(exec, hpx::unwrapping(cublasDaxpy), n, alpha_f,
+                                                   x.data().get(), incx, y.data().get(), incy);
 
-  hpx::future<void> f2 = f1.then([&y](hpx::future<cublasStatus_t> s) {
-    DLAF_CUBLAS_CALL(s.get());
+    hpx::future<void> f2 = f1.then([&y](hpx::future<cublasStatus_t> s) {
+      DLAF_CUBLAS_CALL(s.get());
 
-    // Note: This doesn't lead to a race condition because this executes
-    // after the `cublasDaxpy()`.
-    thrust::host_vector<double> y_h = y;
-    double sum_of_elems = 0;
-    for (double e : y_h)
-      sum_of_elems += e;
+      // Note: This doesn't lead to a race condition because this executes
+      // after the `cublasDaxpy()`.
+      thrust::host_vector<double> y_h = y;
+      double sum_of_elems = 0;
+      for (double e : y_h)
+        sum_of_elems += e;
 
-    std::cout << "result : " << sum_of_elems << std::endl;
-  });
+      std::cout << "result : " << sum_of_elems << std::endl;
+    });
 
-  f2.get();
+    f2.get();
+  }
 
-  dlaf::finalize();
   hpx::finalize();
 
   return 0;

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -71,8 +71,9 @@ linear_system_t sampleLeftTr(blas::Uplo uplo, blas::Op op, blas::Diag diag, T al
 }
 
 int hpx_main(hpx::program_options::variables_map& vm) {
-  dlaf::initialize(vm);
   {
+    dlaf::ScopedInitializer init(vm);
+
     options_t opts = check_options(vm);
 
     Communicator world(MPI_COMM_WORLD);
@@ -150,8 +151,6 @@ int hpx_main(hpx::program_options::variables_map& vm) {
       }
     }
   }
-
-  dlaf::finalize();
 
   return hpx::finalize();
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -311,6 +311,19 @@ void finalize() {
   internal::initialized() = false;
 }
 
+ScopedInitializer::ScopedInitializer(hpx::program_options::variables_map const& vm,
+                                     configuration const& user_cfg) {
+  initialize(vm, user_cfg);
+}
+
+ScopedInitializer::ScopedInitializer(int argc, const char* const argv[], configuration const& user_cfg) {
+  initialize(argc, argv, user_cfg);
+}
+
+ScopedInitializer::~ScopedInitializer() {
+  finalize();
+}
+
 void initResourcePartitionerHandler(hpx::resource::partitioner& rp,
                                     hpx::program_options::variables_map const& vm) {
   // Don't create the MPI pool if the user disabled it

--- a/test/src/gtest_hpx_main.cpp
+++ b/test/src/gtest_hpx_main.cpp
@@ -46,9 +46,10 @@
 
 GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_hpx_main.cpp\n");
-  dlaf::initialize(argc, argv);
-  auto ret = RUN_ALL_TESTS();
-  dlaf::finalize();
+  auto ret = [&] {
+    dlaf::ScopedInitializer init(argc, argv);
+    return RUN_ALL_TESTS();
+  }();
   hpx::finalize();
   return ret;
 }

--- a/test/src/gtest_mpihpx_main.cpp
+++ b/test/src/gtest_mpihpx_main.cpp
@@ -52,9 +52,10 @@
 
 GTEST_API_ int test_main(int argc, char** argv) {
   std::printf("Running main() from gtest_mpihpx_main.cpp\n");
-  dlaf::initialize(argc, argv);
-  auto ret = RUN_ALL_TESTS();
-  dlaf::finalize();
+  auto ret = [&] {
+    dlaf::ScopedInitializer init(argc, argv);
+    return RUN_ALL_TESTS();
+  }();
   hpx::finalize();
   return ret;
 }

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -23,6 +23,64 @@ static const char* command_line_option_name = "--dlaf:num-hp-cuda-streams-per-th
 static int argc_without_option = 1;
 static const char* argv_without_option[] = {binary_name};
 
+enum class InitializerType {
+  RAII,
+  InitializeFinalize,
+};
+
+// This helper primarily exists to test that the free function dlaf::finalize
+// and the RAII helper dlaf::ScopedInitializer constructor accept the same
+// arguments and behave the same.
+struct InitializeTester {
+  InitializerType type_;
+  std::unique_ptr<dlaf::ScopedInitializer> init_ = nullptr;
+
+  template <typename... Args>
+  InitializeTester(InitializerType type, Args&&... args) : type_(type) {
+    if (type_ == InitializerType::RAII) {
+      init_ = std::make_unique<dlaf::ScopedInitializer>(std::forward<Args>(args)...);
+    }
+    else if (type_ == InitializerType::InitializeFinalize) {
+      dlaf::initialize(std::forward<Args>(args)...);
+    }
+    else {
+      EXPECT_TRUE(false);
+    }
+  }
+
+  ~InitializeTester() {
+    if (type_ == InitializerType::RAII) {
+    }
+    else if (type_ == InitializerType::InitializeFinalize) {
+      dlaf::finalize();
+    }
+    else {
+      EXPECT_TRUE(false);
+    }
+  }
+
+  InitializeTester(InitializeTester&&) = delete;
+  InitializeTester(InitializeTester const&) = delete;
+  InitializeTester& operator=(InitializeTester&&) = delete;
+  InitializeTester& operator=(InitializeTester const&) = delete;
+};
+
+static InitializerType current_initializer_type;
+
+template <typename F>
+void initialize_tester_helper(F&& f) {
+  current_initializer_type = InitializerType::RAII;
+  f();
+
+  current_initializer_type = InitializerType::InitializeFinalize;
+  f();
+}
+
+const auto initializer_types =
+    ::testing::Values(InitializerType::RAII, InitializerType::InitializeFinalize);
+
+class InitTest : public ::testing::TestWithParam<InitializerType> {};
+
 int precedence_main(int, char*[]) {
   const dlaf::configuration default_cfg;
   const std::size_t default_val = default_cfg.num_hp_cuda_streams_per_thread;
@@ -35,10 +93,9 @@ int precedence_main(int, char*[]) {
 
   // Default configuration.
   {
-    dlaf::initialize(argc_without_option, argv_without_option);
+    InitializeTester init(current_initializer_type, argc_without_option, argv_without_option);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(default_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   // User configuration should take precedence over default configuration.
@@ -46,10 +103,9 @@ int precedence_main(int, char*[]) {
     dlaf::configuration user_cfg = default_cfg;
     user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
 
-    dlaf::initialize(argc_without_option, argv_without_option, user_cfg);
+    InitializeTester init(current_initializer_type, argc_without_option, argv_without_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(user_cfg.num_hp_cuda_streams_per_thread, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   // Environment variables should take precedence over user configuration.
@@ -60,10 +116,9 @@ int precedence_main(int, char*[]) {
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
 
-    dlaf::initialize(argc_without_option, argv_without_option, user_cfg);
+    InitializeTester init(current_initializer_type, argc_without_option, argv_without_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(env_var_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   // Command-line options should take precedence over environment variables.
@@ -80,16 +135,17 @@ int precedence_main(int, char*[]) {
     const int argc_with_option = 2;
     const char* argv_with_option[] = {binary_name, command_line_option_str.c_str()};
 
-    dlaf::initialize(argc_with_option, argv_with_option, user_cfg);
+    InitializeTester init(current_initializer_type, argc_with_option, argv_with_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   return hpx::finalize();
 }
 
-TEST(Init, Precedence) {
+TEST_P(InitTest, Precedence) {
+  current_initializer_type = GetParam();
+
   // The const_cast is currently necessary for hpx::init. HPX should be updated
   // to take const argc/argv.
   hpx::init(precedence_main, argc_without_option, const_cast<char**>(argv_without_option));
@@ -107,10 +163,9 @@ int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
 
   // Default configuration.
   {
-    dlaf::initialize(vm);
+    InitializeTester init(current_initializer_type, vm);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(default_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   // User configuration should take precedence over default configuration.
@@ -118,10 +173,9 @@ int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
     dlaf::configuration user_cfg = default_cfg;
     user_cfg.num_hp_cuda_streams_per_thread = default_val + 1;
 
-    dlaf::initialize(vm, user_cfg);
+    InitializeTester init(current_initializer_type, vm, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(user_cfg.num_hp_cuda_streams_per_thread, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   // Environment variables should take precedence over user configuration.
@@ -132,10 +186,9 @@ int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
 
-    dlaf::initialize(vm, user_cfg);
+    InitializeTester init(current_initializer_type, vm, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(env_var_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   // Command-line options should take precedence over environment variables.
@@ -152,16 +205,17 @@ int vm_no_command_line_option_main(hpx::program_options::variables_map& vm) {
     const int argc_with_option = 2;
     const char* argv_with_option[] = {binary_name, command_line_option_str.c_str()};
 
-    dlaf::initialize(argc_with_option, argv_with_option, user_cfg);
+    InitializeTester init(current_initializer_type, argc_with_option, argv_with_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   return hpx::finalize();
 }
 
-TEST(Init, VariablesMapNoCommandLineOption) {
+TEST_P(InitTest, VariablesMapNoCommandLineOption) {
+  current_initializer_type = GetParam();
+
   // The const_cast is currently necessary for hpx::init. HPX should be updated
   // to take const argc/argv.
   hpx::init(vm_no_command_line_option_main, argc_without_option,
@@ -181,16 +235,17 @@ int vm_command_line_option_main(hpx::program_options::variables_map& vm) {
     setenv(env_var_name, env_var_val_str.c_str(), 1);
     const std::size_t command_line_option_val = env_var_val + 1;
 
-    dlaf::initialize(vm, user_cfg);
+    InitializeTester init(current_initializer_type, vm, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
     EXPECT_EQ(command_line_option_val, cfg.num_hp_cuda_streams_per_thread);
-    dlaf::finalize();
   }
 
   return hpx::finalize();
 }
 
-TEST(Init, VariablesMapCommandLineOption) {
+TEST_P(InitTest, VariablesMapCommandLineOption) {
+  current_initializer_type = GetParam();
+
   hpx::program_options::options_description options("options");
   options.add(dlaf::getOptionsDescription());
 
@@ -215,3 +270,5 @@ TEST(Init, VariablesMapCommandLineOption) {
 
   hpx::init(vm_command_line_option_main, argc_with_option, argv_with_option, p);
 }
+
+INSTANTIATE_TEST_SUITE_P(Init, InitTest, initializer_types);


### PR DESCRIPTION
Fixes https://github.com/eth-cscs/DLA-Future/issues/411.

This is pretty much as simple as it can be. The wrapper constructor takes the same arguments as the `dlaf::initialize` free function overloads. It initializes in the constructor and finalizes in the destructor. I've changed all uses of `dlaf::initialize` and `dlaf::finalize` to use the the RAII wrapper instead. It's marked `[[nodiscard]]` and the copy and move constructors/assignment operators are conservatively deleted (is there any good use case for having it be movable?). The current name (`ScopedInitializer`) is ok, but not great. I think it would do but suggestions for alternatives are definitely welcome.