### PR TITLE
LAED4 root solver API used in the tridiagonal solver

### DIFF
--- a/include/dlaf/lapack/laed4.h
+++ b/include/dlaf/lapack/laed4.h
@@ -43,10 +43,11 @@ namespace internal {
 ///    the i-th updated eigenvalue
 ///
 /// This overload blocks until completion of the algorithm.
-void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, float rho, float* lambda);
+void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, float rho,
+                   float* lambda) noexcept;
 
 void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta, double rho,
-                   double* lambda);
+                   double* lambda) noexcept;
 
 }
 }

--- a/include/dlaf/lapack/laed4.h
+++ b/include/dlaf/lapack/laed4.h
@@ -1,0 +1,52 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+namespace dlaf {
+namespace internal {
+
+/// Computes the i-th updated eigenvalue of a symmetric rank-1 modification to a diagonal matrix:
+///
+///         D + rho * zz^T
+///
+/// with rho > 0, D[i] < D[j] for i < j and the Euclidean norm of z is 1.
+///
+/// @tparam T
+///    a real number : either `float` or `double`
+///
+/// @param[in] d
+///    the orginal eigenvalues assumed to be in ascending order : d[i] < d[j] for i < j
+///
+/// @param[in] z
+///    the rank-1 updating vector
+///
+/// @param[in] rho
+///    a scalar multiplication factor : rho > 0
+///
+/// @param[in] i
+///    the index of the eigenvalue to be computed : 0 <= i < n
+///
+/// @param[out] delta
+///    a vector used to construct the eigenvectors of the form : d[j] - lambda
+///
+/// @param[out] lambda
+///    the i-th updated eigenvalue
+///
+/// This overload blocks until completion of the algorithm.
+void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, float rho, float* lambda);
+
+void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta, double rho,
+                   double* lambda);
+
+}
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(dlaf.core
     matrix_mirror.cpp
     memory/memory_view.cpp
     memory/memory_chunk.cpp
+    lapack/laed4.cpp
     $<$<BOOL:${DLAF_WITH_CUDA}>:cusolver/assert_info.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/lacpy.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/laset.cu>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,7 +146,7 @@ add_library(dlaf.core
     matrix_mirror.cpp
     memory/memory_view.cpp
     memory/memory_chunk.cpp
-    lapack/laed4.cpp
+    $<$<BOOL:${DLAF_WITH_MKL}>:lapack/laed4.cpp>
     $<$<BOOL:${DLAF_WITH_CUDA}>:cusolver/assert_info.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/lacpy.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/laset.cu>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,7 +146,7 @@ add_library(dlaf.core
     matrix_mirror.cpp
     memory/memory_view.cpp
     memory/memory_chunk.cpp
-    $<$<BOOL:${DLAF_WITH_MKL}>:lapack/laed4.cpp>
+    lapack/laed4.cpp
     $<$<BOOL:${DLAF_WITH_CUDA}>:cusolver/assert_info.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/lacpy.cu>
     $<$<BOOL:${DLAF_WITH_CUDA}>:lapack/gpu/laset.cu>

--- a/src/lapack/laed4.cpp
+++ b/src/lapack/laed4.cpp
@@ -20,7 +20,7 @@ void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, f
   ++i;  // Fortran indexing starts from 1
   int info = 0;
   slaed4(&n, &i, d, z, delta, &rho, lambda, &info);
-  DLAF_ASSERT(info >= 0, info);
+  DLAF_ASSERT(info == 0, info);
 }
 
 void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta, double rho,
@@ -28,7 +28,7 @@ void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta
   ++i;  // Fortran indexing starts from 1
   int info = 0;
   dlaed4(&n, &i, d, z, delta, &rho, lambda, &info);
-  DLAF_ASSERT(info >= 0, info);
+  DLAF_ASSERT(info == 0, info);
 }
 
 }

--- a/src/lapack/laed4.cpp
+++ b/src/lapack/laed4.cpp
@@ -8,9 +8,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <mkl.h>
+#include <lapack/mangling.h>
 #include <dlaf/common/assert.h>
 #include <dlaf/lapack/laed4.h>
