### PR TITLE
algo: Backtransform Tridiagonalization (local GPU/hybrid)

### DIFF
--- a/include/dlaf/eigensolver/bt_band_to_tridiag/api.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/api.h
@@ -20,14 +20,6 @@ struct BackTransformationT2B {
   static void call(const SizeType band_size, Matrix<T, D>& mat_e, Matrix<const T, Device::CPU>& mat_hh);
 };
 
-#ifdef DLAF_WITH_CUDA
-template <class T>
-struct BackTransformationT2B<Backend::GPU, Device::GPU, T> {
-  static void call(const SizeType band_size, Matrix<T, Device::GPU>& mat_e,
-                   Matrix<const T, Device::CPU>& mat_hh);
-};
-#endif
-
 /// ---- ETI
 #define DLAF_EIGENSOLVER_BT_BAND_TO_TRIDIAGONAL_LOCAL_ETI(KWORD, BACKEND, DEVICE, T) \
   KWORD template struct BackTransformationT2B<BACKEND, DEVICE, T>;

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -459,7 +459,8 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
       // At this point W can be overwritten, but this will happen just after W2 and T computations
       // finished. T was already a dependency, but W2 wasn't, meaning it won't run in parallel,
       // but it could.
-      computeW<B>(thread_priority::normal, ex::keep_future(tile_t), splitTile(mat_w(ij), helper.specHH()));
+      computeW<B>(thread_priority::normal, ex::keep_future(tile_t),
+                  splitTile(mat_w(ij), helper.specHH()));
       auto tile_w = mat_w.read(ij);
 
       // E -= W . W2
@@ -476,7 +477,8 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
         if (helper.affectsMultipleTiles()) {
           updateE<B>(pika::threads::thread_priority::normal,
                      ex::keep_future(splitTile(tile_w, helper.bottomPart().specHH())), tile_w2,
-                     splitTile(mat_e(LocalTileIndex{ij.row() + 1, j_e}), helper.bottomPart().specEV(sz_e.cols())));
+                     splitTile(mat_e(LocalTileIndex{ij.row() + 1, j_e}),
+                               helper.bottomPart().specEV(sz_e.cols())));
         }
       }
 

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -261,14 +261,14 @@ private:
 };
 
 template <Backend B, Device D, class T>
-struct Helper;
+struct HHManager;
 
 template <class T>
