### PR TITLE
splitTile discard

### DIFF
--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -375,8 +375,7 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
 
       // Note:
       // And we use it also for computing the T factor
-      auto tile_t =
-          computeTFactor(tile_hh, tile_v, splitTileDiscard(mat_t(ij), {{0, 0}, {nrefls, nrefls}}));
+      auto tile_t = computeTFactor(tile_hh, tile_v, splitTile(mat_t(ij), {{0, 0}, {nrefls, nrefls}}));
 
       // W = V . T
       // Note:
@@ -396,13 +395,13 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
 
         updateE<B>(pika::threads::thread_priority::normal,
                    keep_future(splitTile(tile_w, helper.topPart().specHH())), tile_w2,
-                   matrix::splitTileDiscard(mat_e(idx_e), helper.topPart().specEV(sz_e.cols())));
+                   matrix::splitTile(mat_e(idx_e), helper.topPart().specEV(sz_e.cols())));
 
         if (helper.affectsMultipleTiles()) {
           updateE<B>(pika::threads::thread_priority::normal,
                      keep_future(splitTile(tile_w, helper.bottomPart().specHH())), tile_w2,
-                     matrix::splitTileDiscard(mat_e(LocalTileIndex{ij.row() + 1, j_e}),
-                                              helper.bottomPart().specEV(sz_e.cols())));
+                     matrix::splitTile(mat_e(LocalTileIndex{ij.row() + 1, j_e}),
+                                       helper.bottomPart().specEV(sz_e.cols())));
         }
       }
 

--- a/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
@@ -217,9 +217,8 @@ void BackTransformationReductionToBand<backend, device, T>::call(
     for (const auto& ij : mat_c_view.iteratorLocal()) {
       auto ik = LocalTileIndex{ij.row(), k};
       auto kj = LocalTileIndex{k, ij.col()};
-      auto c_ij = mat_c(ij);
       gemmTrailingMatrix<backend>(np, panelV.read_sender(ik), panelW2.read_sender(kj),
-                                  splitTile(c_ij, mat_c_view(ij)));
+                                  splitTileDiscard(mat_c(ij), mat_c_view(ij)));
     }
 
     panelV.reset();

