### PR TITLE
CI: going to ubuntu22.04

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: 2418cfb79b46491122baad8efd6af596078b396d
+    SPACK_SHA: 63f7053fe8a99c5718a15e94ca385f1c478d53e4
     SPACK_DLAF_REPO: ./spack
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
@@ -36,7 +36,7 @@ stages:
     - docker build -t $BUILD_IMAGE:$TAG -t $BUILD_IMAGE:latest --cache-from $BUILD_IMAGE:$TAG --cache-from $BUILD_IMAGE:latest --build-arg BASE_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg SPACK_SHA --build-arg EXTRA_APTGET --build-arg COMPILER --build-arg SPACK_ENVIRONMENT --build-arg SPACK_DLAF_REPO --build-arg USE_MKL -f $BUILD_DOCKER_FILE --network=host .
     - docker push $BUILD_IMAGE:$TAG
     - docker push $BUILD_IMAGE:latest
-    - docker build -t $DEPLOY_IMAGE --build-arg BUILD_IMAGE=$BUILD_IMAGE:$TAG --build-arg DEPLOY_BASE_IMAGE --build-arg USE_MKL -f $DEPLOY_DOCKER_FILE --network=host .
+    - docker build -t $DEPLOY_IMAGE --build-arg BUILD_IMAGE=$BUILD_IMAGE:$TAG --build-arg DEPLOY_BASE_IMAGE --build-arg EXTRA_APTGET_DEPLOY --build-arg USE_MKL -f $DEPLOY_DOCKER_FILE --network=host .
     - docker push $DEPLOY_IMAGE
     - docker run -v $PWD/ci/ctest_to_gitlab.sh:/ctest_to_gitlab.sh $DEPLOY_IMAGE /ctest_to_gitlab.sh "$DEPLOY_IMAGE" "$USE_CODECOV" "$THREADS_PER_NODE" "$SLURM_CONSTRAINT" > pipeline.yml
   artifacts:
@@ -52,6 +52,8 @@ cpu release build gcc11:
     BASE_IMAGE: ubuntu:22.04
     DEPLOY_BASE_IMAGE: ubuntu:22.04
     EXTRA_APTGET: ""
+    EXTRA_APTGET_DEPLOY: "glibc-tools"
+    # glibc-tools is needed for libSegFault on ubuntu:22.04
     COMPILER: gcc@11.2.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
@@ -69,6 +71,7 @@ cpu release build clang10:
     BASE_IMAGE: ubuntu:20.04
     DEPLOY_BASE_IMAGE: ubuntu:20.04
     EXTRA_APTGET: clang
+    EXTRA_APTGET_DEPLOY: ""
     COMPILER: clang@10.0.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
@@ -86,6 +89,8 @@ cpu release build clang12:
     BASE_IMAGE: ubuntu:22.04
     DEPLOY_BASE_IMAGE: ubuntu:22.04
     EXTRA_APTGET: clang-12
+    EXTRA_APTGET_DEPLOY: "glibc-tools"
+    # glibc-tools is needed for libSegFault on ubuntu:22.04
     COMPILER: clang@12.0.1
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
@@ -103,6 +108,8 @@ cpu codecov build gcc11:
     BASE_IMAGE: ubuntu:22.04
     DEPLOY_BASE_IMAGE: ubuntu:22.04
     EXTRA_APTGET: ""
+    EXTRA_APTGET_DEPLOY: "glibc-tools"
+    # glibc-tools is needed for libSegFault on ubuntu:22.04
     COMPILER: gcc@11.2.0
     USE_MKL: "OFF"
     SPACK_ENVIRONMENT: ci/docker/cpu-debug.yaml
@@ -120,6 +127,7 @@ gpu release build gcc9:
     BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
     DEPLOY_BASE_IMAGE: ubuntu:20.04
     EXTRA_APTGET: ""
+    EXTRA_APTGET_DEPLOY: ""
     COMPILER: gcc@9.3.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
@@ -137,6 +145,7 @@ gpu release build clang10:
     BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
     DEPLOY_BASE_IMAGE: ubuntu:20.04
     EXTRA_APTGET: clang
+    EXTRA_APTGET_DEPLOY: ""
     COMPILER: clang@10.0.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
@@ -154,6 +163,7 @@ gpu codecov build gcc9:
     BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
     DEPLOY_BASE_IMAGE: ubuntu:20.04
     EXTRA_APTGET: ""
