### PR TITLE
Fix Clang warning about unused argument

### DIFF
--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -114,6 +114,17 @@ inline void do_assert(bool expr, const common::internal::source_location& loc, c
 #define DLAF_ASSERT_HEAVY(Expr, ...)
 #endif
 
+namespace dlaf::internal {
+/// Helper function for silencing unused parameter warning.
+///
+/// This allows to not add std::maybe_unused to each argument of an UNIMPLEMENTED function,
+/// but still keeping the name of arguments, so that in the future the signature will be
+/// ready for implementation.
+template <class... Args>
+void silenceUnusedWarningFor(Args&&...) {}
+
+}
+
 #define DLAF_UNIMPLEMENTED(...) DLAF_ASSERT(false, "Not yet implemented!", __VA_ARGS__)
 
 #define DLAF_STATIC_UNIMPLEMENTED(DummyType) \

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -48,6 +48,13 @@ inline void do_assert(bool expr, const common::internal::source_location& loc, c
   }
 }
 
+/// Helper function for silencing unused parameter warning.
+///
+/// This allows to not add std::maybe_unused to each argument of an UNIMPLEMENTED function,
+/// but still keeping the name of arguments, so that in the future the signature will be
+/// ready for implementation.
+template <class... Args>
+void silenceUnusedWarningFor(Args&&...) {}
 }
 }
 
@@ -113,17 +120,6 @@ inline void do_assert(bool expr, const common::internal::source_location& loc, c
 #else
 #define DLAF_ASSERT_HEAVY(Expr, ...)
 #endif
-
-namespace dlaf::internal {
-/// Helper function for silencing unused parameter warning.
-///
-/// This allows to not add std::maybe_unused to each argument of an UNIMPLEMENTED function,
-/// but still keeping the name of arguments, so that in the future the signature will be
-/// ready for implementation.
-template <class... Args>
-void silenceUnusedWarningFor(Args&&...) {}
-
-}
 
 #define DLAF_UNIMPLEMENTED(...) DLAF_ASSERT(false, "Not yet implemented!", __VA_ARGS__)
 

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -396,20 +396,24 @@ void assertExtendInfo(F assertFunc, cusolverDnHandle_t handle, CusolverInfo<T>&&
 }
 
 template <class T>
-dlaf::BaseType<T> lange(cusolverDnHandle_t, const lapack::Norm norm, const Tile<T, Device::GPU>& a) {
+dlaf::BaseType<T> lange(cusolverDnHandle_t handle, const lapack::Norm norm,
+                        const Tile<T, Device::GPU>& a) {
   DLAF_STATIC_UNIMPLEMENTED(T);
+  dlaf::internal::silenceUnusedWarningFor(handle, norm, a);
 }
 
 template <class T>
-dlaf::BaseType<T> lantr(cusolverDnHandle_t, const lapack::Norm norm, const blas::Uplo uplo,
+dlaf::BaseType<T> lantr(cusolverDnHandle_t handle, const lapack::Norm norm, const blas::Uplo uplo,
                         const blas::Diag diag, const Tile<T, Device::GPU>& a) {
   DLAF_STATIC_UNIMPLEMENTED(T);
+  dlaf::internal::silenceUnusedWarningFor(handle, norm, uplo, diag, a);
 }
 
 template <class T>
-void laset(cusolverDnHandle_t, const lapack::MatrixType type, T alpha, T beta,
+void laset(cusolverDnHandle_t handle, const lapack::MatrixType type, T alpha, T beta,
            const Tile<T, Device::GPU>& tile) {
   DLAF_STATIC_UNIMPLEMENTED(T);
+  dlaf::internal::silenceUnusedWarningFor(handle, type, alpha, beta, tile);
 }
 
 template <class T>


### PR DESCRIPTION
This is a leftover from the previous #449.

Instead of removing names for arguments, I opted for adding a `silenceUnusedWarningFor` function that does nothing but "consuming" what has been passed.

The rationale is that the signature can be "fixed" together with the names for all the variants, so that in the future it will be already there and "unified".

It's a very small and secondary feature. Waiting for your thoughts about it in the review.