### PR TITLE
Fix call to os.system in miniapps.py

### DIFF
--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -121,7 +121,7 @@ class JobText:
             return
 
         print(f"Submitting : {job_file}")
-        os.system(f"sbatch --chdir={job_path} {job_file}")
+        system(f"sbatch --chdir={job_path} {job_file}")
         # sleep to not overload the scheduler
         sleep(1)
 


### PR DESCRIPTION
Just a case of `os.system` being imported unqualified, but then used qualified (`os` as a whole is not imported).