### PR TITLE
Additional checks on PR via GitHub actions

### DIFF
--- a/.github/check_license.sh
+++ b/.github/check_license.sh
@@ -9,7 +9,7 @@ usage() {
   echo ""
   echo "SPECIAL TAGS: they can be used inside files to control behavior of this tool"
   echo ""
-  echo "dlaf-no-check-license       skip any check and return 0"
+  echo "dlaf-no-license-check       skip any check and return 0"
   echo "dlaf-multi-license-check    check license in the entire file (-r option is ignored)"
 
   exit 0

--- a/.github/check_license.sh
+++ b/.github/check_license.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "$0 usage: [-r n] license file"
+  echo ""
+  echo "where:"
+  echo "-r n  max line number (1-based) where the first line of license header should start."
+  echo "      First line of the header must fall within range [1,n] (default: 1)"
+  echo ""
+  echo "SPECIAL TAGS: they can be used inside files to control behavior of this tool"
+  echo ""
+  echo "dlaf-no-check-license       skip any check and return 0"
+  echo "dlaf-multi-license-check    check license in the entire file (-r option is ignored)"
+
+  exit 0
+}
+
+MAX_LINE=1
+MULTILICENSE=false
+
+while getopts "hr:" arg; do
+  case $arg in
+    r)
+      MAX_LINE=$OPTARG
+      [ $MAX_LINE -lt 1 ] && echo "line number must be a value >= 1" && exit 1
+      ;;
+    h | *)
+      usage
+      ;;
+  esac
+done
+
+# note: check positional arguments
+[ $((OPTIND+1)) -gt $# ] && usage
+
+LICENSE_FILE=${@:$OPTIND:1}
+FILE_TO_CHECK=${@:$OPTIND+1:1}
+
+[ ! -f $LICENSE_FILE ]  && echo "$LICENSE_FILE not found."   && exit 1
+[ ! -f $FILE_TO_CHECK ] && echo "$FILE_TO_CHECK not found."  && exit 1
+
+
+# SPECIAL TAGs
+
+# note: skip the check
+grep -sq "dlaf-no-license-check" $FILE_TO_CHECK && exit 0
+
+# note: multi-license check
+if grep -sq "dlaf-multi-license-check" $FILE_TO_CHECK; then
+  MAX_LINE=`cat $FILE_TO_CHECK | wc -l | tr -d ' '`
+fi
+
+# Given a "hook" to locate the license header, it is used to:
+#       1. determine the offset of the hook in the license file
+HOOK_STR="Copyright .* ETH Zurich"
+HOOK_LINENUM=`awk -vHOOK="$HOOK_STR" '$0 ~ HOOK { print NR }' $LICENSE_FILE`
+HOOK_LICENSE=`awk -vHOOK="$HOOK_STR" '$0 ~ HOOK { print $0 }' $LICENSE_FILE`
+LICENSE_SIZE=$((`cat $LICENSE_FILE | wc -l` - 1))
+#       2.  locate the hook inside the file to check and determine the (potential) position
+#           where the license header starts in it
+LICENSE_POS=$((`grep -n "$HOOK_LICENSE" $FILE_TO_CHECK | cut -d':' -f1` - HOOK_LINENUM + 1))
+
+# License extraction
+# error: if no hook is found OR it is to close to the beginning of the file
+[ $LICENSE_POS -lt 1 ] && echo "LICENSE NOT FOUND" && exit 1
+
+# note: extract potential license header lines from the file to check, and
+#       compare them with the actual license text
+sed -n "${LICENSE_POS},+${LICENSE_SIZE}p" $FILE_TO_CHECK | diff - $LICENSE_FILE > /dev/null
+LICENSE_FOUND=$?
+
+# Check result
+[ $LICENSE_FOUND -ne 0 ]        && echo "LICENSE NOT FOUND"                       && exit 1
+[ $LICENSE_POS -gt $MAX_LINE ]  && echo "LICENSE NOT IN THE RANGE [1, $MAX_LINE]" && exit 1
+echo "LICENSE OK" && exit 0

--- a/.github/format.sh
+++ b/.github/format.sh
@@ -1,5 +1,15 @@
 #! /usr/bin/env bash
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 FILES_CHANGED=`git diff --name-only origin/master`
 TAB_FOUND=0
 

--- a/.github/format.sh
+++ b/.github/format.sh
@@ -11,7 +11,7 @@ do
   fi
 
   case $FILE in
-    *.cpp|*.h|*.hpp|*.tpp|*.ipp|*.cu)
+    *.cpp|*.h|*.h.in|*.tpp|*.cu)
       clang-format-10 -i --style=file $FILE
       # The following is needed for regions in which clang-format is disabled.
       # Note: clang-format removes trailing spaces even in disabled regions.

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 name: Check format
 
 on:

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions/javascript-action@v1
+
       - name: Install tools
         run: |
           sudo apt-get install --no-install-recommends clang-format-10 python3
           pip3 install black==21.8b0
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Checkout master
         run: git fetch --no-tags --depth=1 origin +refs/heads/master:refs/heads/master
 
