### PR TITLE
Add p2p communication

### DIFF
--- a/include/dlaf/communication/kernels.h
+++ b/include/dlaf/communication/kernels.h
@@ -12,4 +12,5 @@
 
 #include "dlaf/communication/kernels/all_reduce.h"
 #include "dlaf/communication/kernels/broadcast.h"
+#include "dlaf/communication/kernels/p2p.h"
 #include "dlaf/communication/kernels/reduce.h"

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -31,6 +31,10 @@ namespace internal {
 template <class T, Device D>
 void send(const Communicator& comm, const matrix::Tile<const T, D>& tile, IndexT_MPI dest,
           IndexT_MPI tag, MPI_Request* req) {
+#if !defined(DLAF_WITH_CUDA_RDMA)
+  static_assert(D == Device::CPU, "DLAF_WITH_CUDA_RDMA=off, MPI accepts just CPU memory.");
+#endif
+
   auto msg = comm::make_message(common::make_data(tile));
   DLAF_MPI_CHECK_ERROR(
       MPI_Isend(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), dest, tag, comm, req));
@@ -42,6 +46,10 @@ DLAF_MAKE_CALLABLE_OBJECT(send);
 template <class T, Device D>
 auto recv(const Communicator& comm, const matrix::Tile<T, D>& tile, IndexT_MPI source, IndexT_MPI tag,
           MPI_Request* req) {
+#if !defined(DLAF_WITH_CUDA_RDMA)
+  static_assert(D == Device::CPU, "DLAF_WITH_CUDA_RDMA=off, MPI accepts just CPU memory.");
+#endif
+
   auto msg = comm::make_message(common::make_data(tile));
   DLAF_MPI_CHECK_ERROR(MPI_Irecv(msg.data(), msg.count(), msg.mpi_type(), source, tag, comm, req));
 }
@@ -54,8 +62,8 @@ void scheduleSend(IndexT_MPI dest, CommSender&& pcomm, IndexT_MPI tag, Sender&& 
   using dlaf::internal::whenAllLift;
   using pika::execution::experimental::start_detached;
 
-  whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), dest, tag) |
-      internal::transformMPI(internal::send_o) | pika::execution::experimental::start_detached();
+  start_detached(whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), dest, tag) |
+                 internal::transformMPI(internal::send_o));
 }
 
 template <class CommSender, class Sender>
@@ -63,7 +71,7 @@ auto scheduleRecv(IndexT_MPI source, CommSender&& pcomm, IndexT_MPI tag, Sender&
   using dlaf::internal::whenAllLift;
   using pika::execution::experimental::start_detached;
 
-  whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), source, tag) |
-      internal::transformMPI(internal::recv_o) | pika::execution::experimental::start_detached();
+  start_detached(whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), source, tag) |
+                 internal::transformMPI(internal::recv_o));
 }
 }

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -14,61 +14,59 @@
 
 #include <mpi.h>
 
-#include "dlaf/common/assert.h"
 #include "dlaf/common/callable_object.h"
-#include "dlaf/common/data.h"
 #include "dlaf/common/pipeline.h"
 #include "dlaf/communication/communicator.h"
-#include "dlaf/communication/executor.h"
 #include "dlaf/communication/message.h"
-#include "dlaf/communication/rdma.h"
 #include "dlaf/matrix/tile.h"
