### PR TITLE
Introduce gemm (local)

### DIFF
--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -12,7 +12,31 @@
 
 #include <blas.hh>
 
+#include "dlaf/common/assert.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/multiplication/general/api.h"
+#include "dlaf/util_matrix.h"
 
-namespace dlaf::multiplication {}
+namespace dlaf::multiplication {
+
+template <Device D, class T>
+void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, const blas::Op opB,
+                      const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                      Matrix<T, D>& mat_c) {
+  DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_a), mat_a);
+  DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_b), mat_b);
+  DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_c), mat_c);
+
+  // TODO check assertions. these are superflous
+  DLAF_ASSERT(dlaf::matrix::square_size(mat_a), mat_a);
+  DLAF_ASSERT(dlaf::matrix::square_size(mat_b), mat_b);
+  DLAF_ASSERT(dlaf::matrix::square_size(mat_c), mat_c);
+
+  const SizeType m = mat_a.nrTiles().rows();
+  DLAF_ASSERT(a <= b, a, b);
+  DLAF_ASSERT(a >= 0 and a < m, a, m);
+
+  internal::GeneralSub<D, T>::call(a, b, opA, opB, alpha, mat_a, mat_b, beta, mat_c);
+}
+
+}

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -36,7 +36,12 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
   DLAF_ASSERT(a <= b, a, b);
   DLAF_ASSERT(a >= 0 and a < m, a, m);
 
