### PR TITLE
GPU kernel: LACPY 

### DIFF
--- a/include/dlaf/blas/enum_output.h
+++ b/include/dlaf/blas/enum_output.h
@@ -11,9 +11,10 @@
 #pragma once
 
 #include <ostream>
-#include "blas.hh"
 
-#include <dlaf/common/format_short.h>
+#include <blas.hh>
+
+#include "dlaf/common/format_short.h"
 
 namespace blas {
 inline std::ostream& operator<<(std::ostream& out, const blas::Diag& diag) {

--- a/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
@@ -62,7 +62,7 @@ struct Helpers<Backend::GPU> {
   static void copyAndSetHHUpperTiles(SizeType j_diag, const matrix::Tile<const T, Device::GPU>& src,
                                      const matrix::Tile<T, Device::GPU>& dst, cudaStream_t stream) {
     matrix::internal::copy_o(src, dst, stream);
-    gpulapack::laset(CUBLAS_FILL_MODE_UPPER, dst.size().rows(), dst.size().cols() - j_diag, T{0.}, T{1.},
+    gpulapack::laset(blas::Uplo::Upper, dst.size().rows(), dst.size().cols() - j_diag, T{0.}, T{1.},
                      dst.ptr({0, j_diag}), dst.ld(), stream);
   }
 };

--- a/include/dlaf/lapack/gpu/lacpy.h
+++ b/include/dlaf/lapack/gpu/lacpy.h
@@ -1,0 +1,36 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#ifdef DLAF_WITH_CUDA
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+#include "dlaf/types.h"
+
+namespace dlaf::gpulapack {
+
+template <class T>
+void lacpy(cublasFillMode_t uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
+           cudaStream_t stream);
+
+#define DLAF_CUBLAS_LACPY_ETI(kword, Type)                                                              \
+  kword template void lacpy(cublasFillMode_t uplo, SizeType m, SizeType n, const Type* a, SizeType lda, \
+                            Type* b, SizeType ldb, cudaStream_t stream)
+
+DLAF_CUBLAS_LACPY_ETI(extern, float);
+DLAF_CUBLAS_LACPY_ETI(extern, double);
+DLAF_CUBLAS_LACPY_ETI(extern, std::complex<float>);
+DLAF_CUBLAS_LACPY_ETI(extern, std::complex<double>);
+}
+
+#endif

--- a/include/dlaf/lapack/gpu/lacpy.h
+++ b/include/dlaf/lapack/gpu/lacpy.h
@@ -14,17 +14,18 @@
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
+#include <blas.hh>
 
 #include "dlaf/types.h"
 
 namespace dlaf::gpulapack {
 
 template <class T>
-void lacpy(cublasFillMode_t uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
+void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
            cudaStream_t stream);
 
-#define DLAF_CUBLAS_LACPY_ETI(kword, Type)                                                              \
-  kword template void lacpy(cublasFillMode_t uplo, SizeType m, SizeType n, const Type* a, SizeType lda, \
+#define DLAF_CUBLAS_LACPY_ETI(kword, Type)                                                        \
+  kword template void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const Type* a, SizeType lda, \
                             Type* b, SizeType ldb, cudaStream_t stream)
 
 DLAF_CUBLAS_LACPY_ETI(extern, float);

--- a/include/dlaf/lapack/gpu/lacpy.h
+++ b/include/dlaf/lapack/gpu/lacpy.h
@@ -21,12 +21,12 @@
 namespace dlaf::gpulapack {
 
 template <class T>
-void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
-           cudaStream_t stream);
+void lacpy(const blas::Uplo uplo, const SizeType m, const SizeType n, const T* a, const SizeType lda,
+           T* b, const SizeType ldb, const cudaStream_t stream);
 
-#define DLAF_CUBLAS_LACPY_ETI(kword, Type)                                                        \
-  kword template void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const Type* a, SizeType lda, \
-                            Type* b, SizeType ldb, cudaStream_t stream)
+#define DLAF_CUBLAS_LACPY_ETI(kword, Type)                                                            \
+  kword template void lacpy(const blas::Uplo uplo, const SizeType m, const SizeType n, const Type* a, \
+                            const SizeType lda, Type* b, const SizeType ldb, const cudaStream_t stream)
 
 DLAF_CUBLAS_LACPY_ETI(extern, float);
 DLAF_CUBLAS_LACPY_ETI(extern, double);

--- a/include/dlaf/lapack/gpu/laset.h
+++ b/include/dlaf/lapack/gpu/laset.h
@@ -14,17 +14,19 @@
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
+#include <blas.hh>
+
 #include "dlaf/types.h"
 
 namespace dlaf::gpulapack {
 
 template <class T>
-void laset(cublasFillMode_t uplo, SizeType m, SizeType n, T alpha, T beta, T* a, SizeType lda,
+void laset(blas::Uplo uplo, SizeType m, SizeType n, T alpha, T beta, T* a, SizeType lda,
            cudaStream_t stream);
 
-#define DLAF_CUBLAS_LASET_ETI(kword, Type)                                                        \
-  kword template void laset(cublasFillMode_t uplo, SizeType m, SizeType n, Type alpha, Type beta, \
-                            Type* a, SizeType lda, cudaStream_t stream)
+#define DLAF_CUBLAS_LASET_ETI(kword, Type)                                                           \
+  kword template void laset(blas::Uplo uplo, SizeType m, SizeType n, Type alpha, Type beta, Type* a, \
+                            SizeType lda, cudaStream_t stream)
 
 DLAF_CUBLAS_LASET_ETI(extern, float);
 DLAF_CUBLAS_LASET_ETI(extern, double);

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -94,7 +94,7 @@ void lacpy(TileElementSize region, TileElementIndex in_idx, const Tile<const T, 
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
 dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p, const lapack::Norm norm,
-                        const Tile<T, Device::CPU>& a);
+                        const Tile<T, D>& a);
 
 /// \overload lange
 ///
@@ -122,7 +122,7 @@ dlaf::BaseType<T> lange(const dlaf::internal::Policy<B>& p);
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
 dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p, const lapack::Norm norm,
-                        const blas::Uplo uplo, const blas::Diag diag, const Tile<T, Device::CPU>& a);
+                        const blas::Uplo uplo, const blas::Diag diag, const Tile<T, D>& a);
 
 /// \overload lantr
 ///
@@ -144,7 +144,7 @@ dlaf::BaseType<T> lantr(const dlaf::internal::Policy<B>& p);
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
 void laset(const dlaf::internal::Policy<B>& p, const blas::Uplo uplo, T alpha, T beta,
-           const Tile<T, Device::CPU>& tile);
+           const Tile<T, D>& tile);
 
 /// \overload laset
 ///
@@ -165,7 +165,7 @@ void laset(const dlaf::internal::Policy<B>& p);
 ///
 /// This overload blocks until completion of the algorithm.
 template <Backend B, class T, Device D>
-void set0(const dlaf::internal::Policy<B>& p, const Tile<T, Device::CPU>& tile);
+void set0(const dlaf::internal::Policy<B>& p, const Tile<T, D>& tile);
 
 /// \overload set0
 ///

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -413,7 +413,7 @@ void laset(const blas::Uplo uplo, T alpha, T beta, const Tile<T, Device::GPU>& t
   const SizeType m = tile.size().rows();
   const SizeType n = tile.size().cols();
 
-  gpulapack::laset(util::blasToCublas(uplo), m, n, alpha, beta, tile.ptr(), tile.ld(), stream);
+  gpulapack::laset(uplo, m, n, alpha, beta, tile.ptr(), tile.ld(), stream);
 }
 
 template <class T>

--- a/include/dlaf/util_cublas.h
+++ b/include/dlaf/util_cublas.h
@@ -48,6 +48,21 @@ inline constexpr cublasFillMode_t blasToCublas(const blas::Uplo uplo) {
   }
 }
 
