### PR TITLE
change transformMPI to pass Communicator instead of PromiseGuard

### DIFF
--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -13,8 +13,7 @@
 #include <pika/future.hpp>
 #include <pika/unwrap.hpp>
 
-namespace dlaf {
-namespace common {
+namespace dlaf::common {
 
 /// A `promise` like type which is set upon destruction. The type separates the placement of data
 /// (T) into the promise from notifying the corresponding `pika::future`.
@@ -94,5 +93,4 @@ private:
   pika::execution::experimental::unique_any_sender<T>
       sender_;  ///< This contains always the "tail" of the queue of senders.
 };
-}
 }

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -33,10 +33,9 @@ namespace comm {
 namespace internal {
 
 template <class T>
-auto allReduce(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
+auto allReduce(const comm::Communicator& comm, MPI_Op reduce_op,
                common::internal::ContiguousBufferHolder<const T>& cont_buf_in,
                common::internal::ContiguousBufferHolder<T>& cont_buf_out, MPI_Request* req) {
-  auto& comm = pcomm.ref();
   auto msg_in = comm::make_message(cont_buf_in.descriptor);
   auto msg_out = comm::make_message(cont_buf_out.descriptor);
 
@@ -49,9 +48,8 @@ auto allReduce(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
 DLAF_MAKE_CALLABLE_OBJECT(allReduce);
 
 template <class T>
-auto allReduceInPlace(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
+auto allReduceInPlace(const comm::Communicator& comm, MPI_Op reduce_op,
                       common::internal::ContiguousBufferHolder<T>& cont_buf, MPI_Request* req) {
-  auto& comm = pcomm.ref();
   auto msg = comm::make_message(cont_buf.descriptor);
 
   DLAF_MPI_CHECK_ERROR(

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -31,13 +31,11 @@ namespace dlaf {
 namespace comm {
 
 template <class T, Device D>
-void sendBcast(const matrix::Tile<const T, D>& tile, common::PromiseGuard<Communicator> pcomm,
-               MPI_Request* req) {
+void sendBcast(const matrix::Tile<const T, D>& tile, const Communicator& comm, MPI_Request* req) {
 #if !defined(DLAF_WITH_CUDA_RDMA)
   static_assert(D == Device::CPU, "DLAF_WITH_CUDA_RDMA=off, MPI accepts just CPU memory.");
 #endif
 
-  const auto& comm = pcomm.ref();
   auto msg = comm::make_message(common::make_data(tile));
   DLAF_MPI_CHECK_ERROR(
       MPI_Ibcast(const_cast<T*>(msg.data()), msg.count(), msg.mpi_type(), comm.rank(), comm, req));
@@ -46,14 +44,14 @@ void sendBcast(const matrix::Tile<const T, D>& tile, common::PromiseGuard<Commun
 DLAF_MAKE_CALLABLE_OBJECT(sendBcast);
 
 template <class T, Device D>
-void recvBcast(const matrix::Tile<T, D>& tile, comm::IndexT_MPI root_rank,
-               common::PromiseGuard<Communicator> pcomm, MPI_Request* req) {
+void recvBcast(const matrix::Tile<T, D>& tile, comm::IndexT_MPI root_rank, const Communicator& comm,
+               MPI_Request* req) {
 #if !defined(DLAF_WITH_CUDA_RDMA)
   static_assert(D == Device::CPU, "DLAF_WITH_CUDA_RDMA=off, MPI accepts just CPU memory.");
 #endif
 
   auto msg = comm::make_message(common::make_data(tile));
-  DLAF_MPI_CHECK_ERROR(MPI_Ibcast(msg.data(), msg.count(), msg.mpi_type(), root_rank, pcomm.ref(), req));
+  DLAF_MPI_CHECK_ERROR(MPI_Ibcast(msg.data(), msg.count(), msg.mpi_type(), root_rank, comm, req));
 }
 
 DLAF_MAKE_CALLABLE_OBJECT(recvBcast);

--- a/include/dlaf/communication/kernels/reduce.h
+++ b/include/dlaf/communication/kernels/reduce.h
@@ -38,21 +38,18 @@ namespace comm {
 namespace internal {
 
 template <class T>
-void reduceRecvInPlace(common::PromiseGuard<comm::Communicator> pcomm, MPI_Op reduce_op,
+void reduceRecvInPlace(const comm::Communicator& comm, MPI_Op reduce_op,
                        const common::internal::ContiguousBufferHolder<T>& cont_buf, MPI_Request* req) {
   auto msg = comm::make_message(cont_buf.descriptor);
-  auto& comm = pcomm.ref();
 
   DLAF_MPI_CHECK_ERROR(MPI_Ireduce(MPI_IN_PLACE, msg.data(), msg.count(), msg.mpi_type(), reduce_op,
                                    comm.rank(), comm, req));
 }
 
 template <class T>
-void reduceSend(comm::IndexT_MPI rank_root, common::PromiseGuard<comm::Communicator> pcomm,
-                MPI_Op reduce_op, const common::internal::ContiguousBufferHolder<const T>& cont_buf,
-                MPI_Request* req) {
+void reduceSend(comm::IndexT_MPI rank_root, const comm::Communicator& comm, MPI_Op reduce_op,
+                const common::internal::ContiguousBufferHolder<const T>& cont_buf, MPI_Request* req) {
   auto msg = comm::make_message(cont_buf.descriptor);
-  auto& comm = pcomm.ref();
 
   DLAF_MPI_CHECK_ERROR(
       MPI_Ireduce(msg.data(), nullptr, msg.count(), msg.mpi_type(), reduce_op, rank_root, comm, req));

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -91,3 +91,10 @@ DLAF_addTest(test_collective_async
   MPIRANKS 2
   USE_MAIN MPIPIKA
 )
+
+DLAF_addTest(test_transform_mpi
+  SOURCES test_transform_mpi.cpp
+  LIBRARIES dlaf.core
+  MPIRANKS 2
+  USE_MAIN MPIPIKA
+)

--- a/test/unit/communication/test_transform_mpi.cpp
+++ b/test/unit/communication/test_transform_mpi.cpp
@@ -1,0 +1,131 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/sender/transform_mpi.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "dlaf/common/pipeline.h"
+#include "dlaf/communication/communicator.h"
+#include "dlaf/sender/when_all_lift.h"
+
+using namespace dlaf;
+using namespace dlaf::comm;
+
+using TransformMPITest = ::testing::Test;
+
+// wait for guard to become true with a timeout of 200ms
+auto try_waiting_guard = [](std::atomic_bool& guard) {
+  using namespace std::chrono_literals;
+  const auto wait_guard = 20ms;
+
+  for (int i = 0; i < 100 && !guard; ++i)
+    std::this_thread::sleep_for(wait_guard);
+};
+
+TEST_F(TransformMPITest, PromiseGuardManagement) {
+  static_assert(NUM_MPI_RANKS >= 2, "This test requires 2 ranks");
+
+  // Note:
+  // Rank 0 is where the test actually is done, while Rank 1 is just used by Rank 0 to control
+  // its own progress.
+  //
+  // Rank 0 posts an IRecv that will be satisfied by Rank 1 just after it receives from Rank 0
+  // the trigger. So, actually, Rank 0 can control when to unlock its IRecv by deciding when to
+  // send the trigger to Rank 1. In this way, Rank 0 flow can be "paused" for verifiying various
+  // phases of the async communication mechanism for IRecv.
+
+  Communicator world(MPI_COMM_WORLD);
+  const IndexT_MPI rank = world.rank();
+
+  if (rank == 0) {
+    using dlaf::comm::internal::transformMPI;
+    using dlaf::internal::whenAllLift;
+
+    namespace ex = pika::execution::experimental;
+
+    common::Pipeline<Communicator> chain(world);
+
+    // Note:
+    // `sent_guard` represents the status of completion of IRecv. It will be set true by a `then`
+    // task that depends on completion of transformMPI, i.e. it will become true only when IRecv
+    // communication completes (i.e. posted + message received).
+    std::atomic_bool sent_guard = false;
+
+    int message;
+    whenAllLift(&message, 1, MPI_INT, 1, 0, chain()) | transformMPI(MPI_Irecv) |
+        ex::then([&sent_guard](auto mpi_err_code) {
+          EXPECT_EQ(MPI_SUCCESS, mpi_err_code);
+          sent_guard = true;
+        }) |
+        ex::ensure_started();
+
+    // Note:
+    // At this point IRecv is (getting) posted but it won't complete until this Rank 0 will trigger
+    // Rank 1 to send the message. So, here we can check that PromiseGuard<Communicator> gets
+    // consumed just after MPI operation is posted.
+    //
+    // For checking it gets released, we ask the Pipeline for the next PromiseGuard<Communicator> in
+    // the chain. Indeed, if the previous one is released, this one will be unlocked.
+    //
+    // Let's use a guard + try_waiting_guard, so that in case something goes wrong it does not end
+    // up creating a deadlock. The assumption is that try_waiting_guard timeout is enough for
+    // transformMPI to post the IRecv.
+    std::atomic_bool pg_guard = false;
+    auto after_pg = chain() | ex::then([&pg_guard](auto&& pg) {
+                      pg_guard = true;
+                      return std::move(pg);
+                    }) |
+                    ex::ensure_started();
+    try_waiting_guard(pg_guard);
+    EXPECT_TRUE(pg_guard);
+
+    // "ensure" (by waiting a reasonable amount of time) that IRecv doesn't complete
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_FALSE(sent_guard);
+
+    // Note:
+    // At this point we checked if everything went as expected in the posting phase. Let's signal
+    // Rank 1 that it can send back the message that will unlock IRecv.
+    const int signal = 13;
+    MPI_Send(&signal, 1, MPI_INT, 1, 0, world);
+
+    // Note:
+    // Here the assumption is that try_waiting_guard timeout is enough for Rank 1 to receive signal,
+    // send back the unlocking message, and that on Rank 0 the IRecv gets completed and the MPI
+    // scheduler is able to verify its completeness status (i.e. check MPI_Request).
+    // Once the transformMPI mechanism completes, the `then` sets the guard signalling the actual
+    // full completion of the IRecv via `sent_guard`.
+    try_waiting_guard(sent_guard);
+    EXPECT_TRUE(sent_guard);
+
+    // this is just checking that the message received by IRecv is actually the one expected.
+    EXPECT_EQ(26, message);
+  }
+  else if (rank == 1) {
+    // Note:
+    // Rank 1 is just a simple "pinger": as soon as it receives the trigger, it send back a message
+    // that acts as signal for Rank 0 IRecv.
+
+    // blocking recv for the trigger
+    int buffer;
+    MPI_Recv(&buffer, 1, MPI_INT, 0, 0, world, MPI_STATUS_IGNORE);
+    EXPECT_EQ(13, buffer);
+
+    // trigger received at this point, so send the actual message that will pair with Rank 0 IRecv
+    // allowing it to complete.
+    buffer *= 2;
+    MPI_Send(&buffer, 1, MPI_INT, 0, 0, world);
+  }
+}

--- a/test/unit/communication/test_transform_mpi.cpp
+++ b/test/unit/communication/test_transform_mpi.cpp
@@ -25,7 +25,7 @@ using namespace dlaf::comm;
 
 using TransformMPITest = ::testing::Test;
 
-// wait for guard to become true with a timeout of 200ms
+// wait for guard to become true with a timeout of 2000ms
 auto try_waiting_guard = [](std::atomic_bool& guard) {
   using namespace std::chrono_literals;
   const auto wait_guard = 20ms;


### PR DESCRIPTION
This PR aims at proposing a way to make internal communication kernels deal with `Communicator`s instead of `PromiseGuard<Communicator>`s.

Let's consider the internal reduce communication kernel as an example:
https://github.com/eth-cscs/DLA-Future/blob/5a23516e72a2cff20a8672e5a5bb8f71809ae092/include/dlaf/communication/kernels/reduce.h#L40-L48

which currently accepts as parameter a `PromiseGuard<Communicator>`.

For what concerns the kernel implementation, it is interesting just the `Communicator`, but currently it has the burden of unwrapping it from the `PromiseGuard` that contains it before using it.

Apart from the (minor) burden of the unwrapping, passing a `PromiseGuard` implicitly enforces a superfluous constraint: in order to use it, we cannot use a `Communicator` as it is, but we have to wrap it inside a `Pipeline`.

We may want to drop this requirement, since we may soon have use-cases with algorithms that do not require ordered communications, i.e. by means of a `Pipeline`, which might also represent an over-constraint to the parallelisation.

After a quick chat with @msimberg about this, we thought about exploring the solution of adapting `transformMPI` so that it still "consumes" a `PromiseGuard` just after the kernel finishes (i.e. waiting just for the posting, not for its completion), and at the same time it also unwraps the `PromiseGuard<Communicator>` by calling `.ref()`. This is a "conditional" management, which means that if the `Communicator` is passed as it is without a `PromiseGuard`, it will go through and it won't get altered.

There might be drawbacks, and this PR is for sharing with the team so that we can find and implement the best solution.

Looking forward to your comments/feedbacks!