### PR TITLE
Fix CI issue

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -70,6 +70,7 @@ class DlaFuture(CMakePackage, CudaPackage):
         if '+ci-test' in self.spec:
             # Enable TESTS and setup CI specific parameters
             args.append(self.define("CMAKE_CXX_FLAGS", "-Werror"))
+            args.append(self.define("BUILD_TESTING", True))
             args.append(self.define("DLAF_BUILD_TESTING", True))
             args.append(self.define("DLAF_CI_RUNNER_USES_MPIRUN", True))
             args.append(self.define("MPIEXEC_EXECUTABLE", "srun"))


### PR DESCRIPTION
An issue was introduces by spack. They now define BUILD_TESTING=OFF unless spack testing is used.