--- a/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
@@ -218,7 +218,7 @@ void BackTransformationReductionToBand<backend, device, T>::call(
       auto ik = LocalTileIndex{ij.row(), k};
       auto kj = LocalTileIndex{k, ij.col()};
       gemmTrailingMatrix<backend>(np, panelV.read_sender(ik), panelW2.read_sender(kj),
-                                  splitTileDiscard(mat_c(ij), mat_c_view(ij)));
+                                  splitTile(mat_c(ij), mat_c_view(ij)));
     }
 
     panelV.reset();

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -285,7 +285,7 @@ pika::shared_future<common::internal::vector<T>> computePanelReflectors(MatrixT<
       to_sizet(std::distance(panel_view.iteratorLocal().begin(), panel_view.iteratorLocal().end())));
   for (const auto& i : panel_view.iteratorLocal()) {
     const matrix::SubTileSpec& spec = panel_view(i);
-    panel_tiles.emplace_back(matrix::splitTileDiscard(mat_a(i), spec));
+    panel_tiles.emplace_back(matrix::splitTile(mat_a(i), spec));
   }
 
   return pika::dataflow(getHpExecutor<Backend::MC>(), std::move(panel_task),

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -285,8 +285,7 @@ pika::shared_future<common::internal::vector<T>> computePanelReflectors(MatrixT<
       to_sizet(std::distance(panel_view.iteratorLocal().begin(), panel_view.iteratorLocal().end())));
   for (const auto& i : panel_view.iteratorLocal()) {
     const matrix::SubTileSpec& spec = panel_view(i);
-    auto tile = mat_a(i);
-    panel_tiles.emplace_back(matrix::splitTile(tile, spec));
+    panel_tiles.emplace_back(matrix::splitTileDiscard(mat_a(i), spec));
   }
 
   return pika::dataflow(getHpExecutor<Backend::MC>(), std::move(panel_task),

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -147,7 +147,7 @@ struct Panel<axis, const T, D> {
 
     start_ = start_idx.get(coord);
     start_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<coord>(start_);
-    offset_element_ = start_ * dist_matrix_.blockSize().get<coord>();
+    offset_element_ = start_ * dist_matrix_.blockSize().template get<coord>();
 
     end_ = end_idx.get(coord);
     end_local_ = dist_matrix_.template nextLocalTileFromGlobalTile<coord>(end_);
@@ -171,7 +171,7 @@ struct Panel<axis, const T, D> {
 
     start_ = start_idx.get(coord);
     start_local_ = dist_matrix_.nextLocalTileFromGlobalTile<coord>(start_);
-    offset_element_ = start_ * dist_matrix_.blockSize().get<coord>();
+    offset_element_ = start_ * dist_matrix_.blockSize().template get<coord>();
 
     DLAF_ASSERT(rangeStartLocal() >= bias_ && rangeStart() <= rangeEnd(), rangeStart(), rangeEnd(),
                 bias_);

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -454,6 +454,20 @@ pika::future<Tile<T, D>> splitTile(pika::future<Tile<T, D>>& tile, const SubTile
   return internal::createSubTile(old_tile, spec);
 }
 
+/// Create a writeable subtile of a given tile, without replacing given tile with the (full) tile
+/// that will come after the subtile will go out of scope.
+///
+/// The returned subtile will get ready, when the original tile was supposed to get ready.
+/// The next dependency in the dependency chain will become ready only when @p tile goes out of scope.
+template <class T, Device D>
+pika::future<Tile<T, D>> splitTileDiscard(pika::future<Tile<T, D>> tile, const SubTileSpec& spec) {
+  auto old_tile = internal::splitTileInsertFutureInChain(tile);
+  // tile is now the new element of the dependency chain which will be ready
+  // when the subtile will go out of scope.
+
+  return internal::createSubTile(old_tile, spec);
+}
+
 /// Create a writeable subtile of a given tile.
 ///
 /// All the returned subtiles will get ready, when the original tile was supposed to get ready

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -454,18 +454,16 @@ pika::future<Tile<T, D>> splitTile(pika::future<Tile<T, D>>& tile, const SubTile
   return internal::createSubTile(old_tile, spec);
 }
 
-/// Create a writeable subtile of a given tile, without replacing given tile with the (full) tile
-/// that will come after the subtile will go out of scope.
+/// Create a writeable subtile of a given tile.
 ///
 /// The returned subtile will get ready, when the original tile was supposed to get ready.
-/// The next dependency in the dependency chain will become ready only when @p tile goes out of scope.
+/// This variant does not provide access to the (full) tile which will get ready when the subtile goes
+/// out of scope.
+/// The next dependency in the dependency chain will become ready only when @p tile goes
+/// out of scope.
 template <class T, Device D>
-pika::future<Tile<T, D>> splitTileDiscard(pika::future<Tile<T, D>> tile, const SubTileSpec& spec) {
-  auto old_tile = internal::splitTileInsertFutureInChain(tile);
-  // tile is now the new element of the dependency chain which will be ready
-  // when the subtile will go out of scope.
-
-  return internal::createSubTile(old_tile, spec);
+pika::future<Tile<T, D>> splitTile(pika::future<Tile<T, D>>&& tile, const SubTileSpec& spec) {
+  return internal::createSubTile(tile.share(), spec);
 }
 
 /// Create a writeable subtile of a given tile.

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -104,7 +104,7 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
 
         const GlobalTileIndex ij_tile = dist.globalTileIndex(ij);
         pika::dataflow(pika::unwrapping(computeTaus<T>), b, k,
-                       splitTileDiscard(mat_hh(ij_tile), {sub_origin, sub_size}));
+                       splitTile(mat_hh(ij_tile), {sub_origin, sub_size}));
       }
     }
 

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -15,6 +15,7 @@
 #include "dlaf/eigensolver/band_to_tridiag.h"  // for nrSweeps/nrStepsForSweep
 #include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
+#include "dlaf/matrix/tile.h"
 #include "dlaf/util_matrix.h"
 
 #include "dlaf_test/matrix/matrix_local.h"
@@ -102,9 +103,8 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
           continue;
 
         const GlobalTileIndex ij_tile = dist.globalTileIndex(ij);
-        auto tile_v = mat_hh(ij_tile);
         pika::dataflow(pika::unwrapping(computeTaus<T>), b, k,
-                       splitTile(tile_v, {sub_origin, sub_size}));
+                       splitTileDiscard(mat_hh(ij_tile), {sub_origin, sub_size}));
       }
     }
 

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -616,7 +616,7 @@ void testSubtile(std::string name, TileElementSize size, SizeType ld, const SubT
 }
 
 template <class T, Device D>