+    EXTRA_APTGET_DEPLOY: ""
     COMPILER: gcc@9.3.0
     USE_MKL: "OFF"
     SPACK_ENVIRONMENT: ci/docker/gpu-debug.yaml

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v1/.cscs.yml'
+  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.cscs.yml'
 
 stages:
   - build
@@ -26,16 +26,17 @@ stages:
   script:
     # Note: a tag can contain 0-9 A-Z a-z -_.
     - TAG_IMAGE=`echo ${BASE_IMAGE##*/} | sed 's/[:]//g'`
+    - TAG_APTGET=`echo ${EXTRA_APTGET} | sha256sum - | head -c 6`
     - TAG_COMPILER=`echo $COMPILER | sed 's/[@]//g'`
     - TAG_DOCKERFILE=`sha256sum $BUILD_DOCKER_FILE | head -c 16`
     - TAG_SPACK=`echo $SPACK_SHA | head -c 8`
     - TAG_REPO=`find $SPACK_DLAF_REPO -type f -exec sha256sum {} \; | sha256sum - | head -c 16`
     - TAG_ENVIRONMENT=`sha256sum $SPACK_ENVIRONMENT | head -c 16`
-    - TAG=${TAG_IMAGE}-${TAG_COMPILER}-MKL${USE_MKL}-${TAG_DOCKERFILE}-${TAG_SPACK}-${TAG_REPO}-${TAG_ENVIRONMENT}
-    - docker build -t $BUILD_IMAGE:$TAG -t $BUILD_IMAGE:latest --cache-from $BUILD_IMAGE:$TAG --cache-from $BUILD_IMAGE:latest --build-arg BASE_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg SPACK_SHA --build-arg COMPILER --build-arg SPACK_ENVIRONMENT --build-arg SPACK_DLAF_REPO --build-arg USE_MKL -f $BUILD_DOCKER_FILE --network=host .
+    - TAG=${TAG_IMAGE}-${TAG_APTGET}-${TAG_COMPILER}-MKL${USE_MKL}-${TAG_DOCKERFILE}-${TAG_SPACK}-${TAG_REPO}-${TAG_ENVIRONMENT}
+    - docker build -t $BUILD_IMAGE:$TAG -t $BUILD_IMAGE:latest --cache-from $BUILD_IMAGE:$TAG --cache-from $BUILD_IMAGE:latest --build-arg BASE_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg SPACK_SHA --build-arg EXTRA_APTGET --build-arg COMPILER --build-arg SPACK_ENVIRONMENT --build-arg SPACK_DLAF_REPO --build-arg USE_MKL -f $BUILD_DOCKER_FILE --network=host .
     - docker push $BUILD_IMAGE:$TAG
     - docker push $BUILD_IMAGE:latest
-    - docker build -t $DEPLOY_IMAGE --build-arg BUILD_IMAGE=$BUILD_IMAGE:$TAG --build-arg USE_MKL -f $DEPLOY_DOCKER_FILE --network=host .
+    - docker build -t $DEPLOY_IMAGE --build-arg BUILD_IMAGE=$BUILD_IMAGE:$TAG --build-arg DEPLOY_BASE_IMAGE --build-arg USE_MKL -f $DEPLOY_DOCKER_FILE --network=host .
     - docker push $DEPLOY_IMAGE
     - docker run -v $PWD/ci/ctest_to_gitlab.sh:/ctest_to_gitlab.sh $DEPLOY_IMAGE /ctest_to_gitlab.sh "$DEPLOY_IMAGE" "$USE_CODECOV" "$THREADS_PER_NODE" "$SLURM_CONSTRAINT" > pipeline.yml
   artifacts:
@@ -43,17 +44,19 @@ stages:
       - pipeline.yml
 
 # Builds a Docker image for the current commit
-cpu release build gcc9:
+cpu release build gcc11:
   extends: .build_spack_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: ubuntu:20.04
-    COMPILER: gcc@9.3.0
+    BASE_IMAGE: ubuntu:22.04
+    DEPLOY_BASE_IMAGE: ubuntu:22.04
+    EXTRA_APTGET: ""
+    COMPILER: gcc@11.2.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc9/deploy:$CI_COMMIT_SHA
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc11/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-gcc11/deploy:$CI_COMMIT_SHA
     SLURM_CONSTRAINT: mc
     THREADS_PER_NODE: 72
     USE_CODECOV: "false"
@@ -64,6 +67,8 @@ cpu release build clang10:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
     BASE_IMAGE: ubuntu:20.04
