### PR TITLE
Make sure ADL is disabled in callable object wrappers and sender overloads

### DIFF
--- a/include/dlaf/common/callable_object.h
+++ b/include/dlaf/common/callable_object.h
@@ -17,12 +17,16 @@
 /// require explicit selection of the overload when passing the function to
 /// higher-order functions. With this wrapper the overload is selected inside
 /// the wrapper's operator().
-#define DLAF_MAKE_CALLABLE_OBJECT(fname)                                                 \
-  constexpr struct fname##_t {                                                           \
-    template <typename... Ts>                                                            \
-    auto operator()(Ts&&... ts) const noexcept(noexcept(fname(std::forward<Ts>(ts)...))) \
-        -> decltype(fname(std::forward<Ts>(ts)...)) {                                    \
-      return fname(std::forward<Ts>(ts)...);                                             \
-    }                                                                                    \
-  } fname##_o {                                                                          \
+///
+/// The function name is wrapped in parentheses to disable ADL. It is assumed
+/// that all required overloads are found relative to the namespace where the
+/// macro is used.
+#define DLAF_MAKE_CALLABLE_OBJECT(fname)                                                   \
+  constexpr struct fname##_t {                                                             \
+    template <typename... Ts>                                                              \
+    auto operator()(Ts&&... ts) const noexcept(noexcept((fname)(std::forward<Ts>(ts)...))) \
+        -> decltype((fname)(std::forward<Ts>(ts)...)) {                                    \
+      return (fname)(std::forward<Ts>(ts)...);                                             \
+    }                                                                                      \
+  } fname##_o {                                                                            \
   }

--- a/include/dlaf/sender/make_sender_algorithm_overloads.h
+++ b/include/dlaf/sender/make_sender_algorithm_overloads.h
@@ -29,21 +29,24 @@
 /// 3. One that takes a policy and the arguments required by the callable. This is almost equivalent to
 ///    calling the callable directly with the required arguments, with the difference that this overload
 ///    does the required synchronization before returning in cases when the callable is not blocking.
-#define DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(fname, callable)                                    \
-  template <Backend B, typename Sender,                                                          \
-            typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>     \
-  auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                    \
-    return dlaf::internal::transform<B>(p, callable, std::forward<Sender>(s));                   \
-  }                                                                                              \
-                                                                                                 \
-  template <Backend B>                                                                           \
-  auto fname(const dlaf::internal::Policy<B> p) {                                                \
-    return dlaf::internal::PartialTransform{p, callable};                                        \
-  }                                                                                              \
-                                                                                                 \
-  template <Backend B, typename T1, typename T2, typename... Ts>                                 \
-  void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                  \
-    pika::this_thread::experimental::sync_wait(                                                  \
-        fname(p, pika::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
-                                                     std::forward<Ts>(ts)...)));                 \
+///
+/// The function name is wrapped in parentheses in the last overload to disable
+/// ADL. We are only interested in forwarding to the first overload.
+#define DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(fname, callable)                                      \
+  template <Backend B, typename Sender,                                                            \
+            typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>       \
+  auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                      \
+    return dlaf::internal::transform<B>(p, callable, std::forward<Sender>(s));                     \
+  }                                                                                                \
+                                                                                                   \
+  template <Backend B>                                                                             \
+  auto fname(const dlaf::internal::Policy<B> p) {                                                  \
+    return dlaf::internal::PartialTransform{p, callable};                                          \
+  }                                                                                                \
+                                                                                                   \
+  template <Backend B, typename T1, typename T2, typename... Ts>                                   \
+  void fname(const dlaf::internal::Policy<B> p, T1&& t1, T2&& t2, Ts&&... ts) {                    \
+    pika::this_thread::experimental::sync_wait(                                                    \
+        (fname)(p, pika::execution::experimental::just(std::forward<T1>(t1), std::forward<T2>(t2), \
+                                                       std::forward<Ts>(ts)...)));                 \
   }


### PR DESCRIPTION
Avoids accidental use of ADL in cases where it's not desired.

Separating this into a PR since it's not strictly required anymore in #572. However, it's still a useful change so I'm doing it here instead.