### PR TITLE
Fix GPU warnings with Clang

### DIFF
--- a/include/dlaf/blas/tile.h
+++ b/include/dlaf/blas/tile.h
@@ -284,10 +284,11 @@ void gemm(cublasHandle_t handle, const blas::Op op_a, const blas::Op op_b, const
           const matrix::Tile<const T, Device::GPU>& a, const matrix::Tile<const T, Device::GPU>& b,
           const T beta, const matrix::Tile<T, Device::GPU>& c) {
   auto s = getGemmSizes(op_a, op_b, a, b, c);
-  CublasGemm<T>::call(handle, util::blasToCublas(op_a), util::blasToCublas(op_b), s.m, s.n, s.k,
-                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                      util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
-                      util::blasToCublasCast(c.ptr()), c.ld());
+  CublasGemm<T>::call(handle, util::blasToCublas(op_a), util::blasToCublas(op_b), to_int(s.m),
+                      to_int(s.n), to_int(s.k), util::blasToCublasCast(&alpha),
+                      util::blasToCublasCast(a.ptr()), to_int(a.ld()), util::blasToCublasCast(b.ptr()),
+                      to_int(b.ld()), util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()),
+                      to_int(c.ld()));
 }
 
 template <class T>
@@ -295,10 +296,10 @@ void hemm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, c
           const Tile<const T, Device::GPU>& a, const Tile<const T, Device::GPU>& b, const T beta,
           const Tile<T, Device::GPU>& c) {
   auto s = getHemmSizes(side, a, b, c);
-  CublasHemm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), s.m, s.n,
-                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                      util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
-                      util::blasToCublasCast(c.ptr()), c.ld());
+  CublasHemm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), to_int(s.m),
+                      to_int(s.n), util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()),
+                      to_int(a.ld()), util::blasToCublasCast(b.ptr()), to_int(b.ld()),
+                      util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), to_int(c.ld()));
 }
 
 template <class T>
@@ -306,10 +307,10 @@ void her2k(cublasHandle_t handle, const blas::Uplo uplo, const blas::Op op, cons
            const matrix::Tile<const T, Device::GPU>& a, const Tile<const T, Device::GPU>& b,
            const BaseType<T> beta, const matrix::Tile<T, Device::GPU>& c) {
   auto s = getHer2kSizes(op, a, b, c);
-  CublasHer2k<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), s.n, s.k,
-                       util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                       util::blasToCublasCast(b.ptr()), b.ld(), util::blasToCublasCast(&beta),
-                       util::blasToCublasCast(c.ptr()), c.ld());
+  CublasHer2k<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), to_int(s.n),
+                       to_int(s.k), util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()),
+                       to_int(a.ld()), util::blasToCublasCast(b.ptr()), to_int(b.ld()),
+                       util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), to_int(c.ld()));
 }
 
 template <class T>
@@ -317,9 +318,9 @@ void herk(cublasHandle_t handle, const blas::Uplo uplo, const blas::Op op, const
           const matrix::Tile<const T, Device::GPU>& a, const BaseType<T> beta,
           const matrix::Tile<T, Device::GPU>& c) {
   auto s = getHerkSizes(op, a, c);
-  CublasHerk<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), s.n, s.k,
-                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), a.ld(),
-                      util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), c.ld());
+  CublasHerk<T>::call(handle, util::blasToCublas(uplo), util::blasToCublas(op), to_int(s.n), to_int(s.k),
+                      util::blasToCublasCast(&alpha), util::blasToCublasCast(a.ptr()), to_int(a.ld()),
+                      util::blasToCublasCast(&beta), util::blasToCublasCast(c.ptr()), to_int(c.ld()));
 }
 
 template <class T>
@@ -328,9 +329,9 @@ void trmm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, c
           const matrix::Tile<T, Device::GPU>& b) {
   auto s = tile::internal::getTrmmSizes(side, a, b);
   CublasTrmm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), util::blasToCublas(op),
-                      util::blasToCublas(diag), s.m, s.n, util::blasToCublasCast(&alpha),
-                      util::blasToCublasCast(a.ptr()), a.ld(), util::blasToCublasCast(b.ptr()), b.ld(),
-                      util::blasToCublasCast(b.ptr()), b.ld());
+                      util::blasToCublas(diag), to_int(s.m), to_int(s.n), util::blasToCublasCast(&alpha),
+                      util::blasToCublasCast(a.ptr()), to_int(a.ld()), util::blasToCublasCast(b.ptr()),
+                      to_int(b.ld()), util::blasToCublasCast(b.ptr()), to_int(b.ld()));
 }
 
 template <class T>
