### PR TITLE
Generalize library structure for Tridiagonalization

### DIFF
--- a/include/dlaf/eigensolver/band_to_tridiag.h
+++ b/include/dlaf/eigensolver/band_to_tridiag.h
@@ -12,7 +12,7 @@
 #include <blas.hh>
 #include "dlaf/common/assert.h"
 #include "dlaf/communication/communicator_grid.h"
-#include "dlaf/eigensolver/band_to_tridiag/mc.h"
+#include "dlaf/eigensolver/band_to_tridiag/api.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
@@ -67,9 +67,9 @@ namespace eigensolver {
 /// @pre mat_a has a square block size,
 /// @pre band_size is a divisor of mat_a.blockSize().cols(),
 /// @pre mat_a is not distributed.
-template <Backend backend, Device device, class T>
-ReturnTridiagType<T, device> bandToTridiag(blas::Uplo uplo, SizeType band_size,
-                                           Matrix<const T, device>& mat_a) {
+template <Backend B, Device D, class T>
+ReturnTridiagType<T, Device::CPU> bandToTridiag(blas::Uplo uplo, SizeType band_size,
+                                                Matrix<const T, D>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(mat_a.blockSize().rows() % band_size == 0, mat_a.blockSize().rows(), band_size);
@@ -77,7 +77,7 @@ ReturnTridiagType<T, device> bandToTridiag(blas::Uplo uplo, SizeType band_size,
 
   switch (uplo) {
     case blas::Uplo::Lower:
-      return internal::BandToTridiag<backend, device, T>::call_L(band_size, mat_a);
+      return internal::BandToTridiag<B, D, T>::call_L(band_size, mat_a);
       break;
     case blas::Uplo::Upper:
       DLAF_UNIMPLEMENTED(uplo);
@@ -87,8 +87,7 @@ ReturnTridiagType<T, device> bandToTridiag(blas::Uplo uplo, SizeType band_size,
       break;
   }
 
-  return DLAF_UNREACHABLE(ReturnTridiagType<T, device>);
+  return DLAF_UNREACHABLE(ReturnTridiagType<T, D>);
 }
-
 }
 }

--- a/include/dlaf/eigensolver/band_to_tridiag.h
+++ b/include/dlaf/eigensolver/band_to_tridiag.h
@@ -68,8 +68,8 @@ namespace eigensolver {
 /// @pre band_size is a divisor of mat_a.blockSize().cols(),
 /// @pre mat_a is not distributed.
 template <Backend B, Device D, class T>
-ReturnTridiagType<T, Device::CPU> bandToTridiag(blas::Uplo uplo, SizeType band_size,
-                                                Matrix<const T, D>& mat_a) {
+TridiagResult<T, Device::CPU> bandToTridiag(blas::Uplo uplo, SizeType band_size,
+                                            Matrix<const T, D>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(mat_a.blockSize().rows() % band_size == 0, mat_a.blockSize().rows(), band_size);
@@ -87,7 +87,7 @@ ReturnTridiagType<T, Device::CPU> bandToTridiag(blas::Uplo uplo, SizeType band_s
       break;
   }
 
-  return DLAF_UNREACHABLE(ReturnTridiagType<T, Device::CPU>);
+  return DLAF_UNREACHABLE(TridiagResult<T, Device::CPU>);
 }
 }
 }

--- a/include/dlaf/eigensolver/band_to_tridiag.h
+++ b/include/dlaf/eigensolver/band_to_tridiag.h
@@ -87,7 +87,7 @@ ReturnTridiagType<T, Device::CPU> bandToTridiag(blas::Uplo uplo, SizeType band_s
       break;
   }
 
-  return DLAF_UNREACHABLE(ReturnTridiagType<T, D>);
+  return DLAF_UNREACHABLE(ReturnTridiagType<T, Device::CPU>);
 }
 }
 }

--- a/include/dlaf/eigensolver/band_to_tridiag/api.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/api.h
@@ -7,18 +7,18 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
+
 #pragma once
 
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 
-namespace dlaf {
-namespace eigensolver {
+namespace dlaf::eigensolver {
 
-template <class T, Device device>
+template <class T, Device D>
 struct ReturnTridiagType {
-  Matrix<BaseType<T>, device> tridiagonal;
-  Matrix<T, device> hh_reflectors;
+  Matrix<BaseType<T>, D> tridiagonal;
+  Matrix<T, D> hh_reflectors;
 };
 
 namespace internal {
@@ -43,14 +43,6 @@ struct BandToTridiag<Backend::MC, D, T> {
   static ReturnTridiagType<T, Device::CPU> call_L(const SizeType b, Matrix<const T, D>& mat_a) noexcept;
 };
 
-#ifdef DLAF_WITH_CUDA
-template <class T>
-struct BandToTridiag<Backend::MC, Device::GPU, T> {
-  static ReturnTridiagType<T, Device::CPU> call_L(const SizeType b,
-                                                  Matrix<const T, Device::GPU>& mat_a) noexcept;
-};
-#endif
-
 /// ---- ETI
 #define DLAF_EIGENSOLVER_B2T_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
   KWORD template struct BandToTridiag<BACKEND, DEVICE, DATATYPE>;
@@ -60,12 +52,5 @@ DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, double)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
 
-#ifdef DLAF_WITH_CUDA
-DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, float)
-DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, double)
-DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, std::complex<double>)
-#endif
-}
 }
 }