@@ -22,9 +23,24 @@ jobs:
         run: ./.github/format.sh
 
       - name: Check scripts formatting
+        if: always()
         run: black --line-length 105 scripts/
 
          # Fails if there are differences.
       - name: Formatting issues
         if: always()
         run: git diff --color --exit-code
+
+      - name: Check include guards
+        if: always()
+        run: |
+          find include test -type f '(' -name "*.h" -o -name "*.h.in" ')'             \
+            | xargs -I{} sh -c                                                        \
+                "egrep -sq '^#pragma once' {} || echo {}"                             \
+            > pragma-once.check
+
+          for filepath in `cat pragma-once.check`; do                                 \
+            echo "::error file=$filepath,line=1::missing include guard in $filepath"; \
+          done
+
+          test ! -s pragma-once.check

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -1,10 +1,9 @@
 name: Check license
 
-on:
-  - pull_request
+on: [pull_request]
 
 jobs:
-  check:
+  check-cpp:
     runs-on: ubuntu-latest
 
     steps:
@@ -13,24 +12,47 @@ jobs:
 
       - name: Check source code
         run: |
-          # Compare header license in misc/HEADER with the first lines of each source code file
-          find  '(' -type f ! -path './misc*' ')'                                                 \
-                '('                                                                               \
-                        -name '*.cpp'                                                             \
-                    -o  -name '*.h'                                                               \
-                    -o  -name '*.hpp'                                                             \
-                    -o  -name '*.tpp'                                                             \
-                    -o  -name '*.ipp'                                                             \
-                    -o  -name '*.cu'                                                              \
-                ')'                                                                               \
-            | xargs -I{} sh -c                                                                    \
-                "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo {}"                     \
-            > source_code.check
-          for filepath in `cat source_code.check`; do                                         \
-            echo "::error file=$filepath,line=1,title=$filepath::check the license";             \
-          done
-          test ! -s source_code.check
+          if: always()          # needed so that it runs even if previous one fails
+          # Compare first lines of each source file with reference in misc/HEADER
+          find src include test miniapp -type f                                   \
+               '('                                                                \
+                       -name '*.cpp'                                              \
+                   -o  -name '*.h'                                                \
+                   -o  -name '*.h.in'                                             \
+                   -o  -name '*.tpp'                                              \
+                   -o  -name '*.cu'                                               \
+               ')'                                                                \
+            | xargs -I{} sh -c                                                    \
+                "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo {}"     \
+            > result-cpp.check
 
