### PR TITLE
Porting to pika 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
 endif()
 
 # ----- pika
-find_package(pika 0.3.0 REQUIRED EXACT)
+find_package(pika 0.4.0 REQUIRED EXACT)
 
 # ----- BLASPP/LAPACKPP
 find_package(blaspp REQUIRED)

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: b71661eaa6792e12e9a50ebfb58b5123b3aba8e9
+    SPACK_SHA: 2418cfb79b46491122baad8efd6af596078b396d
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -38,7 +38,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@0.3.0")
+    depends_on("pika@main")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -38,7 +38,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@main")
+    depends_on("pika@0.4.0")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")


### PR DESCRIPTION
- Testing pika@main for the 0.4.0 release.
- Porting to pika 0.4.0 once the release is out.

TODO:
- [x] Run CI once last PRs have been merged to pika
- [x] Update spack version requirement to pika@0.4.0
- [x] Update CMake pika version requirement to 0.4.0
- [x] Update spack commit to include pika 0.4.0