### PR TITLE
Panel: add setRangeStart for non-tile aligned offset

### DIFF
--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -26,6 +26,7 @@
 #include "dlaf/factorization/cholesky/api.h"
 #include "dlaf/lapack/tile.h"
 #include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/panel.h"
 #include "dlaf/matrix/tile.h"
@@ -205,7 +206,7 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
     auto& panel = panels.nextResource();
     auto& panelT = panelsT.nextResource();
 
-    panel.setRangeStart({kt, kt});
+    panel.setRangeStart(GlobalTileIndex(kt, kt));
 
     if (kk_rank.col() == this_rank.col()) {
       const LocalTileIndex diag_wp_idx{0, distr.localTileFromGlobalTile<Coord::Col>(k)};
@@ -348,7 +349,7 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
     auto& panel = panels.nextResource();
     auto& panelT = panelsT.nextResource();
 
-    panel.setRangeStart({kt, kt});
+    panel.setRangeStart(GlobalTileIndex(kt, kt));
 
     if (kk_rank.row() == this_rank.row()) {
       const LocalTileIndex diag_wp_idx{distr.localTileFromGlobalTile<Coord::Row>(k), 0};

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -69,7 +69,7 @@ struct Panel<axis, const T, D> {
     return dist_matrix_.rankIndex();
   }
 
-  /// Return the Distribution of the parent matrix
+  /// Return Distribution used for construction
   auto parentDistribution() const noexcept {
     return dist_matrix_;
   }
@@ -331,15 +331,18 @@ protected:
     return {std::move(dist_internal), layout};
   }
 
-  /// Create a Panel related to the Matrix passed as parameter.
+  /// Create a Panel related to Matrix represented by given Distribution.
   ///
-  /// The Panel is strictly related to its parent dlaf::Matrix.
-  /// In particular, it will create a Row or Column with the same size of its parent matrix (local),
-  /// considering the specified offset from the top left origin.
+  /// The Panel is strictly related to its parent Matrix via its @p dist_matrix.
+  /// In particular, it will be created as a Row or Column (1st axis) with:
+  /// - 1st axis size, same as @p dist_matrix, taking into account @p start offset
+  /// - 2nd axis size, same as blocksize (on the same axis) of @p dist_matrix
   ///
-  /// e.g. a 4x5 matrix with an offset 2x1 will have either:
-  /// - a Panel<Col> 2x1
-  /// - or a Panel<Row> 4x1
+  /// e.g.
+  /// A (38, 15) matrix is distributed over (4, 5) tiles, with blocksize (10, 3).
+  /// Using above distribution, together with a (2, 1) start offset results in either:
+  /// - Panel<Col>: (18,  3) with (2, 1) tiles,
+  /// - Panel<Row>: (10, 12) with (1, 4) tiles,
   Panel(matrix::Distribution dist_matrix, GlobalTileIndex start)
       : dist_matrix_(dist_matrix), data_(setupInternalMatrix(dist_matrix, start)) {
     DLAF_ASSERT_HEAVY(data_.nrTiles().get(axis) == 1, data_.nrTiles());

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -64,12 +64,12 @@ bool doesThisRankOwnsJustIncomplete(const matrix::Distribution& dist) {
 struct config_t {
   const GlobalElementSize sz;
   const TileElementSize blocksz;
-  const GlobalTileIndex offset = {0, 0};
+  const GlobalTileIndex offset;
 };
 
 std::vector<config_t> test_params{
-    {{0, 0}, {3, 3}},  // empty matrix
-    {{8, 5}, {3, 3}},
+    {{0, 0}, {3, 3}, {0, 0}},  // empty matrix
+    {{8, 5}, {3, 3}, {0, 0}},
     {{26, 13}, {3, 3}, {1, 2}},
 };
 


### PR DESCRIPTION
This change is extracted from the work going on in #456 with sub-tiles, for which it is needed.

In particular, for what concerns the Panel, the sub-tile requires that:
- first global tile of the panel may be incomplete due to a sub-tile offset;
- panel size along axis dimension has to be "constrained" to sub-tile size;

This PR targets just the first point, since for the second one the choice has been to exploit the non-strictness of the API.

We used to give the actual Distribution of the matrix which the panel supports to construct it. Now, in order to work with sub-tiles, we will pass a Distribution object created ad-hoc, with a blocksize customized to represent the sub-tile size.

It is a **TEMPORARY SOLUTION**, because it will be problematic with the distributed version (e.g. panel transposed broadcast). Anyway the plan is to fix it later when we will address it, so that now we can prioritize the completion of the local version.

- [x] Add documentation