+    DEPLOY_BASE_IMAGE: ubuntu:20.04
+    EXTRA_APTGET: clang
     COMPILER: clang@10.0.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
@@ -73,17 +78,36 @@ cpu release build clang10:
     THREADS_PER_NODE: 72
     USE_CODECOV: "false"
 
-cpu codecov build gcc9:
+cpu release build clang12:
+  extends: .build_spack_common
+  variables:
+    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
+    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
+    BASE_IMAGE: ubuntu:22.04
+    DEPLOY_BASE_IMAGE: ubuntu:22.04
+    EXTRA_APTGET: clang-12
+    COMPILER: clang@12.0.1
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/cpu-release.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang12/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cpu-clang12/deploy:$CI_COMMIT_SHA
+    SLURM_CONSTRAINT: mc
+    THREADS_PER_NODE: 72
+    USE_CODECOV: "false"
+
+cpu codecov build gcc11:
   extends: .build_spack_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
-    BASE_IMAGE: ubuntu:20.04
-    COMPILER: gcc@9.3.0
+    BASE_IMAGE: ubuntu:22.04
+    DEPLOY_BASE_IMAGE: ubuntu:22.04
+    EXTRA_APTGET: ""
+    COMPILER: gcc@11.2.0
     USE_MKL: "OFF"
     SPACK_ENVIRONMENT: ci/docker/cpu-debug.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc9/deploy:$CI_COMMIT_SHA
+    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc11/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/codecov-cpu-gcc11/deploy:$CI_COMMIT_SHA
     SLURM_CONSTRAINT: mc
     THREADS_PER_NODE: 72
     USE_CODECOV: "true"
@@ -94,6 +118,8 @@ gpu release build gcc9:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
     BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+    DEPLOY_BASE_IMAGE: ubuntu:20.04
+    EXTRA_APTGET: ""
     COMPILER: gcc@9.3.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
@@ -109,6 +135,8 @@ gpu release build clang10:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
     BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+    DEPLOY_BASE_IMAGE: ubuntu:20.04
+    EXTRA_APTGET: clang
     COMPILER: clang@10.0.0
     USE_MKL: "ON"
     SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
@@ -124,6 +152,8 @@ gpu codecov build gcc9:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
     BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
+    DEPLOY_BASE_IMAGE: ubuntu:20.04
+    EXTRA_APTGET: ""
     COMPILER: gcc@9.3.0
     USE_MKL: "OFF"
     SPACK_ENVIRONMENT: ci/docker/gpu-debug.yaml
@@ -154,14 +184,14 @@ notify_github_start:
   trigger:
     strategy: depend
 
-cpu release test gcc9:
+cpu release test gcc11:
   extends: .run_common
   needs:
-    - cpu release build gcc9
+    - cpu release build gcc11
   trigger:
     include:
       - artifact: pipeline.yml
-        job: cpu release build gcc9
+        job: cpu release build gcc11
 
 cpu release test clang10:
   extends: .run_common
@@ -172,15 +202,24 @@ cpu release test clang10:
       - artifact: pipeline.yml
         job: cpu release build clang10
 
-cpu codecov test gcc9:
+cpu release test clang12:
   extends: .run_common
   needs:
-    - cpu codecov build gcc9
+    - cpu release build clang12
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: cpu release build clang12
+
+cpu codecov test gcc11:
+  extends: .run_common
+  needs:
+    - cpu codecov build gcc11
   trigger:
     strategy: depend
     include:
       - artifact: pipeline.yml
-        job: cpu codecov build gcc9
+        job: cpu codecov build gcc11
 
 gpu release test gcc9:
   extends: .run_common

--- a/ci/docker/build.Dockerfile
+++ b/ci/docker/build.Dockerfile
@@ -10,14 +10,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
     SPACK_COLOR=always
 SHELL ["/bin/bash", "-c"]
 
+ARG EXTRA_APTGET
 RUN apt-get -yqq update && \
     apt-get -yqq install --no-install-recommends \
     software-properties-common \
     build-essential gfortran \
     autoconf automake \
-    clang \
+    ${EXTRA_APTGET} \
     gawk \
-    python3 python3.8-distutils \
+    python3 python3-distutils \
     git tar wget curl ca-certificates gpg-agent jq tzdata \
     patchelf unzip file gnupg2 && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/codecov.Dockerfile
