### PR TITLE
minor: use `pika::scoped_finalizer` in miniapps

### DIFF
--- a/miniapp/miniapp_band_to_tridiag.cpp
+++ b/miniapp/miniapp_band_to_tridiag.cpp
@@ -176,7 +176,7 @@ int main(int argc, char** argv) {
 
   // options
   using namespace pika::program_options;
-  options_description desc_commandline("Usage: miniapp_bandToTridiag [options]");
+  options_description desc_commandline("Usage: miniapp_band_to_tridiag [options]");
   desc_commandline.add(dlaf::miniapp::getMiniappOptionsDescription());
   desc_commandline.add(dlaf::getOptionsDescription());
 

--- a/miniapp/miniapp_band_to_tridiag.cpp
+++ b/miniapp/miniapp_band_to_tridiag.cpp
@@ -8,10 +8,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 
@@ -159,14 +161,13 @@ struct BandToTridiagMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<BandToTridiagMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<BandToTridiagMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_band_to_tridiag.cpp
+++ b/miniapp/miniapp_band_to_tridiag.cpp
@@ -13,7 +13,6 @@
 #include <limits>
 
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -11,7 +11,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <string>
 
 #include <pika/init.hpp>

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -176,8 +176,7 @@ int main(int argc, char** argv) {
 
   // options
   using namespace pika::program_options;
-  using namespace std::literals;
-  options_description desc_commandline("Usage: "s + argv[0] + " [options]"s);
+  options_description desc_commandline("Usage: miniapp_bt_band_to_tridiag [options]");
   desc_commandline.add(dlaf::miniapp::getMiniappOptionsDescription());
   desc_commandline.add(dlaf::getOptionsDescription());
 

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -8,8 +8,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <string>
 
 #include <pika/init.hpp>
@@ -159,14 +161,13 @@ struct BacktransformBandToTridiagMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
+  const Options opts(vm);
 
-    dlaf::miniapp::dispatchMiniapp<BacktransformBandToTridiagMiniapp>(opts);
-  }
+  dlaf::miniapp::dispatchMiniapp<BacktransformBandToTridiagMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -9,11 +9,13 @@
 //
 
 #include <blas/util.hh>
+#include <cstdlib>
 #include <iostream>
 
 #include <mpi.h>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 #include <pika/unwrap.hpp>
@@ -174,14 +176,13 @@ struct choleskyMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<choleskyMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<choleskyMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -15,7 +15,6 @@
 #include <mpi.h>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 #include <pika/unwrap.hpp>

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -8,10 +8,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 
@@ -142,14 +144,13 @@ struct EigensolverMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<EigensolverMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<EigensolverMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -13,7 +13,6 @@
 #include <limits>
 
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -13,7 +13,6 @@
 #include <limits>
 
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -8,10 +8,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 
@@ -155,14 +157,13 @@ struct GenEigensolverMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<GenEigensolverMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<GenEigensolverMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_gen_to_std.cpp
+++ b/miniapp/miniapp_gen_to_std.cpp
@@ -9,11 +9,13 @@
 //
 
 #include <blas/util.hh>
+#include <cstdlib>
 #include <iostream>
 
 #include <mpi.h>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 #include <pika/unwrap.hpp>
@@ -167,14 +169,13 @@ struct GenToStdMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<GenToStdMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<GenToStdMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_gen_to_std.cpp
+++ b/miniapp/miniapp_gen_to_std.cpp
@@ -15,7 +15,6 @@
 #include <mpi.h>
 #include <pika/future.hpp>
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 #include <pika/unwrap.hpp>

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -8,10 +8,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 
@@ -168,14 +170,13 @@ struct reductionToBandMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<reductionToBandMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<reductionToBandMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -13,7 +13,6 @@
 #include <limits>
 
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -16,7 +16,6 @@
 #include <mpi.h>
 #include <blas/util.hh>
 #include <pika/init.hpp>
-#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
 

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -195,7 +195,8 @@ int main(int argc, char** argv) {
   options_description desc_commandline(
       "Benchmark computation of solution for A . X = 2 . B, "
       "where A is a non-unit lower triangular matrix, and B is an m by n matrix\n\n"
-      "options");
+      "options\n"
+      "Usage: miniapp_triangular_solver [options]");
   desc_commandline.add(dlaf::miniapp::getMiniappOptionsDescription());
   desc_commandline.add(dlaf::getOptionsDescription());
 

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -8,16 +8,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <type_traits>
 
 #include <mpi.h>
+#include <blas/util.hh>
 #include <pika/init.hpp>
+#include <pika/init_runtime/scoped_finalize.hpp>
 #include <pika/program_options.hpp>
 #include <pika/runtime.hpp>
-
-#include <blas/util.hh>
 
 #include "dlaf/common/format_short.h"
 #include "dlaf/common/index2d.h"
@@ -177,14 +178,13 @@ struct triangularSolverMiniapp {
 };
 
 int pika_main(pika::program_options::variables_map& vm) {
-  {
-    dlaf::ScopedInitializer init(vm);
-    const Options opts(vm);
+  pika::scoped_finalize pika_finalizer;
+  dlaf::ScopedInitializer init(vm);
 
-    dlaf::miniapp::dispatchMiniapp<triangularSolverMiniapp>(opts);
-  }
+  const Options opts(vm);
+  dlaf::miniapp::dispatchMiniapp<triangularSolverMiniapp>(opts);
 
-  return pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Follow up https://github.com/eth-cscs/DLA-Future/pull/561#discussion_r890892362

- Use `pika::scoped_finalizer`
- Minor fix: names in some miniapps help messages