### PR TITLE
Fix empty cases for tridiagonal solver

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/mc.h
+++ b/include/dlaf/eigensolver/tridiag_solver/mc.h
@@ -59,7 +59,9 @@ inline void splitIntervalInTheMiddleRecursively(
 /// Note: the intervals are all closed!
 ///
 inline std::vector<std::tuple<SizeType, SizeType, SizeType>> generateSubproblemIndices(SizeType n) {
-  DLAF_ASSERT(n > 0, n);
+  if (n == 0)
+    return {};
+
   std::vector<std::tuple<SizeType, SizeType, SizeType>> indices;
   indices.reserve(to_sizet(n));
   splitIntervalInTheMiddleRecursively(0, n - 1, indices);
@@ -93,7 +95,10 @@ std::vector<pika::shared_future<T>> cuppensDecomposition(Matrix<T, Device::CPU>&
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
-  SizeType i_end = mat_trd.distribution().nrTiles().rows() - 1;
+  if (mat_trd.nrTiles().rows() == 0)
+    return {};
+
+  const SizeType i_end = mat_trd.nrTiles().rows() - 1;
   std::vector<pika::shared_future<T>> offdiag_vals;
   offdiag_vals.reserve(to_sizet(i_end));
 

--- a/test/unit/eigensolver/test_tridiag_solver.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver.cpp
@@ -99,6 +99,9 @@ void solveLaplace1D(SizeType n, SizeType nb) {
 
   eigensolver::tridiagSolver<Backend::MC>(tridiag, evals, evecs);
 
+  if (n == 0)
+    return;
+
   // Eigenvalues
   auto expected_evals_fn = [n](GlobalElementIndex i) {
     return RealParam(2 * (1 - std::cos(M_PI * (i.row() + 1) / (n + 1))));
@@ -158,7 +161,7 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
   std::vector<RealParam> diag_arr(to_sizet(n));
   std::vector<RealParam> offdiag_arr(to_sizet(n));
   SizeType diag_seed = n;
-  SizeType offdiag_seed = n - 1;
+  SizeType offdiag_seed = n + 1;
   dlaf::matrix::util::internal::getter_random<RealParam> diag_rand_gen(diag_seed);
   dlaf::matrix::util::internal::getter_random<RealParam> offdiag_rand_gen(offdiag_seed);
   std::generate(std::begin(diag_arr), std::end(diag_arr), diag_rand_gen);
@@ -177,6 +180,9 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
   //
   // Note: this modifies `tridiag`
   eigensolver::tridiagSolver<Backend::MC>(tridiag, evals, evecs);
+
+  if (n == 0)
+    return;
 
   // Check correctness with the following equation:
   //

--- a/test/unit/eigensolver/test_tridiag_solver.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver.cpp
@@ -237,11 +237,7 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
 
 const std::vector<std::tuple<SizeType, SizeType>> tested_problems = {
     // n, nb
-    {16, 8},
-    {16, 4},
-    {16, 5},
-    {100, 10},
-    {93, 7}};
+    {0, 8}, {16, 8}, {16, 4}, {16, 5}, {100, 10}, {93, 7}};
 
 TYPED_TEST(TridiagEigensolverTest, Laplace1D) {
   for (auto [n, nb] : tested_problems) {


### PR DESCRIPTION
Fix #625

This is required by #547.