+#include "dlaf/sender/traits.h"
+#include "dlaf/sender/transform_mpi.h"
+#include "dlaf/sender/when_all_lift.h"
 
 namespace dlaf {
 namespace comm {
+
+namespace internal {
 
 // Non-blocking point to point send
 template <class T, Device D>
 void send(const matrix::Tile<const T, D>& tile, IndexT_MPI receiver, IndexT_MPI tag,
           common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
   auto msg = comm::make_message(common::make_data(tile));
-  DLAF_MPI_CALL(MPI_Isend(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), receiver, tag,
-                          pcomm.ref(), req));
+  DLAF_MPI_CHECK_ERROR(MPI_Isend(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), receiver, tag,
+                                 pcomm.ref(), req));
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(send);
 
 // Non-blocking point to point receive
 template <class T, Device D>
-matrix::Tile<const T, D> recvAlloc(TileElementSize tile_size, IndexT_MPI sender, IndexT_MPI tag,
-                                   common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
-  using Tile_t = matrix::Tile<T, D>;
-  using ConstTile_t = matrix::Tile<const T, D>;
-  using MemView_t = memory::MemoryView<T, D>;
-
-  MemView_t mem_view(tile_size.rows() * tile_size.cols());
-  Tile_t tile(tile_size, std::move(mem_view), tile_size.rows());
-
+auto recv(const matrix::Tile<T, D>& tile, IndexT_MPI sender, IndexT_MPI tag,
+          common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
   auto msg = comm::make_message(common::make_data(tile));
-  DLAF_MPI_CALL(MPI_Irecv(msg.data(), msg.count(), msg.mpi_type(), sender, tag, pcomm.ref(), req));
-  return ConstTile_t(std::move(tile));
+  DLAF_MPI_CHECK_ERROR(
+      MPI_Irecv(msg.data(), msg.count(), msg.mpi_type(), sender, tag, pcomm.ref(), req));
 }
 
-template <class T, Device D, class Executor, template <class> class Future>
-void scheduleSend(Executor&& ex, Future<matrix::Tile<const T, D>> tile, IndexT_MPI receiver,
-                  IndexT_MPI tag, hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
-  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(send_o),
-                internal::prepareSendTile(std::move(tile)), receiver, tag, std::move(pcomm));
+DLAF_MAKE_CALLABLE_OBJECT(recv);
 }
 
-template <class T, Device D, class Executor>
-hpx::future<matrix::Tile<const T, D>> scheduleRecvAlloc(
-    Executor&& ex, TileElementSize tile_size, IndexT_MPI sender, IndexT_MPI tag,
-    hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
-  return internal::handleRecvTile<D>(
-      hpx::dataflow(std::forward<Executor>(ex),
-                    hpx::unwrapping(recvAlloc<T, CommunicationDevice<D>::value>), tile_size, sender, tag,
-                    std::move(pcomm)));
+template <class CommSender, class Sender>
+void scheduleSend(IndexT_MPI receiver, CommSender&& pcomm, IndexT_MPI tag, Sender tile) {
+  using dlaf::internal::whenAllLift;
+  using pika::execution::experimental::start_detached;
+
+  whenAllLift(std::move(tile), receiver, tag, std::forward<CommSender>(pcomm)) |
+      internal::transformMPI(internal::send_o) | pika::execution::experimental::start_detached();
+}
+
+template <class CommSender, class Sender>
+auto scheduleRecv(IndexT_MPI sender, CommSender&& pcomm, IndexT_MPI tag, Sender tile) {
+  using dlaf::internal::whenAllLift;
+  using pika::execution::experimental::start_detached;
+
+  whenAllLift(std::move(tile), sender, tag, std::forward<CommSender>(pcomm)) |
+      internal::transformMPI(internal::recv_o) | pika::execution::experimental::start_detached();
 }
 }
 }

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -1,7 +1,7 @@
 //
 // Distributed Linear Algebra with Future (DLAF)
 //
-// Copyright (c) 2018-2021, ETH Zurich
+// Copyright (c) 2018-2022, ETH Zurich
 // All rights reserved.
 //
 // Please, refer to the LICENSE file in the root directory.

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -58,20 +58,19 @@ DLAF_MAKE_CALLABLE_OBJECT(recv);
 }
 
 template <class CommSender, class Sender>
-void scheduleSend(IndexT_MPI dest, CommSender&& pcomm, IndexT_MPI tag, Sender&& tile) {
+[[nodiscard]] auto scheduleSend(IndexT_MPI dest, CommSender&& pcomm, IndexT_MPI tag, Sender&& tile) {
   using dlaf::internal::whenAllLift;
   using pika::execution::experimental::start_detached;
 
-  start_detached(whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), dest, tag) |
-                 internal::transformMPI(internal::send_o));
+  return whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), dest, tag) |
+         internal::transformMPI(internal::send_o);
 }
 
 template <class CommSender, class Sender>
-auto scheduleRecv(IndexT_MPI source, CommSender&& pcomm, IndexT_MPI tag, Sender&& tile) {
+[[nodiscard]] auto scheduleRecv(IndexT_MPI source, CommSender&& pcomm, IndexT_MPI tag, Sender&& tile) {
   using dlaf::internal::whenAllLift;
-  using pika::execution::experimental::start_detached;
 
-  start_detached(whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), source, tag) |
-                 internal::transformMPI(internal::recv_o));
+  return whenAllLift(std::forward<CommSender>(pcomm), std::forward<Sender>(tile), source, tag) |
+         internal::transformMPI(internal::recv_o);
 }
 }

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -52,20 +52,20 @@ DLAF_MAKE_CALLABLE_OBJECT(recv);
 }
 
 template <class CommSender, class Sender>