-void testSubtileDiscard(std::string name, TileElementSize size, SizeType ld, const SubTileSpec& spec) {
+void testSubtileMove(std::string name, TileElementSize size, SizeType ld, const SubTileSpec& spec) {
   SCOPED_TRACE(name);
 
   auto [tile, tile_ptr] = createTileAndPtrChecker<T, D>(size, ld);
@@ -626,7 +626,7 @@ void testSubtileDiscard(std::string name, TileElementSize size, SizeType ld, con
   ASSERT_TRUE(next_tile_f.valid() && !next_tile_f.is_ready());
 
   // create subtiles
-  auto subtile = splitTileDiscard(std::move(tile_f), spec);
+  auto subtile = splitTile(std::move(tile_f), spec);
 
   // append the full tile to the end of the subtile vector and add its specs to full_specs.
   std::vector<pika::future<Tile<T, D>>> subtiles;
@@ -755,7 +755,9 @@ TYPED_TEST(TileTest, Subtile) {
   testSubtile<Type, Device::CPU>("Test 2", {5, 7}, 8, {{4, 6}, {1, 1}});
   testSubtile<Type, Device::CPU>("Test 3", {5, 7}, 8, {{0, 0}, {5, 7}});
 
-  testSubtileDiscard<Type, Device::CPU>("Test 4", {5, 7}, 8, {{0, 0}, {5, 7}});
+  testSubtileMove<Type, Device::CPU>("Test Move 1", {5, 7}, 8, {{3, 4}, {2, 3}});
+  testSubtileMove<Type, Device::CPU>("Test Move 2", {5, 7}, 8, {{4, 6}, {1, 1}});
+  testSubtileMove<Type, Device::CPU>("Test Move 3", {5, 7}, 8, {{0, 0}, {5, 7}});
 
   testSubtilesDisjoint<Type, Device::CPU>("Test Vector Empty", {5, 7}, 8, {}, 0);
   testSubtilesDisjoint<Type, Device::CPU>("Test Vector 1", {5, 7}, 8, {{{3, 4}, {2, 3}}}, 0);

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -481,9 +481,7 @@ void testSubtilesConst(std::string name, TileElementSize size, SizeType ld,
   SCOPED_TRACE(name);
   ASSERT_LE(last_dep, specs.size());
 
-  auto tmp = createTileAndPtrChecker<T, D>(size, ld);
-  auto tile = std::move(std::get<0>(tmp));
-  auto tile_ptr = std::move(std::get<1>(tmp));
+  auto [tile, tile_ptr] = createTileAndPtrChecker<T, D>(size, ld);
 
   auto [tile_p, tile_f, next_tile_f] = createTileChain<const T, D>();
   auto tile_sf = tile_f.share();
@@ -518,9 +516,7 @@ void testSubOfSubtileConst(std::string name, TileElementSize size, SizeType ld,
   // specs.size() -> subsubtile
   // specs.size() + 1 -> full tile
 
-  auto tmp = createTileAndPtrChecker<T, D>(size, ld);
-  auto tile = std::move(std::get<0>(tmp));
-  auto tile_ptr = std::move(std::get<1>(tmp));
+  auto [tile, tile_ptr] = createTileAndPtrChecker<T, D>(size, ld);
 
   auto [tile_p, tile_f, next_tile_f] = createTileChain<const T, D>();
   auto tile_sf = tile_f.share();
@@ -584,9 +580,7 @@ template <class T, Device D>
 void testSubtile(std::string name, TileElementSize size, SizeType ld, const SubTileSpec& spec) {
   SCOPED_TRACE(name);
 
-  auto tmp = createTileAndPtrChecker<T, D>(size, ld);
-  auto tile = std::move(std::get<0>(tmp));
-  auto tile_ptr = std::move(std::get<1>(tmp));
+  auto [tile, tile_ptr] = createTileAndPtrChecker<T, D>(size, ld);
 
   auto [tile_p, tile_f, next_tile_f] = createTileChain<T, D>();
   ASSERT_TRUE(tile_f.valid() && !tile_f.is_ready());
@@ -629,9 +623,7 @@ void testSubtilesDisjoint(std::string name, TileElementSize size, SizeType ld,
     ASSERT_LT(last_dep, specs.size());
   }
 
-  auto tmp = createTileAndPtrChecker<T, D>(size, ld);
-  auto tile = std::move(std::get<0>(tmp));
-  auto tile_ptr = std::move(std::get<1>(tmp));
+  auto [tile, tile_ptr] = createTileAndPtrChecker<T, D>(size, ld);
 
   auto [tile_p, tile_f, next_tile_f] = createTileChain<T, D>();
   ASSERT_TRUE(tile_f.valid() && !tile_f.is_ready());
@@ -670,9 +662,7 @@ void testSubOfSubtile(std::string name, TileElementSize size, SizeType ld,
   ASSERT_LE(1, specs.size());  // Need at least a subtile to create a subsubtile
   // last_dep = 0 -> subsubtile
 
-  auto tmp = createTileAndPtrChecker<T, D>(size, ld);
-  auto tile = std::move(std::get<0>(tmp));
-  auto tile_ptr = std::move(std::get<1>(tmp));
+  auto [tile, tile_ptr] = createTileAndPtrChecker<T, D>(size, ld);
 
   auto [tile_p, tile_f, next_tile_f] = createTileChain<T, D>();
   ASSERT_TRUE(tile_f.valid() && !tile_f.is_ready());


### PR DESCRIPTION
I often address the situation where a subtile is needed, but the immediately after full tile, unlocked when the subtile goes out of scope, is not.

Dealing with readonly tiles is ok, I can do:

```cpp
auto ro_subtile = splitTile(matrix.read(ij), spec);
```

But when a readwrite one is needed, there is a downside. Indeed, it is required to do

```cpp
auto rw_fulltile = matrix(ij);
auto rw_subtile = splitTile(rw_fulltile, spec);
```

and it is not possible to simply do

```cpp
// this doesn't work, because splitTile requires a left-value reference `&`
auto rw_subtile = splitTile(matrix(ij), spec);
```



In my first proposal here, I used an additional name because of the "clash" that would provoke overloading `splitTile(future&)` (accepting lvalue ref) with a `splitTile(future)` (by value).

We may even evaluate if keeping `spitTile(future&)` is needed. The use-cases of `splitTile` as it is now, i.e. returing the immedaiately after tile, for which I think the main uses-cases are:
- accessing subtile of subtiles (recursive use-case), otherwise we would always had to start from the full tile everytime
- when we know we will attach something to the full tile as soon as we finish working on the subtiles; this removes the overhead introduced by an additional future "hop" it would otherwise require asking for the same tile to the "source"


### Minor changes:
- apply newly introduced split tile function where it is already useful in codebase
- fix build with apple-clang (which requires `.template foo<>()` syntax in some cases
- use structured bindings for `test_tile` replacing `tmp` + `std::get<>`.