+++ b/ci/docker/codecov.Dockerfile
@@ -57,6 +57,7 @@ ARG BUILD
 ARG SOURCE
 ARG DEPLOY
 
+ARG EXTRA_APTGET_DEPLOY
 # python is needed for fastcov
 # pip is needed only to install fastcov (it is removed with
 #     its dependencies after fastcov installation)
@@ -64,6 +65,7 @@ ARG DEPLOY
 # tzdata is needed to print correct time
 RUN apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
+      ${EXTRA_APTGET_DEPLOY} \
       python3 python3-pip \
       curl \
       ca-certificates \

--- a/ci/docker/codecov.Dockerfile
+++ b/ci/docker/codecov.Dockerfile
@@ -1,4 +1,5 @@
 ARG BUILD_IMAGE
+ARG DEPLOY_BASE_IMAGE
 
 # This is the folder where the project is built
 ARG BUILD=/DLA-Future-build
@@ -44,7 +45,7 @@ RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \
     rm -rf ${SOURCE}/.git
 
 # Multistage build, this is the final small image
-FROM ubuntu:20.04
+FROM $DEPLOY_BASE_IMAGE
 
 # set jfrog autoclean policy
 LABEL com.jfrog.artifactory.retention.maxDays="7"

--- a/ci/docker/cpu-debug.yaml
+++ b/ci/docker/cpu-debug.yaml
@@ -27,6 +27,7 @@ spack:
     pika:
       variants:
         - 'build_type=Debug'
+        - 'malloc=system'
     mpich:
       version:
         - 3.4.2

--- a/ci/docker/cpu-debug.yaml
+++ b/ci/docker/cpu-debug.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop build_type=Debug +miniapps +ci-test ^openblas ^mpich@3.4.2
+    - dla-future@develop build_type=Debug +miniapps +ci-test ^openblas ^mpich
   view: false
   concretization: together
 
@@ -28,5 +28,11 @@ spack:
       variants:
         - 'build_type=Debug'
     mpich:
+      version:
+        - 3.4.2
       variants:
         - '~fortran'
+    git:
+      # Force git as non-buildable to allow deprecated versions in environments
+      # https://github.com/spack/spack/pull/30040
+      buildable: false

--- a/ci/docker/cpu-release.yaml
+++ b/ci/docker/cpu-release.yaml
@@ -24,6 +24,9 @@ spack:
       variants:
         - '~cuda'
         - '~openmp'
+    pika:
+      variants:
+        - 'malloc=mimalloc'
     mpich:
       version:
         - 3.4.2

--- a/ci/docker/cpu-release.yaml
+++ b/ci/docker/cpu-release.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop +miniapps +ci-test ^intel-mkl ^mpich@3.4.2
+    - dla-future@develop +miniapps +ci-test ^intel-mkl ^mpich
   view: false
   concretization: together
 
@@ -25,5 +25,11 @@ spack:
         - '~cuda'
         - '~openmp'
     mpich:
+      version:
+        - 3.4.2
       variants:
         - '~fortran'
+    git:
+      # Force git as non-buildable to allow deprecated versions in environments
+      # https://github.com/spack/spack/pull/30040
+      buildable: false

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -74,9 +74,11 @@ ENV DEBIAN_FRONTEND noninteractive
 ARG BUILD
 ARG DEPLOY
 
+ARG EXTRA_APTGET_DEPLOY
 # tzdata is needed to print correct time
 RUN apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
+      ${EXTRA_APTGET_DEPLOY} \
       tzdata && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -1,4 +1,5 @@
 ARG BUILD_IMAGE
+ARG DEPLOY_BASE_IMAGE
 
 # This is the folder where the project is built
 ARG BUILD=/DLA-Future-build
@@ -61,7 +62,8 @@ RUN if [ "$USE_MKL" = "ON" ]; then \
       ${MKL_LIB}/libmkl_vml_mc3.so ; \
     fi
 
-FROM ubuntu:20.04
+# Multistage build, this is the final small image
+FROM $DEPLOY_BASE_IMAGE
 
 # set jfrog autoclean policy
 LABEL com.jfrog.artifactory.retention.maxDays="7"

--- a/ci/docker/gpu-debug.yaml
+++ b/ci/docker/gpu-debug.yaml
@@ -27,6 +27,7 @@ spack:
     pika:
       variants:
         - 'build_type=Debug'
+        - 'malloc=system'
     mpich:
       version:
         - 3.4.2

