### PR TITLE
Allow using pika 0.4.0 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
 endif()
 
 # ----- pika
-find_package(pika 0.4.0 REQUIRED EXACT)
+find_package(pika 0.4.0 REQUIRED)
 
 # ----- BLASPP/LAPACKPP
 find_package(blaspp REQUIRED)

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     - trying
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: 63f7053fe8a99c5718a15e94ca385f1c478d53e4
+    SPACK_SHA: dac5fec255f95b8b546899db707337ac2d907e1d
     SPACK_DLAF_REPO: ./spack
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY

--- a/ci/docker/build.Dockerfile
+++ b/ci/docker/build.Dockerfile
@@ -96,4 +96,4 @@ ARG SPACK_ENVIRONMENT
 # 2. Install only the dependencies of this (top level is our package)
 COPY $SPACK_ENVIRONMENT /spack_environment/spack.yaml
 RUN spack env create --without-view ci /spack_environment/spack.yaml
-RUN spack -e ci install --fail-fast --only=dependencies --require-full-hash-match
+RUN spack -e ci install --fail-fast --only=dependencies

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -38,7 +38,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@main")
+    depends_on("pika@0.4:")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -38,7 +38,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@0.4:")
+    depends_on("pika@main")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -38,7 +38,7 @@ class DlaFuture(CMakePackage, CudaPackage):
     conflicts("umpire@6:")
 
     depends_on("pika cxxstd=17 +mpi")
-    depends_on("pika@0.4.0")
+    depends_on("pika@0.4:")
     depends_on("pika +cuda", when="+cuda")
 
     depends_on("pika build_type=Debug", when="build_type=Debug")


### PR DESCRIPTION
pika 0.5.0 will be added to spack here: https://github.com/spack/spack/pull/30960. For non-HIP functionality 0.4.0 or 0.5.0 can be used, and none of the bugs fixed in 0.5.0 would require DLA-Future to use 0.5.0. #459 should require pika 0.5.0.

To do:
- [x] Update spack commit
- [x] Update pika version constraint in `package.py`