### PR TITLE
Eigensolver + Gen Eigensolver Implementation + Test

### DIFF
--- a/include/dlaf/eigensolver.h
+++ b/include/dlaf/eigensolver.h
@@ -12,5 +12,6 @@
 #include "dlaf/eigensolver/backtransformation.h"
 #include "dlaf/eigensolver/band_to_tridiag.h"
 #include "dlaf/eigensolver/eigensolver.h"
+#include "dlaf/eigensolver/gen_eigensolver.h"
 #include "dlaf/eigensolver/gen_to_std.h"
 #include "dlaf/eigensolver/reduction_to_band.h"

--- a/include/dlaf/eigensolver.h
+++ b/include/dlaf/eigensolver.h
@@ -10,4 +10,7 @@
 #pragma once
 
 #include "dlaf/eigensolver/backtransformation.h"
+#include "dlaf/eigensolver/band_to_tridiag.h"
+#include "dlaf/eigensolver/eigensolver.h"
 #include "dlaf/eigensolver/gen_to_std.h"
+#include "dlaf/eigensolver/reduction_to_band.h"

--- a/include/dlaf/eigensolver/eigensolver.h
+++ b/include/dlaf/eigensolver/eigensolver.h
@@ -31,7 +31,7 @@ namespace eigensolver {
 /// @param uplo specifies if upper or lower triangular part of @p mat will be referenced
 /// @param mat contains the Hermitian matrix A
 template <Backend backend, Device device, class T>
-ReturnEigensolverType<T, device> eigensolver(blas::Uplo uplo, Matrix<T, device>& mat) {
+EigensolverResult<T, device> eigensolver(blas::Uplo uplo, Matrix<T, device>& mat) {
   DLAF_ASSERT(matrix::local_matrix(mat), mat);
   DLAF_ASSERT(square_size(mat), mat);
   DLAF_ASSERT(square_blocksize(mat), mat);

--- a/include/dlaf/eigensolver/eigensolver.h
+++ b/include/dlaf/eigensolver/eigensolver.h
@@ -18,7 +18,18 @@
 namespace dlaf {
 namespace eigensolver {
 
-/// TODO
+/// Standard Eigensolver.
+///
+/// It solves the standard eigenvalue problem A * x = lambda * x.
+///
+/// On exit, the lower triangle or the upper triangle (depending on @p uplo) of @p mat_a,
+/// including the diagonal, is destroyed.
+///
+/// Implementation on local memory.
+///
+/// @return struct ReturnEigensolverType with eigenvalues, as a vector<T>, and eigenvectors as a Matrix
+/// @param uplo specifies if upper or lower triangular part of @p mat will be referenced
+/// @param mat contains the Hermitian matrix A
 template <Backend backend, Device device, class T>
 ReturnEigensolverType<T, device> eigensolver(blas::Uplo uplo, Matrix<T, device>& mat) {
   DLAF_ASSERT(matrix::local_matrix(mat), mat);

--- a/include/dlaf/eigensolver/eigensolver.h
+++ b/include/dlaf/eigensolver/eigensolver.h
@@ -1,0 +1,31 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <blas.hh>
+#include "dlaf/eigensolver/eigensolver/mc.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/types.h"
+#include "dlaf/util_matrix.h"
+
+namespace dlaf {
+namespace eigensolver {
+
+/// TODO
+template <Backend backend, Device device, class T>
+ReturnEigensolverType<T, device> eigensolver(blas::Uplo uplo, Matrix<T, device>& mat) {
+  DLAF_ASSERT(matrix::local_matrix(mat), mat);
+  DLAF_ASSERT(square_size(mat), mat);
+  DLAF_ASSERT(square_blocksize(mat), mat);
+
+  return internal::Eigensolver<backend, device, T>::call(uplo, mat);
+}
+}
+}

--- a/include/dlaf/eigensolver/eigensolver.h
+++ b/include/dlaf/eigensolver/eigensolver.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2018-2021, ETH Zurich
+// Copyright (c) 2018-2022, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/include/dlaf/eigensolver/eigensolver/api.h
+++ b/include/dlaf/eigensolver/eigensolver/api.h
@@ -17,7 +17,7 @@ namespace dlaf {
 namespace eigensolver {
 
 template <class T, Device device>
-struct ReturnEigensolverType {
+struct EigensolverResult {
   common::internal::vector<BaseType<T>> eigenvalues;
   Matrix<T, device> eigenvectors;
 };

--- a/include/dlaf/eigensolver/eigensolver/api.h
+++ b/include/dlaf/eigensolver/eigensolver/api.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2018-2021, ETH Zurich
+// Copyright (c) 2018-2022, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/include/dlaf/eigensolver/eigensolver/api.h
+++ b/include/dlaf/eigensolver/eigensolver/api.h
@@ -1,0 +1,32 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "dlaf/common/vector.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/types.h"
+
+namespace dlaf {
+namespace eigensolver {
+
+template <class T, Device device>
+struct ReturnEigensolverType {
+  common::internal::vector<BaseType<T>> eigenvalues;
+  Matrix<T, device> eigenvectors;
+};
+
+namespace internal {
+
+template <Backend backend, Device device, class T>
+struct Eigensolver {};
+
+}
+}
+}

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2018-2021, ETH Zurich
+// Copyright (c) 2018-2022, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.
@@ -16,6 +16,7 @@
 #include "dlaf/common/vector.h"
 #include "dlaf/eigensolver/backtransformation.h"
 #include "dlaf/eigensolver/band_to_tridiag.h"
+#include "dlaf/eigensolver/bt_band_to_tridiag.h"
 #include "dlaf/eigensolver/reduction_to_band.h"
 #include "dlaf/lapack/tile.h"
 #include "dlaf/matrix/distribution.h"
@@ -74,9 +75,8 @@ struct Eigensolver<Backend::MC, Device::CPU, T> {
     // Note: no sync needed here as next tasks are only scheduled
     //       after the completion of stemr.
 
-    // TODO needs updated branch
-    // backTransformationT2B<Backend::MC>(mat_e, ret.hh_reflectors);
-    auto taus_ = (common::internal::vector<hpx::shared_future<common::internal::vector<T>>>*) &taus;
+    backTransformationBandToTridiag<Backend::MC>(mat_e, ret.hh_reflectors);
+    auto taus_ = (common::internal::vector<pika::shared_future<common::internal::vector<T>>>*) &taus;
     backTransformation<Backend::MC>(mat_e, mat_a, *taus_);
 
     return {std::move(w), std::move(mat_e)};

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -1,0 +1,97 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+#include "dlaf/blas/tile.h"
+#include "dlaf/common/vector.h"
+#include "dlaf/eigensolver/backtransformation.h"
+#include "dlaf/eigensolver/band_to_tridiag.h"
+#include "dlaf/eigensolver/reduction_to_band.h"
+#include "dlaf/lapack/tile.h"
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/util_matrix.h"
+
+#include "dlaf/eigensolver/eigensolver/api.h"
+
+namespace dlaf {
+namespace eigensolver {
+namespace internal {
+
+template <class T>
+struct Eigensolver<Backend::MC, Device::CPU, T> {
+  static ReturnEigensolverType<T, Device::CPU> call(blas::Uplo uplo, Matrix<T, Device::CPU>& mat_a) {
+    using common::internal::vector;
+
+    const SizeType size = mat_a.size().rows();
+
+    // need uplo check as reduction to band doesn't have the uplo argument yet.
+    if (uplo != blas::Uplo::Lower)
+      DLAF_UNIMPLEMENTED(uplo);
+
+    auto taus = reductionToBand<Backend::MC>(mat_a);
+    auto ret = bandToTridiag<Backend::MC>(uplo, mat_a.blockSize().rows(), mat_a);
+
+    auto& mat_trid = ret.tridiagonal;
+    vector<BaseType<T>> d(size);
+    vector<BaseType<T>> e(size);
+
+    // Synchronize mat_trid and copy tile by tile.
+    for (SizeType j = 0; j < mat_a.nrTiles().cols(); ++j) {
+      auto tile_sf = mat_trid.read(GlobalTileIndex(0, j));
+      auto& tile = tile_sf.get();
+      auto start = j * mat_a.blockSize().cols();
+      blas::copy(tile.size().cols(), tile.ptr({0, 0}), tile.ld(), &d[start], 1);
+      blas::copy(tile.size().cols(), tile.ptr({1, 0}), tile.ld(), &e[start], 1);
+    }
+
+    // mat_e ia allocated in lapack layout to be able to call stemr directly on it.
+    SizeType lde = std::max<SizeType>(1, size);
+    auto distr_a = mat_a.distribution();
+    auto layout = matrix::colMajorLayout(distr_a, lde);
+    Matrix<T, Device::CPU> mat_e(distr_a, layout);
+    auto ptr_e = mat_e(GlobalTileIndex(0, 0)).get().ptr();
+
+    // Note I'm using mrrr instead of divide & conquer as
+    // mrrr is more suitable for a single core task.
+    int64_t tmp;
+    vector<BaseType<T>> w(size);
+    vector<int64_t> isuppz(2 * std::max<SizeType>(1, size));
+    bool tryrac = false;
+    lapack::stemr(lapack::Job::Vec, lapack::Range::All, size, d.data(), e.data(), 0, 0, 0, 0, &tmp,
+                  w.data(), ptr_e, lde, size, isuppz.data(), &tryrac);
+
+    // Note: no sync needed here as next tasks are only scheduled
+    //       after the completion of stemr.
+
+    // TODO needs updated branch
+    // backTransformationT2B<Backend::MC>(mat_e, ret.hh_reflectors);
+    auto taus_ = (common::internal::vector<hpx::shared_future<common::internal::vector<T>>>*) &taus;
+    backTransformation<Backend::MC>(mat_e, mat_a, *taus_);
+
+    return {std::move(w), std::move(mat_e)};
+  }
+};
+
+/// ---- ETI
+#define DLAF_EIGENSOLVER_MC_ETI(KWORD, DATATYPE) \
+  KWORD template struct Eigensolver<Backend::MC, Device::CPU, DATATYPE>;
+
+DLAF_EIGENSOLVER_MC_ETI(extern, float)
+DLAF_EIGENSOLVER_MC_ETI(extern, double)
+DLAF_EIGENSOLVER_MC_ETI(extern, std::complex<float>)
+DLAF_EIGENSOLVER_MC_ETI(extern, std::complex<double>)
+
+}
+}
+}

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -35,12 +35,13 @@ struct Eigensolver<Backend::MC, Device::CPU, T> {
     using common::internal::vector;
 
     const SizeType size = mat_a.size().rows();
+    const SizeType band_size = mat_a.blockSize().rows();
 
     // need uplo check as reduction to band doesn't have the uplo argument yet.
     if (uplo != blas::Uplo::Lower)
       DLAF_UNIMPLEMENTED(uplo);
 
-    auto taus = reductionToBand<Backend::MC>(mat_a);
+    auto taus = reductionToBand<Backend::MC>(mat_a, band_size);
     auto ret = bandToTridiag<Backend::MC>(uplo, mat_a.blockSize().rows(), mat_a);
 
     auto& mat_trid = ret.tridiagonal;

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -56,7 +56,7 @@ struct Eigensolver<Backend::MC, Device::CPU, T> {
       blas::copy(tile.size().cols(), tile.ptr({1, 0}), tile.ld(), &e[start], 1);
     }
 
-    // mat_e ia allocated in lapack layout to be able to call stemr directly on it.
+    // mat_e is allocated in lapack layout to be able to call stemr directly on it.
     SizeType lde = std::max<SizeType>(1, size);
     auto distr_a = mat_a.distribution();
     auto layout = matrix::colMajorLayout(distr_a, lde);

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -31,7 +31,7 @@ namespace internal {
 
 template <class T>
 struct Eigensolver<Backend::MC, Device::CPU, T> {
-  static ReturnEigensolverType<T, Device::CPU> call(blas::Uplo uplo, Matrix<T, Device::CPU>& mat_a) {
+  static EigensolverResult<T, Device::CPU> call(blas::Uplo uplo, Matrix<T, Device::CPU>& mat_a) {
     using common::internal::vector;
 
     const SizeType size = mat_a.size().rows();

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -76,8 +76,7 @@ struct Eigensolver<Backend::MC, Device::CPU, T> {
     //       after the completion of stemr.
 
     backTransformationBandToTridiag<Backend::MC>(mat_e, ret.hh_reflectors);
-    auto taus_ = (common::internal::vector<pika::shared_future<common::internal::vector<T>>>*) &taus;
-    backTransformation<Backend::MC>(mat_e, mat_a, *taus_);
+    backTransformation<Backend::MC>(mat_e, mat_a, taus);
 
     return {std::move(w), std::move(mat_e)};
   }

--- a/include/dlaf/eigensolver/gen_eigensolver.h
+++ b/include/dlaf/eigensolver/gen_eigensolver.h
@@ -1,0 +1,37 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <blas.hh>
+#include "dlaf/eigensolver/gen_eigensolver/impl.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/types.h"
+#include "dlaf/util_matrix.h"
+
+namespace dlaf {
+namespace eigensolver {
+
+/// TODO
+template <Backend backend, Device device, class T>
+ReturnEigensolverType<T, device> genEigensolver(blas::Uplo uplo, Matrix<T, device>& mat_a,
+                                                Matrix<T, device>& mat_b) {
+  DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
+  DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
+  DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
+  DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
+  DLAF_ASSERT(matrix::square_size(mat_b), mat_b);
+  DLAF_ASSERT(matrix::square_blocksize(mat_b), mat_b);
+  DLAF_ASSERT(mat_a.size() == mat_b.size(), mat_a, mat_b);
+  DLAF_ASSERT(mat_a.blockSize() == mat_b.blockSize(), mat_a, mat_b);
+
+  return internal::GenEigensolver<backend, device, T>::call(uplo, mat_a, mat_b);
+}
+}
+}

--- a/include/dlaf/eigensolver/gen_eigensolver.h
+++ b/include/dlaf/eigensolver/gen_eigensolver.h
@@ -34,8 +34,8 @@ namespace eigensolver {
 /// @param mat_a contains the Hermitian matrix A
 /// @param mat_b contains the Hermitian positive definite matrix B
 template <Backend backend, Device device, class T>
-ReturnEigensolverType<T, device> genEigensolver(blas::Uplo uplo, Matrix<T, device>& mat_a,
-                                                Matrix<T, device>& mat_b) {
+EigensolverResult<T, device> genEigensolver(blas::Uplo uplo, Matrix<T, device>& mat_a,
+                                            Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
   DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);

--- a/include/dlaf/eigensolver/gen_eigensolver.h
+++ b/include/dlaf/eigensolver/gen_eigensolver.h
@@ -18,7 +18,21 @@
 namespace dlaf {
 namespace eigensolver {
 
-/// TODO
+/// Generalized Eigensolver.
+///
+/// It solves the generalized eigenvalue problem A * x = lambda * B * x.
+///
+/// On exit:
+/// - the lower triangle or the upper triangle (depending on @p uplo) of @p mat_a,
+/// including the diagonal, is destroyed.
+/// - @p mat_b contains the Cholesky decomposition of B
+///
+/// Implementation on local memory.
+///
+/// @return struct ReturnEigensolverType with eigenvalues, as a vector<T>, and eigenvectors as a Matrix
+/// @param uplo specifies if upper or lower triangular part of @p mat_a and @p mat_b will be referenced
+/// @param mat_a contains the Hermitian matrix A
+/// @param mat_b contains the Hermitian positive definite matrix B
 template <Backend backend, Device device, class T>
 ReturnEigensolverType<T, device> genEigensolver(blas::Uplo uplo, Matrix<T, device>& mat_a,
                                                 Matrix<T, device>& mat_b) {

--- a/include/dlaf/eigensolver/gen_eigensolver/api.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/api.h
@@ -18,8 +18,8 @@ namespace eigensolver {
 namespace internal {
 template <Backend backend, Device device, class T>
 struct GenEigensolver {
-  static ReturnEigensolverType<T, device> call(blas::Uplo uplo, Matrix<T, device>& mat_a,
-                                               Matrix<T, device>& mat_b);
+  static EigensolverResult<T, device> call(blas::Uplo uplo, Matrix<T, device>& mat_a,
+                                           Matrix<T, device>& mat_b);
 };
 
 /// ---- ETI

--- a/include/dlaf/eigensolver/gen_eigensolver/api.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/api.h
@@ -1,0 +1,36 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include "dlaf/eigensolver/eigensolver/api.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/types.h"
+
+namespace dlaf {
+namespace eigensolver {
+namespace internal {
+template <Backend backend, Device device, class T>
+struct GenEigensolver {
+  static ReturnEigensolverType<T, device> call(blas::Uplo uplo, Matrix<T, device>& mat_a,
+                                               Matrix<T, device>& mat_b);
+};
+
+/// ---- ETI
+#define DLAF_EIGENSOLVER_GEN_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct GenEigensolver<BACKEND, DEVICE, DATATYPE>;
+
+DLAF_EIGENSOLVER_GEN_ETI(extern, Backend::MC, Device::CPU, float)
+DLAF_EIGENSOLVER_GEN_ETI(extern, Backend::MC, Device::CPU, double)
+DLAF_EIGENSOLVER_GEN_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_EIGENSOLVER_GEN_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
+
+}
+}
+}

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -1,0 +1,42 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include "dlaf/eigensolver/eigensolver.h"
+#include "dlaf/eigensolver/gen_to_std.h"
+#include "dlaf/factorization/cholesky.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/solver/triangular.h"
+#include "dlaf/util_matrix.h"
+
+#include "dlaf/eigensolver/gen_eigensolver/api.h"
+
+namespace dlaf {
+namespace eigensolver {
+namespace internal {
+
+template <Backend backend, Device device, class T>
+ReturnEigensolverType<T, device> GenEigensolver<backend, device, T>::call(blas::Uplo uplo,
+                                                                          Matrix<T, device>& mat_a,
+                                                                          Matrix<T, device>& mat_b) {
+  factorization::cholesky<backend>(uplo, mat_b);
+  eigensolver::genToStd<backend>(uplo, mat_a, mat_b);
+
+  auto ret = eigensolver::eigensolver<backend>(uplo, mat_a);
+
+  solver::triangular<backend>(blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1),
+                              mat_b, ret.eigenvectors);
+
+  return ret;
+}
+
+}
+}
+}

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -23,9 +23,9 @@ namespace eigensolver {
 namespace internal {
 
 template <Backend backend, Device device, class T>
-ReturnEigensolverType<T, device> GenEigensolver<backend, device, T>::call(blas::Uplo uplo,
-                                                                          Matrix<T, device>& mat_a,
-                                                                          Matrix<T, device>& mat_b) {
+EigensolverResult<T, device> GenEigensolver<backend, device, T>::call(blas::Uplo uplo,
+                                                                      Matrix<T, device>& mat_a,
+                                                                      Matrix<T, device>& mat_b) {
   factorization::cholesky<backend>(uplo, mat_b);
   eigensolver::genToStd<backend>(uplo, mat_a, mat_b);
 

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -31,8 +31,8 @@ namespace eigensolver {
 /// @pre mat_a has a square block size
 /// @pre mat_a is a local matrix
 template <Backend backend, Device device, class T>
-std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(Matrix<T, device>& mat_a,
-                                                                              const SizeType band_size) {
+common::internal::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(
+    Matrix<T, device>& mat_a, const SizeType band_size) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
 
@@ -79,7 +79,7 @@ std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(Ma
 /// @pre mat_a has a square block size
 /// @pre mat_a is distributed according to @p grid
 template <Backend backend, Device device, class T>
-std::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(
+common::internal::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(
     comm::CommunicatorGrid grid, Matrix<T, device>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -736,7 +736,7 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     return taus;
 
   const SizeType nblocks = (nrefls - 1) / band_size + 1;
-  taus.reserve(to_sizet(nblocks));
+  taus.reserve(nblocks);
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<PanelT<Coord::Col, T>> panels_v(n_workspaces, dist);
@@ -864,7 +864,7 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
   if (nblocks == 0)
     return taus;
 
-  taus.reserve(to_sizet(nblocks));
+  taus.reserve(nblocks);
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<PanelT<Coord::Col, T>> panels_v(n_workspaces, dist);

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -48,9 +48,9 @@ namespace internal {
 
 template <class T>
 struct ReductionToBand<Backend::MC, Device::CPU, T> {
-  static std::vector<pika::shared_future<common::internal::vector<T>>> call(
+  static common::internal::vector<pika::shared_future<common::internal::vector<T>>> call(
       Matrix<T, Device::CPU>& mat_a, const SizeType band_size);
-  static std::vector<pika::shared_future<common::internal::vector<T>>> call(
+  static common::internal::vector<pika::shared_future<common::internal::vector<T>>> call(
       comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& mat_a);
 };
 
@@ -712,7 +712,7 @@ void her2kUpdateTrailingMatrix(const LocalTileSize& at_start, MatrixT<T>& a,
 /// Local implementation of reduction to band
 /// @return a vector of shared futures of vectors, where each inner vector contains a block of taus
 template <class T>
-std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
+common::internal::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
     Backend::MC, Device::CPU, T>::call(Matrix<T, Device::CPU>& mat_a, const SizeType band_size) {
   using namespace red2band::local;
   using red2band::MatrixT;
@@ -730,7 +730,7 @@ std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
   // Reflector of size = 1 is not considered whatever T is (i.e. neither real nor complex)
   const SizeType nrefls = std::max<SizeType>(0, dist_a.size().rows() - band_size - 1);
 
-  std::vector<pika::shared_future<common::internal::vector<T>>> taus;
+  common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus;
 
   if (nrefls == 0)
     return taus;
@@ -840,7 +840,7 @@ std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
 /// Distributed implementation of reduction to band
 /// @return a vector of shared futures of vectors, where each inner vector contains a block of taus
 template <class T>
-std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
+common::internal::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
     Backend::MC, Device::CPU, T>::call(comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& mat_a) {
   using namespace red2band::distributed;
   using red2band::MatrixT;
@@ -858,7 +858,7 @@ std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
   const auto& dist = mat_a.distribution();
   const comm::Index2D rank = dist.rankIndex();
 
-  std::vector<pika::shared_future<common::internal::vector<T>>> taus;
+  common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus;
   const SizeType nblocks = std::max<SizeType>(0, dist.nrTiles().cols() - 1);
 
   if (nblocks == 0)

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -1033,13 +1033,13 @@ std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
 }
 
 /// ---- ETI
-#define DLAF_EIGENSOLVER_MC_ETI(KWORD, DATATYPE) \
+#define DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(KWORD, DATATYPE) \
   KWORD template struct ReductionToBand<Backend::MC, Device::CPU, DATATYPE>;
 
-DLAF_EIGENSOLVER_MC_ETI(extern, float)
-DLAF_EIGENSOLVER_MC_ETI(extern, double)
-DLAF_EIGENSOLVER_MC_ETI(extern, std::complex<float>)
-DLAF_EIGENSOLVER_MC_ETI(extern, std::complex<double>)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, float)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, double)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, std::complex<float>)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, std::complex<double>)
 
 }
 }

--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -1040,7 +1040,6 @@ DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, float)
 DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, double)
 DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, std::complex<float>)
 DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(extern, std::complex<double>)
-
 }
 }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(dlaf.eigensolver OBJECT
   eigensolver/backtransformation/mc.cpp
   eigensolver/band_to_tridiag/mc.cpp
   eigensolver/bt_band_to_tridiag/mc.cpp
+  eigensolver/eigensolver/mc.cpp
   eigensolver/gen_to_std/mc.cpp
   $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/gen_to_std/gpu.cpp>
   eigensolver/reduction_to_band/mc.cpp)
@@ -149,6 +150,9 @@ add_library(dlaf.solver OBJECT
   $<$<BOOL:${DLAF_WITH_CUDA}>:solver/triangular/gpu.cpp>)
 target_link_libraries(dlaf.solver PUBLIC dlaf.prop)
 target_add_warnings(dlaf.solver)
+
+target_link_libraries(dlaf.eigensolver PUBLIC $<TARGET_OBJECTS:dlaf.factorization>)
+target_link_libraries(dlaf.eigensolver PUBLIC $<TARGET_OBJECTS:dlaf.solver>)
 
 # Define DLAF's complete library
 add_library(DLAF

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(dlaf.eigensolver OBJECT
   eigensolver/band_to_tridiag/mc.cpp
   eigensolver/bt_band_to_tridiag/mc.cpp
   eigensolver/eigensolver/mc.cpp
+  eigensolver/gen_eigensolver/mc.cpp
   eigensolver/gen_to_std/mc.cpp
   $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/gen_to_std/gpu.cpp>
   eigensolver/reduction_to_band/mc.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,9 +152,6 @@ add_library(dlaf.solver OBJECT
 target_link_libraries(dlaf.solver PUBLIC dlaf.prop)
 target_add_warnings(dlaf.solver)
 
-target_link_libraries(dlaf.eigensolver PUBLIC $<TARGET_OBJECTS:dlaf.factorization>)
-target_link_libraries(dlaf.eigensolver PUBLIC $<TARGET_OBJECTS:dlaf.solver>)
-
 # Define DLAF's complete library
 add_library(DLAF
   $<TARGET_OBJECTS:dlaf.core>

--- a/src/eigensolver/eigensolver/mc.cpp
+++ b/src/eigensolver/eigensolver/mc.cpp
@@ -1,0 +1,14 @@
+#include "dlaf/eigensolver/eigensolver/mc.h"
+
+namespace dlaf {
+namespace eigensolver {
+namespace internal {
+
+DLAF_EIGENSOLVER_MC_ETI(, float)
+DLAF_EIGENSOLVER_MC_ETI(, double)
+DLAF_EIGENSOLVER_MC_ETI(, std::complex<float>)
+DLAF_EIGENSOLVER_MC_ETI(, std::complex<double>)
+
+}
+}
+}

--- a/src/eigensolver/gen_eigensolver/mc.cpp
+++ b/src/eigensolver/gen_eigensolver/mc.cpp
@@ -1,0 +1,14 @@
+#include "dlaf/eigensolver/gen_eigensolver/impl.h"
+
+namespace dlaf {
+namespace eigensolver {
+namespace internal {
+
+DLAF_EIGENSOLVER_GEN_ETI(, Backend::MC, Device::CPU, float)
+DLAF_EIGENSOLVER_GEN_ETI(, Backend::MC, Device::CPU, double)
+DLAF_EIGENSOLVER_GEN_ETI(, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_EIGENSOLVER_GEN_ETI(, Backend::MC, Device::CPU, std::complex<double>)
+
+}
+}
+}

--- a/src/eigensolver/reduction_to_band/mc.cpp
+++ b/src/eigensolver/reduction_to_band/mc.cpp
@@ -8,7 +8,6 @@ DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, float)
 DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, double)
 DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, std::complex<float>)
 DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, std::complex<double>)
-
 }
 }
 }

--- a/src/eigensolver/reduction_to_band/mc.cpp
+++ b/src/eigensolver/reduction_to_band/mc.cpp
@@ -4,10 +4,10 @@ namespace dlaf {
 namespace eigensolver {
 namespace internal {
 
-DLAF_EIGENSOLVER_MC_ETI(, float)
-DLAF_EIGENSOLVER_MC_ETI(, double)
-DLAF_EIGENSOLVER_MC_ETI(, std::complex<float>)
-DLAF_EIGENSOLVER_MC_ETI(, std::complex<double>)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, float)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, double)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, std::complex<float>)
+DLAF_EIGENSOLVER_RED_TO_BAND_MC_ETI(, std::complex<double>)
 
 }
 }

--- a/test/include/dlaf_test/comm_grids/grids_6_ranks.h
+++ b/test/include/dlaf_test/comm_grids/grids_6_ranks.h
@@ -70,6 +70,5 @@ struct TestWithCommGrids : public ::testing::Test {
     return comm_grids;
   }
 };
-
 }
 }

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -25,7 +25,13 @@ DLAF_addTest(test_bt_band_to_tridiag
 DLAF_addTest(test_eigensolver
   SOURCES test_eigensolver.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
-  USE_MAIN HPX
+  USE_MAIN PIKA
+)
+
+DLAF_addTest(test_gen_eigensolver
+  SOURCES test_gen_eigensolver.cpp
+  LIBRARIES dlaf.eigensolver dlaf.core
+  USE_MAIN PIKA
 )
 
 DLAF_addTest(test_gen_to_std

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -12,31 +12,31 @@ add_subdirectory(mc)
 
 DLAF_addTest(test_band_to_tridiag
   SOURCES test_band_to_tridiag.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN PIKA
 )
 
 DLAF_addTest(test_bt_band_to_tridiag
   SOURCES test_bt_band_to_tridiag.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN PIKA
 )
 
 DLAF_addTest(test_eigensolver
   SOURCES test_eigensolver.cpp
-  LIBRARIES dlaf.eigensolver dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN PIKA
 )
 
 DLAF_addTest(test_gen_eigensolver
   SOURCES test_gen_eigensolver.cpp
-  LIBRARIES dlaf.eigensolver dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN PIKA
 )
 
 DLAF_addTest(test_gen_to_std
   SOURCES test_gen_to_std.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -22,6 +22,12 @@ DLAF_addTest(test_bt_band_to_tridiag
   USE_MAIN PIKA
 )
 
+DLAF_addTest(test_eigensolver
+  SOURCES test_eigensolver.cpp
+  LIBRARIES dlaf.eigensolver dlaf.core
+  USE_MAIN HPX
+)
+
 DLAF_addTest(test_gen_to_std
   SOURCES test_gen_to_std.cpp
   LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.core

--- a/test/unit/eigensolver/mc/CMakeLists.txt
+++ b/test/unit/eigensolver/mc/CMakeLists.txt
@@ -10,14 +10,14 @@
 
 DLAF_addTest(test_backtransformation
   SOURCES test_backtransformation.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
 
 DLAF_addTest(test_reduction_to_band
   SOURCES test_reduction_to_band.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.core
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -1,0 +1,98 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#include "dlaf/eigensolver/eigensolver.h"
+
+#include <functional>
+#include <tuple>
+#include "gtest/gtest.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf_test/matrix/matrix_local.h"
+#include "dlaf_test/matrix/util_matrix.h"
+#include "dlaf_test/matrix/util_matrix_local.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::comm;
+using namespace dlaf::matrix;
+using namespace dlaf::matrix::test;
+using namespace dlaf::test;
+using namespace testing;
+
+template <typename Type>
+class EigensolverTestMC : public ::testing::Test {};
+TYPED_TEST_SUITE(EigensolverTestMC, MatrixElementTypes);
+
+const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower});
+
+const std::vector<std::tuple<SizeType, SizeType>> sizes = {
+    //    {0, 2},                              // m = 0
+    {5, 8}, {34, 34},                    // m <= mb
+    {4, 3}, {16, 10}, {34, 13}, {32, 5}  // m > mb
+};
+
+template <class T, Backend B, Device D>
+void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb) {
+  const LocalElementSize size(m, m);
+  const TileElementSize block_size(mb, mb);
+
+  Matrix<const T, Device::CPU> reference = [&]() {
+    Matrix<T, Device::CPU> reference(size, block_size);
+    matrix::util::set_random_hermitian(reference);
+    return reference;
+  }();
+
+  Matrix<T, D> mat_a(reference.distribution());
+  copy(reference, mat_a);
+
+  auto ret = eigensolver::eigensolver<B>(uplo, mat_a);
+
+  auto mat_a_local = allGather(lapack::MatrixType::General, reference);
+  auto mat_e_local = allGather(lapack::MatrixType::General, ret.eigenvectors);
+
+  MatrixLocal<T> workspace({m, m}, block_size);
+
+  // Check eigenvectors orthogonality (E^H E == Id)
+  blas::gemm(blas::Layout::ColMajor, blas::Op::ConjTrans, blas::Op::NoTrans, m, m, m, T{1},
+             mat_e_local.ptr(), mat_e_local.ld(), mat_e_local.ptr(), mat_e_local.ld(), T{0},
+             workspace.ptr(), workspace.ld());
+
+  auto id = [](GlobalElementIndex index) {
+    if (index.row() == index.col())
+      return T{1};
+    return T{0};
+  };
+  CHECK_MATRIX_NEAR(id, workspace, m * TypeUtilities<T>::error, 10 * m * TypeUtilities<T>::error);
+
+  // Check Ax = lambda x
+  // Compute A E
+  blas::hemm(blas::Layout::ColMajor, blas::Side::Left, uplo, m, m, T{1}, mat_a_local.ptr(),
+             mat_a_local.ld(), mat_e_local.ptr(), mat_e_local.ld(), T{0}, workspace.ptr(),
+             workspace.ld());
+
+  // Compute Lambda E (in place in mat_e_local)
+  for (SizeType j = 0; j < m; ++j) {
+    blas::scal(m, ret.eigenvalues[j], mat_e_local.ptr({0, j}), 1);
+  }
+
+  // Check A E == Lambda E
+  auto res = [&mat_e_local](GlobalElementIndex index) { return mat_e_local(index); };
+  CHECK_MATRIX_NEAR(res, workspace, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
+}
+
+TYPED_TEST(EigensolverTestMC, CorrectnessLocal) {
+  SizeType m, mb;
+
+  for (auto uplo : blas_uplos) {
+    for (auto sz : sizes) {
+      std::tie(m, mb) = sz;
+      testEigensolver<TypeParam, Backend::MC, Device::CPU>(uplo, m, mb);
+    }
+  }
+}

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -87,11 +87,9 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb)
 }
 
 TYPED_TEST(EigensolverTestMC, CorrectnessLocal) {
-  SizeType m, mb;
-
   for (auto uplo : blas_uplos) {
     for (auto sz : sizes) {
-      std::tie(m, mb) = sz;
+      const auto& [m, mb] = sz;
       testEigensolver<TypeParam, Backend::MC, Device::CPU>(uplo, m, mb);
     }
   }

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -86,7 +86,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb)
 
   // Check A E == Lambda E
   auto res = [&mat_e_local](GlobalElementIndex index) { return mat_e_local(index); };
-  CHECK_MATRIX_NEAR(res, workspace, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
+  CHECK_MATRIX_NEAR(res, workspace, 2 * m * TypeUtilities<T>::error, 2 * m * TypeUtilities<T>::error);
 }
 
 TYPED_TEST(EigensolverTestMC, CorrectnessLocal) {

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -32,7 +32,7 @@ TYPED_TEST_SUITE(EigensolverTestMC, MatrixElementTypes);
 const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower});
 
 const std::vector<std::tuple<SizeType, SizeType>> sizes = {
-    //    {0, 2},                              // m = 0
+    {0, 2},                              // m = 0
     {5, 8}, {34, 34},                    // m <= mb
     {4, 3}, {16, 10}, {34, 13}, {32, 5}  // m > mb
 };
@@ -52,6 +52,9 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb)
   copy(reference, mat_a);
 
   auto ret = eigensolver::eigensolver<B>(uplo, mat_a);
+
+  if (mat_a.size().isEmpty())
+    return;
 
   auto mat_a_local = allGather(lapack::MatrixType::General, reference);
   auto mat_e_local = allGather(lapack::MatrixType::General, ret.eigenvectors);

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -101,11 +101,9 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
 }
 
 TYPED_TEST(GenEigensolverTestMC, CorrectnessLocal) {
-  SizeType m, mb;
-
   for (auto uplo : blas_uplos) {
     for (auto sz : sizes) {
-      std::tie(m, mb) = sz;
+      const auto& [m, mb] = sz;
       testGenEigensolver<TypeParam, Backend::MC, Device::CPU>(uplo, m, mb);
     }
   }

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -32,7 +32,7 @@ TYPED_TEST_SUITE(GenEigensolverTestMC, MatrixElementTypes);
 const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower});
 
 const std::vector<std::tuple<SizeType, SizeType>> sizes = {
-    //    {0, 2},                              // m = 0
+    {0, 2},                              // m = 0
     {5, 8}, {34, 34},                    // m <= mb
     {4, 3}, {16, 10}, {34, 13}, {32, 5}  // m > mb
 };
@@ -60,6 +60,9 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
   copy(reference_b, mat_b);
 
   auto ret = eigensolver::genEigensolver<B>(uplo, mat_a, mat_b);
+
+  if (mat_a.size().isEmpty())
+    return;
 
   auto mat_a_local = allGather(lapack::MatrixType::General, reference_a);
   auto mat_b_local = allGather(lapack::MatrixType::General, reference_b);


### PR DESCRIPTION
This is what @rasolca worked on few months ago when we tested the (almost) full pipeline for both generalized and standard eigensolver.

This PR adds the implementation of them together with their tests.

- [x] Fix test (it seems a matter of numeric error allowed)
- [x] Add documentation

I will highlight a couple of things inline that may be worth being commented and discussed.

Changelog:
- ReductionToBand API was not coherent with its backtransform: now both deals with `common::internal::vector<shared_future<common::internal::vector<T>>>`