### PR TITLE
algo: backtransform tridiagonal to band, adaptation to sub-band

### DIFF
--- a/include/dlaf/eigensolver/bt_band_to_tridiag.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag.h
@@ -17,7 +17,7 @@
 namespace dlaf::eigensolver {
 
 // Eigenvalue back-transformation implementation on local memory, which applies the inverse of the
-// transformation used to get a tridiagonal matrix from band one.
+// transformation used to get a tridiagonal matrix from a band one.
 //
 // It computes E -= V T V* E, applying to a general matrix E the inverse of the transformation described
 // by the reflectors in V (block-wise, so T represents the T factor which embeds the information about
@@ -40,9 +40,17 @@ namespace dlaf::eigensolver {
 //
 // @param mat_hh matrix containing reflectors together with taus (compact form see representation above)
 // @param mat_e matrix to which the inverse transformation is applied to
+// @param band_size size of the reflectors (normal one, not constrained by any matrix size limit)
+// @pre mat_hh has a square size
+// @pre mat_hh has a square block size
+// @pre mat_e and mat_hh share the same number of rows
+// @pre mat_e block size and mat_hh block size share the same number of rows
+// @pre band_size is a divisor of mat_hh.blockSize().cols()
+// @pre mat_e is not distributed
+// @pre mat_hh is not distributed
 template <Backend backend, Device device, class T>
 void backTransformationBandToTridiag(matrix::Matrix<T, device>& mat_e,
-                                     matrix::Matrix<const T, device>& mat_hh) {
+                                     matrix::Matrix<const T, device>& mat_hh, const SizeType band_size) {
   DLAF_ASSERT(matrix::local_matrix(mat_e), mat_e);
   DLAF_ASSERT(matrix::local_matrix(mat_hh), mat_hh);
 
@@ -52,6 +60,8 @@ void backTransformationBandToTridiag(matrix::Matrix<T, device>& mat_e,
   DLAF_ASSERT(mat_hh.size().rows() == mat_e.size().rows(), mat_hh, mat_e);
   DLAF_ASSERT(mat_hh.blockSize().rows() == mat_e.blockSize().rows(), mat_hh, mat_e);
 
-  internal::BackTransformationT2B<backend, device, T>::call(mat_e, mat_hh);
+  DLAF_ASSERT(mat_hh.blockSize().rows() % band_size == 0, mat_hh.blockSize(), band_size);
+
+  internal::BackTransformationT2B<backend, device, T>::call(mat_e, mat_hh, band_size);
 }
 }

--- a/include/dlaf/eigensolver/bt_band_to_tridiag.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag.h
@@ -49,8 +49,8 @@ namespace dlaf::eigensolver {
 // @pre mat_e is not distributed
 // @pre mat_hh is not distributed
 template <Backend backend, Device device, class T>
-void backTransformationBandToTridiag(matrix::Matrix<T, device>& mat_e,
-                                     matrix::Matrix<const T, device>& mat_hh, const SizeType band_size) {
+void backTransformationBandToTridiag(const SizeType band_size, matrix::Matrix<T, device>& mat_e,
+                                     matrix::Matrix<const T, device>& mat_hh) {
   DLAF_ASSERT(matrix::local_matrix(mat_e), mat_e);
   DLAF_ASSERT(matrix::local_matrix(mat_hh), mat_hh);
 
@@ -62,6 +62,6 @@ void backTransformationBandToTridiag(matrix::Matrix<T, device>& mat_e,
 
   DLAF_ASSERT(mat_hh.blockSize().rows() % band_size == 0, mat_hh.blockSize(), band_size);
 
-  internal::BackTransformationT2B<backend, device, T>::call(mat_e, mat_hh, band_size);
+  internal::BackTransformationT2B<backend, device, T>::call(band_size, mat_e, mat_hh);
 }
 }

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -195,11 +195,11 @@ struct TileAccessHelper {
 
     if (acrossTiles_) {
       const auto part0_nrows = b - 1;
-      part_top_ = part_t(sub_offset.row() + 1, part0_nrows, nrefls);
-      part_bottom_ = part_t(0, std::min(b, rows_below - b), nrefls, part0_nrows);
+      part_top_ = Part(sub_offset.row() + 1, part0_nrows, nrefls);
+      part_bottom_ = Part(0, std::min(b, rows_below - b), nrefls, part0_nrows);
     }
     else {
-      part_top_ = part_t(sub_offset.row() + 1, std::min(fullsize, rows_below - 1), nrefls);
+      part_top_ = Part(sub_offset.row() + 1, std::min(fullsize, rows_below - 1), nrefls);
     }
   };
 
@@ -228,11 +228,11 @@ struct TileAccessHelper {
   }
 
 private:
-  struct part_t {
+  struct Part {
     // Create an "empty" part
-    part_t() = default;
+    Part() = default;
 
-    part_t(const SizeType origin, const SizeType nrows, const SizeType nrefls, const SizeType offset = 0)
+    Part(const SizeType origin, const SizeType nrows, const SizeType nrefls, const SizeType offset = 0)
         : origin_(origin), nrows_(nrows), nrefls_(nrefls), offset_(offset) {}
 
     // Return the number of rows that this part involves
@@ -261,8 +261,8 @@ private:
   matrix::SubTileSpec input_spec_;
 
   bool acrossTiles_;
-  part_t part_top_;
-  part_t part_bottom_;
+  Part part_top_;
+  Part part_bottom_;
 };
 }
 

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -247,6 +247,10 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::
   if (mat_hh.size().isEmpty() || mat_e.size().isEmpty())
     return;
 
+  // Note: if no householder reflectors are going to be applied (in case of trivial matrix)
+  if (mat_hh.size().rows() <= (dlaf::isComplex_v<T> ? 1 : 2))
+    return;
+
   const SizeType b = band_size;
   const SizeType nsweeps = nrSweeps<T>(mat_hh.size().cols());
 
@@ -267,9 +271,7 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::
   //               0 0 0 d
   const TileElementSize w_tile_sz(2 * b - 1, b);
 
-  // TODO optimize allocated space for w
   const SizeType dist_w_rows = [&]() { return mat_e.nrTiles().rows() * w_tile_sz.rows(); }();
-
   const matrix::Distribution dist_w({dist_w_rows, b}, w_tile_sz);
   const matrix::Distribution dist_t({mat_hh.size().rows(), b}, {b, b});
   const matrix::Distribution dist_w2({b, mat_e.size().cols()}, {b, mat_e.blockSize().cols()});

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -167,10 +167,6 @@ struct Helper {
         parts_[1] = part_t{std::min(b, mb2), nrefls, 0, b - 1};
       }
     }
-
-    input_spec_ = {sub_offset,
-                   {std::min(b, dist.size().rows() - offset.row()),
-                    std::min(b, dist.size().cols() - offset.col())}};
   };
 
   // Return true if the application of Householder reflectors involves multiple tiles
@@ -271,7 +267,7 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(const SizeType ban
   //               0 0 0 d
   const TileElementSize w_tile_sz(2 * b - 1, b);
 
-  const SizeType dist_w_rows = [&]() { return mat_e.nrTiles().rows() * w_tile_sz.rows(); }();
+  const SizeType dist_w_rows = mat_e.nrTiles().rows() * w_tile_sz.rows();
   const matrix::Distribution dist_w({dist_w_rows, b}, w_tile_sz);
   const matrix::Distribution dist_t({mat_hh.size().rows(), b}, {b, b});
   const matrix::Distribution dist_w2({b, mat_e.size().cols()}, {b, mat_e.blockSize().cols()});

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -250,7 +250,7 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(const SizeType ban
   const SizeType b = band_size;
   const SizeType nsweeps = nrSweeps<T>(mat_hh.size().cols());
 
-  const auto& dist_i = mat_hh.distribution();
+  const auto& dist_hh = mat_hh.distribution();
 
   // Note: w_tile_sz can store reflectors as they are actually applied, opposed to how they are
   // stored in compact form.
@@ -290,14 +290,14 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(const SizeType ban
       const SizeType i = j + step;
 
       const GlobalElementIndex ij_e(i * b, j * b);
-      const LocalTileIndex ij(dist_i.localTileIndex(dist_i.globalTileIndex(ij_e)));
+      const LocalTileIndex ij(dist_hh.localTileIndex(dist_hh.globalTileIndex(ij_e)));
 
       // Note:  reflector with size = 1 must be ignored, except for the last step of the last sweep
       //        with complex type
       const SizeType nrefls = [&]() {
         const bool allowSize1 = isComplex_v<T> && j == j_last_sweep && step == steps - 1;
-        const GlobalElementSize delta(dist_i.size().rows() - ij_e.row() - 1,
-                                      std::min(b, dist_i.size().cols() - ij_e.col()));
+        const GlobalElementSize delta(dist_hh.size().rows() - ij_e.row() - 1,
+                                      std::min(b, dist_hh.size().cols() - ij_e.col()));
         return std::min(b, std::min(delta.rows() - (allowSize1 ? 0 : 1), delta.cols()));
       }();
 

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -45,6 +45,9 @@ pika::shared_future<matrix::Tile<const T, Device::CPU>> setupVWellFormed(
     const SizeType b, pika::shared_future<matrix::Tile<const T, Device::CPU>> tile_i,
     pika::future<matrix::Tile<T, Device::CPU>> tile_v) {
   auto unzipV_func = [b](const auto& tile_i, auto tile_v) {
+    using lapack::lacpy;
+    using lapack::laset;
+
     // Note: the size of of tile_i and tile_v embeds a relevant information about the number of
     // reflecotrs and their max size. This will be exploited to correctly setup the well formed
     // tile with reflectors in place as they will be applied.

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -33,7 +33,8 @@ namespace dlaf::eigensolver::internal {
 
 template <class T>
 struct BackTransformationT2B<Backend::MC, Device::CPU, T> {
-  static void call(Matrix<T, Device::CPU>& mat_e, Matrix<const T, Device::CPU>& mat_hh);
+  static void call(Matrix<T, Device::CPU>& mat_e, Matrix<const T, Device::CPU>& mat_hh,
+                   const SizeType band_size);
 };
 
 template <class T>
@@ -137,7 +138,8 @@ auto updateE(pika::threads::thread_priority priority, WSender&& tile_w, W2Sender
 
 template <class T>
 void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::CPU>& mat_e,
-                                                              Matrix<const T, Device::CPU>& mat_hh) {
+                                                              Matrix<const T, Device::CPU>& mat_hh,
+                                                              const SizeType band_size) {
   static constexpr Backend backend = Backend::MC;
   using pika::threads::thread_priority;
   using pika::execution::experimental::keep_future;
@@ -150,7 +152,7 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::
     return;
 
   const SizeType mb = mat_e.blockSize().rows();
-  const SizeType b = mb;
+  const SizeType b = band_size;
   const SizeType nsweeps = nrSweeps<T>(mat_hh.size().cols());
 
   const auto& dist_i = mat_hh.distribution();

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -36,8 +36,8 @@ namespace dlaf::eigensolver::internal {
 
 template <class T>
 struct BackTransformationT2B<Backend::MC, Device::CPU, T> {
-  static void call(Matrix<T, Device::CPU>& mat_e, Matrix<const T, Device::CPU>& mat_hh,
-                   const SizeType band_size);
+  static void call(const SizeType band_size, Matrix<T, Device::CPU>& mat_e,
+                   Matrix<const T, Device::CPU>& mat_hh);
 };
 
 template <class T>
@@ -233,9 +233,9 @@ private:
 };
 
 template <class T>
-void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::CPU>& mat_e,
-                                                              Matrix<const T, Device::CPU>& mat_hh,
-                                                              const SizeType band_size) {
+void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(const SizeType band_size,
+                                                              Matrix<T, Device::CPU>& mat_e,
+                                                              Matrix<const T, Device::CPU>& mat_hh) {
   static constexpr Backend backend = Backend::MC;
   using pika::threads::thread_priority;
   using pika::execution::experimental::keep_future;

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -109,8 +109,8 @@ pika::shared_future<matrix::Tile<const T, Device::CPU>> computeTFactor(
                         std::move(mat_t));
 }
 
-template <Backend backend, class VSender, class TSender>
-auto computeW(pika::threads::thread_priority priority, VSender&& tile_v, TSender&& tile_t) {
+template <Backend backend, class TSender, class VSender>
+auto computeW(pika::threads::thread_priority priority, TSender&& tile_t, VSender&& tile_v) {
   using namespace blas;
   using T = dlaf::internal::SenderElementType<VSender>;
   dlaf::internal::whenAllLift(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(1),
@@ -392,7 +392,7 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(const SizeType ban
       // finished. T was already a dependency, but W2 wasn't, meaning it won't run in parallel,
       // but it could.
       tile_w_rw = splitTile(tile_w_full, helper.specHH());
-      computeW<backend>(thread_priority::normal, std::move(tile_w_rw), keep_future(tile_t));
+      computeW<backend>(thread_priority::normal, keep_future(tile_t), std::move(tile_w_rw));
       auto tile_w = mat_w.read(ij);
 
       // E -= W . W2

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/mc.h
@@ -21,6 +21,8 @@
 #include "dlaf/common/round_robin.h"
 #include "dlaf/eigensolver/band_to_tridiag/api.h"
 #include "dlaf/eigensolver/bt_band_to_tridiag/api.h"
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/panel.h"
 #include "dlaf/matrix/tile.h"
@@ -39,12 +41,9 @@ struct BackTransformationT2B<Backend::MC, Device::CPU, T> {
 
 template <class T>
 pika::shared_future<matrix::Tile<const T, Device::CPU>> setupVWellFormed(
-    pika::shared_future<matrix::Tile<const T, Device::CPU>> tile_i,
+    const SizeType b, pika::shared_future<matrix::Tile<const T, Device::CPU>> tile_i,
     pika::future<matrix::Tile<T, Device::CPU>> tile_v) {
-  using lapack::lacpy;
-  using lapack::laset;
-
-  auto unzipV_func = [](const auto& tile_i, auto tile_v) {
+  auto unzipV_func = [b](const auto& tile_i, auto tile_v) {
     // Note: the size of of tile_i and tile_v embeds a relevant information about the number of
     // reflecotrs and their max size. This will be exploited to correctly setup the well formed
     // tile with reflectors in place as they will be applied.
@@ -70,9 +69,8 @@ pika::shared_future<matrix::Tile<const T, Device::CPU>> setupVWellFormed(
     // multiplication, i.e. `V . T`, and the gemm `V* . E`, will use V as a general matrix.
     laset(blas::Uplo::Upper, tile_v.size().rows(), k, T(0), T(1), tile_v.ptr({0, 0}), tile_v.ld());
 
-    const SizeType mb = tile_i.size().cols();
-    if (tile_v.size().rows() > mb)
-      laset(blas::Uplo::Lower, tile_v.size().rows() - mb, k - 1, T(0), T(0), tile_v.ptr({mb, 0}),
+    if (tile_v.size().rows() > b)
+      laset(blas::Uplo::Lower, tile_v.size().rows() - b, k - 1, T(0), T(0), tile_v.ptr({b, 0}),
             tile_v.ld());
 
     return matrix::Tile<const T, Device::CPU>(std::move(tile_v));
@@ -136,6 +134,80 @@ auto updateE(pika::threads::thread_priority priority, WSender&& tile_w, W2Sender
       pika::execution::experimental::start_detached();
 }
 
+class Helper {
+  struct part_t {
+    SizeType rows() const noexcept {
+      return nrows_;
+    }
+
+    TileElementIndex origin() const noexcept {
+      return {origin_, 0};
+    }
+
+    TileElementIndex origin_full() const noexcept {
+      return {offset_, 0};
+    }
+
+    SizeType nrows_ = 0;
+    SizeType origin_;
+    SizeType offset_ = 0;
+  };
+
+public:
+  Helper(const SizeType b, matrix::Distribution dist, const GlobalElementIndex offset)
+      : b_(b), dist_(dist), offset_(offset) {
+    const TileElementIndex sub_offset = dist_.tileElementIndex(offset_);
+
+    const SizeType tile_row = dist_.globalTileFromGlobalElement<Coord::Row>(offset_.row());
+    const bool isLastRow = tile_row == dist.nrTiles().rows() - 1;
+
+    const SizeType max_size = dist_.size().rows() - offset_.row() - 1;
+    if (isLastRow && max_size < 2 * b_ - 1) {
+      mode_ = Mode::SINGLE_PART;
+      parts_[0] = part_t{max_size, sub_offset.row() + 1};
+    }
+    else {
+      const SizeType mb = dist.blockSize().rows();
+      if (mb - sub_offset.row() - 1 >= 2 * b_ - 1) {
+        mode_ = Mode::SINGLE_FULL;
+        parts_[0] = part_t{2 * b_ - 1, sub_offset.row() + 1};
+      }
+      else {
+        mode_ = Mode::DOUBLE_FULL;
+        const SizeType mb2 = dist_.size().rows() - offset_.row() - b_;
+        parts_[0] = part_t{b_ - 1, sub_offset.row() + 1};
+        parts_[1] = part_t{std::min(b_, mb2), 0, b_ - 1};
+      }
+    }
+
+    input_spec_ = {sub_offset,
+                   {std::min(b_, dist_.size().rows() - offset_.row()),
+                    std::min(b_, dist_.size().cols() - offset_.col())}};
+  };
+
+  bool isMultiPart() const noexcept {
+    return mode_ == Mode::DOUBLE_FULL;
+  }
+
+  matrix::SubTileSpec inputSpec() const noexcept {
+    return input_spec_;
+  }
+
+  const part_t& operator[](const SizeType index) const noexcept {
+    return parts_[to_sizet(index)];
+  }
+
+private:
+  SizeType b_;
+  matrix::Distribution dist_;
+  GlobalElementIndex offset_;
+
+  matrix::SubTileSpec input_spec_ = {{}, {0, 0}};
+
+  enum class Mode { SINGLE_FULL, DOUBLE_FULL, SINGLE_PART } mode_;
+  std::array<part_t, 2> parts_;
+};
+
 template <class T>
 void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::CPU>& mat_e,
                                                               Matrix<const T, Device::CPU>& mat_hh,
@@ -151,13 +223,12 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::
   if (mat_hh.size().isEmpty() || mat_e.size().isEmpty())
     return;
 
-  const SizeType mb = mat_e.blockSize().rows();
   const SizeType b = band_size;
   const SizeType nsweeps = nrSweeps<T>(mat_hh.size().cols());
 
   const auto& dist_i = mat_hh.distribution();
 
-  // Note: w_tile_sz can store reflectors are they are actually applied, opposed to how they are
+  // Note: w_tile_sz can store reflectors as they are actually applied, opposed to how they are
   // stored in compact form.
   //
   // e.g. Given b = 4
@@ -170,151 +241,91 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::
   //               0 b c d
   //               0 0 c d
   //               0 0 0 d
-
   const TileElementSize w_tile_sz(2 * b - 1, b);
 
-  // Note: The above formula is valid until it meets the constraints imposed by the matrix which
-  // reflectors are applied to. Indeed, `2b-1` means `b-1` rows refers to the current row tile and
-  // `b` elements to the next one.
-  //
-  // For sure last tile will not have room at all for the second part of the formula, because there is no
-  // next tile since it is the last. Moreover, it may not have space for the first part of the formula,
-  // e.g. when matrix size is not a multiple of its blocksize, so its dimension can be tailored according
-  // to the number of reflectors that fits there (considering also the last reflector of size 1 for
-  // complex martrices).
-  //
-  // Additionally, the constraints may affect also the before last tile of W. Indeed, it will have
-  // for sure room for the first part of the formula, but the second part may be limited by the size
-  // of the last tile of E.
-  //
-  // Considering all the cases, it may end up:
-  // - last tile is full (matrix size is a multiple of blocksize), so just this last one is reduced;
-  // - last tile is incomplete, last two tiles are both reduced in size (not the same)
-  //
-  // In this latter case, since the blocksize is fixed for a matrix, we can just limit the size of
-  // the last tile by constraining the size of the matrix containing it. This means that the before
-  // last tile will have a full size even if it will not be fully used, while the last one can be
-  // reduced as needed.
-  //
-  // But, there is one last case: if the last tile of E does not have enough room for applying
-  // reflectors, it will result that in W the last tile will be the one linked with the before last tile
-  // in E, so we can actually reduce its size.
-  const auto last_tile_size =
-      mat_hh.tileSize(indexFromOrigin(mat_hh.nrTiles() - GlobalTileSize{1, 1})).rows();
-  const SizeType last_w_tile_sz = [&]() {
-    const auto last_refl_size = last_tile_size - 1;
-    if (last_refl_size == 1)
-      return isComplex_v<T> ? SizeType(1) : SizeType(0);
-    return std::max<SizeType>(0, last_refl_size);
-  }();
+  // TODO optimize allocated space for w
+  const SizeType dist_w_rows = [&]() { return mat_e.nrTiles().rows() * w_tile_sz.rows(); }();
 
-  const SizeType dist_w_rows = [&]() {
-    if (last_w_tile_sz != 0)
-      return (mat_e.nrTiles().rows() - 1) * w_tile_sz.rows() + last_w_tile_sz;
-    return (mat_e.nrTiles().rows() - 2) * w_tile_sz.rows() + (b - 1) + last_tile_size;
-  }();
-
-  const matrix::Distribution dist_w({dist_w_rows, w_tile_sz.cols()}, w_tile_sz, dist_i.commGridSize(),
-                                    dist_i.rankIndex(), dist_i.sourceRankIndex());
+  const matrix::Distribution dist_w({dist_w_rows, b}, w_tile_sz);
+  const matrix::Distribution dist_t({mat_hh.size().rows(), b}, {b, b});
+  const matrix::Distribution dist_w2({b, mat_e.size().cols()}, {b, mat_e.blockSize().cols()});
 
   constexpr std::size_t n_workspaces = 2;
-  RoundRobin<Panel<Coord::Col, T, Device::CPU>> t_panels(n_workspaces, mat_hh.distribution());
+  RoundRobin<Panel<Coord::Col, T, Device::CPU>> t_panels(n_workspaces, dist_t);
   RoundRobin<Panel<Coord::Col, T, Device::CPU>> w_panels(n_workspaces, dist_w);
-  RoundRobin<Panel<Coord::Row, T, Device::CPU>> w2_panels(n_workspaces, mat_e.distribution());
+  RoundRobin<Panel<Coord::Row, T, Device::CPU>> w2_panels(n_workspaces, dist_w2);
 
   // Note: sweep are on diagonals, steps are on verticals
-  const SizeType j_last_sweep = (nsweeps - 1) / mb;
+  const SizeType j_last_sweep = (nsweeps - 1) / b;
   for (SizeType j = j_last_sweep; j >= 0; --j) {
     auto& mat_w = w_panels.nextResource();
     auto& mat_t = t_panels.nextResource();
     auto& mat_w2 = w2_panels.nextResource();
 
     // Note: apply the entire column (steps)
-    const SizeType steps = nrStepsForSweep(j * mb, mat_hh.size().cols(), mb);
+    const SizeType steps = nrStepsForSweep(j * b, mat_hh.size().cols(), b);
     for (SizeType step = 0; step < steps; ++step) {
       const SizeType i = j + step;
-      const LocalTileIndex ij_refls(i, j);
 
-      const bool affectsTwoRows = i < (mat_hh.nrTiles().rows() - 1);
+      const GlobalElementIndex ij_e(i * b, j * b);
+      const LocalTileIndex ij(dist_i.localTileIndex(dist_i.globalTileIndex(ij_e)));
 
-      // Note: Since the band is of size (mb + 1), in order to tridiagonalize the matrix,
-      // reflectors are of length mb and start with an offset of 1. This means that the application
-      // of the reflector involves multiple tiles.
-      //
-      // e.g. mb = 4
-      // reflectors   matrix
-      //              X X X X
-      // 1 0 0 0      X X X X
-      // a 1 0 0      X X X X
-      // a b 1 0      X X X X
-      //              -------
-      // a b c 1      Y Y Y Y
-      // 0 b c d      Y Y Y Y
-      // 0 0 c d      Y Y Y Y
-      // 0 0 0 d      Y Y Y Y
-      //
-      // From the drawing above, it is possible to see the dashed tile separation between X and Y,
-      // and how the reflectors on the left are going to be applied. In particular, the first row of
-      // the upper tile is not afftected.
-      //
-      // For this reason, we pre-compute the size of the upper and lower (in case there is one) tiles,
-      // together with the size of the tile of the refelctors (v_rows), that as depicted above it
-      // has a different blocksize (no dashed line, it's a single tile)
-      const std::array<SizeType, 2> sizes{
-          mat_hh.tileSize({i, j}).rows() - 1,
-          affectsTwoRows ? mat_hh.tileSize({i + 1, j}).rows() : 0,
-      };
-      const SizeType v_rows = sizes[0] + sizes[1];
+      const Helper helper(b, mat_hh.distribution(), ij_e);
+      const SizeType v_rows = helper[0].rows() + helper[1].rows();
 
       // Note: In general a tile contains a reflector per column, but in case there aren't enough
       // rows for storing a reflector whose length is greater than 1, then the number is reduced
       // accordingly. An exception is represented by the last bottom right tile, where the refelctors
       // are all the remaining ones (i.e. there may be a length 1 reflector in complex cases)
-      const SizeType k_refls = (j != j_last_sweep) ? std::min(v_rows - 1, mb) : (nsweeps - j * mb);
+      const SizeType nrefls = (j != j_last_sweep) ? std::min(v_rows - 1, b) : (nsweeps - j * b);
 
-      const matrix::SubTileSpec v_spec{{0, 0}, {v_rows, k_refls}};
-      const matrix::SubTileSpec v_up{{0, 0}, {sizes[0], k_refls}};
-      const matrix::SubTileSpec v_dn{{sizes[0], 0}, {sizes[1], k_refls}};
-
-      if (k_refls < mat_hh.tileSize({i, j}).cols()) {
-        mat_w.setWidth(k_refls);
-        mat_t.setWidth(k_refls);
-        mat_w2.setHeight(k_refls);
+      if (nrefls < b) {
+        mat_w.setWidth(nrefls);
+        mat_t.setWidth(nrefls);
+        mat_w2.setHeight(nrefls);
       }
+
+      const matrix::SubTileSpec v_spec{helper[0].origin_full(), {v_rows, nrefls}};
+      const matrix::SubTileSpec v_up{helper[0].origin_full(), {helper[0].rows(), nrefls}};
+      const matrix::SubTileSpec v_dn{helper[1].origin_full(), {helper[1].rows(), nrefls}};
 
       // TODO setRange? it would mean setting the range to a specific tile for each step, and resetting at the end
 
       // Note:
       // Let's use W as a temporary storage for the well formed version of V, which is needed
       // for computing W2 = V . E, and it is also useful for computing T
-      auto tile_w_full = mat_w(ij_refls);
+      auto tile_w_full = mat_w(ij);
       auto tile_w_rw = splitTile(tile_w_full, v_spec);
 
-      const auto& tile_i = mat_hh.read(ij_refls);
-      auto tile_v = setupVWellFormed(tile_i, std::move(tile_w_rw));
+      auto tile_i = splitTile(mat_hh.read(ij), helper.inputSpec());
+      auto tile_v = setupVWellFormed(b, tile_i, std::move(tile_w_rw));
 
       // W2 = V* . E
       // Note:
       // Since the well-formed V is stored in W, we have to use it before W will get overwritten.
       // For this reason W2 is computed before W.
       for (SizeType j_e = 0; j_e < mat_e.nrTiles().cols(); ++j_e) {
-        const auto sz_e = mat_e.tileSize({i, j_e});
-        auto tile_e = mat_e.read(LocalTileIndex(i, j_e));
+        const auto sz_e = mat_e.tileSize({ij.row(), j_e});
+        auto tile_e = mat_e.read(LocalTileIndex(ij.row(), j_e));
 
         computeW2<backend>(thread_priority::normal, keep_future(splitTile(tile_v, v_up)),
-                           keep_future(splitTile(tile_e, {{1, 0}, {sizes[0], sz_e.cols()}})), T(0),
-                           mat_w2.readwrite_sender(LocalTileIndex(0, j_e)));
+                           keep_future(
+                               splitTile(tile_e, {helper[0].origin(), {helper[0].rows(), sz_e.cols()}})),
+                           T(0), mat_w2.readwrite_sender(LocalTileIndex(0, j_e)));
 
-        if (affectsTwoRows)
+        if (helper.isMultiPart()) {
+          auto tile_e = mat_e.read(LocalTileIndex(ij.row() + 1, j_e));
           computeW2<backend>(thread_priority::normal, keep_future(splitTile(tile_v, v_dn)),
-                             mat_e.read_sender(LocalTileIndex(i + 1, j_e)), T(1),
-                             mat_w2.readwrite_sender(LocalTileIndex(0, j_e)));
+                             keep_future(splitTile(tile_e, {helper[1].origin(),
+                                                            {helper[1].rows(), sz_e.cols()}})),
+                             T(1), mat_w2.readwrite_sender(LocalTileIndex(0, j_e)));
+        }
       }
 
       // Note:
       // And we use it also for computing the T factor
-      auto tile_t_full = mat_t(LocalTileIndex(i, 0));
-      auto tile_t = computeTFactor(tile_i, tile_v, splitTile(tile_t_full, {{0, 0}, {k_refls, k_refls}}));
+      auto tile_t_full = mat_t(LocalTileIndex(ij.row(), 0));
+      auto tile_t = computeTFactor(tile_i, tile_v, splitTile(tile_t_full, {{0, 0}, {nrefls, nrefls}}));
 
       // W = V . T
       // Note:
@@ -323,22 +334,27 @@ void BackTransformationT2B<Backend::MC, Device::CPU, T>::call(Matrix<T, Device::
       // but it could.
       tile_w_rw = splitTile(tile_w_full, v_spec);
       computeW<backend>(thread_priority::normal, std::move(tile_w_rw), keep_future(tile_t));
-      auto tile_w = mat_w.read(ij_refls);
+      auto tile_w = mat_w.read(ij);
 
       // E -= W . W2
       for (SizeType j_e = 0; j_e < mat_e.nrTiles().cols(); ++j_e) {
-        const LocalTileIndex idx_e(i, j_e);
-        const auto sz_e = mat_e.tileSize({i, j_e});
+        const LocalTileIndex idx_e(ij.row(), j_e);
+        const auto sz_e = mat_e.tileSize({ij.row(), j_e});
 
         auto tile_e = mat_e(idx_e);
         const auto& tile_w2 = mat_w2.read_sender(idx_e);
 
         updateE<backend>(pika::threads::thread_priority::normal, keep_future(splitTile(tile_w, v_up)),
-                         tile_w2, splitTile(tile_e, {{1, 0}, {sizes[0], sz_e.cols()}}));
+                         tile_w2,
+                         splitTile(tile_e, {helper[0].origin(), {helper[0].rows(), sz_e.cols()}}));
 
-        if (affectsTwoRows)
+        if (helper.isMultiPart()) {
+          auto tile_e = mat_e.readwrite_sender(LocalTileIndex{ij.row() + 1, j_e});
           updateE<backend>(pika::threads::thread_priority::normal, keep_future(splitTile(tile_w, v_dn)),
-                           tile_w2, mat_e.readwrite_sender(LocalTileIndex{i + 1, j_e}));
+                           tile_w2,
+                           keep_future(splitTile(tile_e, {helper[1].origin(),
+                                                          {helper[1].rows(), sz_e.cols()}})));
+        }
       }
 
       mat_t.reset();
@@ -356,5 +372,4 @@ DLAF_EIGENSOLVER_BACKTRANSFORMATION_B2T_MC_ETI(extern, float)
 DLAF_EIGENSOLVER_BACKTRANSFORMATION_B2T_MC_ETI(extern, double)
 DLAF_EIGENSOLVER_BACKTRANSFORMATION_B2T_MC_ETI(extern, std::complex<float>)
 DLAF_EIGENSOLVER_BACKTRANSFORMATION_B2T_MC_ETI(extern, std::complex<double>)
-
 }

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -82,7 +82,7 @@ struct Eigensolver<Backend::MC, Device::CPU, T> {
       //       after the completion of stemr.
     }
 
-    backTransformationBandToTridiag<Backend::MC>(mat_e, ret.hh_reflectors, band_size);
+    backTransformationBandToTridiag<Backend::MC>(band_size, mat_e, ret.hh_reflectors);
     backTransformationReductionToBand<Backend::MC>(band_size, mat_e, mat_a, taus);
 
     return {std::move(w), std::move(mat_e)};

--- a/include/dlaf/eigensolver/eigensolver/mc.h
+++ b/include/dlaf/eigensolver/eigensolver/mc.h
@@ -82,7 +82,7 @@ struct Eigensolver<Backend::MC, Device::CPU, T> {
       //       after the completion of stemr.
     }
 
-    backTransformationBandToTridiag<Backend::MC>(mat_e, ret.hh_reflectors);
+    backTransformationBandToTridiag<Backend::MC>(mat_e, ret.hh_reflectors, band_size);
     backTransformationReductionToBand<Backend::MC>(band_size, mat_e, mat_a, taus);
 
     return {std::move(w), std::move(mat_e)};

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -64,7 +64,7 @@ void computeTaus(const SizeType max_refl_size, const SizeType k, matrix::Tile<T,
 }
 
 struct config_t {
-  const SizeType m, n, mb, nb;
+  const SizeType m, n, mb, nb, b = mb;
 };
 
 std::vector<config_t> configs{
@@ -73,24 +73,35 @@ std::vector<config_t> configs{
 };
 
 template <class T>
-void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb) {
+void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, const SizeType b) {
   Matrix<T, Device::CPU> mat_e({m, n}, {mb, nb});
   set_random(mat_e);
   auto mat_e_local = allGather(blas::Uplo::General, mat_e);
 
-  Matrix<const T, Device::CPU> mat_hh = [m, mb]() {
+  Matrix<const T, Device::CPU> mat_hh = [m, mb, b]() {
     Matrix<T, Device::CPU> mat_hh({m, m}, {mb, mb});
     set_random(mat_hh);
 
-    const auto m = mat_hh.distribution().localNrTiles().cols();
-    for (SizeType j = 0; j < m; ++j) {
-      for (SizeType i = j; i < m; ++i) {
-        const GlobalTileIndex ij(i, j);
-        const bool affectsTwoRows = i < m - 1;
-        const SizeType k = affectsTwoRows ? mat_hh.tileSize(ij).cols() : mat_hh.tileSize(ij).rows() - 2;
+    const auto& dist = mat_hh.distribution();
+
+    for (SizeType j = 0; j < mat_hh.size().cols(); j += b) {
+      for (SizeType i = j; i < mat_hh.size().rows(); i += b) {
+        const GlobalElementIndex ij(i, j);
+
+        const TileElementIndex sub_origin = dist.tileElementIndex(ij);
+        const TileElementSize sub_size(std::min(b, mat_hh.size().rows() - ij.row()),
+                                       std::min(b, mat_hh.size().cols() - ij.col()));
+
+        const SizeType n = std::min(2 * b - 1, mat_hh.size().rows() - ij.row() - 1);
+        const SizeType k = std::min(n - 1, sub_size.cols());
+
         if (k <= 0)
           continue;
-        pika::dataflow(pika::unwrapping(computeTaus<T>), b, k, mat_hh(ij));
+
+        const GlobalTileIndex ij_tile = dist.globalTileIndex(ij);
+        auto tile_v = mat_hh(ij_tile);
+        pika::dataflow(pika::unwrapping(computeTaus<T>), b, k,
+                       splitTile(tile_v, {sub_origin, sub_size}));
       }
     }
 
@@ -99,7 +110,7 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb) {
 
   MatrixLocal<T> mat_hh_local = allGather(blas::Uplo::Lower, mat_hh);
 
-  eigensolver::backTransformationBandToTridiag<Backend::MC>(mat_e, mat_hh);
+  eigensolver::backTransformationBandToTridiag<Backend::MC>(mat_e, mat_hh, b);
 
   if (m == 0 || n == 0)
     return;
@@ -107,12 +118,12 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb) {
   using eigensolver::internal::nrSweeps;
   using eigensolver::internal::nrStepsForSweep;
   for (SizeType sweep = nrSweeps<T>(m) - 1; sweep >= 0; --sweep) {
-    for (SizeType step = nrStepsForSweep(sweep, m, mb) - 1; step >= 0; --step) {
+    for (SizeType step = nrStepsForSweep(sweep, m, b) - 1; step >= 0; --step) {
       const SizeType j = sweep;
-      const SizeType i = j + 1 + step * mb;
+      const SizeType i = j + 1 + step * b;
 
-      const SizeType size = std::min(mb, m - i);
-      const SizeType i_v = (i - 1) / mb * mb;
+      const SizeType size = std::min(b, m - i);
+      const SizeType i_v = (i - 1) / b * b;
 
       T& v_head = *mat_hh_local.ptr({i_v, j});
       const T tau = v_head;
@@ -134,6 +145,6 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb) {
 }
 
 TYPED_TEST(BacktransformationT2BTest, CorrectnessLocal) {
-  for (const auto& [m, n, mb, nb] : configs)
-    testBacktransformation<TypeParam>(m, n, mb, nb);
+  for (const auto& [m, n, mb, nb, b] : configs)
+    testBacktransformation<TypeParam>(m, n, mb, nb, b);
 }

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -150,9 +150,10 @@ TYPED_TEST(BacktransformationT2BTest, CorrectnessLocal) {
 }
 
 std::vector<config_t> configs_subband{
+    {0, 12, 4, 4, 2},
     {12, 12, 4, 4, 2},
-    {12, 12, 6, 6, 2},
-    {11, 11, 6, 6, 3},
+    {12, 25, 6, 3, 2},
+    {11, 13, 6, 4, 2},
 };
 
 TYPED_TEST(BacktransformationT2BTest, CorrectnessLocalSubBand) {

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -148,3 +148,14 @@ TYPED_TEST(BacktransformationT2BTest, CorrectnessLocal) {
   for (const auto& [m, n, mb, nb, b] : configs)
     testBacktransformation<TypeParam>(m, n, mb, nb, b);
 }
+
+std::vector<config_t> configs_subband{
+    {12, 12, 4, 4, 2},
+    {12, 12, 6, 6, 2},
+    {11, 11, 6, 6, 3},
+};
+
+TYPED_TEST(BacktransformationT2BTest, CorrectnessLocalSubBand) {
+  for (const auto& [m, n, mb, nb, b] : configs_subband)
+    testBacktransformation<TypeParam>(m, n, mb, nb, b);
+}

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -68,8 +68,10 @@ struct config_t {
 };
 
 std::vector<config_t> configs{
-    {0, 0, 4, 4}, {12, 12, 4, 4}, {12, 12, 4, 3}, {20, 30, 5, 5}, {20, 30, 5, 6},
-    {8, 8, 3, 3}, {10, 10, 3, 3}, {12, 12, 5, 5}, {12, 30, 5, 6},
+    {0, 0, 4, 4},                                  // empty
+    {1, 1, 4, 4},   {2, 2, 4, 4},   {2, 2, 1, 1},  // edge-cases
+    {12, 12, 4, 4}, {12, 12, 4, 3}, {20, 30, 5, 5}, {20, 30, 5, 6},
+    {8, 8, 3, 3},   {10, 10, 3, 3}, {12, 12, 5, 5}, {12, 30, 5, 6},
 };
 
 template <class T>
@@ -150,10 +152,7 @@ TYPED_TEST(BacktransformationT2BTest, CorrectnessLocal) {
 }
 
 std::vector<config_t> configs_subband{
-    {0, 12, 4, 4, 2},
-    {12, 12, 4, 4, 2},
-    {12, 25, 6, 3, 2},
-    {11, 13, 6, 4, 2},
+    {0, 12, 4, 4, 2}, {4, 4, 4, 4, 2}, {12, 12, 4, 4, 2}, {12, 25, 6, 3, 2}, {11, 13, 6, 4, 2},
 };
 
 TYPED_TEST(BacktransformationT2BTest, CorrectnessLocalSubBand) {

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -112,7 +112,7 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
 
   MatrixLocal<T> mat_hh_local = allGather(blas::Uplo::Lower, mat_hh);
 
-  eigensolver::backTransformationBandToTridiag<Backend::MC>(mat_e, mat_hh, b);
+  eigensolver::backTransformationBandToTridiag<Backend::MC>(b, mat_e, mat_hh);
 
   if (m == 0 || n == 0)
     return;


### PR DESCRIPTION
This PR introduces the possibility to compute the backtransformation from tridiagonal to a band matrix, where the band size is a divisor of the blocksize.

This removes the constraint about having the band size equal to the blocksize, which will be mainly useful with the next GPU version of the algorithm. Indeed, with GPU block sizes will be bigger, but with this it is possible to keep the band size smaller, reducing the overload on the entire eigensolver pipeline.

- [x] Refactor `Helper`, from spaghetti code to something a bit more structured (and add some notes in there)
- [x] Add more test-cases for sub-band
- [x] ~minor: Improve allocation size for W panel (minor optimization)~ it's not worth it
- [x] minor: check tau calculation for complex case

Changelog:
- https://github.com/eth-cscs/DLA-Future/commit/aba53a5c0b1d74ea1f7ccfb2392d6ee5633b9a9c fixes a bug in the test, where tau was computed not using all reflector components (1 less). It didn't affect the test results because there is no check about orthogonality of the result (@rasolca already knew the limitation of this test).