-struct Helper<Backend::MC, Device::CPU, T> {
+struct HHManager<Backend::MC, Device::CPU, T> {
   static constexpr Backend B = Backend::MC;
   static constexpr Device D = Device::CPU;
 
-  Helper(const SizeType b, const std::size_t, matrix::Distribution, matrix::Distribution) : b(b) {}
+  HHManager(const SizeType b, const std::size_t, matrix::Distribution, matrix::Distribution) : b(b) {}
 
   auto setupVAndComputeT(const LocalTileIndex ij, const SizeType nrefls, const TileAccessHelper& helper,
                          matrix::Matrix<const T, Device::CPU>& mat_hh,
@@ -289,12 +289,12 @@ protected:
 };
 
 template <class T>
-struct Helper<Backend::GPU, Device::GPU, T> {
+struct HHManager<Backend::GPU, Device::GPU, T> {
   static constexpr Backend B = Backend::GPU;
   static constexpr Device D = Device::GPU;
 
-  Helper(const SizeType b, const std::size_t n_workspaces, matrix::Distribution dist_t,
-         matrix::Distribution dist_w)
+  HHManager(const SizeType b, const std::size_t n_workspaces, matrix::Distribution dist_t,
+            matrix::Distribution dist_w)
       : b(b), t_panels_h(n_workspaces, dist_t), w_panels_h(n_workspaces, dist_w) {}
 
   auto setupVAndComputeT(const LocalTileIndex ij, const SizeType nrefls, const TileAccessHelper& helper,
@@ -391,7 +391,7 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
   RoundRobin<Panel<Coord::Col, T, D>> w_panels(n_workspaces, dist_w);
   RoundRobin<Panel<Coord::Row, T, D>> w2_panels(n_workspaces, dist_w2);
 
-  Helper<B, D, T> helperBackend(b, n_workspaces, dist_t, dist_w);
+  HHManager<B, D, T> helperBackend(b, n_workspaces, dist_t, dist_w);
 
   // Note: sweep are on diagonals, steps are on verticals
   const SizeType j_last_sweep = (nsweeps - 1) / b;

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -259,13 +259,98 @@ private:
   Part part_top_;
   Part part_bottom_;
 };
+
+template <Backend B, Device D, class T>
+struct Helper;
+
+template <class T>
+struct Helper<Backend::MC, Device::CPU, T> {
+  static constexpr Backend B = Backend::MC;
+  static constexpr Device D = Device::CPU;
+
+  Helper(const SizeType b, const std::size_t, matrix::Distribution, matrix::Distribution) : b(b) {}
+
+  auto setupVAndComputeT(const LocalTileIndex ij, const SizeType nrefls, const TileAccessHelper& helper,
+                         matrix::Matrix<const T, Device::CPU>& mat_hh,
+                         matrix::Panel<Coord::Col, T, D>& mat_v,
+                         matrix::Panel<Coord::Col, T, D>& mat_t) {
+    auto tile_v_full = mat_v(ij);
+    auto tile_v_rw = splitTile(tile_v_full, helper.specHH());
+
+    auto tile_hh = splitTile(mat_hh.read(ij), helper.specHHCompact());
+    auto tile_v = setupVWellFormed(b, tile_hh, std::move(tile_v_rw));
+
+    auto tile_t_full = mat_t(LocalTileIndex(ij.row(), 0));
+    auto tile_t = computeTFactor(tile_hh, tile_v, splitTile(tile_t_full, {{0, 0}, {nrefls, nrefls}}));
+
+    return std::make_pair(std::move(tile_v), std::move(tile_t));
+  }
+
+protected:
+  const SizeType b;
+};
+
+template <class T>
+struct Helper<Backend::GPU, Device::GPU, T> {
+  static constexpr Backend B = Backend::GPU;
+  static constexpr Device D = Device::GPU;
+
+  Helper(const SizeType b, const std::size_t n_workspaces, matrix::Distribution dist_t,
+         matrix::Distribution dist_w)
+      : b(b), t_panels_h(n_workspaces, dist_t), w_panels_h(n_workspaces, dist_w) {}
+
+  auto setupVAndComputeT(const LocalTileIndex ij, const SizeType nrefls, const TileAccessHelper& helper,
+                         matrix::Matrix<const T, Device::CPU>& mat_hh,
+                         matrix::Panel<Coord::Col, T, D>& mat_v,
+                         matrix::Panel<Coord::Col, T, D>& mat_t) {
+    namespace ex = pika::execution::experimental;
+
+    auto& mat_v_h = w_panels_h.nextResource();
+    auto& mat_t_h = t_panels_h.nextResource();
+
+    auto tile_v_h_full = mat_v_h(ij);
+    auto tile_v_h_rw = splitTile(tile_v_h_full, helper.specHH());
+
+    auto tile_hh = splitTile(mat_hh.read(ij), helper.specHHCompact());
+    auto tile_v_h = setupVWellFormed(b, tile_hh, std::move(tile_v_h_rw));
+
+    auto tile_v_full = mat_v(ij);
+    auto tile_v_rw = splitTile(tile_v_full, helper.specHH());
+
+    dlaf::internal::whenAllLift(ex::keep_future(tile_v_h), std::move(tile_v_rw)) |
+        matrix::copy(dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::CPU, D>>()) |
+        ex::start_detached();
+
+    auto tile_v = splitTile(tile_v_full, helper.specHH());
+
+    auto tile_t_h_full = mat_t_h(LocalTileIndex(ij.row(), 0));
+    auto tile_t_h =
+        computeTFactor(tile_hh, tile_v_h, splitTile(tile_t_h_full, {{0, 0}, {nrefls, nrefls}}));
+
+    auto tile_t_full = mat_t(LocalTileIndex(ij.row(), 0));
+    auto tile_t_rw = splitTile(tile_t_full, {{0, 0}, {nrefls, nrefls}});
+
+    dlaf::internal::whenAllLift(ex::keep_future(tile_t_h), std::move(tile_t_rw)) |
+        matrix::copy(dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::CPU, D>>()) |
+        ex::start_detached();
+
+    auto tile_t = splitTile(mat_t.read(LocalTileIndex(ij.row(), 0)), {{0, 0}, {nrefls, nrefls}});
+
+    return std::make_pair(std::move(tile_v), std::move(tile_t));
+  }
+
+protected:
+  const SizeType b;
+  common::RoundRobin<matrix::Panel<Coord::Col, T, Device::CPU>> t_panels_h;
+  common::RoundRobin<matrix::Panel<Coord::Col, T, Device::CPU>> w_panels_h;
+};
 }
 
 template <Backend B, Device D, class T>
 void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>& mat_e,
                                           Matrix<const T, Device::CPU>& mat_hh) {
   using pika::threads::thread_priority;
-  using pika::execution::experimental::keep_future;
+  namespace ex = pika::execution::experimental;
 
   using matrix::Panel;
   using common::RoundRobin;
@@ -305,9 +390,11 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
   const matrix::Distribution dist_w2({b, mat_e.size().cols()}, {b, mat_e.blockSize().cols()});
 
   constexpr std::size_t n_workspaces = 2;
-  RoundRobin<Panel<Coord::Col, T, Device::CPU>> t_panels(n_workspaces, dist_t);
-  RoundRobin<Panel<Coord::Col, T, Device::CPU>> w_panels(n_workspaces, dist_w);
-  RoundRobin<Panel<Coord::Row, T, Device::CPU>> w2_panels(n_workspaces, dist_w2);
+  RoundRobin<Panel<Coord::Col, T, D>> t_panels(n_workspaces, dist_t);
+  RoundRobin<Panel<Coord::Col, T, D>> w_panels(n_workspaces, dist_w);
+  RoundRobin<Panel<Coord::Row, T, D>> w2_panels(n_workspaces, dist_w2);
+
+  Helper<B, D, T> helperBackend(b, n_workspaces, dist_t, dist_w);
 
   // Note: sweep are on diagonals, steps are on verticals
   const SizeType j_last_sweep = (nsweeps - 1) / b;
@@ -346,11 +433,7 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
       // Note:
       // Let's use W as a temporary storage for the well formed version of V, which is needed
       // for computing W2 = V . E, and it is also useful for computing T
-      auto tile_w_full = mat_w(ij);
-      auto tile_w_rw = splitTile(tile_w_full, helper.specHH());
-
-      auto tile_hh = splitTile(mat_hh.read(ij), helper.specHHCompact());
-      auto tile_v = setupVWellFormed(b, tile_hh, std::move(tile_w_rw));
+      auto [tile_v, tile_t] = helperBackend.setupVAndComputeT(ij, nrefls, helper, mat_hh, mat_w, mat_t);
 
       // W2 = V* . E
       // Note:
@@ -360,30 +443,26 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
         const auto sz_e = mat_e.tileSize({ij.row(), j_e});
         auto tile_e = mat_e.read(LocalTileIndex(ij.row(), j_e));
 
-        computeW2<B>(thread_priority::normal, keep_future(splitTile(tile_v, helper.topPart().specHH())),
-                     keep_future(splitTile(tile_e, helper.topPart().specEV(sz_e.cols()))), T(0),
+        computeW2<B>(thread_priority::normal,
+                     ex::keep_future(splitTile(tile_v, helper.topPart().specHH())),
+                     ex::keep_future(splitTile(tile_e, helper.topPart().specEV(sz_e.cols()))), T(0),
                      mat_w2.readwrite_sender(LocalTileIndex(0, j_e)));
 
         if (helper.affectsMultipleTiles()) {
           auto tile_e = mat_e.read(LocalTileIndex(ij.row() + 1, j_e));
           computeW2<B>(thread_priority::normal,
-                       keep_future(splitTile(tile_v, helper.bottomPart().specHH())),
-                       keep_future(splitTile(tile_e, helper.bottomPart().specEV(sz_e.cols()))), T(1),
+                       ex::keep_future(splitTile(tile_v, helper.bottomPart().specHH())),
+                       ex::keep_future(splitTile(tile_e, helper.bottomPart().specEV(sz_e.cols()))), T(1),
                        mat_w2.readwrite_sender(LocalTileIndex(0, j_e)));
         }
       }
-
-      // Note:
-      // And we use it also for computing the T factor
-      auto tile_t = computeTFactor(tile_hh, tile_v, splitTile(mat_t(ij), {{0, 0}, {nrefls, nrefls}}));
 
       // W = V . T
       // Note:
       // At this point W can be overwritten, but this will happen just after W2 and T computations
       // finished. T was already a dependency, but W2 wasn't, meaning it won't run in parallel,
       // but it could.
-      tile_w_rw = splitTile(tile_w_full, helper.specHH());
-      computeW<B>(thread_priority::normal, keep_future(tile_t), std::move(tile_w_rw));
+      computeW<B>(thread_priority::normal, ex::keep_future(tile_t), splitTile(mat_w(ij), helper.specHH()));
       auto tile_w = mat_w.read(ij);
 
       // E -= W . W2
@@ -394,14 +473,13 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
         const auto& tile_w2 = mat_w2.read_sender(idx_e);
 
         updateE<B>(pika::threads::thread_priority::normal,
-                   keep_future(splitTile(tile_w, helper.topPart().specHH())), tile_w2,
-                   matrix::splitTile(mat_e(idx_e), helper.topPart().specEV(sz_e.cols())));
+                   ex::keep_future(splitTile(tile_w, helper.topPart().specHH())), tile_w2,
+                   splitTile(mat_e(idx_e), helper.topPart().specEV(sz_e.cols())));
 
         if (helper.affectsMultipleTiles()) {
           updateE<B>(pika::threads::thread_priority::normal,
-                     keep_future(splitTile(tile_w, helper.bottomPart().specHH())), tile_w2,
-                     matrix::splitTile(mat_e(LocalTileIndex{ij.row() + 1, j_e}),
-                                       helper.bottomPart().specEV(sz_e.cols())));
+                     ex::keep_future(splitTile(tile_w, helper.bottomPart().specHH())), tile_w2,
+                     splitTile(mat_e(LocalTileIndex{ij.row() + 1, j_e}), helper.bottomPart().specEV(sz_e.cols())));
         }
       }
 