-  internal::GeneralSub<D, T>::call(a, b, opA, opB, alpha, mat_a, mat_b, beta, mat_c);
+  using namespace blas;
+
+  if (opA == Op::NoTrans && opB == Op::NoTrans)
+    internal::GeneralSub<D, T>::callNN(a, b, opA, opB, alpha, mat_a, mat_b, beta, mat_c);
+  else
+    DLAF_UNIMPLEMENTED(opA, opB);
 }
 
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -1,0 +1,18 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <blas.hh>
+
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/multiplication/general/api.h"
+
+namespace dlaf::multiplication {}

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -20,9 +20,9 @@ namespace internal {
 
 template <Device D, class T>
 struct GeneralSub {
-  static void call(const SizeType i_tile_from, const SizeType i_tile_to, const blas::Op opA,
-                   const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
-                   Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c);
+  static void callNN(const SizeType i_tile_from, const SizeType i_tile_to, const blas::Op opA,
+                     const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
+                     Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c);
 };
 
 /// ---- ETI

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -10,6 +10,29 @@
 
 #pragma once
 
+#include <blas.hh>
+
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/types.h"
+
 namespace dlaf::multiplication {
-namespace internal {}
+namespace internal {
+
+template <Device D, class T>
+struct GeneralSub {
+  static void call(const SizeType i_tile_from, const SizeType i_tile_to, const blas::Op opA,
+                   const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
+                   Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c);
+};
+
+/// ---- ETI
+#define DLAF_MULTIPLICATION_GENERAL_ETI(KWORD, DEVICE, DATATYPE) \
+  KWORD template struct GeneralSub<DEVICE, DATATYPE>;
+
+DLAF_MULTIPLICATION_GENERAL_ETI(extern, Device::CPU, float)
+DLAF_MULTIPLICATION_GENERAL_ETI(extern, Device::CPU, double)
+DLAF_MULTIPLICATION_GENERAL_ETI(extern, Device::CPU, std::complex<float>)
+DLAF_MULTIPLICATION_GENERAL_ETI(extern, Device::CPU, std::complex<double>)
+
+}
 }

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -1,0 +1,15 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+namespace dlaf::multiplication {
+namespace internal {}
+}

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -10,6 +10,39 @@
 
 #pragma once
 
+#include "dlaf/multiplication/general/api.h"
+
+#include "dlaf/blas/enum_output.h"
+#include "dlaf/blas/tile.h"
+#include "dlaf/common/index2d.h"
+#include "dlaf/sender/transform.h"
+#include "dlaf/sender/when_all_lift.h"
+
 namespace dlaf::multiplication {
-namespace internal {}
+namespace internal {
+
+template <Device D, class T>
+void GeneralSub<D, T>::call(const SizeType a, const SizeType b, const blas::Op opA, const blas::Op opB,
+                            const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b,
+                            const T beta, Matrix<T, D>& mat_c) {
+  namespace ex = pika::execution::experimental;
+
+  if (opA != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opA);
+  if (opB != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opB);
+
+  for (SizeType j = a; j <= b; ++j) {
+    for (SizeType i = a; i <= b; ++i) {
+      for (SizeType k = a; k <= b; ++k) {
+        dlaf::internal::whenAllLift(opA, opB, alpha, mat_a.read_sender(GlobalTileIndex(i, k)),
+                                    mat_b.read_sender(GlobalTileIndex(k, j)), k == a ? beta : T(1),
+                                    mat_c.readwrite_sender(GlobalTileIndex(i, j))) |
+            tile::gemm(dlaf::internal::Policy<Backend::MC>()) | ex::start_detached();
+      }
+    }
+  }
+}
+
+}
 }

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -22,15 +22,10 @@ namespace dlaf::multiplication {
 namespace internal {
 
 template <Device D, class T>
-void GeneralSub<D, T>::call(const SizeType idx_begin, const SizeType idx_end, const blas::Op opA,
-                            const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
-                            Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
+void GeneralSub<D, T>::callNN(const SizeType idx_begin, const SizeType idx_end, const blas::Op opA,
+                              const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
+                              Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
-
-  if (opA != blas::Op::NoTrans)
-    DLAF_UNIMPLEMENTED(opA);
-  if (opB != blas::Op::NoTrans)
-    DLAF_UNIMPLEMENTED(opB);
 
   for (SizeType j = idx_begin; j <= idx_end; ++j) {
     for (SizeType i = idx_begin; i <= idx_end; ++i) {
@@ -44,6 +39,5 @@ void GeneralSub<D, T>::call(const SizeType idx_begin, const SizeType idx_end, co
     }
   }
 }
-
 }
 }

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -1,0 +1,15 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+namespace dlaf::multiplication {
+namespace internal {}
+}

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -22,9 +22,9 @@ namespace dlaf::multiplication {
 namespace internal {
 
 template <Device D, class T>
-void GeneralSub<D, T>::call(const SizeType a, const SizeType b, const blas::Op opA, const blas::Op opB,
-                            const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b,
-                            const T beta, Matrix<T, D>& mat_c) {
+void GeneralSub<D, T>::call(const SizeType idx_begin, const SizeType idx_end, const blas::Op opA,
+                            const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
+                            Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
   if (opA != blas::Op::NoTrans)
@@ -32,11 +32,12 @@ void GeneralSub<D, T>::call(const SizeType a, const SizeType b, const blas::Op o
   if (opB != blas::Op::NoTrans)
     DLAF_UNIMPLEMENTED(opB);
 
-  for (SizeType j = a; j <= b; ++j) {
-    for (SizeType i = a; i <= b; ++i) {
-      for (SizeType k = a; k <= b; ++k) {
+  for (SizeType j = idx_begin; j <= idx_end; ++j) {
+    for (SizeType i = idx_begin; i <= idx_end; ++i) {
+      for (SizeType k = idx_begin; k <= idx_end; ++k) {
         dlaf::internal::whenAllLift(opA, opB, alpha, mat_a.read_sender(GlobalTileIndex(i, k)),
-                                    mat_b.read_sender(GlobalTileIndex(k, j)), k == a ? beta : T(1),
+                                    mat_b.read_sender(GlobalTileIndex(k, j)),
+                                    k == idx_begin ? beta : T(1),
                                     mat_c.readwrite_sender(GlobalTileIndex(i, j))) |
             tile::gemm(dlaf::internal::Policy<Backend::MC>()) | ex::start_detached();
       }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,7 @@ DLAF_addPrecompiledHeaders(dlaf.factorization)
 
 # Define DLAF's multiplication library
 add_library(dlaf.multiplication OBJECT
+  multiplication/general/mc.cpp
   multiplication/triangular/mc.cpp
   $<$<BOOL:${DLAF_WITH_CUDA}>:multiplication/triangular/gpu.cpp>)
 target_link_libraries(dlaf.multiplication PUBLIC dlaf.prop)

--- a/src/multiplication/general/mc.cpp
+++ b/src/multiplication/general/mc.cpp
@@ -1,0 +1,13 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/multiplication/general/impl.h"
+
+namespace dlaf::multiplication::internal {}

--- a/src/multiplication/general/mc.cpp
+++ b/src/multiplication/general/mc.cpp
@@ -10,4 +10,11 @@
 
 #include "dlaf/multiplication/general/impl.h"
 
-namespace dlaf::multiplication::internal {}
+namespace dlaf::multiplication::internal {
+
+DLAF_MULTIPLICATION_GENERAL_ETI(, Device::CPU, float)
+DLAF_MULTIPLICATION_GENERAL_ETI(, Device::CPU, double)
+DLAF_MULTIPLICATION_GENERAL_ETI(, Device::CPU, std::complex<float>)
+DLAF_MULTIPLICATION_GENERAL_ETI(, Device::CPU, std::complex<double>)
+
+}

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -59,7 +59,15 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
     return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
   };
 
-  auto elC = [a, b](const GlobalElementIndex) { return TypeUtilities<T>::polar(0, 0); };
+  auto elC = [a, b](const GlobalElementIndex ij) {
+    if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
+      return TypeUtilities<T>::polar(-99, 99);
+
+    const double i = ij.row();
+    const double j = ij.col();
+
+    return TypeUtilities<T>::polar((i + 3) / (j + 5), i + j);
+  };
 
   auto elR = [a, b, k, alpha, beta](const GlobalElementIndex ij) {
     if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
@@ -68,7 +76,8 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
     const double i = ij.row();
     const double j = ij.col();
 
-    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * (b - a + 1), (2 * i) + j);
+    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * (b - a + 1), (2 * i) + j) +
+           beta * TypeUtilities<T>::polar((i + 3) / (j + 5), i + j);
   };
 
   return std::make_tuple<>(elA, elB, elC, elR);

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -15,13 +15,64 @@
 
 #include <blas.hh>
 
+#include "dlaf/common/assert.h"
+#include "dlaf/matrix/index.h"
+#include "dlaf/types.h"
 #include "dlaf_test/util_types.h"
 
 /// @file
 
-namespace dlaf {
-namespace matrix {
-namespace test {
+namespace dlaf::matrix::test {
+
+template <class T>
+auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const SizeType m,
+                                      const SizeType n, const SizeType k, const T alpha, const T beta,
+                                      const blas::Op opA, const blas::Op opB) {
+  using dlaf::test::TypeUtilities;
+
+  if (opA != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opA);
+  if (opB != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opB);
+
+  DLAF_ASSERT(a >= 0 and a < m and a < n, a, m, n);
+  DLAF_ASSERT(b >= 0 and b < m and b < n, b, m, n);
+  DLAF_ASSERT(a <= b, a, b);
+
+  auto elA = [a, b](const GlobalElementIndex ik) {
+    if (ik.row() < a || ik.row() > b || ik.col() < a || ik.col() > b)
+      return TypeUtilities<T>::polar(13, -26);
+
+    const double i = ik.row();
+    const double k = ik.col();
+
+    return TypeUtilities<T>::polar((i + 1) / (k + .5), 2 * i - k);
+  };
+
+  auto elB = [a, b](const GlobalElementIndex kj) {
+    if (kj.row() < a || kj.row() > b || kj.col() < a || kj.col() > b)
+      return TypeUtilities<T>::polar(13, -26);
+
+    const double k = kj.row();
+    const double j = kj.col();
+
+    return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
+  };
+
+  auto elC = [a, b](const GlobalElementIndex) { return TypeUtilities<T>::polar(0, 0); };
+
+  auto elR = [a, b, k, alpha, beta](const GlobalElementIndex ij) {
+    if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
+      return TypeUtilities<T>::polar(13, -26);
+
+    const double i = ij.row();
+    const double j = ij.col();
+
+    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * (b - a + 1), (2 * i) + j);
+  };
+
+  return std::make_tuple<>(elA, elB, elC, elR);
+}
 
 /// Returns a tuple of element generators of three matrices A(m x m), B (m x n), X (m x n), for which it
 /// holds op(A) X = alpha B (n can be any value).
@@ -161,6 +212,4 @@ auto getTriangularSystem(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Di
     return dlaf::matrix::test::getRightTriangularSystem<ElementIndex, T>(uplo, op, diag, alpha, n);
 }
 
-}
-}
 }

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -59,14 +59,14 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
     return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
   };
 
-  auto elC = [a, b](const GlobalElementIndex ij) {
+  auto elC = [a, b, k](const GlobalElementIndex ij) {
     if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
       return TypeUtilities<T>::polar(-99, 99);
 
     const double i = ij.row();
     const double j = ij.col();
 
-    return TypeUtilities<T>::polar((i + 3) / (j + 5), i + j);
+    return TypeUtilities<T>::polar((i + k + 1) / (j + 5), i + j + k);
   };
 
   auto elR = [a, b, k, alpha, beta](const GlobalElementIndex ij) {
@@ -77,7 +77,7 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
     const double j = ij.col();
 
     return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * (b - a + 1), (2 * i) + j) +
-           beta * TypeUtilities<T>::polar((i + 3) / (j + 5), i + j);
+           beta * TypeUtilities<T>::polar((i + k + 1) / (j + 5), k + i + j);
   };
 
   return std::make_tuple<>(elA, elB, elC, elR);

--- a/test/unit/multiplication/CMakeLists.txt
+++ b/test/unit/multiplication/CMakeLists.txt
@@ -8,6 +8,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+DLAF_addTest(test_multiplication_general
+  SOURCES test_multiplication_general.cpp
+  LIBRARIES dlaf.multiplication dlaf.core
+  USE_MAIN PIKA
+)
+
 DLAF_addTest(test_multiplication_triangular
   SOURCES test_multiplication_triangular.cpp
   LIBRARIES dlaf.multiplication dlaf.core

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -1,0 +1,49 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#include "dlaf/common/assert.h"
+#include "dlaf/multiplication/general.h"
+
+#include <gtest/gtest.h>
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::test;
+
+template <class T>
+struct GeneralMultiplicationTestMC : public ::testing::Test {};
+
+TYPED_TEST_SUITE(GeneralMultiplicationTestMC, MatrixElementTypes);
+
+const std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
+
+const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType>> sizes;
+
+GlobalElementSize globalTestSize(const LocalElementSize& size) {
+  return {size.rows(), size.cols()};
+}
+
+template <class T, Backend B, Device D>
+void testGeneralMultiplication(const blas::Op opA, const blas::Op opB, const T alpha, const T beta,
+                               SizeType m, SizeType n, SizeType k, SizeType mb, SizeType nb) {
+  dlaf::internal::silenceUnusedWarningFor(opA, opB, alpha, beta, m, n, k, mb, nb);
+}
+
+TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocal) {
+  for (const auto opA : blas_ops) {
+    for (const auto opB : blas_ops) {
+      for (const auto& [m, n, k, mb, nb] : sizes) {
+        const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .7);
+        const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+        testGeneralMultiplication<TypeParam, Backend::MC, Device::CPU>(opA, opB, alpha, beta, m, n, k,
+                                                                       mb, nb);
+      }
+    }
+  }
+}

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -7,10 +7,17 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
-#include "dlaf/common/assert.h"
 #include "dlaf/multiplication/general.h"
 
 #include <gtest/gtest.h>
+
+#include "dlaf/blas/enum_output.h"
+#include "dlaf/common/assert.h"
+#include "dlaf/matrix/index.h"
+#include "dlaf/util_matrix.h"
+
+#include "dlaf_test/matrix/util_generic_blas.h"
+#include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/util_types.h"
 
 using namespace dlaf;
@@ -22,27 +29,54 @@ struct GeneralMultiplicationTestMC : public ::testing::Test {};
 TYPED_TEST_SUITE(GeneralMultiplicationTestMC, MatrixElementTypes);
 
 const std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
-
-const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType>> sizes;
+const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, SizeType>> sizes = {
+    // m, n, k, mb, a, b
+    {3, 3, 3, 1, 0, 2}, {3, 3, 3, 3, 0, 0},    {6, 6, 6, 3, 0, 1},
+    {9, 9, 9, 3, 0, 2}, {21, 21, 21, 3, 0, 6},
+};
 
 GlobalElementSize globalTestSize(const LocalElementSize& size) {
   return {size.rows(), size.cols()};
 }
 
 template <class T, Backend B, Device D>
-void testGeneralMultiplication(const blas::Op opA, const blas::Op opB, const T alpha, const T beta,
-                               SizeType m, SizeType n, SizeType k, SizeType mb, SizeType nb) {
-  dlaf::internal::silenceUnusedWarningFor(opA, opB, alpha, beta, m, n, k, mb, nb);
+void testGeneralMultiplication(const SizeType a, const SizeType b, const blas::Op opA,
+                               const blas::Op opB, const T alpha, const T beta, const SizeType m,
+                               const SizeType n, const SizeType k, const SizeType mb) {
+  const SizeType a_el = a * mb;
+  const SizeType b_el = std::min((b + 1) * mb - 1, m - 1);
+
+  auto [refA, refB, refC, refResult] =
+      matrix::test::getSubMatrixMatrixMultiplication(a_el, b_el, m, n, k, alpha, beta, opA, opB);
+
+  auto setMatrix = [&](auto elSetter, const LocalElementSize size, const TileElementSize block_size) {
+    Matrix<T, Device::CPU> matrix(size, block_size);
+    dlaf::matrix::util::set(matrix, elSetter);
+    return matrix;
+  };
+
+  Matrix<const T, Device::CPU> mat_a = setMatrix(refA, {m, k}, {mb, mb});
+  Matrix<const T, Device::CPU> mat_b = setMatrix(refB, {k, n}, {mb, mb});
+  Matrix<T, Device::CPU> mat_c = setMatrix(refC, {m, n}, {mb, mb});
+
+  dlaf::multiplication::generalSubMatrix(a, b, opA, opB, alpha, mat_a, mat_b, beta, mat_c);
+
+  CHECK_MATRIX_NEAR(refResult, mat_c, 40 * (mat_c.size().rows() + 1) * TypeUtilities<T>::error,
+                    40 * (mat_c.size().rows() + 1) * TypeUtilities<T>::error);
 }
 
 TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocal) {
   for (const auto opA : blas_ops) {
     for (const auto opB : blas_ops) {
-      for (const auto& [m, n, k, mb, nb] : sizes) {
-        const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .7);
+      // Note: not yet implemented
+      if (opA != blas::Op::NoTrans || opB != blas::Op::NoTrans)
+        continue;
+
+      for (const auto& [m, n, k, mb, a, b] : sizes) {
+        const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
         const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
-        testGeneralMultiplication<TypeParam, Backend::MC, Device::CPU>(opA, opB, alpha, beta, m, n, k,
-                                                                       mb, nb);
+        testGeneralMultiplication<TypeParam, Backend::MC, Device::CPU>(a, b, opA, opB, alpha, beta, m, n,
+                                                                       k, mb);
       }
     }
   }


### PR DESCRIPTION
This PR has its root in a very small part of the work going on in #436, where a constrained use-case of a `gemm` is used.

The specific use-case is a gemm between sub-matrices, which have the characteristic of being placed in the same exact spot in all matrices, so both inputs and output.
For this reason, given a linear range `[s, e]`, the operations is `C[s:e, s:e] = beta * C[s:e, s:e] + alpha * A[s:e, s:e] * B[s:e, s:e]`.
In particular, elements outside these 2D ranges are not referenced/modified in any of the matrices involved.

It is a specific use-case but, as soon as we will change Matrix API to manage sub-matrix not as a special case, it will become a normal `gemm`. In the meanwhile, I think we can go a bit more "easier" on its API.

Looking forward to suggestions/feedbacks.