### PR TITLE
Added some debug utilities

### DIFF
--- a/include/dlaf/matrix/print_gpu.h
+++ b/include/dlaf/matrix/print_gpu.h
@@ -33,7 +33,7 @@ void print(Format format, const Tile<const T, Device::GPU>& tile, std::ostream& 
            cudaStream_t stream) {
   const auto size = tile.size();
   const auto ld = std::max<SizeType>(1, size.rows());
-  Tile<T, Device::CPU> tile_h(size, memory::MemoryView<T, Device::CPU>(size.rows() * size.cols()), ld);
+  Tile<T, Device::CPU> tile_h(size, memory::MemoryView<T, Device::CPU>(size.linear_size()), ld);
 
   if (!size.isEmpty()) {
     internal::copy_o(tile, tile_h, stream);

--- a/include/dlaf/matrix/print_gpu.h
+++ b/include/dlaf/matrix/print_gpu.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <iostream>
+
 #include <cuda_runtime.h>
 
 #include "dlaf/matrix/tile.h"

--- a/include/dlaf/matrix/print_gpu.h
+++ b/include/dlaf/matrix/print_gpu.h
@@ -1,0 +1,37 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#ifdef DLAF_WITH_CUDA
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include "dlaf/matrix/tile.h"
+
+namespace dlaf {
+
+namespace matrix {
+
+/// Print a tile in csv format to standard output
+template <class Format, class T>
+void print(Format format, const Tile<const T, Device::GPU>& tile, std::ostream& os = std::cout,
+           cudaStream_t stream = NULL) {
+  const auto size = tile.size();
+  Tile<T, Device::CPU> tile_h(size, memory::MemoryView<T, Device::CPU>(size.rows() * size.cols()),
+                              size.rows());
+
+  internal::copy_o(tile, tile_h, stream);
+  DLAF_CUDA_CALL(cudaStreamSynchronize(stream));
+  print(format, tile_h, os);
+}
+
+}
+}
+#endif

--- a/test/include/dlaf_test/comm_grids/grids_6_ranks.h
+++ b/test/include/dlaf_test/comm_grids/grids_6_ranks.h
@@ -64,5 +64,12 @@ public:
   }
 };
 
+struct TestWithCommGrids : public ::testing::Test {
+  const std::vector<comm::CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
+    return comm_grids;
+  }
+};
+
 }
 }

