### PR TITLE
algo: BackTransform from Tridiagonal - attempt to reduce micro-tasking overhead

### DIFF
--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -125,10 +125,10 @@ std::tuple<matrix::Tile<const T, Device::CPU>, matrix::Tile<const T, Device::CPU
 }
 
 template <Backend B, class T>
-struct single_tile_f;
+struct ApplyHHToSingleTileRow;
 
 template <class T>
-struct single_tile_f<Backend::MC, T> {
+struct ApplyHHToSingleTileRow<Backend::MC, T> {
   void operator()(const matrix::Tile<const T, Device::CPU>& tile_v,
                   const matrix::Tile<const T, Device::CPU>& tile_w, matrix::Tile<T, Device::CPU> tile_w2,
                   const matrix::Tile<T, Device::CPU>& tile_e) {
@@ -143,7 +143,7 @@ struct single_tile_f<Backend::MC, T> {
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-struct single_tile_f<Backend::GPU, T> {
+struct ApplyHHToSingleTileRow<Backend::GPU, T> {
   void operator()(cublasHandle_t handle, const matrix::Tile<const T, Device::GPU>& tile_v,
                   const matrix::Tile<const T, Device::GPU>& tile_w,
                   const matrix::Tile<T, Device::GPU>& tile_w2,
@@ -159,10 +159,10 @@ struct single_tile_f<Backend::GPU, T> {
 #endif
 
 template <Backend B, class T>
-struct double_tile_f;
+struct ApplyHHToDoubleTileRow;
 
 template <class T>
-struct double_tile_f<Backend::MC, T> {
+struct ApplyHHToDoubleTileRow<Backend::MC, T> {
   void operator()(const matrix::Tile<const T, Device::CPU>& tile_v0,
                   const matrix::Tile<const T, Device::CPU>& tile_v1,
                   const matrix::Tile<const T, Device::CPU>& tile_w0,
@@ -183,7 +183,7 @@ struct double_tile_f<Backend::MC, T> {
 
 #ifdef DLAF_WITH_CUDA
 template <class T>
-struct double_tile_f<Backend::GPU, T> {
+struct ApplyHHToDoubleTileRow<Backend::GPU, T> {
   void operator()(cublasHandle_t handle, const matrix::Tile<const T, Device::GPU>& tile_v0,
                   const matrix::Tile<const T, Device::GPU>& tile_v1,
                   const matrix::Tile<const T, Device::GPU>& tile_w0,
@@ -531,7 +531,7 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
                        mat_w2.readwrite_sender(LocalTileIndex(0, j_e)),
                        splitTile(mat_e(idx_e), helper.topPart().specEV(sz_e.cols()))) |
               dlaf::internal::transform(dlaf::internal::Policy<B>(thread_priority::normal),
-                                        single_tile_f<B, T>{}) |
+                                        ApplyHHToSingleTileRow<B, T>{}) |
               ex::start_detached();
         }
         else {
@@ -544,7 +544,7 @@ void BackTransformationT2B<B, D, T>::call(const SizeType band_size, Matrix<T, D>
                        splitTile(mat_e(LocalTileIndex{ij.row() + 1, j_e}),
                                  helper.bottomPart().specEV(sz_e.cols()))) |
               dlaf::internal::transform(dlaf::internal::Policy<B>(thread_priority::normal),
-                                        double_tile_f<B, T>{}) |
+                                        ApplyHHToDoubleTileRow<B, T>{}) |
               ex::start_detached();
         }
       }

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -119,8 +119,8 @@ std::tuple<matrix::Tile<const T, Device::CPU>, matrix::Tile<const T, Device::CPU
 
   auto [tile_v_c, tile_t_c] = computeVT(b, tile_hh, std::move(tile_v), std::move(tile_t));
 
-  dlaf::tile::internal::trmm3_o(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(1), tile_t_c,
-                                tile_v_c, tile_w);
+  dlaf::tile::internal::trmm3(Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, T(1), tile_t_c,
+                              tile_v_c, tile_w);
   return std::make_tuple(std::move(tile_v_c), std::move(tile_w));
 }
 

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -136,7 +136,7 @@ struct single_tile_f<Backend::MC, T> {
     using tile::internal::gemm;
     // W2 = V* . E
     gemm(Op::ConjTrans, Op::NoTrans, T(1), tile_v, tile_e, T(0), tile_w2);
-    // E -= W . V2
+    // E -= W . W2
     gemm(Op::NoTrans, Op::NoTrans, T(-1), tile_w, tile_w2, T(1), tile_e);
   }
 };
@@ -151,7 +151,7 @@ struct single_tile_f<Backend::GPU, T> {
     using tile::internal::gemm;
     // W2 = V* . E
     gemm(handle, Op::ConjTrans, Op::NoTrans, T(1), tile_v, tile_e, T(0), tile_w2);
-    // E -= W . V2
+    // E -= W . W2
     gemm(handle, Op::NoTrans, Op::NoTrans, T(-1), tile_w, tile_w2, T(1), tile_e);
   }
 };
@@ -173,7 +173,7 @@ struct double_tile_f<Backend::MC, T> {
     // W2 = V* . E
     gemm(Op::ConjTrans, Op::NoTrans, T(1), tile_v0, tile_e_top, T(0), tile_w2);
     gemm(Op::ConjTrans, Op::NoTrans, T(1), tile_v1, tile_e_bottom, T(1), tile_w2);
-    // E -= W . V2
+    // E -= W . W2
     gemm(Op::NoTrans, Op::NoTrans, T(-1), tile_w0, tile_w2, T(1), tile_e_top);
     gemm(Op::NoTrans, Op::NoTrans, T(-1), tile_w1, tile_w2, T(1), tile_e_bottom);
   }
@@ -193,7 +193,7 @@ struct double_tile_f<Backend::GPU, T> {
     // W2 = V* . E
     gemm(handle, Op::ConjTrans, Op::NoTrans, T(1), tile_v0, tile_e_top, T(0), tile_w2);
     gemm(handle, Op::ConjTrans, Op::NoTrans, T(1), tile_v1, tile_e_bottom, T(1), tile_w2);
-    // E -= W . V2
+    // E -= W . W2
     gemm(handle, Op::NoTrans, Op::NoTrans, T(-1), tile_w0, tile_w2, T(1), tile_e_top);
     gemm(handle, Op::NoTrans, Op::NoTrans, T(-1), tile_w1, tile_w2, T(1), tile_e_bottom);
   }

--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -131,7 +131,7 @@ template <class T>
 struct single_tile_f<Backend::MC, T> {
   void operator()(const matrix::Tile<const T, Device::CPU>& tile_v,
                   const matrix::Tile<const T, Device::CPU>& tile_w, matrix::Tile<T, Device::CPU> tile_w2,
-                  matrix::Tile<T, Device::CPU> tile_e) {
+                  const matrix::Tile<T, Device::CPU>& tile_e) {
     using namespace blas;
     using tile::internal::gemm;
     // W2 = V* . E
@@ -146,7 +146,8 @@ template <class T>
 struct single_tile_f<Backend::GPU, T> {
   void operator()(cublasHandle_t handle, const matrix::Tile<const T, Device::GPU>& tile_v,
                   const matrix::Tile<const T, Device::GPU>& tile_w,
-                  matrix::Tile<T, Device::GPU>& tile_w2, matrix::Tile<T, Device::GPU>& tile_e) {
+                  const matrix::Tile<T, Device::GPU>& tile_w2,
+                  const matrix::Tile<T, Device::GPU>& tile_e) {
     using namespace blas;
     using tile::internal::gemm;
     // W2 = V* . E
@@ -166,8 +167,9 @@ struct double_tile_f<Backend::MC, T> {
                   const matrix::Tile<const T, Device::CPU>& tile_v1,
                   const matrix::Tile<const T, Device::CPU>& tile_w0,
                   const matrix::Tile<const T, Device::CPU>& tile_w1,
-                  matrix::Tile<T, Device::CPU> tile_w2, matrix::Tile<T, Device::CPU> tile_e_top,
-                  matrix::Tile<T, Device::CPU> tile_e_bottom) {
+                  const matrix::Tile<T, Device::CPU>& tile_w2,
+                  const matrix::Tile<T, Device::CPU>& tile_e_top,
+                  const matrix::Tile<T, Device::CPU>& tile_e_bottom) {
     using namespace blas;
     using tile::internal::gemm;
     // W2 = V* . E
@@ -186,8 +188,9 @@ struct double_tile_f<Backend::GPU, T> {
                   const matrix::Tile<const T, Device::GPU>& tile_v1,
                   const matrix::Tile<const T, Device::GPU>& tile_w0,
                   const matrix::Tile<const T, Device::GPU>& tile_w1,
-                  matrix::Tile<T, Device::GPU>& tile_w2, matrix::Tile<T, Device::GPU>& tile_e_top,
-                  matrix::Tile<T, Device::GPU>& tile_e_bottom) {
+                  const matrix::Tile<T, Device::GPU>& tile_w2,
+                  const matrix::Tile<T, Device::GPU>& tile_e_top,
+                  const matrix::Tile<T, Device::GPU>& tile_e_bottom) {
     using namespace blas;
     using tile::internal::gemm;
     // W2 = V* . E

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -254,8 +254,6 @@ private:
   }
 
   TileDataType data_;
-
-public:
   std::variant<std::monostate, TilePromise, pika::shared_future<TileType>,
                pika::shared_future<ConstTileType>>
       dep_tracker_;

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -254,6 +254,8 @@ private:
   }
 
   TileDataType data_;
+
+public:
   std::variant<std::monostate, TilePromise, pika::shared_future<TileType>,
                pika::shared_future<ConstTileType>>
       dep_tracker_;


### PR DESCRIPTION
This is an attempt at reducing the problem related to micro-tasking, where there is a lot of overhead due to small tasks scheduled.

This algorithm was structured to re-use memory for multiple computations, which constrained algorithmic steps order together, together with a minor reduction of parallelisation chances (W2 and W could not be computed in parallel).

At the cost of using slightly more memory, having two independent memory areas for V and W, this PR proposes to:
- [x] group V, T and W computations tasks*
- [x] group W2 and E computations

*note: on GPU there will be two tasks, one for the computation on CPU of V and T, and one on GPU for copying (V,T) to the device and computing W

TODO
- [x] ~cleanup and refactoring (e.g. `split_future` can be avoided in favour of passing tuples)~
- [x] verify build problem 6c55a5acb1c13ead4552b9cc1a7ba0eab9513553 (it seems related to `friend`-ness of a lambda, but it's just a speculation at the moment)
- [x] verify difference between passing by-ref or by-value between CPU and GPU