-void scheduleSend(IndexT_MPI dest, CommSender&& pcomm, IndexT_MPI tag, Sender tile) {
+void scheduleSend(IndexT_MPI dest, CommSender&& pcomm, IndexT_MPI tag, Sender&& tile) {
   using dlaf::internal::whenAllLift;
   using pika::execution::experimental::start_detached;
 
-  whenAllLift(std::move(tile), dest, tag, std::forward<CommSender>(pcomm)) |
+  whenAllLift(std::forward<Sender>(tile), dest, tag, std::forward<CommSender>(pcomm)) |
       internal::transformMPI(internal::send_o) | pika::execution::experimental::start_detached();
 }
 
 template <class CommSender, class Sender>
-auto scheduleRecv(IndexT_MPI source, CommSender&& pcomm, IndexT_MPI tag, Sender tile) {
+auto scheduleRecv(IndexT_MPI source, CommSender&& pcomm, IndexT_MPI tag, Sender&& tile) {
   using dlaf::internal::whenAllLift;
   using pika::execution::experimental::start_detached;
 
-  whenAllLift(std::move(tile), source, tag, std::forward<CommSender>(pcomm)) |
+  whenAllLift(std::forward<Sender>(tile), source, tag, std::forward<CommSender>(pcomm)) |
       internal::transformMPI(internal::recv_o) | pika::execution::experimental::start_detached();
 }
 }

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -23,8 +23,7 @@
 #include "dlaf/sender/transform_mpi.h"
 #include "dlaf/sender/when_all_lift.h"
 
-namespace dlaf {
-namespace comm {
+namespace dlaf::comm {
 
 namespace internal {
 
@@ -67,6 +66,5 @@ auto scheduleRecv(IndexT_MPI source, CommSender&& pcomm, IndexT_MPI tag, Sender&
 
   whenAllLift(std::forward<Sender>(tile), source, tag, std::forward<CommSender>(pcomm)) |
       internal::transformMPI(internal::recv_o) | pika::execution::experimental::start_detached();
-}
 }
 }

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -1,0 +1,74 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2021, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <mpi.h>
+
+#include "dlaf/common/assert.h"
+#include "dlaf/common/callable_object.h"
+#include "dlaf/common/data.h"
+#include "dlaf/common/pipeline.h"
+#include "dlaf/communication/communicator.h"
+#include "dlaf/communication/executor.h"
+#include "dlaf/communication/message.h"
+#include "dlaf/communication/rdma.h"
+#include "dlaf/matrix/tile.h"
+
+namespace dlaf {
+namespace comm {
+
+// Non-blocking point to point send
+template <class T, Device D>
+void send(const matrix::Tile<const T, D>& tile, IndexT_MPI receiver, IndexT_MPI tag,
+          common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
+  auto msg = comm::make_message(common::make_data(tile));
+  DLAF_MPI_CALL(MPI_Isend(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), receiver, tag,
+                          pcomm.ref(), req));
+}
+
+DLAF_MAKE_CALLABLE_OBJECT(send);
+
+// Non-blocking point to point receive
+template <class T, Device D>
+matrix::Tile<const T, D> recvAlloc(TileElementSize tile_size, IndexT_MPI sender, IndexT_MPI tag,
+                                   common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
+  using Tile_t = matrix::Tile<T, D>;
+  using ConstTile_t = matrix::Tile<const T, D>;
+  using MemView_t = memory::MemoryView<T, D>;
+
+  MemView_t mem_view(tile_size.rows() * tile_size.cols());
+  Tile_t tile(tile_size, std::move(mem_view), tile_size.rows());
+
+  auto msg = comm::make_message(common::make_data(tile));
+  DLAF_MPI_CALL(MPI_Irecv(msg.data(), msg.count(), msg.mpi_type(), sender, tag, pcomm.ref(), req));
+  return ConstTile_t(std::move(tile));
+}
+
+template <class T, Device D, class Executor, template <class> class Future>
+void scheduleSend(Executor&& ex, Future<matrix::Tile<const T, D>> tile, IndexT_MPI receiver,
+                  IndexT_MPI tag, hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
+  hpx::dataflow(std::forward<Executor>(ex), matrix::unwrapExtendTiles(send_o),
+                internal::prepareSendTile(std::move(tile)), receiver, tag, std::move(pcomm));
+}
+
+template <class T, Device D, class Executor>
+hpx::future<matrix::Tile<const T, D>> scheduleRecvAlloc(
+    Executor&& ex, TileElementSize tile_size, IndexT_MPI sender, IndexT_MPI tag,
+    hpx::future<common::PromiseGuard<comm::Communicator>> pcomm) {
+  return internal::handleRecvTile<D>(
+      hpx::dataflow(std::forward<Executor>(ex),
+                    hpx::unwrapping(recvAlloc<T, CommunicationDevice<D>::value>), tile_size, sender, tag,
+                    std::move(pcomm)));
+}
+}
+}

--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <functional>
 #include <type_traits>
+#include <vector>
 
 #include "dlaf/types.h"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,10 +203,10 @@ target_add_warnings(dlaf.multiplication)
 DLAF_addPrecompiledHeaders(dlaf.multiplication)
 
 # Define DLAF's permutations library
-add_library(dlaf.permutations OBJECT
-  permutations/general/mc.cpp
-  $<$<BOOL:${DLAF_WITH_CUDA}>:permutations/general/gpu.cpp>
-  )
+add_library(
+  dlaf.permutations OBJECT permutations/general/mc.cpp
+                           $<$<BOOL:${DLAF_WITH_CUDA}>:permutations/general/gpu.cpp>
+)
 target_link_libraries(dlaf.permutations PUBLIC dlaf.prop)
 target_add_warnings(dlaf.permutations)
 DLAF_addPrecompiledHeaders(dlaf.permutations)
@@ -220,7 +220,8 @@ target_add_warnings(dlaf.solver)
 DLAF_addPrecompiledHeaders(dlaf.solver)
 
 # Define DLAF's complete library
-add_library(DLAF
+add_library(
+  DLAF
   $<TARGET_OBJECTS:dlaf.core>
   $<TARGET_OBJECTS:dlaf.auxiliary>
   $<TARGET_OBJECTS:dlaf.eigensolver>

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -111,3 +111,11 @@ DLAF_addTest(
   MPIRANKS 2
   USE_MAIN MPIPIKA
 )
+
+DLAF_addTest(
+  test_comm_p2p
+  SOURCES test_comm_p2p.cpp
+  LIBRARIES dlaf.core
+  MPIRANKS 2
+  USE_MAIN MPIPIKA
+)

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -104,7 +104,8 @@ DLAF_addTest(
   USE_MAIN MPIPIKA
 )
 
-DLAF_addTest(test_transform_mpi
+DLAF_addTest(
+  test_transform_mpi
   SOURCES test_transform_mpi.cpp
   LIBRARIES dlaf.core
   MPIRANKS 2

--- a/test/unit/communication/test_comm_p2p.cpp
+++ b/test/unit/communication/test_comm_p2p.cpp
@@ -66,18 +66,18 @@ void testSendRecv(comm::Communicator world, matrix::Matrix<T, device> matrix, st
 
   const LocalTileIndex idx(0, 0);
 
-  const comm::IndexT_MPI sender_rank = world.size() - 1;
-  const comm::IndexT_MPI receiver_rank = (world.size() - 1) / 2;
+  const comm::IndexT_MPI rank_src = world.size() - 1;
+  const comm::IndexT_MPI rank_dst = (world.size() - 1) / 2;
 
   auto input_tile = fixedValueTile(26);
 
-  if (sender_rank == world.rank()) {
+  if (rank_src == world.rank()) {
     matrix::test::set(matrix(idx).get(), input_tile);
-    comm::scheduleSend(receiver_rank, chain(), tag, matrix.read_sender(idx));
+    comm::scheduleSend(rank_dst, chain(), tag, matrix.read_sender(idx));
   }
-  else if (receiver_rank == world.rank()) {
+  else if (rank_dst == world.rank()) {
     matrix::test::set(matrix(idx).get(), fixedValueTile(13));
-    comm::scheduleRecv(sender_rank, chain(), tag, matrix.readwrite_sender(idx));
+    comm::scheduleRecv(rank_src, chain(), tag, matrix.readwrite_sender(idx));
   }
 
   const auto& tile = matrix.read(idx).get();

--- a/test/unit/communication/test_comm_p2p.cpp
+++ b/test/unit/communication/test_comm_p2p.cpp
@@ -14,7 +14,6 @@
 #include <mpi.h>
 
 #include "dlaf/common/data.h"
-#include "dlaf/common/pipeline.h"
 #include "dlaf/communication/communicator.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
@@ -62,7 +61,6 @@ auto newBlockMatrixStrided() {
 template <class T, Device device>
 void testSendRecv(comm::Communicator world, matrix::Matrix<T, device> matrix, std::string test_name) {
   constexpr comm::IndexT_MPI tag = 13;
-  common::Pipeline<comm::Communicator> chain(world);
 
   const LocalTileIndex idx(0, 0);
 
@@ -73,11 +71,11 @@ void testSendRecv(comm::Communicator world, matrix::Matrix<T, device> matrix, st
 
   if (rank_src == world.rank()) {
     matrix::test::set(matrix(idx).get(), input_tile);
-    comm::scheduleSend(rank_dst, chain(), tag, matrix.read_sender(idx));
+    comm::scheduleSend(rank_dst, world, tag, matrix.read_sender(idx));
   }
   else if (rank_dst == world.rank()) {
     matrix::test::set(matrix(idx).get(), fixedValueTile(13));
-    comm::scheduleRecv(rank_src, chain(), tag, matrix.readwrite_sender(idx));
+    comm::scheduleRecv(rank_src, world, tag, matrix.readwrite_sender(idx));
   }
 
   const auto& tile = matrix.read(idx).get();

--- a/test/unit/communication/test_comm_p2p.cpp
+++ b/test/unit/communication/test_comm_p2p.cpp
@@ -1,0 +1,91 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/communication/kernels/p2p.h"
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include "dlaf/common/data.h"
+#include "dlaf/common/pipeline.h"
+#include "dlaf/communication/communicator.h"
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/memory/memory_view.h"
+
+#include "dlaf_test/matrix/util_tile.h"
+
+using namespace dlaf;
+using namespace dlaf::matrix::test;
+
+class P2PTest : public ::testing::Test {
+  static_assert(NUM_MPI_RANKS >= 2, "at least 2 ranks are required");
+
+protected:
+  using T = int;
+  static constexpr auto device = Device::CPU;
+
+  comm::Communicator world = MPI_COMM_WORLD;
+};
+
+template <class T, Device device>
+auto newBlockMatrixContiguous() {
+  auto layout = matrix::colMajorLayout({13, 13}, {13, 13}, 13);
+  auto dist = matrix::Distribution({13, 13}, {13, 13});
+
+  auto matrix = matrix::Matrix<T, device>(dist, layout);
+
+  EXPECT_TRUE(data_iscontiguous(common::make_data(matrix.read(LocalTileIndex(0, 0)).get())));
+
+  return matrix;
+}
+
+template <class T, Device device>
+auto newBlockMatrixStrided() {
+  auto layout = matrix::colMajorLayout({13, 13}, {13, 13}, 26);
+  auto dist = matrix::Distribution({13, 13}, {13, 13});
+
+  auto matrix = matrix::Matrix<T, device>(dist, layout);
+
+  EXPECT_FALSE(data_iscontiguous(common::make_data(matrix.read(LocalTileIndex(0, 0)).get())));
+
+  return matrix;
+}
+
+template <class T, Device device>
+void testSendRecv(comm::Communicator world, matrix::Matrix<T, device> matrix, std::string test_name) {
+  constexpr comm::IndexT_MPI tag = 13;
+  common::Pipeline<comm::Communicator> chain(world);
+
+  const LocalTileIndex idx(0, 0);
+
+  const comm::IndexT_MPI sender_rank = world.size() - 1;
+  const comm::IndexT_MPI receiver_rank = (world.size() - 1) / 2;
+
+  auto input_tile = fixedValueTile(26);
+
+  if (sender_rank == world.rank()) {
+    matrix::test::set(matrix(idx).get(), input_tile);
+    comm::scheduleSend(receiver_rank, chain(), tag, matrix.read_sender(idx));
+  }
+  else if (receiver_rank == world.rank()) {
+    matrix::test::set(matrix(idx).get(), fixedValueTile(13));
+    comm::scheduleRecv(sender_rank, chain(), tag, matrix.readwrite_sender(idx));
+  }
+
+  const auto& tile = matrix.read(idx).get();
+  SCOPED_TRACE(test_name);
+  CHECK_TILE_EQ(input_tile, tile);
+}
+
+TEST_F(P2PTest, SendRecv) {
+  testSendRecv(world, newBlockMatrixContiguous<T, device>(), "Contiguous");
+  testSendRecv(world, newBlockMatrixStrided<T, device>(), "Strided");
+}

--- a/test/unit/permutations/CMakeLists.txt
+++ b/test/unit/permutations/CMakeLists.txt
@@ -8,7 +8,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_permutations
+DLAF_addTest(
+  test_permutations
   SOURCES test_permutations.cpp
   LIBRARIES dlaf.permutations dlaf.core
   USE_MAIN PIKA


### PR DESCRIPTION
This PR revamps a byproduct of @rasolca and "senderifise" it.

This is needed by distributed versions of BandToTridiagonal and its BackTransformation.

Additional changes:
- fix cmake-format problems on `master`
- fix build problem (missing header)