### PR TITLE
CMake MPI preset: use --pika:threads and --pika:bind with `plain-mpi` preset

### DIFF
--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -51,7 +51,7 @@ function(_set_element_to_fallback_value LIST_NAME ELEMENT_REGEX FALLBACK)
   set(_TMP_LIST ${${LIST_NAME}})
   list(FILTER _TMP_LIST INCLUDE REGEX ${ELEMENT_REGEX})
   list(LENGTH _TMP_LIST _NUM_TMP_LIST)
-  if (_NUM_TMP_LIST EQUAL 0)
+  if(_NUM_TMP_LIST EQUAL 0)
     list(APPEND ${LIST_NAME} ${FALLBACK})
     set(${LIST_NAME} ${${LIST_NAME}} PARENT_SCOPE)
   endif()
@@ -170,7 +170,9 @@ function(DLAF_addTest test_target_name)
         set(_DLAF_PIKA_THREADS 2)
       endif()
 
-      _set_element_to_fallback_value(_PIKA_EXTRA_ARGS_LIST "--pika:threads" "--pika:threads=${_DLAF_PIKA_THREADS}")
+      _set_element_to_fallback_value(
+        _PIKA_EXTRA_ARGS_LIST "--pika:threads" "--pika:threads=${_DLAF_PIKA_THREADS}"
+      )
     endif()
 
     list(APPEND _TEST_ARGUMENTS ${_PIKA_EXTRA_ARGS_LIST})

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -144,8 +144,27 @@ function(DLAF_addTest test_target_name)
   if(IS_AN_PIKA_TEST)
     separate_arguments(_PIKA_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_PIKATEST_EXTRA_ARGS})
 
+    # APPLE platform does not support thread binding
+    if(NOT APPLE)
+      # TODO pika:bind=none?
+      list(FILTER _PIKA_EXTRA_ARGS_LIST EXCLUDE REGEX "--pika:use-process-mask")
+      list(APPEND _PIKA_EXTRA_ARGS_LIST "--pika:use-process-mask")
+    endif()
+
     if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)
-      list(APPEND _TEST_ARGUMENTS "--pika:bind=none")
+      list(FILTER _PIKA_EXTRA_ARGS_LIST EXCLUDE REGEX "--pika:bind")
+      list(APPEND _PIKA_EXTRA_ARGS_LIST "--pika:bind=none")
+    endif()
+
+    if(IS_AN_MPI_TEST AND DLAF_MPI_PRESET STREQUAL "plain-mpi")
+      if(DLAF_CORE_PER_RANK GREATER_EQUAL 2)
+        set(_DLAF_PIKA_THREADS ${DLAF_CORE_PER_RANK})
+      else()
+        set(_DLAF_PIKA_THREADS 2)
+      endif()
+
+      list(FILTER _PIKA_EXTRA_ARGS_LIST EXCLUDE REGEX "--pika:threads")
+      list(APPEND _PIKA_EXTRA_ARGS_LIST "--pika:threads=${_DLAF_PIKA_THREADS}")
     endif()
 
     list(APPEND _TEST_ARGUMENTS ${_PIKA_EXTRA_ARGS_LIST})

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -146,9 +146,8 @@ function(DLAF_addTest test_target_name)
 
     # APPLE platform does not support thread binding
     if(NOT APPLE)
-      # TODO pika:bind=none?
-      list(FILTER _PIKA_EXTRA_ARGS_LIST EXCLUDE REGEX "--pika:use-process-mask")
       list(APPEND _PIKA_EXTRA_ARGS_LIST "--pika:use-process-mask")
+      list(REMOVE_DUPLICATES _PIKA_EXTRA_ARGS_LIST)
     endif()
 
     if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -32,6 +32,9 @@
 #   - MPIPIKA: uses a main that initializes both pika and MPI
 # If not specified, no external main is used and it should exist in the test source code.
 #
+# Moreover, the variable DLAF_PIKATEST_EXTRA_ARGS can be used to pass extra arguments that will
+# be given to all tests involving PIKA (i.e. USE_MAIN=PIKA or USE_MAIN=MPIPIKA).
+#
 # e.g.
 #
 # DLAF_addTest(example_test

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -159,9 +159,9 @@ function(DLAF_addTest test_target_name)
     endif()
 
     if(IS_AN_MPI_TEST AND DLAF_MPI_PRESET STREQUAL "plain-mpi")
-      if(DLAF_CORE_PER_RANK GREATER_EQUAL 2)
-        set(_DLAF_PIKA_THREADS ${DLAF_CORE_PER_RANK})
-      else()
+      math(EXPR _DLAF_PIKA_THREADS "${MPIEXEC_MAX_NUMPROCS}/${DLAF_AT_MPIRANKS}")
+
+      if(_DLAF_PIKA_THREADS LESS 2)
         set(_DLAF_PIKA_THREADS 2)
       endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,16 +37,16 @@ if(NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
           FORCE
     )
     set(MPIEXEC_NUMCORES "" CACHE STRING "Number of cores available for each MPI rank." FORCE)
