### PR TITLE
Introduce MC tridiagonal solver in SEP

### DIFF
--- a/include/dlaf/eigensolver/eigensolver/api.h
+++ b/include/dlaf/eigensolver/eigensolver/api.h
@@ -19,7 +19,7 @@ namespace dlaf::eigensolver {
 
 template <class T, Device D>
 struct EigensolverResult {
-  common::internal::vector<BaseType<T>> eigenvalues;
+  Matrix<BaseType<T>, D> eigenvalues;
   Matrix<T, D> eigenvectors;
 };
 

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -18,6 +18,7 @@
 #include "dlaf/matrix/copy.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/matrix_mirror.h"
+#include "dlaf/types.h"
 #include "dlaf_test/matrix/matrix_local.h"
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/matrix/util_matrix_local.h"
@@ -77,7 +78,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb)
 
   auto mat_a_local = allGather(blas::Uplo::General, reference);
   auto mat_evalues_local = [&]() {
-    MatrixMirror<const T, Device::CPU, D> mat_evals(ret.eigenvalues);
+    MatrixMirror<const BaseType<T>, Device::CPU, D> mat_evals(ret.eigenvalues);
     return allGather(blas::Uplo::General, mat_evals.get());
   }();
   auto mat_e_local = [&]() {

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -76,7 +76,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb)
     return;
 
   auto mat_a_local = allGather(blas::Uplo::General, reference);
-  auto mat_evalues_local  = [&]() {
+  auto mat_evalues_local = [&]() {
     MatrixMirror<const T, Device::CPU, D> mat_evals(ret.eigenvalues);
     return allGather(blas::Uplo::General, mat_evals.get());
   }();

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -85,7 +85,7 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
 
   auto mat_a_local = allGather(blas::Uplo::General, reference_a);
   auto mat_b_local = allGather(blas::Uplo::General, reference_b);
-  auto mat_evalues_local  = [&]() {
+  auto mat_evalues_local = [&]() {
     MatrixMirror<const T, Device::CPU, D> mat_evals(ret.eigenvalues);
     return allGather(blas::Uplo::General, mat_evals.get());
   }();

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -85,7 +85,10 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
 
   auto mat_a_local = allGather(blas::Uplo::General, reference_a);
   auto mat_b_local = allGather(blas::Uplo::General, reference_b);
-
+  auto mat_evalues_local  = [&]() {
+    MatrixMirror<const T, Device::CPU, D> mat_evals(ret.eigenvalues);
+    return allGather(blas::Uplo::General, mat_evals.get());
+  }();
   auto mat_e_local = [&]() {
     MatrixMirror<const T, Device::CPU, D> mat_e(ret.eigenvectors);
     return allGather(blas::Uplo::General, mat_e.get());
@@ -119,7 +122,7 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
 
   // Compute Lambda E (in place in mat_e_local)
   for (SizeType j = 0; j < m; ++j) {
-    blas::scal(m, ret.eigenvalues[j], mat_be_local.ptr({0, j}), 1);
+    blas::scal(m, mat_evalues_local({j, 0}), mat_be_local.ptr({0, j}), 1);
   }
 
   // Check A E == Lambda E

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -86,7 +86,7 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
   auto mat_a_local = allGather(blas::Uplo::General, reference_a);
   auto mat_b_local = allGather(blas::Uplo::General, reference_b);
   auto mat_evalues_local = [&]() {
-    MatrixMirror<const T, Device::CPU, D> mat_evals(ret.eigenvalues);
+    MatrixMirror<const BaseType<T>, Device::CPU, D> mat_evals(ret.eigenvalues);
     return allGather(blas::Uplo::General, mat_evals.get());
   }();
   auto mat_e_local = [&]() {


### PR DESCRIPTION
This PR is about changes currently required to introduce #436 in the eigensolver pipeline, replacing the placeholder.

It requires:
- [x] #436 - (actually it is a fork of it)
- [x] #546 
- [x] #632 

TODO:
- [x] Complex values are not yet supported (disabled tests, miniapps and ETIs)
- [x] Empty matrices tests are disabled