@@ -339,8 +340,9 @@ void trsm(cublasHandle_t handle, const blas::Side side, const blas::Uplo uplo, c
           const matrix::Tile<T, Device::GPU>& b) {
   auto s = getTrsmSizes(side, a, b);
   CublasTrsm<T>::call(handle, util::blasToCublas(side), util::blasToCublas(uplo), util::blasToCublas(op),
-                      util::blasToCublas(diag), s.m, s.n, util::blasToCublasCast(&alpha),
-                      util::blasToCublasCast(a.ptr()), a.ld(), util::blasToCublasCast(b.ptr()), b.ld());
+                      util::blasToCublas(diag), to_int(s.m), to_int(s.n), util::blasToCublasCast(&alpha),
+                      util::blasToCublasCast(a.ptr()), to_int(a.ld()), util::blasToCublasCast(b.ptr()),
+                      to_int(b.ld()));
 }
 #endif
 

--- a/include/dlaf/blas/tile_extensions.h
+++ b/include/dlaf/blas/tile_extensions.h
@@ -70,7 +70,8 @@ void add(cublasHandle_t handle, T alpha, const matrix::Tile<const T, Device::GPU
          const matrix::Tile<T, Device::GPU>& tile_a) {
   DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
   for (auto j = 0; j < tile_a.size().cols(); ++j)
-    tile::internal::CublasAxpy<T>::call(handle, tile_a.size().rows(), util::blasToCublasCast(&alpha),
+    tile::internal::CublasAxpy<T>::call(handle, to_int(tile_a.size().rows()),
+                                        util::blasToCublasCast(&alpha),
                                         util::blasToCublasCast(tile_b.ptr({0, j})), 1,
                                         util::blasToCublasCast(tile_a.ptr({0, j})), 1);
 }

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -425,16 +425,17 @@ void hegst(cusolverDnHandle_t handle, const int itype, const blas::Uplo uplo,
   DLAF_ASSERT(square_size(a), a);
   DLAF_ASSERT(square_size(b), b);
   DLAF_ASSERT(a.size() == b.size(), a, b);
-  const int n = a.size().rows();
+  const auto n = a.size().rows();
 
   int workspace_size;
-  internal::CusolverHegst<T>::callBufferSize(handle, itype, util::blasToCublas(uplo), n,
-                                             util::blasToCublasCast(a.ptr()), a.ld(),
-                                             util::blasToCublasCast(b.ptr()), b.ld(), &workspace_size);
+  internal::CusolverHegst<T>::callBufferSize(handle, itype, util::blasToCublas(uplo), to_int(n),
+                                             util::blasToCublasCast(a.ptr()), to_int(a.ld()),
+                                             util::blasToCublasCast(b.ptr()), to_int(b.ld()),
+                                             &workspace_size);
   internal::CusolverInfo<T> info{std::max(1, workspace_size)};
-  internal::CusolverHegst<T>::call(handle, itype, util::blasToCublas(uplo), n,
-                                   util::blasToCublasCast(a.ptr()), a.ld(),
-                                   util::blasToCublasCast(b.ptr()), b.ld(),
+  internal::CusolverHegst<T>::call(handle, itype, util::blasToCublas(uplo), to_int(n),
+                                   util::blasToCublasCast(a.ptr()), to_int(a.ld()),
+                                   util::blasToCublasCast(b.ptr()), to_int(b.ld()),
                                    util::blasToCublasCast(info.workspace()), info.info());
 
   assertExtendInfo(dlaf::cusolver::assertInfoHegst, handle, std::move(info));
@@ -444,14 +445,16 @@ template <class T>
 internal::CusolverInfo<T> potrfInfo(cusolverDnHandle_t handle, const blas::Uplo uplo,
                                     const matrix::Tile<T, Device::GPU>& a) {
   DLAF_ASSERT(square_size(a), a);
-  const int n = a.size().rows();
+  const auto n = a.size().rows();
 
   int workspace_size;
-  internal::CusolverPotrf<T>::callBufferSize(handle, util::blasToCublas(uplo), n,
-                                             util::blasToCublasCast(a.ptr()), a.ld(), &workspace_size);
+  internal::CusolverPotrf<T>::callBufferSize(handle, util::blasToCublas(uplo), to_int(n),
+                                             util::blasToCublasCast(a.ptr()), to_int(a.ld()),
+                                             &workspace_size);
   internal::CusolverInfo<T> info{workspace_size};
-  internal::CusolverPotrf<T>::call(handle, util::blasToCublas(uplo), n, util::blasToCublasCast(a.ptr()),
-                                   a.ld(), util::blasToCublasCast(info.workspace()), workspace_size,
+  internal::CusolverPotrf<T>::call(handle, util::blasToCublas(uplo), to_int(n),
+                                   util::blasToCublasCast(a.ptr()), to_int(a.ld()),
+                                   util::blasToCublasCast(info.workspace()), workspace_size,
                                    info.info());
 
   return info;


### PR DESCRIPTION
Fix warnings in the GPU part of the codebase, raised by `clang` (and not by `gcc`).

@rasolca do you want to rebase your work in #442 onto this?