-    if (DLAF_TEST_THREAD_BINDING_ENABLED)
+    if(DLAF_TEST_THREAD_BINDING_ENABLED)
       message(WARNING "Disabling pika binding")
       set(DLAF_TEST_THREAD_BINDING_ENABLED FALSE CACHE BOOL "" FORCE)
     endif()
 
   elseif(DLAF_MPI_PRESET STREQUAL "slurm")
     if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)
-      message(WARNING
-        "When using DLAF_MPI_PRESET=slurm this option should be enabled. "
-        "You may incur in performance drop. Do it at your own risk.")
+      message(WARNING "When using DLAF_MPI_PRESET=slurm this option should be enabled. "
+                      "You may incur in performance drop. Do it at your own risk."
+      )
     endif()
 
     execute_process(COMMAND which srun OUTPUT_VARIABLE SLURM_EXECUTABLE OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -107,7 +107,6 @@ if((MPIEXEC_NUMCORE_FLAG OR MPIEXEC_NUMCORES) AND NOT (MPIEXEC_NUMCORE_FLAG AND 
     FATAL_ERROR "MPIEXEC_NUMCORES and MPIEXEC_NUMCORE_FLAG must be either both sets or both empty."
   )
 endif()
-
 
 add_library(DLAF_test INTERFACE)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,8 @@ option(
 # significantly faster when threads are not pinned.
 option(DLAF_TEST_THREAD_BINDING_ENABLED "If OFF disables pika thread binding." ON)
 
+set(DLAF_PIKATEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with pika")
+
 # if a preset has been selected and it has been changed from previous configurations
 if(NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
 
@@ -35,8 +37,18 @@ if(NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
           FORCE
     )
     set(MPIEXEC_NUMCORES "" CACHE STRING "Number of cores available for each MPI rank." FORCE)
+    if (DLAF_TEST_THREAD_BINDING_ENABLED)
+      message(WARNING "Disabling pika binding")
+      set(DLAF_TEST_THREAD_BINDING_ENABLED FALSE CACHE BOOL "" FORCE)
+    endif()
 
   elseif(DLAF_MPI_PRESET STREQUAL "slurm")
+    if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)
+      message(WARNING
+        "When using DLAF_MPI_PRESET=slurm this option should be enabled. "
+        "You may incur in performance drop. Do it are your own risk")
+    endif()
+
     execute_process(COMMAND which srun OUTPUT_VARIABLE SLURM_EXECUTABLE OUTPUT_STRIP_TRAILING_WHITESPACE)
     set(MPIEXEC_EXECUTABLE ${SLURM_EXECUTABLE} CACHE STRING "Executable for running MPI programs" FORCE)
     set(MPIEXEC_NUMPROC_FLAG
@@ -96,8 +108,6 @@ if((MPIEXEC_NUMCORE_FLAG OR MPIEXEC_NUMCORES) AND NOT (MPIEXEC_NUMCORE_FLAG AND 
   )
 endif()
 
-# ----- pika
-set(DLAF_PIKATEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with pika")
 
 add_library(DLAF_test INTERFACE)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
     if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)
       message(WARNING
         "When using DLAF_MPI_PRESET=slurm this option should be enabled. "
-        "You may incur in performance drop. Do it are your own risk")
+        "You may incur in performance drop. Do it at your own risk.")
     endif()
 
     execute_process(COMMAND which srun OUTPUT_VARIABLE SLURM_EXECUTABLE OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
I started working on one of the suggestions available here https://github.com/eth-cscs/DLA-Future/issues/568#issuecomment-1155175874

In particular this one
> Other possible TODOs:
> [...]
> improve the CMAKE logic that setups test, to add --pika:threads=? --pika:bind=none when slurm is not available.

Main changes:
- when `DLAF_MPI_PRESET=slurm`, check that `DLAF_TEST_THREAD_BINDING_ENABLED=TRUE` otherwise just emits a warning message (no value change)
- when `DLAF_MPI_PRESET=plain-mpi`:
  - `DLAF_TEST_THREAD_BINDING_ENABLED=FALSE` (forced, with warning message in case it was set differently)
  - for MPIPIKA tests, add `--pika:threads=x`, where `x` is the the maximum  between 2 and the number of cores per rank (test-dependent, function of number of ranks)

Moreover, there is a trivial **silent** PIKA_EXTRA_ARGS preprocessor, that "overwrites" user provided arguments in case dlaf internal logic wants to set the same parameter.

This needs to be tested and refined, looking forward to your comments.