-      - name: Check failed
-        if: failure()
-        run: cat source_code.check
+          # Genearate an error message for each offending file
+          for filepath in `cat result-cpp.check`; do                              \
+            echo "::error file=$filepath,line=1::check the license in $filepath"; \
+          done
+
+          test ! -s result-cpp.check
+
+      - name: Check CMake files
+        if: always()          # needed so that it runs even if previous one fails
+        run: |
+          # Generate header license CMake compliant
+          sed 's|^//|#|g' misc/HEADER > HEADER_CMAKE
+
+          # Compare first lines of cmake files with the reference
+          find  '(' -type f ! -path './misc*' ')'                                 \
+                '('                                                               \
+                        -name 'CMakeLists.txt'                                    \
+                    -o  -name 'DLAF*.cmake'                                       \
+                    -o  -name 'DLAF*.cmake.in'                                    \
+                ')'                                                               \
+            | xargs -I{} sh -c                                                    \
+                "head -n9 {} | diff -sq - HEADER_CMAKE > /dev/null || echo {}"    \
+            > result-cmake.check
+
+          # Genearate an error message for each offending file
+          for filepath in `cat result-cmake.check`; do                            \
+            echo "::error file=$filepath,line=1::check the license in $filepath"; \
+          done
+
+          test ! -s result-cmake.check

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -10,9 +10,30 @@ jobs:
       - uses: actions/javascript-action@v1
       - uses: actions/checkout@v2
 
-      - name: Check source code
+      - name: Check file extensions
+        if: always()          # needed so that it runs even if previous one fails
         run: |
-          if: always()          # needed so that it runs even if previous one fails
+          # highlight if in these folders there are files with other extensions
+          find src include test miniapp -type f                                   \
+               ! '('                                                              \
+                       -name '*.cpp'                                              \
+                   -o  -name '*.h'                                                \
+                   -o  -name '*.h.in'                                             \
+                   -o  -name '*.tpp'                                              \
+                   -o  -name '*.cu'                                               \
+                   -o  -name 'CMakeLists.txt'                                     \
+               ')'                                                                \
+            > result-extension.check
+          # Genearate an error message for each file with an unkown extension
+          for filepath in `cat result-extension.check`; do                        \
+            echo "::error file=$filepath,line=1::check extension of $filepath";   \
+          done
+
+          test ! -s result-extension.check
+
+      - name: Check source code
+        if: always()          # needed so that it runs even if previous one fails
+        run: |
           # Compare first lines of each source file with reference in misc/HEADER
           find src include test miniapp -type f                                   \
                '('                                                                \

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -3,7 +3,7 @@ name: Check license
 on: [pull_request]
 
 jobs:
-  check-cpp:
+  check-licenses:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +24,7 @@ jobs:
                    -o  -name 'CMakeLists.txt'                                     \
                ')'                                                                \
             > result-extension.check
-          # Genearate an error message for each file with an unkown extension
+          # Generate an error message for each file with an unkown extension
           for filepath in `cat result-extension.check`; do                        \
             echo "::error file=$filepath,line=1::check extension of $filepath";   \
           done
@@ -47,7 +47,7 @@ jobs:
                 "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo {}"     \
             > result-cpp.check
 
-          # Genearate an error message for each offending file
+          # Generate an error message for each offending file
           for filepath in `cat result-cpp.check`; do                              \
             echo "::error file=$filepath,line=1::check the license in $filepath"; \
           done
@@ -71,7 +71,7 @@ jobs:
                 "head -n9 {} | diff -sq - HEADER_CMAKE > /dev/null || echo {}"    \
             > result-cmake.check
 
-          # Genearate an error message for each offending file
+          # Generate an error message for each offending file
           for filepath in `cat result-cmake.check`; do                            \
             echo "::error file=$filepath,line=1::check the license in $filepath"; \
           done

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -44,8 +44,7 @@ jobs:
                    -o  -name '*.cu'                                               \
                ')'                                                                \
             | xargs -I{} sh -c                                                    \
-                "grep -sq 'dlaf-no-license-check' {}                              \
-                || head -n9 {} | diff - misc/HEADER > /dev/null || echo {}"       \
+                ".github/check_license.sh misc/HEADER {} > /dev/null || echo {}"  \
             > result-cpp.check
 
           # Generate an error message for each offending file