+
+extern "C" {
+#define LAPACK_slaed4 LAPACK_GLOBAL(slaed4, SLAED4)
+#define LAPACK_dlaed4 LAPACK_GLOBAL(dlaed4, DLAED4)
+
+void LAPACK_slaed4(...);
+void LAPACK_dlaed4(...);
+}
 
 namespace dlaf {
 namespace internal {
@@ -19,7 +27,7 @@ void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, f
                    float* lambda) noexcept {
   ++i;  // Fortran indexing starts from 1
   int info = 0;
-  slaed4(&n, &i, d, z, delta, &rho, lambda, &info);
+  LAPACK_slaed4(&n, &i, d, z, delta, &rho, lambda, &info);
   DLAF_ASSERT(info == 0, info);
 }
 
@@ -27,7 +35,7 @@ void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta
                    double* lambda) noexcept {
   ++i;  // Fortran indexing starts from 1
   int info = 0;
-  dlaed4(&n, &i, d, z, delta, &rho, lambda, &info);
+  LAPACK_dlaed4(&n, &i, d, z, delta, &rho, lambda, &info);
   DLAF_ASSERT(info == 0, info);
 }
 

--- a/src/lapack/laed4.cpp
+++ b/src/lapack/laed4.cpp
@@ -1,0 +1,35 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <mkl.h>
+#include <dlaf/common/assert.h>
+#include <dlaf/lapack/laed4.h>
+
+namespace dlaf {
+namespace internal {
+
+void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, float rho,
+                   float* lambda) {
+  ++i;  // Fortran indexing starts from 1
+  int info = 0;
+  slaed4(&n, &i, d, z, delta, &rho, lambda, &info);
+  DLAF_ASSERT(info >= 0, info);
+}
+
+void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta, double rho,
+                   double* lambda) {
+  ++i;  // Fortran indexing starts from 1
+  int info = 0;
+  dlaed4(&n, &i, d, z, delta, &rho, lambda, &info);
+  DLAF_ASSERT(info >= 0, info);
+}
+
+}
+}

