### PR TITLE
Revert senderified matrix copy

### DIFF
--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -40,9 +40,9 @@ void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
 
   for (SizeType j = 0; j < local_tile_cols; ++j) {
     for (SizeType i = 0; i < local_tile_rows; ++i) {
-      ex::when_all(source.read_sender(LocalTileIndex(i, j)),
-                   dest.readwrite_sender(LocalTileIndex(i, j))) |
-          copy(dlaf::internal::Policy<internal::CopyBackend_v<Source, Destination>>{}) | ex::detach();
+      hpx::dataflow(dlaf::getCopyExecutor<Source, Destination>(),
+                    unwrapExtendTiles(dlaf::matrix::internal::copy_o), source.read(LocalTileIndex(i, j)),
+                    dest(LocalTileIndex(i, j)));
     }
   }
 }


### PR DESCRIPTION
While testing a change for #420 I noticed that the cholesky miniapp occasionally hangs (and probably other miniapps/tests would too if run often enough). My only clue is at the moment is that the senderified matrix copy triggers the hang, but I don't know why (it could be a second order effect as well).

To avoid others being affected while I investigate I'd like to revert that particular change until I understand the problem.