--- a/ci/docker/gpu-debug.yaml
+++ b/ci/docker/gpu-debug.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop build_type=Debug +cuda +miniapps +ci-test ^openblas ^mpich@3.4.2
+    - dla-future@develop build_type=Debug +cuda +miniapps +ci-test ^openblas ^mpich
   view: false
   concretization: together
 
@@ -28,5 +28,11 @@ spack:
       variants:
         - 'build_type=Debug'
     mpich:
+      version:
+        - 3.4.2
       variants:
         - '~fortran'
+    git:
+      # Force git as non-buildable to allow deprecated versions in environments
+      # https://github.com/spack/spack/pull/30040
+      buildable: false

--- a/ci/docker/gpu-release.yaml
+++ b/ci/docker/gpu-release.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-    - dla-future@develop +cuda +miniapps +ci-test ^intel-mkl ^mpich@3.4.2
+    - dla-future@develop +cuda +miniapps +ci-test ^intel-mkl ^mpich
   view: false
   concretization: together
 
@@ -25,5 +25,11 @@ spack:
         - '~cuda'
         - '~openmp'
     mpich:
+      version:
+        - 3.4.2
       variants:
         - '~fortran'
+    git:
+      # Force git as non-buildable to allow deprecated versions in environments
+      # https://github.com/spack/spack/pull/30040
+      buildable: false

--- a/ci/docker/gpu-release.yaml
+++ b/ci/docker/gpu-release.yaml
@@ -24,6 +24,9 @@ spack:
       variants:
         - '~cuda'
         - '~openmp'
+    pika:
+      variants:
+        - 'malloc=mimalloc'
     mpich:
       version:
         - 3.4.2

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -91,7 +91,8 @@ TYPED_TEST(PanelTest, AssignToConstRef) {
       EXPECT_EQ(exp_indices, ref_indices);
 
       for (const auto& idx : exp_indices) {
-        const auto& exp_tile = panel.read(idx).get();
+        auto exp_tile_f = panel.read(idx);
+        const auto& exp_tile = exp_tile_f.get();
         auto get_element_ptr = [&exp_tile](const TileElementIndex& index) {
           return exp_tile.ptr(index);
         };
@@ -378,17 +379,37 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
       const LocalTileIndex idx(coord, k);
       dlaf::internal::transformLiftDetach(dlaf::internal::Policy<Backend::MC>(), setTile,
                                           panel.readwrite_sender(idx), counter++);
-      const auto& tile = panel.read(idx).get();
+
+      // Getting the future from the panel and getting a reference to the tile
+      // are separated because combining them into one operation would lead to
+      // the tile being a dangling reference since the shared_future from
+      // panel.read(idx) is released at the end of the expression.
+      //
+      // Also note that shared_future::get is not called inside EXPECT_EQ
+      // because it may yield and change worker thread. SCOPED_TRACE uses thread
+      // locals and does not support being created on one thread and destroyed
+      // on another and will segfault if that happens.
+      auto panel_tile_f = panel.read(idx);
+      const auto& panel_tile = panel_tile_f.get();
+      auto matrix_tile_f = matrix.read(idx);
+      const auto& matrix_tile = matrix_tile_f.get();
+
       SCOPED_TRACE(message);
-      EXPECT_EQ(tile.size(), matrix.read(idx).get().size());
+      EXPECT_EQ(panel_tile.size(), matrix_tile.size());
     }
 
     counter = 0;
     for (const auto& idx : panel.iteratorLocal()) {
+      // See comment in previous for loop. This section has the same concerns
+      // regarding dangling references and yielding with SCOPED_TRACE.
+      auto panel_tile_f = panel.read(idx);
+      const auto& panel_tile = panel_tile_f.get();
+      auto matrix_tile_f = matrix.read(idx);
+      const auto& matrix_tile = matrix_tile_f.get();
+
       SCOPED_TRACE(message);
-      CHECK_TILE_EQ(fixedValueTile(counter++), panel.read(idx).get());
-      const auto& tile = panel.read(idx).get();
-      EXPECT_EQ(tile.size(), matrix.read(idx).get().size());
+      CHECK_TILE_EQ(fixedValueTile(counter++), panel_tile);
+      EXPECT_EQ(panel_tile.size(), matrix_tile.size());
     }
   };
 


### PR DESCRIPTION
Move mc tests to ubuntu22.04.

Note: nvidia images are not available yet with ubuntu22.04, therefore gpu tests were not touched.