--- a/src/lapack/laed4.cpp
+++ b/src/lapack/laed4.cpp
@@ -16,7 +16,7 @@ namespace dlaf {
 namespace internal {
 
 void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, float rho,
-                   float* lambda) {
+                   float* lambda) noexcept {
   ++i;  // Fortran indexing starts from 1
   int info = 0;
   slaed4(&n, &i, d, z, delta, &rho, lambda, &info);
@@ -24,7 +24,7 @@ void laed4_wrapper(int n, int i, float const* d, float const* z, float* delta, f
 }
 
 void laed4_wrapper(int n, int i, double const* d, double const* z, double* delta, double rho,
-                   double* lambda) {
+                   double* lambda) noexcept {
   ++i;  // Fortran indexing starts from 1
   int info = 0;
   dlaed4(&n, &i, d, z, delta, &rho, lambda, &info);

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -19,6 +19,7 @@ namespace test {
 using ElementTypes =
     ::testing::Types<int, long long, float, double, std::complex<float>, std::complex<double>>;
 using MatrixElementTypes = ::testing::Types<float, double, std::complex<float>, std::complex<double>>;
+using RealMatrixElementTypes = ::testing::Types<float, double>;
 
 template <class T>
 struct TypeUtilities {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -46,7 +46,7 @@ add_subdirectory(communication)
 add_subdirectory(init)
 add_subdirectory(matrix)
 add_subdirectory(memory)
-add_subdirectory(lapack/gpu)
+add_subdirectory(lapack)
 
 # Operations
 add_subdirectory(auxiliary)

--- a/test/unit/lapack/CMakeLists.txt
+++ b/test/unit/lapack/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_subdirectory(mc)
+add_subdirectory(gpu)

--- a/test/unit/lapack/mc/CMakeLists.txt
+++ b/test/unit/lapack/mc/CMakeLists.txt
@@ -9,10 +9,8 @@
 #
 
 
-if (DLAF_WITH_MKL)
-  DLAF_addTest(test_laed4
-    SOURCES test_laed4.cpp
-    LIBRARIES dlaf.core
-    USE_MAIN PLAIN
-  )
-endif()
+DLAF_addTest(test_laed4
+  SOURCES test_laed4.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)

--- a/test/unit/lapack/mc/CMakeLists.txt
+++ b/test/unit/lapack/mc/CMakeLists.txt
@@ -8,8 +8,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_laed4
-  SOURCES test_laed4.cpp
-  LIBRARIES dlaf.core
-  USE_MAIN PLAIN
-)
+
+if (DLAF_WITH_MKL)
+  DLAF_addTest(test_laed4
+    SOURCES test_laed4.cpp
+    LIBRARIES dlaf.core
+    USE_MAIN PLAIN
+  )
+endif()

--- a/test/unit/lapack/mc/CMakeLists.txt
+++ b/test/unit/lapack/mc/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2022, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+DLAF_addTest(test_laed4
+  SOURCES test_laed4.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PLAIN
+)

--- a/test/unit/lapack/mc/test_laed4.cpp
+++ b/test/unit/lapack/mc/test_laed4.cpp
@@ -1,0 +1,63 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#include "dlaf/lapack/laed4.h"
+
+#include "gtest/gtest.h"
+
+#include "dlaf/types.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::test;
+using namespace testing;
+
+template <class T, Device D>
+class TileOperationsTest : public ::testing::Test {};
+
+template <class T>
+using RealTileOperationsTestMC = TileOperationsTest<T, Device::CPU>;
+
+TYPED_TEST_SUITE(RealTileOperationsTestMC, RealMatrixElementTypes);
+
+// To reproduce the setup in python:
+//
+// ```
+// import numpy as np
+// from scipy.linalg import eigh
+// from scipy.linalg import norm
+//
+// n = 20
+// d = np.log(np.arange(2, n + 2))
+// z = np.arange(1, n + 1) / n
+// z = z / norm(z)
+// eigh(np.diag(d) + np.outer(z, np.transpose(z)), eigvals_only=True, subset_by_index=[n / 2, n / 2])
+//
+// ```
+//
+TYPED_TEST(RealTileOperationsTestMC, Laed4) {
+  int n = 20;
+  std::vector<TypeParam> d(to_sizet(n));
+  std::vector<TypeParam> z(to_sizet(n));
+  TypeParam sumsq = 0;
+  for (std::size_t i = 0; i < to_sizet(n); ++i) {
+    d[i] = std::log(TypeParam(i + 2));
+    z[i] = TypeParam(i + 1) / n;
+    sumsq += z[i] * z[i];
+  }
+  TypeParam rho = 1.0 / sumsq;  // the factor essentially normalizes `z`
+  int i = n / 2;                // the index of the middle eigenvalue
+  std::vector<TypeParam> delta(to_sizet(n));
+  TypeParam lambda;
+
+  dlaf::internal::laed4_wrapper(n, i, d.data(), z.data(), delta.data(), rho, &lambda);
+
+  TypeParam expected_lambda = 2.497336;
+  EXPECT_NEAR(lambda, expected_lambda, 1e-7);
+}

--- a/test/unit/lapack/mc/test_laed4.cpp
+++ b/test/unit/lapack/mc/test_laed4.cpp
@@ -30,8 +30,7 @@ TYPED_TEST_SUITE(RealTileOperationsTestMC, RealMatrixElementTypes);
 //
 // ```
 // import numpy as np
-// from scipy.linalg import eigh
-// from scipy.linalg import norm
+// from scipy.linalg import eigh, norm
 //
 // n = 20
 // d = np.log(np.arange(2, n + 2))
@@ -58,6 +57,6 @@ TYPED_TEST(RealTileOperationsTestMC, Laed4) {
 
   dlaf::internal::laed4_wrapper(n, i, d.data(), z.data(), delta.data(), rho, &lambda);
 
-  TypeParam expected_lambda = 2.497336;
-  EXPECT_NEAR(lambda, expected_lambda, 1e-7);
+  TypeParam expected_lambda = 2.497335998568758;
+  EXPECT_NEAR(lambda, expected_lambda, n * TypeUtilities<TypeParam>::error);
 }

--- a/test/unit/lapack/mc/test_laed4.cpp
+++ b/test/unit/lapack/mc/test_laed4.cpp
@@ -50,13 +50,13 @@ TYPED_TEST(RealTileOperationsTestMC, Laed4) {
     z[i] = TypeParam(i + 1) / n;
     sumsq += z[i] * z[i];
   }
-  TypeParam rho = 1.0 / sumsq;  // the factor essentially normalizes `z`
-  int i = n / 2;                // the index of the middle eigenvalue
+  TypeParam rho = 1 / sumsq;  // the factor essentially normalizes `z`
+  int i = n / 2;              // the index of the middle eigenvalue
   std::vector<TypeParam> delta(to_sizet(n));
   TypeParam lambda;
 
   dlaf::internal::laed4_wrapper(n, i, d.data(), z.data(), delta.data(), rho, &lambda);
 
-  TypeParam expected_lambda = 2.497335998568758;
+  TypeParam expected_lambda = TypeParam(2.497335998568758);
   EXPECT_NEAR(lambda, expected_lambda, n * TypeUtilities<TypeParam>::error);
 }


### PR DESCRIPTION
The API is needed until the new version of `lapackpp` is released which has it.