@@ -411,15 +489,5 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
     }
   }
 }
-
-#ifdef DLAF_WITH_CUDA
-template <class T>
-void BackTransformationT2B<Backend::GPU, Device::GPU, T>::call(const SizeType band_size,
-                                                               Matrix<T, Device::GPU>& mat_e,
-                                                               Matrix<const T, Device::CPU>& mat_hh) {
-  dlaf::internal::silenceUnusedWarningFor(band_size, mat_e, mat_hh);
-  DLAF_UNIMPLEMENTED(Backend::GPU);
-}
-#endif
 
 }

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -15,8 +15,8 @@
 #include "dlaf/eigensolver/band_to_tridiag.h"  // for nrSweeps/nrStepsForSweep
 #include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
-#include "dlaf/matrix/tile.h"
 #include "dlaf/matrix/matrix_mirror.h"
+#include "dlaf/matrix/tile.h"
 #include "dlaf/util_matrix.h"
 
 #include "dlaf_test/matrix/matrix_local.h"

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -16,6 +16,7 @@
 #include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/tile.h"
+#include "dlaf/matrix/matrix_mirror.h"
 #include "dlaf/util_matrix.h"
 
 #include "dlaf_test/matrix/matrix_local.h"
@@ -33,7 +34,17 @@ using namespace dlaf::matrix::test;
 template <typename Type>
 class BacktransformationT2BTest : public ::testing::Test {};
 
