### PR TITLE
Change barrier in `cholesky` and `reduction_to_band` miniapps

### DIFF
--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -142,15 +142,10 @@ struct choleskyMiniapp {
         dlaf::factorization::cholesky<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,
                                                                             matrix.get());
 
-        // wait for last task and barrier for all ranks
-        {
-          GlobalTileIndex last_tile(matrix.get().nrTiles().rows() - 1,
-                                    matrix.get().nrTiles().cols() - 1);
-          if (matrix.get().rankIndex() == distribution.rankGlobalTile(last_tile))
-            matrix.get()(last_tile).get();
+        // wait and barrier for all ranks
+        matrix.get().waitLocalTiles();
+        DLAF_MPI_CALL(MPI_Barrier(world));
 
-          DLAF_MPI_CALL(MPI_Barrier(world));
-        }
         elapsed_time = timeit.elapsed();
       }
 

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -118,8 +118,6 @@ struct choleskyMiniapp {
       return hermitian_pos_def;
     }();
 
-    const auto& distribution = matrix_ref.distribution();
-
     for (int64_t run_index = -opts.nwarmups; run_index < opts.nruns; ++run_index) {
       if (0 == world.rank() && run_index >= 0)
         std::cout << "[" << run_index << "]" << std::endl;
@@ -127,16 +125,13 @@ struct choleskyMiniapp {
       HostMatrixType matrix_host(matrix_size, block_size, comm_grid);
       copy(matrix_ref, matrix_host);
 
-      // wait all setup tasks before starting benchmark
-      matrix_host.waitLocalTiles();
-      DLAF_MPI_CALL(MPI_Barrier(world));
-
       double elapsed_time;
       {
         MatrixMirrorType matrix(matrix_host);
 
         // Wait for matrix to be copied to GPU (if necessary)
         matrix.get().waitLocalTiles();
+        DLAF_MPI_CALL(MPI_Barrier(world));
 
         dlaf::common::Timer<> timeit;
         dlaf::factorization::cholesky<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -101,14 +101,10 @@ struct reductionToBandMiniapp {
       dlaf::common::Timer<> timeit;
       auto taus = dlaf::eigensolver::reductionToBand<dlaf::Backend::MC>(comm_grid, matrix);
 
-      // wait for last task and barrier for all ranks
-      {
-        GlobalTileIndex last_tile(matrix.nrTiles().rows() - 1, matrix.nrTiles().cols() - 2);
-        if (matrix.rankIndex() == distribution.rankGlobalTile(last_tile))
-          matrix(last_tile).get();
+      // wait and barrier for all ranks
+      matrix.waitLocalTiles();
+      DLAF_MPI_CALL(MPI_Barrier(world));
 
-        DLAF_MPI_CALL(MPI_Barrier(world));
-      }
       auto elapsed_time = timeit.elapsed();
 
       double gigaflops = std::numeric_limits<double>::quiet_NaN();

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -85,8 +85,6 @@ struct reductionToBandMiniapp {
       return hermitian;
     }();
 
-    const auto& distribution = matrix_ref.distribution();
-
     for (int64_t run_index = -opts.nwarmups; run_index < opts.nruns; ++run_index) {
       if (0 == world.rank() && run_index >= 0)
         std::cout << "[" << run_index << "]" << std::endl;


### PR DESCRIPTION
Wait for all tiles first to avoid blocking the pika thread with `MPI_Barrier`. This is similar to how it's done in the other miniapps.