### PR TITLE
Don't allocate shared state for empty `MemoryView`s

### DIFF
--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -32,7 +32,7 @@ public:
   friend MemoryView<const ElementType, device>;
 
   /// Creates a MemoryView of size 0.
-  MemoryView() : memory_(std::make_shared<MemoryChunk<ElementType, device>>()), offset_(0), size_(0) {}
+  MemoryView() : memory_(), offset_(0), size_(0) {}
 
   /// Creates a MemoryView object allocating the required memory.
   ///
@@ -41,7 +41,8 @@ public:
   /// Memory of @p size elements of type @c T is allocated on the given device.
   template <class U = T, class = typename std::enable_if_t<!std::is_const_v<U> && std::is_same_v<T, U>>>
   explicit MemoryView(SizeType size)
-      : memory_(std::make_shared<MemoryChunk<ElementType, device>>(size)), offset_(0), size_(size) {
+      : memory_(size > 0 ? std::make_shared<MemoryChunk<ElementType, device>>(size) : nullptr),
+        offset_(0), size_(size) {
     DLAF_ASSERT(size >= 0, size);
   }
 
@@ -61,8 +62,8 @@ public:
   MemoryView(const MemoryView<ElementType, device>& rhs)
       : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {}
 
-  MemoryView(MemoryView&& rhs) : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {
-    rhs.memory_ = std::make_shared<MemoryChunk<ElementType, device>>();
+  MemoryView(MemoryView&& rhs)
+      : memory_(std::move(rhs.memory_)), offset_(rhs.offset_), size_(rhs.size_) {
     rhs.size_ = 0;
     rhs.offset_ = 0;
   }
@@ -82,13 +83,13 @@ public:
   /// @param size        The size (in number of elements of type @c T) of the subview,
   /// @pre subview should not exceeds the limits of @p memory_view.
   MemoryView(const MemoryView& memory_view, SizeType offset, SizeType size)
-      : memory_(size > 0 ? memory_view.memory_ : std::make_shared<MemoryChunk<ElementType, device>>()),
+      : memory_(size > 0 ? memory_view.memory_ : nullptr),
         offset_(size > 0 ? offset + memory_view.offset_ : 0), size_(size) {
     DLAF_ASSERT(offset + size <= memory_view.size_, offset + size, memory_view.size_);
   }
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
   MemoryView(const MemoryView<ElementType, device>& memory_view, SizeType offset, SizeType size)
-      : memory_(size > 0 ? memory_view.memory_ : std::make_shared<MemoryChunk<ElementType, device>>()),
+      : memory_(size > 0 ? memory_view.memory_ : nullptr),
         offset_(size > 0 ? offset + memory_view.offset_ : 0), size_(size) {
     DLAF_ASSERT(offset + size <= memory_view.size_, offset + size, memory_view.size_);
   }
@@ -108,7 +109,6 @@ public:
     offset_ = rhs.offset_;
     size_ = rhs.size_;
 
-    rhs.memory_ = std::make_shared<MemoryChunk<ElementType, device>>();
     rhs.size_ = 0;
     rhs.offset_ = 0;
 
@@ -120,7 +120,6 @@ public:
     offset_ = rhs.offset_;
     size_ = rhs.size_;
 
-    rhs.memory_ = std::make_shared<MemoryChunk<ElementType, device>>();
     rhs.size_ = 0;
     rhs.offset_ = 0;
 


### PR DESCRIPTION
Default and size-0 constructed, and moved-from `MemoryView`s allocate shared states for a `shared_ptr`, but that `shared_ptr` is never accessed and doesn't need to be accessed since assertions fail if one tries to access an element and getting the pointer gives a `nullptr` when the `MemoryView` is empty. This is relatively expensive and sometimes makes a noticeable (but not very significant) difference with blocksize 256 and makes a significant difference with 128 (and likely even worse with 64, but I did not benchmark that). With the GPU backend there is no difference (at blocksize 512 and up).

I'll post more comprehensive plots on slack, but to give you an idea this is Cholesky strong scaling with 20k x 20k and block size 128 (the orange line is master (https://github.com/eth-cscs/DLA-Future/commit/5a23516e72a2cff20a8672e5a5bb8f71809ae092) and the blue line is this branch (with a different hash because I force-pushed to remove some comments that I had there earlier):
![chol_strong_ppn_20480_128](https://user-images.githubusercontent.com/42977/175005866-08c4ead2-bea4-4d89-859e-2d49697ee774.png)

It's likely worth investigating if we might be causing other similarly unnecessary heap allocations elsewhere.