--- a/test/include/dlaf_test/comm_grids/grids_6_ranks.h
+++ b/test/include/dlaf_test/comm_grids/grids_6_ranks.h
@@ -25,7 +25,7 @@ public:
     if (comm_grids.empty()) {
       comm::Communicator world(MPI_COMM_WORLD);
 
-      // Leave comm_grid empty if invoked with only one rank.
+      // Leave comm_grids empty if invoked with only one rank.
       // Useful to debug local algorithms that otherwise are executed independently on multiple ranks.
       if (world.size() == 1)
         return;

--- a/test/include/dlaf_test/comm_grids/grids_6_ranks.h
+++ b/test/include/dlaf_test/comm_grids/grids_6_ranks.h
@@ -24,6 +24,12 @@ public:
   virtual void SetUp() override {
     if (comm_grids.empty()) {
       comm::Communicator world(MPI_COMM_WORLD);
+
+      // Leave comm_grid empty if invoked with only one rank.
+      // Useful to debug local algorithms that otherwise are executed independently on multiple ranks.
+      if (world.size() == 1)
+        return;
+
       comm_grids.emplace_back(world, 3, 2, common::Ordering::RowMajor);
       comm_grids.emplace_back(world, 2, 3, common::Ordering::ColumnMajor);
 

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -38,13 +38,7 @@ using NormT = dlaf::BaseType<T>;
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <typename Type>
-class NormDistributedTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct NormDistributedTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(NormDistributedTest, MatrixElementTypes);
 

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -41,6 +41,7 @@ template <typename Type>
 class NormDistributedTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -32,12 +32,7 @@ using namespace dlaf::comm;
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <typename Type>
-struct PanelBcastTest : public ::testing::Test {
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct PanelBcastTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(PanelBcastTest, MatrixElementTypes);
 

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -34,6 +34,7 @@ using namespace dlaf::comm;
 template <typename Type>
 struct PanelBcastTest : public ::testing::Test {
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -41,17 +41,8 @@ using namespace testing;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-class BackTransformationEigenSolverTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using BackTransformationEigenSolverTestMC = BackTransformationEigenSolverTest<T, Device::CPU>;
+struct BackTransformationEigenSolverTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(BackTransformationEigenSolverTestMC, MatrixElementTypes);
 

--- a/test/unit/eigensolver/mc/test_backtransformation.cpp
+++ b/test/unit/eigensolver/mc/test_backtransformation.cpp
@@ -45,6 +45,7 @@ template <class T, Device D>
 class BackTransformationEigenSolverTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -50,6 +50,7 @@ template <class T, Device D>
 class ReductionToBandTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/eigensolver/mc/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/mc/test_reduction_to_band.cpp
@@ -46,17 +46,8 @@ using namespace dlaf::matrix::test;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-class ReductionToBandTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using ReductionToBandTestMC = ReductionToBandTest<T, Device::CPU>;
+struct ReductionToBandTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(ReductionToBandTestMC, MatrixElementTypes);
 

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -34,23 +34,14 @@ using namespace testing;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-class EigensolverGenToStdTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using EigensolverGenToStdTestMC = EigensolverGenToStdTest<T, Device::CPU>;
+struct EigensolverGenToStdTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(EigensolverGenToStdTestMC, MatrixElementTypes);
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-using EigensolverGenToStdTestGPU = EigensolverGenToStdTest<T, Device::GPU>;
+struct EigensolverGenToStdTestGPU : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(EigensolverGenToStdTestGPU, MatrixElementTypes);
 #endif

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -38,6 +38,7 @@ template <class T, Device D>
 class EigensolverGenToStdTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -39,16 +39,8 @@ using dlaf::matrix::test::MatrixLocal;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-struct ComputeTFactorTest : public ::testing::Test {
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using ComputeTFactorTestMC = ComputeTFactorTest<T, Device::CPU>;
+struct ComputeTFactorTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(ComputeTFactorTestMC, MatrixElementTypes);
 

--- a/test/unit/factorization/mc/test_compute_t_factor.cpp
+++ b/test/unit/factorization/mc/test_compute_t_factor.cpp
@@ -42,6 +42,7 @@ using dlaf::matrix::test::MatrixLocal;
 template <class T, Device D>
 struct ComputeTFactorTest : public ::testing::Test {
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -34,23 +34,14 @@ using namespace testing;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-class CholeskyTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using CholeskyTestMC = CholeskyTest<T, Device::CPU>;
+struct CholeskyTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(CholeskyTestMC, MatrixElementTypes);
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-using CholeskyTestGPU = CholeskyTest<T, Device::GPU>;
+struct CholeskyTestGPU : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(CholeskyTestGPU, MatrixElementTypes);
 #endif

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -38,6 +38,7 @@ template <class T, Device D>
 class CholeskyTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -46,13 +46,7 @@ class MatrixLocalTest : public ::testing::Test {};
 TYPED_TEST_SUITE(MatrixLocalTest, MatrixElementTypes);
 
 template <typename Type>
-class MatrixTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct MatrixTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(MatrixTest, MatrixElementTypes);
 
@@ -1125,13 +1119,7 @@ TYPED_TEST(MatrixTest, GPUCopy) {
 }
 #endif
 
-class MatrixGenericTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct MatrixGenericTest : public TestWithCommGrids {};
 
 TEST_F(MatrixGenericTest, SelectTilesReadonly) {
   using TypeParam = double;

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -49,6 +49,7 @@ template <typename Type>
 class MatrixTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };
@@ -1127,6 +1128,7 @@ TYPED_TEST(MatrixTest, GPUCopy) {
 class MatrixGenericTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/matrix/test_matrix_local.cpp
+++ b/test/unit/matrix/test_matrix_local.cpp
@@ -168,6 +168,7 @@ template <typename Type>
 class MatrixLocalWithCommTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/matrix/test_matrix_local.cpp
+++ b/test/unit/matrix/test_matrix_local.cpp
@@ -165,13 +165,7 @@ TYPED_TEST(MatrixLocalTest, OutputNumpyFormat) {
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <typename Type>
-class MatrixLocalWithCommTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct MatrixLocalWithCommTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(MatrixLocalWithCommTest, MatrixElementTypes);
 

--- a/test/unit/matrix/test_matrix_mirror.cpp
+++ b/test/unit/matrix/test_matrix_mirror.cpp
@@ -31,13 +31,7 @@ using namespace testing;
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <typename Type>
-class MatrixMirrorTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct MatrixMirrorTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(MatrixMirrorTest, MatrixElementTypes);
 

--- a/test/unit/matrix/test_matrix_mirror.cpp
+++ b/test/unit/matrix/test_matrix_mirror.cpp
@@ -34,6 +34,7 @@ template <typename Type>
 class MatrixMirrorTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/matrix/test_matrix_output.cpp
+++ b/test/unit/matrix/test_matrix_output.cpp
@@ -123,8 +123,7 @@ template <class T>
 matrix::Tile<T, Device::GPU> gpuTile(const matrix::Tile<const T, Device::CPU>& tile) {
   const auto size = tile.size();
   const auto ld = std::max<SizeType>(1, size.rows());
-  matrix::Tile<T, Device::GPU> tile_gpu(size,
-                                        memory::MemoryView<T, Device::GPU>(size.linear_size()),
+  matrix::Tile<T, Device::GPU> tile_gpu(size, memory::MemoryView<T, Device::GPU>(size.linear_size()),
                                         ld);
 
   matrix::internal::copy_o(tile, tile_gpu);

--- a/test/unit/matrix/test_matrix_output.cpp
+++ b/test/unit/matrix/test_matrix_output.cpp
@@ -124,7 +124,7 @@ matrix::Tile<T, Device::GPU> gpuTile(const matrix::Tile<const T, Device::CPU>& t
   const auto size = tile.size();
   const auto ld = std::max<SizeType>(1, size.rows());
   matrix::Tile<T, Device::GPU> tile_gpu(size,
-                                        memory::MemoryView<T, Device::GPU>(size.rows() * size.cols()),
+                                        memory::MemoryView<T, Device::GPU>(size.linear_size()),
                                         ld);
 
   matrix::internal::copy_o(tile, tile_gpu);

--- a/test/unit/matrix/test_matrix_output.cpp
+++ b/test/unit/matrix/test_matrix_output.cpp
@@ -11,12 +11,19 @@
 #include "dlaf/matrix/print_csv.h"
 #include "dlaf/matrix/print_numpy.h"
 
+#ifdef DLAF_WITH_CUDA
+#include "dlaf/matrix/print_gpu.h"
+#endif
+
 #include <sstream>
 #include <tuple>
 
 #include <gtest/gtest.h>
 
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/matrix/matrix_mirror.h"
+#include "dlaf/matrix/tile.h"
 
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/matrix/util_tile.h"
@@ -33,6 +40,13 @@ template <typename Type>
 class MatrixOutputTest : public ::testing::Test {};
 
 TYPED_TEST_SUITE(MatrixOutputTest, dlaf::test::MatrixElementTypes);
+
+#ifdef DLAF_WITH_CUDA
+template <typename Type>
+class MatrixOutputTestGPU : public ::testing::Test {};
+
+TYPED_TEST_SUITE(MatrixOutputTestGPU, dlaf::test::MatrixElementTypes);
+#endif
 
 template <class T>
 struct test_tile_output {
@@ -104,6 +118,20 @@ struct test_tile_output<std::complex<T>> {
   }
 };
 
+#ifdef DLAF_WITH_CUDA
+template <class T>
+matrix::Tile<T, Device::GPU> gpuTile(const matrix::Tile<const T, Device::CPU>& tile) {
+  const auto size = tile.size();
+  const auto ld = std::max<SizeType>(1, size.rows());
+  matrix::Tile<T, Device::GPU> tile_gpu(size,
+                                        memory::MemoryView<T, Device::GPU>(size.rows() * size.cols()),
+                                        ld);
+
+  matrix::internal::copy_o(tile, tile_gpu);
+  return tile_gpu;
+}
+#endif
+
 TYPED_TEST(MatrixOutputTest, NumpyFormatTile) {
   using test_output = test_tile_output<TypeParam>;
   for (auto get_test_config : {test_output::empty, test_output::nonempty}) {
@@ -118,6 +146,22 @@ TYPED_TEST(MatrixOutputTest, NumpyFormatTile) {
   }
 }
 
+#ifdef DLAF_WITH_CUDA
+TYPED_TEST(MatrixOutputTestGPU, NumpyFormatTile) {
+  using test_output = test_tile_output<TypeParam>;
+  for (auto get_test_config : {test_output::empty, test_output::nonempty}) {
+    const auto config = get_test_config();
+    auto tile = gpuTile(std::get<0>(config));
+    std::string output_np = std::get<1>(config);
+
+    std::ostringstream stream_tile_output;
+    print(format::numpy{}, tile, stream_tile_output);
+
+    EXPECT_EQ(output_np, stream_tile_output.str());
+  }
+}
+#endif
+
 TYPED_TEST(MatrixOutputTest, CsvFormatTile) {
   using test_output = test_tile_output<TypeParam>;
   for (auto get_test_config : {test_output::empty, test_output::nonempty}) {
@@ -131,6 +175,22 @@ TYPED_TEST(MatrixOutputTest, CsvFormatTile) {
     EXPECT_EQ(output_csv, stream_tile_output.str());
   }
 }
+
+#ifdef DLAF_WITH_CUDA
+TYPED_TEST(MatrixOutputTestGPU, CsvFormatTile) {
+  using test_output = test_tile_output<TypeParam>;
+  for (auto get_test_config : {test_output::empty, test_output::nonempty}) {
+    const auto config = get_test_config();
+    auto tile = gpuTile(std::get<0>(config));
+    std::string output_np = std::get<2>(config);
+
+    std::ostringstream stream_tile_output;
+    print(format::csv{}, tile, stream_tile_output);
+
+    EXPECT_EQ(output_np, stream_tile_output.str());
+  }
+}
+#endif
 
 template <class T>
 struct test_matrix_output {
@@ -238,6 +298,24 @@ TYPED_TEST(MatrixOutputTest, NumpyFormatMatrix) {
     EXPECT_EQ(output_np, stream_matrix_output.str());
   }
 }
+
+#ifdef DLAF_WITH_CUDA
+TYPED_TEST(MatrixOutputTestGPU, NumpyFormatMatrix) {
+  using test_output = test_matrix_output<TypeParam>;
+  for (auto get_test_config : {test_output::empty, test_output::nonempty}) {
+    auto config = get_test_config();
+    auto& matrix = std::get<0>(config);
+    MatrixMirror<const TypeParam, Device::GPU, Device::CPU> matrix_d(matrix);
+
+    std::string output_np = std::get<1>(config);
+
+    std::ostringstream stream_matrix_output;
+    print(format::numpy{}, "mat", matrix_d.get(), stream_matrix_output);
+
+    EXPECT_EQ(output_np, stream_matrix_output.str());
+  }
+}
+#endif
 
 TYPED_TEST(MatrixOutputTest, CsvFormatMatrix) {
   using test_output = test_matrix_output<TypeParam>;
@@ -387,6 +465,26 @@ TYPED_TEST(MatrixOutputTest, NumpyFormatMatrixDist) {
     EXPECT_EQ(output_np, stream_matrix_output.str());
   }
 }
+
+#ifdef DLAF_WITH_CUDA
+TYPED_TEST(MatrixOutputTestGPU, NumpyFormatMatrixDist) {
+  using test_output_t = test_matrix_dist_output<TypeParam>;
+  test_output_t instance;
+
+  for (auto get_test_config : {&test_output_t::empty, &test_output_t::nonempty}) {
+    auto config = (instance.*get_test_config)();
+    auto& matrix = std::get<0>(config);
+    MatrixMirror<const TypeParam, Device::GPU, Device::CPU> matrix_d(matrix);
+
+    std::string output_np = std::get<1>(config);
+
+    std::ostringstream stream_matrix_output;
+    print(format::numpy{}, "M", matrix_d.get(), stream_matrix_output);
+
+    EXPECT_EQ(output_np, stream_matrix_output.str());
+  }
+}
+#endif
 
 TYPED_TEST(MatrixOutputTest, CsvFormatMatrixDist) {
   using test_output_t = test_matrix_dist_output<TypeParam>;

--- a/test/unit/matrix/test_matrix_view.cpp
+++ b/test/unit/matrix/test_matrix_view.cpp
@@ -38,6 +38,7 @@ template <typename Type>
 class MatrixViewTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/matrix/test_matrix_view.cpp
+++ b/test/unit/matrix/test_matrix_view.cpp
@@ -35,13 +35,7 @@ class MatrixLocalViewTest : public ::testing::Test {};
 TYPED_TEST_SUITE(MatrixLocalViewTest, MatrixElementTypes);
 
 template <typename Type>
-class MatrixViewTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct MatrixViewTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(MatrixViewTest, MatrixElementTypes);
 

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -40,6 +40,7 @@ using namespace dlaf::comm;
 template <typename Type>
 struct PanelTest : public ::testing::Test {
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -38,12 +38,7 @@ using namespace dlaf::comm;
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <typename Type>
-struct PanelTest : public ::testing::Test {
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct PanelTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(PanelTest, MatrixElementTypes);
 

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -34,13 +34,7 @@ using namespace dlaf::test;
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <class T>
-class MatrixUtilsTest : public ::testing::Test {
-public:
-  const std::vector<comm::CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct MatrixUtilsTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(MatrixUtilsTest, MatrixElementTypes);
 
@@ -213,12 +207,7 @@ TYPED_TEST(MatrixUtilsTest, SetRandomHermitianPositiveDefinite) {
 }
 
 template <typename Type>
-struct PanelUtilsTest : public ::testing::Test {
-  const std::vector<comm::CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
+struct PanelUtilsTest : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(PanelUtilsTest, MatrixElementTypes);
 

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -37,6 +37,7 @@ template <class T>
 class MatrixUtilsTest : public ::testing::Test {
 public:
   const std::vector<comm::CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };
@@ -214,6 +215,7 @@ TYPED_TEST(MatrixUtilsTest, SetRandomHermitianPositiveDefinite) {
 template <typename Type>
 struct PanelUtilsTest : public ::testing::Test {
   const std::vector<comm::CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/multiplication/test_multiplication_triangular.cpp
+++ b/test/unit/multiplication/test_multiplication_triangular.cpp
@@ -36,23 +36,14 @@ using namespace testing;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-class TriangularMultiplicationTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using TriangularMultiplicationTestMC = TriangularMultiplicationTest<T, Device::CPU>;
+struct TriangularMultiplicationTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(TriangularMultiplicationTestMC, MatrixElementTypes);
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-using TriangularMultiplicationTestGPU = TriangularMultiplicationTest<T, Device::GPU>;
+struct TriangularMultiplicationTestGPU : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(TriangularMultiplicationTestGPU, MatrixElementTypes);
 #endif

--- a/test/unit/multiplication/test_multiplication_triangular.cpp
+++ b/test/unit/multiplication/test_multiplication_triangular.cpp
@@ -40,6 +40,7 @@ template <class T, Device D>
 class TriangularMultiplicationTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -40,6 +40,7 @@ template <class T, Device D>
 class TriangularSolverTest : public ::testing::Test {
 public:
   const std::vector<CommunicatorGrid>& commGrids() {
+    EXPECT_FALSE(comm_grids.empty());
     return comm_grids;
   }
 };

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -36,23 +36,14 @@ using namespace testing;
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <class T, Device D>
-class TriangularSolverTest : public ::testing::Test {
-public:
-  const std::vector<CommunicatorGrid>& commGrids() {
-    EXPECT_FALSE(comm_grids.empty());
-    return comm_grids;
-  }
-};
-
 template <class T>
-using TriangularSolverTestMC = TriangularSolverTest<T, Device::CPU>;
+struct TriangularSolverTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(TriangularSolverTestMC, MatrixElementTypes);
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-using TriangularSolverTestGPU = TriangularSolverTest<T, Device::GPU>;
+struct TriangularSolverTestGPU : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(TriangularSolverTestGPU, MatrixElementTypes);
 #endif


### PR DESCRIPTION
- Added the possibility to run the 6 ranks tests with a single rank to debug local tests more easily.
  Note: the check on comm_grids makes sure that distributed tests fails.

- Added a utility that allows to print GPU tiles using the available formats.