@@ -58,10 +57,10 @@ jobs:
       - name: Check CMake and Python files
         if: always()          # needed so that it runs even if previous one fails
         run: |
-          # Generate header license CMake compliant
+          # Generate header license CMake/Python compliant (with hashes)
           sed 's|^//|#|g' misc/HEADER > HEADER_HASH
 
-          # Compare first lines of cmake files with the reference
+          # Check license in CMake files
           find  '(' -type f ! -path './misc*' ')'                                 \
                 '('                                                               \
                         -name 'CMakeLists.txt'                                    \
@@ -69,15 +68,14 @@ jobs:
                     -o  -name 'DLAF*.cmake.in'                                    \
                 ')'                                                               \
             | xargs -I{} sh -c                                                    \
-                "head -n9 {} | diff - HEADER_HASH > /dev/null || echo {}"         \
+                ".github/check_license.sh HEADER_HASH {} > /dev/null || echo {}"  \
             >> result.check
 
-          # Look for the LICENSE inside the python file
-          function streambin { xxd -p $1 | tr -d "\n"; }
-          BIN_HEADER_CMAKE=`streambin HEADER_HASH`
-          for file in `find scripts -type f -name "*.py"`; do                     \
-            streambin $file | grep -sq $BIN_HEADER_CMAKE || echo $file;           \
-          done >> result.check
+          # Check license in Python files
+          find scripts -type f -name '*.py'                                           \
+            | xargs -I{} sh -c                                                        \
+                ".github/check_license.sh -r 4 HEADER_HASH {} > /dev/null || echo {}" \
+            >> result.check
 
           # Generate an error message for each offending file
           for filepath in `cat result.check`; do                                  \

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 name: Check license
 
 on: [pull_request]

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -54,11 +54,11 @@ jobs:
 
           test ! -s result-cpp.check
 
-      - name: Check CMake files
+      - name: Check CMake and Python files
         if: always()          # needed so that it runs even if previous one fails
         run: |
           # Generate header license CMake compliant
-          sed 's|^//|#|g' misc/HEADER > HEADER_CMAKE
+          sed 's|^//|#|g' misc/HEADER > HEADER_HASH
 
           # Compare first lines of cmake files with the reference
           find  '(' -type f ! -path './misc*' ')'                                 \
@@ -68,12 +68,19 @@ jobs:
                     -o  -name 'DLAF*.cmake.in'                                    \
                 ')'                                                               \
             | xargs -I{} sh -c                                                    \
-                "head -n9 {} | diff -sq - HEADER_CMAKE > /dev/null || echo {}"    \
-            > result-cmake.check
+                "head -n9 {} | diff -sq - HEADER_HASH > /dev/null || echo {}"     \
+            >> result.check
+
+          # Look for the LICENSE inside the python file
+          function streambin { xxd -p $1 | tr -d "\n"; }
+          BIN_HEADER_CMAKE=`streambin HEADER_HASH`
+          for file in `find scripts -type f -name "*.py"`; do                     \
+            streambin $file | grep -sq $BIN_HEADER_CMAKE || echo $file;           \
+          done >> result.check
 
           # Generate an error message for each offending file
-          for filepath in `cat result-cmake.check`; do                            \
+          for filepath in `cat result.check`; do                                  \
             echo "::error file=$filepath,line=1::check the license in $filepath"; \
           done
 
-          test ! -s result-cmake.check
+          test ! -s result.check

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -31,7 +31,7 @@ jobs:
 
           test ! -s result-extension.check
 
-      - name: Check source code
+      - name: Check license in source code
         if: always()          # needed so that it runs even if previous one fails
         run: |
           # Compare first lines of each source file with reference in misc/HEADER
@@ -54,25 +54,26 @@ jobs:
 
           test ! -s result-cpp.check
 
