### PR TITLE
Find Umpire in `DLAFConfig.cmake`

### DIFF
--- a/cmake/template/DLAFConfig.cmake.in
+++ b/cmake/template/DLAFConfig.cmake.in
@@ -44,6 +44,7 @@ endif()
 
 find_dependency(blaspp PATHS @blaspp_DIR@)
 find_dependency(lapackpp PATHS @lapackpp_DIR@)
+find_dependency(Umpire PATHS @Umpire_DIR@)
 
 # ----- pika
 find_dependency(pika PATHS @pika_DIR@)


### PR DESCRIPTION
Part of #628.

Interesting side observations from this:
- CMake did not complain during configuration because the Umpire target is only called `umpire` which becomes `-lumpire` if there's no target by that name
- Spack hides these kind of mistakes because it adds include directories by default
- This only came up when compiling the DLAF wrapper as a HIP file in CP2K, because the `clang++` that `enable_language(HIP)` uses is not the `clang++` spack wrapper and it did not know where to find Umpire includes