-TYPED_TEST_SUITE(BacktransformationT2BTest, MatrixElementTypes);
+template <class T>
+using BacktransformationT2BTestMC = BacktransformationT2BTest<T>;
+
+TYPED_TEST_SUITE(BacktransformationT2BTestMC, MatrixElementTypes);
+
+#ifdef DLAF_WITH_CUDA
+template <class T>
+using BacktransformationT2BTestGPU = BacktransformationT2BTest<T>;
+
+TYPED_TEST_SUITE(BacktransformationT2BTestGPU, MatrixElementTypes);
+#endif
 
 // Note: Helper functions for computing the tau of a given reflector. Reflector pointer should
 // point to its 2nd component, i.e. the 1st component equal to 1 is implicitly considered in the
@@ -76,11 +87,11 @@ std::vector<config_t> configs{
     {8, 8, 3, 3},   {10, 10, 3, 3}, {12, 12, 5, 5}, {12, 30, 5, 6},
 };
 
-template <class T>
+template <Backend B, Device D, class T>
 void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, const SizeType b) {
-  Matrix<T, Device::CPU> mat_e({m, n}, {mb, nb});
-  set_random(mat_e);
-  auto mat_e_local = allGather(blas::Uplo::General, mat_e);
+  Matrix<T, Device::CPU> mat_e_h({m, n}, {mb, nb});
+  set_random(mat_e_h);
+  auto mat_e_local = allGather(blas::Uplo::General, mat_e_h);
 
   Matrix<const T, Device::CPU> mat_hh = [m, mb, b]() {
     Matrix<T, Device::CPU> mat_hh({m, m}, {mb, mb});
@@ -113,7 +124,10 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
 
   MatrixLocal<T> mat_hh_local = allGather(blas::Uplo::Lower, mat_hh);
 
-  eigensolver::backTransformationBandToTridiag<Backend::MC>(b, mat_e, mat_hh);
+  {
+    MatrixMirror<T, D, Device::CPU> mat_e(mat_e_h);
+    eigensolver::backTransformationBandToTridiag<B>(b, mat_e.get(), mat_hh);
+  }
 
   if (m == 0 || n == 0)
     return;
@@ -137,26 +151,40 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
     }
   }
 