+/// Predicate returning true for all coordinates lying in the lower part or on the diagonal of a matrix
+__device__ inline constexpr bool isLower(unsigned i, unsigned j) noexcept {
+  return i >= j;
+}
+
+/// Predicate returning true for all coordinates lying in the upper part or on the diagonal of a matrix
+__device__ inline constexpr bool isUpper(unsigned i, unsigned j) noexcept {
+  return i <= j;
+}
+
+/// Predicate returning true for all coordinates valid for a "general" matrix (i.e. always true)
+__device__ inline constexpr bool isGeneral(unsigned, unsigned) noexcept {
+  return true;
+}
+
 inline constexpr cublasOperation_t blasToCublas(const blas::Op op) {
   switch (op) {
     case blas::Op::NoTrans:

--- a/miniapp/kernel/miniapp_laset.cpp
+++ b/miniapp/kernel/miniapp_laset.cpp
@@ -76,8 +76,7 @@ struct Test {
 #ifdef DLAF_WITH_CUDA
     [[maybe_unused]] auto kernel_GPU = [uplo, m, n, alpha, beta, &tiles](SizeType i,
                                                                          cudaStream_t stream) {
-      gpulapack::laset(util::blasToCublas(uplo), m, n, alpha, beta, tiles(i).ptr(), tiles(i).ld(),
-                       stream);
+      gpulapack::laset(uplo, m, n, alpha, beta, tiles(i).ptr(), tiles(i).ld(), stream);
     };
 #endif
     const double mem_ops = memOps(uplo, m, n);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ add_library(dlaf.core
     memory/memory_view.cpp
     memory/memory_chunk.cpp
     $<$<BOOL:${DLAF_WITH_CUDA}>:cusolver/assert_info.cu>
+    $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/lacpy.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/laset.cu>
 )
 target_compile_options(dlaf.core PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -108,8 +108,11 @@ __global__ void lacpy(cublasFillMode_t uplo, const unsigned m, const unsigned n,
 template <class T>
 void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
            cudaStream_t stream) {
-  DLAF_ASSERT_HEAVY(m >= lda, m, lda);
-  DLAF_ASSERT_HEAVY(m >= ldb, m, ldb);
+  if (m == 0 || n == 0)
+    return;
+
+  DLAF_ASSERT_HEAVY(m <= lda, m, lda);
+  DLAF_ASSERT_HEAVY(m <= ldb, m, ldb);
 
   constexpr unsigned kernel_tile_size_rows = kernels::LacpyParams::kernel_tile_size_rows;
   constexpr unsigned kernel_tile_size_cols = kernels::LacpyParams::kernel_tile_size_cols;

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -97,7 +97,9 @@ __global__ void lacpy(cublasFillMode_t uplo, const unsigned m, const unsigned n,
         copyAll(m, n, a, lda, b, ldb);
       break;
     case CUBLAS_FILL_MODE_FULL:
-      copyAll(m, n, a, lda, b, ldb);
+      // Note: it seems more appropriate to use cudaMemcpy2DAsync in this case
+      DLAF_GPU_ASSERT_HEAVY(false);
+      // copyAll(m, n, a, lda, b, ldb);
       break;
   }
 }

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -1,0 +1,125 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/cuda/assert.cu.h"
+#include "dlaf/lapack/gpu/lacpy.h"
+#include "dlaf/util_cublas.h"
+#include "dlaf/util_math.h"
+
+namespace dlaf::gpulapack {
+namespace kernels {
+
+using namespace dlaf::util::cuda_operators;
+
+struct LacpyParams {
+  static constexpr unsigned kernel_tile_size_rows = 64;
+  static constexpr unsigned kernel_tile_size_cols = 16;
+};
+
+template <class T>
+__device__ void copyAll(const unsigned m, const unsigned n, const T* a, const unsigned lda, T* b,
+                        const unsigned ldb) {
+  constexpr unsigned kernel_tile_size_rows = LacpyParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = LacpyParams::kernel_tile_size_cols;
+
+  const unsigned i = blockIdx.x * kernel_tile_size_rows + threadIdx.x;
+  const unsigned j = blockIdx.y * kernel_tile_size_cols;
+
+  if (i >= m)
+    return;
+
+  const unsigned k_max = min(j + kernel_tile_size_cols, n);
+
+  for (unsigned k = j; k < k_max; ++k)
+    b[i + k * ldb] = a[i + k * lda];
+}
+
+template <bool (*comp)(unsigned, unsigned), class T>
+__device__ void copyDiag(const unsigned m, const unsigned n, const T* a, const unsigned lda, T* b,
+                         const unsigned ldb) {
+  constexpr unsigned kernel_tile_size_rows = LacpyParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = LacpyParams::kernel_tile_size_cols;
+
+  const unsigned i = blockIdx.x * kernel_tile_size_rows + threadIdx.x;
+  const unsigned j = blockIdx.y * kernel_tile_size_cols;
+
+  if (i >= m)
+    return;
+
+  const unsigned k_max = min(j + kernel_tile_size_cols, n);
+
+  for (unsigned k = j; k < k_max; ++k)
+    if (i == k or (comp(i, k)))
+      b[i + k * ldb] = a[i + k * lda];
+}
+
+template <class T>
+__global__ void lacpy(cublasFillMode_t uplo, const unsigned m, const unsigned n, const T* a,
+                      const unsigned lda, T* b, const unsigned ldb) {
+  constexpr unsigned kernel_tile_size_rows = LacpyParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = LacpyParams::kernel_tile_size_cols;
+
+  DLAF_GPU_ASSERT_HEAVY(kernel_tile_size_rows % kernel_tile_size_cols == 0);
+  DLAF_GPU_ASSERT_HEAVY(kernel_tile_size_rows == blockDim.x);
+  DLAF_GPU_ASSERT_HEAVY(1 == blockDim.y);
+  DLAF_GPU_ASSERT_HEAVY(1 == blockDim.z);
+  DLAF_GPU_ASSERT_HEAVY(gridDim.x == ceilDiv(m, kernel_tile_size_rows));
+  DLAF_GPU_ASSERT_HEAVY(gridDim.y == ceilDiv(n, kernel_tile_size_cols));
+  DLAF_GPU_ASSERT_HEAVY(1 == gridDim.z);
+
+  const unsigned i = blockIdx.x;
+  const unsigned j = blockIdx.y * kernel_tile_size_cols / kernel_tile_size_rows;
+
+  // Note: if (i == j) the kernel tile contains parts of the diagonal
+
+  switch (uplo) {
+    case CUBLAS_FILL_MODE_LOWER:
+      if (i == j)
+        copyDiag<dlaf::util::isLower>(m, n, a, lda, b, ldb);
+      else if (i > j)
+        copyAll(m, n, a, lda, b, ldb);
+      break;
+    case CUBLAS_FILL_MODE_UPPER:
+      if (i == j)
+        copyDiag<dlaf::util::isUpper>(m, n, a, lda, b, ldb);
+      else if (i < j)
+        copyAll(m, n, a, lda, b, ldb);
+      break;
+    case CUBLAS_FILL_MODE_FULL:
+      copyAll(m, n, a, lda, b, ldb);
+      break;
+  }
+}
+}
+
+template <class T>
+void lacpy(cublasFillMode_t uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
+           cudaStream_t stream) {
+  DLAF_ASSERT_HEAVY(m >= lda, m, lda);
+  DLAF_ASSERT_HEAVY(m >= ldb, m, ldb);
+
+  constexpr unsigned kernel_tile_size_rows = kernels::LacpyParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = kernels::LacpyParams::kernel_tile_size_cols;
+
+  const unsigned um = to_uint(m);
+  const unsigned un = to_uint(n);
+
+  dim3 nr_threads(kernel_tile_size_rows, 1);
+  dim3 nr_blocks(util::ceilDiv(um, kernel_tile_size_rows), util::ceilDiv(un, kernel_tile_size_cols));
+  kernels::lacpy<<<nr_blocks, nr_threads, 0, stream>>>(uplo, um, un, util::cppToCudaCast(a),
+                                                       to_uint(lda), util::cppToCudaCast(b),
+                                                       to_uint(ldb));
+}
+
+DLAF_CUBLAS_LACPY_ETI(, float);
+DLAF_CUBLAS_LACPY_ETI(, double);
+DLAF_CUBLAS_LACPY_ETI(, std::complex<float>);
+DLAF_CUBLAS_LACPY_ETI(, std::complex<double>);
+}

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -13,6 +13,7 @@
 #include "dlaf/cuda/assert.cu.h"
 #include "dlaf/cuda/error.h"
 #include "dlaf/lapack/gpu/lacpy.h"
+#include "dlaf/types.h"
 #include "dlaf/util_cublas.h"
 #include "dlaf/util_math.h"
 
@@ -112,9 +113,9 @@ void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const T* a, SizeType lda, T*
   constexpr unsigned kernel_tile_size_cols = kernels::LacpyParams::kernel_tile_size_cols;
 
   if (uplo == blas::Uplo::General) {
-    const auto kind = cudaMemcpyDefault;
-    DLAF_CUDA_CALL(cudaMemcpy2DAsync(b, ldb * sizeof(T), a, lda * sizeof(T), sizeof(T) * m, to_sizet(n),
-                                     kind, stream));
+    const cudaMemcpyKind kind = cudaMemcpyDefault;
+    DLAF_CUDA_CALL(cudaMemcpy2DAsync(b, to_sizet(ldb) * sizeof(T), a, to_sizet(lda) * sizeof(T),
+                                     to_sizet(m) * sizeof(T), to_sizet(n), kind, stream));
   }
   else {
     const unsigned um = to_uint(m);

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -97,7 +97,7 @@ __global__ void lacpy(cublasFillMode_t uplo, const unsigned m, const unsigned n,
         copyAll(m, n, a, lda, b, ldb);
       break;
     case CUBLAS_FILL_MODE_FULL:
-      // Note: it seems more appropriate to use cudaMemcpy2DAsync in this case
+      // Note: it is more appropriate to use cudaMemcpy2DAsync in this case
       DLAF_GPU_ASSERT_HEAVY(false);
       // copyAll(m, n, a, lda, b, ldb);
       break;
@@ -106,8 +106,8 @@ __global__ void lacpy(cublasFillMode_t uplo, const unsigned m, const unsigned n,
 }
 
 template <class T>
-void lacpy(blas::Uplo uplo, SizeType m, SizeType n, const T* a, SizeType lda, T* b, SizeType ldb,
-           cudaStream_t stream) {
+void lacpy(const blas::Uplo uplo, const SizeType m, const SizeType n, const T* a, const SizeType lda,
+           T* b, const SizeType ldb, const cudaStream_t stream) {
   if (m == 0 || n == 0)
     return;
 

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -60,7 +60,7 @@ __device__ void copyDiag(const unsigned m, const unsigned n, const T* a, const u
   const unsigned k_max = min(j + kernel_tile_size_cols, n);
 
   for (unsigned k = j; k < k_max; ++k)
-    if (i == k or (comp(i, k)))
+    if (comp(i, k))
       b[i + k * ldb] = a[i + k * lda];
 }
 

--- a/src/lapack/gpu/laset.cu
+++ b/src/lapack/gpu/laset.cu
@@ -100,7 +100,7 @@ __global__ void laset(cublasFillMode_t uplo, const unsigned m, const unsigned n,
 }
 
 template <class T>
-void laset(cublasFillMode_t uplo, SizeType m, SizeType n, T alpha, T beta, T* a, SizeType lda,
+void laset(blas::Uplo uplo, SizeType m, SizeType n, T alpha, T beta, T* a, SizeType lda,
            cudaStream_t stream) {
   constexpr unsigned kernel_tile_size_rows = kernels::LasetParams::kernel_tile_size_rows;
   constexpr unsigned kernel_tile_size_cols = kernels::LasetParams::kernel_tile_size_cols;
@@ -109,7 +109,8 @@ void laset(cublasFillMode_t uplo, SizeType m, SizeType n, T alpha, T beta, T* a,
 
   dim3 nr_threads(kernel_tile_size_rows, 1);
   dim3 nr_blocks(util::ceilDiv(um, kernel_tile_size_rows), util::ceilDiv(un, kernel_tile_size_cols));
-  kernels::laset<<<nr_blocks, nr_threads, 0, stream>>>(uplo, um, un, util::cppToCudaCast(alpha),
+  kernels::laset<<<nr_blocks, nr_threads, 0, stream>>>(util::blasToCublas(uplo), um, un,
+                                                       util::cppToCudaCast(alpha),
                                                        util::cppToCudaCast(beta), util::cppToCudaCast(a),
                                                        to_uint(lda));
 }

--- a/src/lapack/gpu/laset.cu
+++ b/src/lapack/gpu/laset.cu
@@ -10,7 +10,7 @@
 
 #include "dlaf/cuda/assert.cu.h"
 #include "dlaf/lapack/gpu/laset.h"
-#include "dlaf/util_cuda.h"
+#include "dlaf/util_cublas.h"
 #include "dlaf/util_math.h"
 
 namespace dlaf::gpulapack {
@@ -22,18 +22,6 @@ struct LasetParams {
   static constexpr unsigned kernel_tile_size_rows = 64;
   static constexpr unsigned kernel_tile_size_cols = 64;
 };
-
-__device__ inline constexpr bool all(unsigned i, unsigned j) noexcept {
-  return true;
-}
-
-__device__ inline constexpr bool lower(unsigned i, unsigned j) noexcept {
-  return i >= j;
-}
-
-__device__ inline constexpr bool upper(unsigned i, unsigned j) noexcept {
-  return i <= j;
-}
 
 template <class T>
 __device__ void setAll(const unsigned m, const unsigned n, const T alpha, T* a, const unsigned lda) {
@@ -92,23 +80,22 @@ __global__ void laset(cublasFillMode_t uplo, const unsigned m, const unsigned n,
 
   if (uplo == CUBLAS_FILL_MODE_LOWER) {
     if (i == j)
-      setDiag<lower>(m, n, alpha, beta, a, lda);
+      setDiag<dlaf::util::isLower>(m, n, alpha, beta, a, lda);
     else if (i > j)
       setAll(m, n, alpha, a, lda);
   }
   else if (uplo == CUBLAS_FILL_MODE_UPPER) {
     if (i == j)
-      setDiag<upper>(m, n, alpha, beta, a, lda);
+      setDiag<dlaf::util::isUpper>(m, n, alpha, beta, a, lda);
     else if (i < j)
       setAll(m, n, alpha, a, lda);
   }
   else {
     if (i == j && alpha != beta)
-      setDiag<all>(m, n, alpha, beta, a, lda);
+      setDiag<dlaf::util::isGeneral>(m, n, alpha, beta, a, lda);
     else
       setAll(m, n, alpha, a, lda);
   }
-  return;
 }
 }
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(communication)
 add_subdirectory(init)
 add_subdirectory(matrix)
 add_subdirectory(memory)
+add_subdirectory(lapack/gpu)
 
 # Operations
 add_subdirectory(auxiliary)

--- a/test/unit/lapack/gpu/CMakeLists.txt
+++ b/test/unit/lapack/gpu/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+if (DLAF_WITH_CUDA)
+  DLAF_addTest(test_lacpy
+    SOURCES test_lacpy.cpp
+    LIBRARIES dlaf.core
+    USE_MAIN PLAIN
+  )
+endif()

--- a/test/unit/lapack/gpu/test_lacpy.cpp
+++ b/test/unit/lapack/gpu/test_lacpy.cpp
@@ -1,0 +1,82 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/lapack/gpu/lacpy.h"
+
+#include <gtest/gtest.h>
+
+#include "dlaf/blas/enum_output.h"
+#include "dlaf_test/matrix/util_tile.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::test;
+using dlaf::matrix::test::createTile;
+
+template <class T>
+struct LacpyTestGPU : public ::testing::Test {};
+
+TYPED_TEST_SUITE(LacpyTestGPU, MatrixElementTypes);
+
+std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> configs{
+    // m, n, lda, ldb
+    {0, 0, 1, 1},        {0, 4, 4, 4},         {4, 0, 5, 5},                       // Empty
+    {6, 6, 6, 6},        {5, 3, 5, 6},         {7, 3, 10, 13},      {3, 7, 8, 8},  // Very Small
+    {127, 35, 128, 200}, {128, 128, 128, 128}, {96, 127, 256, 256},                // A bit larger
+};
+
+TYPED_TEST(LacpyTestGPU, CorrectnessLocal) {
+  using T = TypeParam;
+
+  using blas::Uplo;
+
+  cudaStream_t stream;
+  DLAF_CUDA_CALL(cudaStreamCreate(&stream));
+  cublasHandle_t handle;
+  DLAF_CUBLAS_CALL(cublasCreate(&handle));
+  DLAF_CUBLAS_CALL(cublasSetStream(handle, stream));
+
+  auto zero = [](const TileElementIndex&) { return T(0); };
+
+  auto el = [](const TileElementIndex& ij) {
+    if (ij.row() == ij.col())
+      return T(ij.row());
+    else
+      return T(ij.row() - ij.col());
+  };
+
+  for (const auto& [m, n, lda, ldb] : configs) {
+    for (const auto uplo : {Uplo::Lower, Uplo::Upper, Uplo::General}) {
+      // Reference
+      auto tile_input = createTile<const T, Device::CPU>(el, {m, n}, lda);
+      auto tile_result = createTile<T, Device::CPU>(zero, {m, n}, ldb);
+
+      lapack::lacpy(uplo, m, n, tile_input.ptr(), tile_input.ld(), tile_result.ptr(), tile_result.ld());
+
+      // Test
+      auto tile_src = createTile<const T, Device::GPU>(el, {m, n}, lda);
+      auto tile_dst = createTile<T, Device::GPU>(zero, {m, n}, ldb);
+
+      gpulapack::lacpy(dlaf::util::blasToCublas(uplo), m, n, tile_src.ptr(), tile_src.ld(),
+                       tile_dst.ptr(), tile_dst.ld(), stream);
+      DLAF_CUDA_CALL(cudaStreamSynchronize(stream));
+
+      // Verify
+      SCOPED_TRACE(::testing::Message() << "Comparison test m=" << m << " n=" << n << " lda=" << lda
+                                        << " ldb=" << ldb << " uplo=" << uplo);
+
+      const auto error = TypeUtilities<T>::error;
+      CHECK_TILE_NEAR(tile_result, tile_dst, error, error);
+    }
+  }
+
+  DLAF_CUBLAS_CALL(cublasDestroy(handle));
+  DLAF_CUDA_CALL(cudaStreamDestroy(stream));
+}

--- a/test/unit/lapack/gpu/test_lacpy.cpp
+++ b/test/unit/lapack/gpu/test_lacpy.cpp
@@ -64,8 +64,7 @@ TYPED_TEST(LacpyTestGPU, CorrectnessLocal) {
       auto tile_src = createTile<const T, Device::GPU>(el, {m, n}, lda);
       auto tile_dst = createTile<T, Device::GPU>(zero, {m, n}, ldb);
 
-      gpulapack::lacpy(dlaf::util::blasToCublas(uplo), m, n, tile_src.ptr(), tile_src.ld(),
-                       tile_dst.ptr(), tile_dst.ld(), stream);
+      gpulapack::lacpy(uplo, m, n, tile_src.ptr(), tile_src.ld(), tile_dst.ptr(), tile_dst.ld(), stream);
       DLAF_CUDA_CALL(cudaStreamSynchronize(stream));
 
       // Verify

--- a/test/unit/test_util_cuda.cu
+++ b/test/unit/test_util_cuda.cu
@@ -138,7 +138,7 @@ TYPED_TEST(CudaUtilTestHost, CudaOperatorsComplex) {
   const ComplexT a = cppToCudaCast(std::complex<T>(3.55f, -2.35f));
   const ComplexT b = cppToCudaCast(std::complex<T>(2.15f, 0.66f));
   const ComplexT c = cppToCudaCast(std::complex<T>(-7.65f, -5.12f));
-  const T d = 7.77;
+  const T d = 7.77f;
 
   // The equality operator test is designed requiring a.x != b.x and a.y != b.y.
   ASSERT_TRUE(a.x != b.x && a.y != b.y);
@@ -304,7 +304,7 @@ TYPED_TEST(CudaUtilTestDevice, CudaOperatorsComplex) {
   const ComplexT a = cppToCudaCast(std::complex<T>(3.55f, -2.35f));
   const ComplexT b = cppToCudaCast(std::complex<T>(2.15f, 0.66f));
   const ComplexT c = cppToCudaCast(std::complex<T>(-7.65f, -5.12f));
-  const T d = 7.77;
+  const T d = 7.77f;
 
   // The equality operator test is designed requiring a.x != b.x and a.y != b.y.
   ASSERT_FALSE(a.x == b.x || a.y == b.y);


### PR DESCRIPTION
Implementation of `lacpy` GPU kernel (preparatory work for #501).

It's a basic implementation that uses `cudaMemcpy2DAsync` for the general case and a custom kernel for the lower and upper cases (note: the kernel implemented supports also the general case, even if it is not used).

IMHO it is a reasonable basic implementation that I can use for completing tasks related to the local GPU eigensolver deadline (specifically this kernel is required for tridiagonalization input management).

If you agree, as soon as them will be completed, we can iterate over this and benchmark different solutions/options.

Changes:
- `gpulapack::` kernels (currently `laset` and `lacpy`) now uses `blas::Uplo` instead of `cublasFillMode_t` (uniformly with cpu routines/wrappers)
- move lower/upper/all predicates to `util_cublas.h`
- minor fix doxygen documentation in `lapack/tile.h`