-      - name: Check CMake and Python files
+      - name: Check license in files using "#" comments
         if: always()          # needed so that it runs even if previous one fails
         run: |
           # Generate header license CMake/Python compliant (with hashes)
           sed 's|^//|#|g' misc/HEADER > HEADER_HASH
 
-          # Check license in CMake files
+          # Check license in files that should the license at the very beginning
           find  '(' -type f ! -path './misc*' ')'                                 \
                 '('                                                               \
                         -name 'CMakeLists.txt'                                    \
-                    -o  -name 'DLAF*.cmake'                                       \
-                    -o  -name 'DLAF*.cmake.in'                                    \
+                    -o  -name '*.cmake'                                           \
+                    -o  -name '*.cmake.in'                                        \
+                    -o  -name '*.yaml'                                            \
                 ')'                                                               \
             | xargs -I{} sh -c                                                    \
                 ".github/check_license.sh HEADER_HASH {} > /dev/null || echo {}"  \
             >> result.check
 
-          # Check license in Python files
-          find scripts -type f -name '*.py'                                           \
+          # Check license in scripts which may start with #! shebang and other directives
+          find -type f '(' -name '*.py' -o -name '*.sh' ')'                           \
             | xargs -I{} sh -c                                                        \
                 ".github/check_license.sh -r 4 HEADER_HASH {} > /dev/null || echo {}" \
             >> result.check

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/javascript-action@v1
+      - uses: actions/checkout@v2
 
       - name: Check source code
         run: |
@@ -24,8 +24,11 @@ jobs:
                     -o  -name '*.cu'                                                              \
                 ')'                                                                               \
             | xargs -I{} sh -c                                                                    \
-                "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo 'CHECK LICENSE IN {}'"  \
+                "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo {}"                     \
             > source_code.check
+          for filepath in `cat source_code.check`; do                                         \
+            echo "::error file=$filepath,line=1,title=$filepath::check the license";             \
+          done
           test ! -s source_code.check
 
       - name: Check failed

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -1,0 +1,33 @@
+name: Check license
+
+on:
+  - pull_request
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check source code
+        run: |
+          # Compare header license in misc/HEADER with the first lines of each source code file
+          find  '(' -type f ! -path './misc*' ')'                                                 \
+                '('                                                                               \
+                        -name '*.cpp'                                                             \
+                    -o  -name '*.h'                                                               \
+                    -o  -name '*.hpp'                                                             \
+                    -o  -name '*.tpp'                                                             \
+                    -o  -name '*.ipp'                                                             \
+                    -o  -name '*.cu'                                                              \
+                ')'                                                                               \
+            | xargs -I{} sh -c                                                                    \
+                "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo 'CHECK LICENSE IN {}'"  \
+            > source_code.check
+          test ! -s source_code.check
+
+      - name: Check failed
+        if: failure()
+        run: cat source_code.check

--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -44,7 +44,8 @@ jobs:
                    -o  -name '*.cu'                                               \
                ')'                                                                \
             | xargs -I{} sh -c                                                    \
-                "head -n9 {} | diff -sq - misc/HEADER > /dev/null || echo {}"     \
+                "grep -sq 'dlaf-no-license-check' {}                              \
+                || head -n9 {} | diff - misc/HEADER > /dev/null || echo {}"       \
             > result-cpp.check
 
           # Generate an error message for each offending file
@@ -68,7 +69,7 @@ jobs:
                     -o  -name 'DLAF*.cmake.in'                                    \
                 ')'                                                               \
             | xargs -I{} sh -c                                                    \
-                "head -n9 {} | diff -sq - HEADER_HASH > /dev/null || echo {}"     \
+                "head -n9 {} | diff - HEADER_HASH > /dev/null || echo {}"         \
             >> result.check
 
           # Look for the LICENSE inside the python file

--- a/ci/ctest_to_gitlab.sh
+++ b/ci/ctest_to_gitlab.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 IMAGE="$1"
 USE_CODECOV="$2"
 THREADS_PER_NODE="$3"