-  auto result = [&dist = mat_e.distribution(),
+  auto result = [&dist = mat_e_h.distribution(),
                  &mat_local = mat_e_local](const GlobalElementIndex& element) {
     const auto tile_index = dist.globalTileIndex(element);
     const auto tile_element = dist.tileElementIndex(element);
     return mat_local.tile_read(tile_index)(tile_element);
   };
 
-  CHECK_MATRIX_NEAR(result, mat_e, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
+  CHECK_MATRIX_NEAR(result, mat_e_h, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
 }
 
-TYPED_TEST(BacktransformationT2BTest, CorrectnessLocal) {
+TYPED_TEST(BacktransformationT2BTestMC, CorrectnessLocal) {
   for (const auto& [m, n, mb, nb, b] : configs)
-    testBacktransformation<TypeParam>(m, n, mb, nb, b);
+    testBacktransformation<Backend::MC, Device::CPU, TypeParam>(m, n, mb, nb, b);
 }
+
+#ifdef DLAF_WITH_CUDA
+TYPED_TEST(BacktransformationT2BTestGPU, CorrectnessLocal) {
+  for (const auto& [m, n, mb, nb, b] : configs)
+    testBacktransformation<Backend::GPU, Device::GPU, TypeParam>(m, n, mb, nb, b);
+}
+#endif
 
 std::vector<config_t> configs_subband{
     {0, 12, 4, 4, 2}, {4, 4, 4, 4, 2}, {12, 12, 4, 4, 2}, {12, 25, 6, 3, 2}, {11, 13, 6, 4, 2},
 };
 
-TYPED_TEST(BacktransformationT2BTest, CorrectnessLocalSubBand) {
+TYPED_TEST(BacktransformationT2BTestMC, CorrectnessLocalSubBand) {
   for (const auto& [m, n, mb, nb, b] : configs_subband)
-    testBacktransformation<TypeParam>(m, n, mb, nb, b);
+    testBacktransformation<Backend::MC, Device::CPU, TypeParam>(m, n, mb, nb, b);
 }
+
+#ifdef DLAF_WITH_CUDA
+TYPED_TEST(BacktransformationT2BTestGPU, CorrectnessLocalSubBand) {
+  for (const auto& [m, n, mb, nb, b] : configs_subband)
+    testBacktransformation<Backend::GPU, Device::GPU, TypeParam>(m, n, mb, nb, b);
+}
+#endif


### PR DESCRIPTION
Close #474

Implementation of backtransfom tridiagonalization on GPU. It's an hybrid solution with LARFT (computeT) computed on CPU.

Legend:
- RED: CPU related things
- BLU: GPU related things

<img width="343" alt="image" src="https://user-images.githubusercontent.com/9337627/158397229-7ef48daf-306e-44f7-891b-4ed9f16ec65e.png">

TODO:
- [x] Evaluate helper refactoring (there is one for tile access of sub-band and one for gpu/cpu code unification)
- [x] Rename helper
- [x] Cleanup helper code