### PR TITLE
Separate arguments for mpiexec preflags to allow map-by usage

### DIFF
--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -128,6 +128,7 @@ function(DLAF_addTest test_target_name)
     if(DLAF_CI_RUNNER_USES_MPIRUN)
       set(_TEST_COMMAND $<TARGET_FILE:${test_target_name}>)
     else()
+      separate_arguments(MPIEXEC_PREFLAGS)
       set(_TEST_COMMAND
           ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${DLAF_AT_MPIRANKS} ${_MPI_CORE_ARGS}
           ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${test_target_name}> ${MPIEXEC_POSTFLAGS}


### PR DESCRIPTION
When using openMPI "--map-by slot:PE=N" is considered a single option and is therefore failing, separating arguments makes it work.