### PR TITLE
Panel sub-tile improvements

### DIFF
--- a/include/dlaf/eigensolver/reduction_to_band/mc.h
+++ b/include/dlaf/eigensolver/reduction_to_band/mc.h
@@ -736,9 +736,10 @@ std::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<
   taus.reserve(to_sizet(nblocks));
 
   constexpr std::size_t n_workspaces = 2;
-  common::RoundRobin<PanelT<Coord::Col, T>> panels_v(n_workspaces, dist);
-  common::RoundRobin<PanelT<Coord::Col, T>> panels_w(n_workspaces, dist);
-  common::RoundRobin<PanelT<Coord::Col, T>> panels_x(n_workspaces, dist);
+  using common::RoundRobin;
+  RoundRobin<PanelT<Coord::Col, T>> panels_v(n_workspaces, dist, GlobalTileIndex(0, 0), band_size);
+  RoundRobin<PanelT<Coord::Col, T>> panels_w(n_workspaces, dist, GlobalTileIndex(0, 0), band_size);
+  RoundRobin<PanelT<Coord::Col, T>> panels_x(n_workspaces, dist, GlobalTileIndex(0, 0), band_size);
 
   for (SizeType j_sub = 0; j_sub < nblocks; ++j_sub) {
     const auto i_sub = j_sub + 1;


### PR DESCRIPTION
This is a fork of #456, with a change proposal for improving Panel when dealing with sub-tile.
Discussion started from https://github.com/eth-cscs/DLA-Future/pull/456#discussion_r802942287.

Mainly, it avoids allocating full-tiles even when it is known it will work with sub-tiles.

Before merging:
- [ ] Add doc for new Panel constructor
- [ ] Additional check for avoiding `splitTile` if first global tile is a "full sub-tile"