--- a/include/dlaf/eigensolver/band_to_tridiag/api.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/api.h
@@ -16,7 +16,7 @@
 namespace dlaf::eigensolver {
 
 template <class T, Device D>
-struct ReturnTridiagType {
+struct TridiagResult {
   Matrix<BaseType<T>, D> tridiagonal;
   Matrix<T, D> hh_reflectors;
 };
@@ -40,7 +40,7 @@ struct BandToTridiag;
 
 template <Device D, class T>
 struct BandToTridiag<Backend::MC, D, T> {
-  static ReturnTridiagType<T, Device::CPU> call_L(const SizeType b, Matrix<const T, D>& mat_a) noexcept;
+  static TridiagResult<T, Device::CPU> call_L(const SizeType b, Matrix<const T, D>& mat_a) noexcept;
 };
 
 /// ---- ETI
@@ -51,6 +51,5 @@ DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, float)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, double)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
-
 }
 }

--- a/include/dlaf/eigensolver/band_to_tridiag/api.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/api.h
@@ -35,9 +35,37 @@ inline SizeType nrStepsForSweep(SizeType sweep, SizeType size, SizeType band) no
   return sweep == size - 2 ? 1 : util::ceilDiv(size - sweep - 2, band);
 }
 
-template <Backend backend, Device device, class T>
-struct BandToTridiag {};
+template <Backend B, Device D, class T>
+struct BandToTridiag;
 
+template <Device D, class T>
+struct BandToTridiag<Backend::MC, D, T> {
+  static ReturnTridiagType<T, Device::CPU> call_L(const SizeType b, Matrix<const T, D>& mat_a) noexcept;
+};
+
+#ifdef DLAF_WITH_CUDA
+template <class T>
+struct BandToTridiag<Backend::MC, Device::GPU, T> {
+  static ReturnTridiagType<T, Device::CPU> call_L(const SizeType b,
+                                                  Matrix<const T, Device::GPU>& mat_a) noexcept;
+};
+#endif
+
+/// ---- ETI
+#define DLAF_EIGENSOLVER_B2T_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct BandToTridiag<BACKEND, DEVICE, DATATYPE>;
+
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, float)
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, double)
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
+
+#ifdef DLAF_WITH_CUDA
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, float)
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, double)
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, std::complex<double>)
+#endif
 }
 }
 }

--- a/include/dlaf/eigensolver/band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/mc.h
@@ -247,7 +247,7 @@ protected:
 };
 
 template <Device D, class T>
-ReturnTridiagType<T, Device::CPU> BandToTridiag<Backend::MC, D, T>::call_L(
+TridiagResult<T, Device::CPU> BandToTridiag<Backend::MC, D, T>::call_L(
     const SizeType b, Matrix<const T, D>& mat_a) noexcept {
   using MatrixType = Matrix<T, Device::CPU>;
   using ConstTileType = typename MatrixType::ConstTileType;

--- a/include/dlaf/eigensolver/band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/mc.h
@@ -374,12 +374,4 @@ ReturnTridiagType<T, Device::CPU> BandToTridiag<Backend::MC, D, T>::call_L(
   return {std::move(mat_trid), std::move(mat_v)};
 }
 
-template <class T>
-ReturnTridiagType<T, Device::CPU> BandToTridiag<Backend::MC, Device::GPU, T>::call_L(
-    const SizeType b, Matrix<const T, Device::GPU>& mat_a) noexcept {
-  dlaf::internal::silenceUnusedWarningFor(b, mat_a);
-  DLAF_UNIMPLEMENTED(Device::GPU);
-  return DLAF_UNREACHABLE(ReturnTridiagType<T, Device::CPU>);
-}
-
 }

--- a/src/eigensolver/band_to_tridiag/mc.cpp
+++ b/src/eigensolver/band_to_tridiag/mc.cpp
@@ -7,17 +7,21 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
+
 #include "dlaf/eigensolver/band_to_tridiag/mc.h"
 
-namespace dlaf {
-namespace eigensolver {
-namespace internal {
+namespace dlaf::eigensolver::internal {
 
-DLAF_EIGENSOLVER_B2T_MC_ETI(, float)
-DLAF_EIGENSOLVER_B2T_MC_ETI(, double)
-DLAF_EIGENSOLVER_B2T_MC_ETI(, std::complex<float>)
-DLAF_EIGENSOLVER_B2T_MC_ETI(, std::complex<double>)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, float)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, double)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, std::complex<double>)
 
-}
-}
+#ifdef DLAF_WITH_CUDA
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, float)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, double)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, std::complex<double>)
+#endif
+
 }

--- a/src/eigensolver/band_to_tridiag/mc.cpp
+++ b/src/eigensolver/band_to_tridiag/mc.cpp
@@ -17,11 +17,4 @@ DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, double)
 DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, std::complex<double>)
 
-#ifdef DLAF_WITH_CUDA
-DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, float)
-DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, double)
-DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, std::complex<double>)
-#endif
-
 }


### PR DESCRIPTION
Preparatory work for next Tridiagonalization PR to make it accept input matrix on `Device::GPU`.
Computation will still be on `Backend::MC`.