### PR TITLE
Use only public pika API headers

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: 0dc3c85a909ec722084b72457ae97f972059166e
+    SPACK_SHA: b71661eaa6792e12e9a50ebfb58b5123b3aba8e9
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/include/dlaf/communication/executor.h
+++ b/include/dlaf/communication/executor.h
@@ -17,10 +17,10 @@
 #include <type_traits>
 #include <utility>
 
-#include <pika/async_mpi/mpi_future.hpp>
 #include <pika/execution.hpp>
 #include <pika/functional.hpp>
 #include <pika/future.hpp>
+#include <pika/mpi.hpp>
 #include <pika/mutex.hpp>
 #include <pika/tuple.hpp>
 #include <pika/type_support/unused.hpp>

--- a/include/dlaf/cublas/executor.h
+++ b/include/dlaf/cublas/executor.h
@@ -21,10 +21,10 @@
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/functional.hpp>
 #include <pika/future.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/mutex.hpp>
 #include <pika/tuple.hpp>
 #include <pika/type_traits.hpp>

--- a/include/dlaf/cusolver/executor.h
+++ b/include/dlaf/cusolver/executor.h
@@ -21,10 +21,10 @@
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
 
+#include <pika/cuda.hpp>
 #include <pika/execution.hpp>
 #include <pika/functional.hpp>
 #include <pika/future.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/mutex.hpp>
 #include <pika/tuple.hpp>
 #include <pika/type_traits.hpp>

--- a/include/dlaf/executors.h
+++ b/include/dlaf/executors.h
@@ -10,11 +10,11 @@
 #pragma once
 
 #include <pika/execution.hpp>
-#include <pika/modules/resource_partitioner.hpp>
+#include <pika/runtime.hpp>
 #include <pika/thread.hpp>
 
 #ifdef DLAF_WITH_CUDA
-#include <pika/modules/async_cuda.hpp>
+#include <pika/cuda.hpp>
 #endif
 
 #include <dlaf/communication/executor.h>

--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -11,11 +11,11 @@
 
 #include <iostream>
 
-#include <pika/modules/resource_partitioner.hpp>
 #include <pika/program_options.hpp>
+#include <pika/runtime.hpp>
 
 #ifdef DLAF_WITH_CUDA
-#include <pika/modules/async_cuda.hpp>
+#include <pika/cuda.hpp>
 #endif
 
 #include <dlaf/communication/mech.h>

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -22,7 +22,7 @@
 #ifdef DLAF_WITH_CUDA
 #include <cusolverDn.h>
 
-#include <pika/modules/async_cuda.hpp>
+#include <pika/cuda.hpp>
 #endif
 
 #include "dlaf/common/assert.h"

--- a/include/dlaf/schedulers.h
+++ b/include/dlaf/schedulers.h
@@ -10,12 +10,11 @@
 #pragma once
 
 #include <pika/execution.hpp>
-#include <pika/modules/resource_partitioner.hpp>
 #include <pika/runtime.hpp>
 #include <pika/thread.hpp>
 
 #ifdef DLAF_WITH_CUDA
-#include <pika/modules/async_cuda.hpp>
+#include <pika/cuda.hpp>
 #endif
 
 #include <dlaf/init.h>

--- a/include/dlaf/sender/transform.h
+++ b/include/dlaf/sender/transform.h
@@ -24,7 +24,7 @@
 #include <cuda_runtime.h>
 #include <cusolverDn.h>
 
-#include <pika/modules/async_cuda.hpp>
+#include <pika/cuda.hpp>
 
 #include "dlaf/cublas/handle_pool.h"
 #include "dlaf/cuda/stream_pool.h"

--- a/miniapp/miniapp_cublas.cpp
+++ b/miniapp/miniapp_cublas.cpp
@@ -14,9 +14,9 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
+#include <pika/cuda.hpp>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
-#include <pika/modules/async_cuda.hpp>
 #include <pika/thread.hpp>
 #include <pika/unwrap.hpp>
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <pika/async_mpi/mpi_future.hpp>
+#include <pika/mpi.hpp>
 #include <pika/runtime.hpp>
 
 #include <dlaf/common/assert.h>

--- a/test/src/gtest_mpipika_main.cpp
+++ b/test/src/gtest_mpipika_main.cpp
@@ -44,7 +44,6 @@
 #include <gtest/gtest.h>
 
 #include <pika/init.hpp>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -14,7 +14,6 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
 
 #include "dlaf/common/index2d.h"

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -13,7 +13,6 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"

--- a/test/unit/eigensolver/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_reduction_to_band.cpp
@@ -15,7 +15,6 @@
 #include <gtest/gtest.h>
 #include <lapack/util.hh>
 #include <pika/future.hpp>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
 
 #include "dlaf/common/index2d.h"

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -13,7 +13,6 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"

--- a/test/unit/multiplication/test_multiplication_triangular.cpp
+++ b/test/unit/multiplication/test_multiplication_triangular.cpp
@@ -13,7 +13,6 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
 
 #include "dlaf/blas/tile.h"

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -13,7 +13,6 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-#include <pika/modules/threadmanager.hpp>
 #include <pika/runtime.hpp>
 
 #include "dlaf/communication/communicator_grid.h"


### PR DESCRIPTION
There's on reference for this yet, but the rule of thumb is that almost all headers are internal, in particular `pika/modules/x.hpp`. Now that we have replacements for these I've changed the headers to use the public headers. We'll work on creating a list of which headers are considered public as well.

Summary:
- `pika/modules/threadmanager.hpp` and `pika/modules/resource_partitioner.hpp` -> `pika/runtime.hpp`.
- `pika/async_cuda/*.hpp` -> `pika/cuda.hpp`
- `pika/async_mpi/*.hpp` -> `pika/mpi.hpp`

There are two remaining non-public headers included in DLA-Future. These will be removed latest by #497.

This is based on #519 because it requires pika 0.3.0.