### PR TITLE
Porting to pika 0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
 endif()
 
 # ----- pika
-find_package(pika 0.2.0 REQUIRED EXACT)
+find_package(pika 0.3.0 REQUIRED EXACT)
 
 # ----- BLASPP/LAPACKPP
 find_package(blaspp REQUIRED)

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: b559b99c8f168f5473559cacd8638c98dbebf162
+    SPACK_SHA: 0dc3c85a909ec722084b72457ae97f972059166e
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/ci/docker/cpu-debug.yaml
+++ b/ci/docker/cpu-debug.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop build_type=Debug +miniapps +ci-test ^openblas ^mpich
+    - dla-future@develop build_type=Debug +miniapps +ci-test ^openblas ^mpich@3.4.2
   view: false
   concretization: together
 

--- a/ci/docker/cpu-release.yaml
+++ b/ci/docker/cpu-release.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop +miniapps +ci-test ^intel-mkl ^mpich
+    - dla-future@develop +miniapps +ci-test ^intel-mkl ^mpich@3.4.2
   view: false
   concretization: together
 

--- a/ci/docker/gpu-debug.yaml
+++ b/ci/docker/gpu-debug.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop build_type=Debug +cuda +miniapps +ci-test ^openblas ^mpich
+    - dla-future@develop build_type=Debug +cuda +miniapps +ci-test ^openblas ^mpich@3.4.2
   view: false
   concretization: together
 

--- a/ci/docker/gpu-release.yaml
+++ b/ci/docker/gpu-release.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop +cuda +miniapps +ci-test ^intel-mkl ^mpich
+    - dla-future@develop +cuda +miniapps +ci-test ^intel-mkl ^mpich@3.4.2
   view: false
   concretization: together
 

--- a/include/dlaf/sender/make_sender_algorithm_overloads.h
+++ b/include/dlaf/sender/make_sender_algorithm_overloads.h
@@ -44,7 +44,7 @@
                                                                                                  \
   template <Backend B, typename T1, typename T2, typename... Ts>                                 \
   void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                  \
-    pika::execution::experimental::sync_wait(                                                    \
+    pika::this_thread::experimental::sync_wait(                                                  \
         fname(p, pika::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
                                                      std::forward<Ts>(ts)...)));                 \
   }

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -38,7 +38,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@0.2.0")
+    depends_on("pika@0.3.0")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")


### PR DESCRIPTION
The only breaking API change is the move of `pika::execution::experimental::sync_wait` to `pika::this_thread::experimental::sync_wait` to match a similar move of `std::this_thread::sync_wait` in P2300. The reasoning is that `sync_wait` is specific to the context in which it's running, e.g. `std::this_thread::sync_wait` might use `std::condition_variable` under the hood and thus should not be called on a pika thread.

All other changes are either completely internal cleanups or minor fixes that don't affect the use of the functionalities. Among other things [this](https://github.com/eth-cscs/DLA-Future/pull/460#discussion_r822561060) has been fixed, and the lifetimes of arguments have been shortened for `make_future`.

To do:
- [x] Run CI once last PRs have been merged to pika
- [x] Update spack version requirement to `pika@0.3.0`
- [x] Update CMake pika version requirement to 0.3.0
- [x] Update spack commit to include pika 0.3.0