--- a/ci/docker/cpu-debug.yaml
+++ b/ci/docker/cpu-debug.yaml
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 spack:
   specs:
     - dla-future@develop build_type=Debug +miniapps +ci-test ^openblas ^mpich

--- a/ci/docker/cpu-release.yaml
+++ b/ci/docker/cpu-release.yaml
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 spack:
   specs:
     - dla-future@develop +miniapps +ci-test ^intel-mkl ^mpich

--- a/ci/docker/gpu-debug.yaml
+++ b/ci/docker/gpu-debug.yaml
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 spack:
   specs:
     - dla-future@develop build_type=Debug +cuda +miniapps +ci-test ^openblas ^mpich

--- a/ci/docker/gpu-release.yaml
+++ b/ci/docker/gpu-release.yaml
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 spack:
   specs:
     - dla-future@develop +cuda +miniapps +ci-test ^intel-mkl ^mpich

--- a/ci/set_github_status.sh
+++ b/ci/set_github_status.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 function submit() {
     local commit_status=${1}
     local commit_sha=${2}

--- a/cmake/FindLAPACK.cmake
+++ b/cmake/FindLAPACK.cmake
@@ -7,6 +7,8 @@
 # author: Alberto Invernizzi (a.invernizzi@cscs.ch)
 #
 
+# dlaf-no-license-check
+
 # Find LAPACK library
 #
 # LAPACK depends on BLAS and it is up to the user to honor this dependency by specifying

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -7,6 +7,9 @@
 #
 # Author: Teodor Nikolov (tnikolov@cscs.ch)
 #
+
+# dlaf-no-license-check
+
 #[=======================================================================[.rst:
 FindMKL
 -------

--- a/cmake/template/DLAFConfig.cmake.in
+++ b/cmake/template/DLAFConfig.cmake.in
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 @PACKAGE_INIT@
 
 if (NOT TARGET DLAF)

--- a/include/dlaf/cusolver/hegst.h
+++ b/include/dlaf/cusolver/hegst.h
@@ -47,6 +47,8 @@
  * Users Notice.
  */
 
+// dlaf-no-license-check
+
 #pragma once
 
 #include <cusolverDn.h>

--- a/include/dlaf/eigensolver/eigensolver/api.h
+++ b/include/dlaf/eigensolver/eigensolver/api.h
@@ -6,6 +6,7 @@
 //
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
+//
 
 #pragma once
 

--- a/include/dlaf/eigensolver/reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/reduction_to_band/api.h
@@ -6,6 +6,7 @@
 //
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
+//
 
 #pragma once
 

--- a/include/dlaf/factorization/qr/mc.h
+++ b/include/dlaf/factorization/qr/mc.h
@@ -6,6 +6,7 @@
 //
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
+//
 
 #pragma once
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 # Template build script
 # ---------------------
 

--- a/scripts/gen_strong.py
+++ b/scripts/gen_strong.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 # This file is an example on how to use the miniapp module.
 # Please do not add gen scripts used for benchmarks into the source repository,
 # they should be kept with the result produced.

--- a/scripts/gen_weak.py
+++ b/scripts/gen_weak.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 # This file is an example on how to use the miniapp module.
 # Please do not add gen scripts used for benchmarks into the source repository,
 # they should be kept with the result produced.

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 from itertools import product
 from math import sqrt
 from os import makedirs, system

--- a/scripts/plot_chol_strong.py
+++ b/scripts/plot_chol_strong.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import postprocess as pp
 
 df = pp.parse_jobs_cmdargs(description="Plot Cholesky strong scaling benchmarks.")

--- a/scripts/plot_chol_weak.py
+++ b/scripts/plot_chol_weak.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import postprocess as pp
 
 df = pp.parse_jobs_cmdargs(description="Plot Cholesky weak scaling benchmarks.")

--- a/scripts/plot_hegst_strong.py
+++ b/scripts/plot_hegst_strong.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import postprocess as pp
 
 df = pp.parse_jobs_cmdargs(description="Plot gen2std strong scaling benchmarks.")

--- a/scripts/plot_hegst_weak.py
+++ b/scripts/plot_hegst_weak.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import postprocess as pp
 
 df = pp.parse_jobs_cmdargs(description="Plot gen2std weak scaling benchmarks.")

--- a/scripts/plot_trsm_strong.py
+++ b/scripts/plot_trsm_strong.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import postprocess as pp
 
 df = pp.parse_jobs_cmdargs(description="Plot trsm strong scaling benchmarks.")

--- a/scripts/plot_trsm_weak.py
+++ b/scripts/plot_trsm_weak.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import postprocess as pp
 
 df = pp.parse_jobs_cmdargs(description="Plot trsm weak scaling benchmarks.")

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 import argparse
 import os
 import re

--- a/scripts/systems.py
+++ b/scripts/systems.py
@@ -1,3 +1,13 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 # a system is a dict containing the following data:
 # "Cores" (int > 0),
 # "Threads per core" (int > 0),

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+# dlaf-no-license-check
+
 from spack import *
 
 

--- a/spack/repo.yaml
+++ b/spack/repo.yaml
@@ -1,2 +1,12 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
 repo:
   namespace: 'dlaf'

--- a/src/auxiliary/norm/mc.cpp
+++ b/src/auxiliary/norm/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/auxiliary/norm/mc.h"
 
 namespace dlaf {

--- a/src/communication/communicator_impl.cpp
+++ b/src/communication/communicator_impl.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "communicator_impl.h"
 
 #include "dlaf/common/assert.h"

--- a/src/communication/communicator_impl.h
+++ b/src/communication/communicator_impl.h
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #pragma once
 
 #include "dlaf/communication/error.h"

--- a/src/communication/datatypes.cpp
+++ b/src/communication/datatypes.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include <dlaf/communication/datatypes.h>
 
 namespace dlaf {

--- a/src/eigensolver/bt_band_to_tridiag/mc.cpp
+++ b/src/eigensolver/bt_band_to_tridiag/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/bt_band_to_tridiag/mc.h"
 
 namespace dlaf::eigensolver::internal {

--- a/src/eigensolver/bt_reduction_to_band/mc.cpp
+++ b/src/eigensolver/bt_reduction_to_band/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/bt_reduction_to_band.h"
 
 namespace dlaf::eigensolver {

--- a/src/eigensolver/eigensolver/mc.cpp
+++ b/src/eigensolver/eigensolver/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/eigensolver/mc.h"
 
 namespace dlaf {

--- a/src/eigensolver/gen_eigensolver/mc.cpp
+++ b/src/eigensolver/gen_eigensolver/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/gen_eigensolver/impl.h"
 
 namespace dlaf {

--- a/src/eigensolver/gen_to_std/gpu.cpp
+++ b/src/eigensolver/gen_to_std/gpu.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/gen_to_std/impl.h"
 
 namespace dlaf {

--- a/src/eigensolver/gen_to_std/mc.cpp
+++ b/src/eigensolver/gen_to_std/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/gen_to_std/impl.h"
 
 namespace dlaf {

--- a/src/eigensolver/reduction_to_band/mc.cpp
+++ b/src/eigensolver/reduction_to_band/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/eigensolver/reduction_to_band/mc.h"
 
 namespace dlaf {

--- a/src/factorization/cholesky/gpu.cpp
+++ b/src/factorization/cholesky/gpu.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/factorization/cholesky/impl.h"
 
 namespace dlaf {

--- a/src/factorization/cholesky/mc.cpp
+++ b/src/factorization/cholesky/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/factorization/cholesky/impl.h"
 
 namespace dlaf {

--- a/src/factorization/qr/gpu.cpp
+++ b/src/factorization/qr/gpu.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/factorization/qr.h"
 
 namespace dlaf::factorization::internal {

--- a/src/factorization/qr/mc.cpp
+++ b/src/factorization/qr/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/factorization/qr.h"
 
 namespace dlaf::factorization::internal {

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include <dlaf/matrix/matrix.h>
 
 namespace dlaf {

--- a/src/matrix/tile.cpp
+++ b/src/matrix/tile.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include <dlaf/matrix/tile.h>
 
 namespace dlaf {

--- a/src/matrix_mirror.cpp
+++ b/src/matrix_mirror.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include <dlaf/matrix/matrix_mirror.h>
 
 namespace dlaf {

--- a/src/memory/memory_chunk.cpp
+++ b/src/memory/memory_chunk.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include <dlaf/memory/memory_chunk.h>
 
 #include <umpire/ResourceManager.hpp>

--- a/src/memory/memory_view.cpp
+++ b/src/memory/memory_view.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include <dlaf/memory/memory_view.h>
 
 namespace dlaf {

--- a/src/multiplication/triangular/gpu.cpp
+++ b/src/multiplication/triangular/gpu.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/multiplication/triangular/impl.h"
 
 namespace dlaf {

--- a/src/multiplication/triangular/mc.cpp
+++ b/src/multiplication/triangular/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/multiplication/triangular/impl.h"
 
 namespace dlaf {

--- a/src/solver/triangular/gpu.cpp
+++ b/src/solver/triangular/gpu.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/solver/triangular/impl.h"
 
 namespace dlaf {

--- a/src/solver/triangular/mc.cpp
+++ b/src/solver/triangular/mc.cpp
@@ -1,3 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
 #include "dlaf/solver/triangular/impl.h"
 
 namespace dlaf {

--- a/test/include/dlaf_test/comm_grids/grids_6_ranks.h
+++ b/test/include/dlaf_test/comm_grids/grids_6_ranks.h
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#pragma once
+
 #include "gtest/gtest.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/error.h"

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -1,3 +1,4 @@
+//
 // Distributed Linear Algebra with Future (DLAF)
 //
 // Copyright (c) 2018-2022, ETH Zurich

--- a/test/src/gtest_mpi_listener.h
+++ b/test/src/gtest_mpi_listener.h
@@ -1,3 +1,4 @@
+//
 // Distributed Linear Algebra with Future (DLAF)
 //
 // Copyright (c) 2018-2022, ETH Zurich

--- a/test/src/gtest_mpi_main.cpp
+++ b/test/src/gtest_mpi_main.cpp
@@ -37,6 +37,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+// dlaf-no-license-check
+
 #include <gtest/gtest.h>
 #include <mpi.h>
 

--- a/test/src/gtest_mpipika_main.cpp
+++ b/test/src/gtest_mpipika_main.cpp
@@ -37,6 +37,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+// dlaf-no-license-check
+
 #include <cstdio>
 
 #include <gtest/gtest.h>

--- a/test/src/gtest_pika_main.cpp
+++ b/test/src/gtest_pika_main.cpp
@@ -37,6 +37,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+// dlaf-no-license-check
+
 #include <cstdio>
 
 #include <gtest/gtest.h>

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -6,6 +6,7 @@
 //
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
+//
 
 #include "dlaf/eigensolver/bt_band_to_tridiag.h"
 


### PR DESCRIPTION
After realizing there were files without license header in our codebase, let's see if we can add an action that checks that for us.

- [x] add check for file with non-standard extensions
- [x] add check presence of license header in source files
  - we may want to add a "exclude-list", e.g. [`include/dlaf/cusolver/hegst.h`](https://github.com/eth-cscs/DLA-Future/blob/master/include/dlaf/cusolver/hegst.h)
  - some files have multiple licenses, e.g. all `gtest_*_main` like [test/src/gtest_mpipika_main.cpp](https://github.com/eth-cscs/DLA-Future/blob/master/test/src/gtest_mpipika_main.cpp)
- [x] add check presence of license header in CMake files
  - there is at least a Find*.cmake module which is not checked
- [x] add check for include guards (e.g. pragma once)

