### PR TITLE
Try to speed CI up

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
     - TAG_REPO=`find $SPACK_DLAF_REPO -type f -exec sha256sum {} \; | sha256sum - | head -c 16`
     - TAG_ENVIRONMENT=`sha256sum $SPACK_ENVIRONMENT | head -c 16`
     - TAG=${TAG_IMAGE}-${TAG_APTGET}-${TAG_COMPILER}-MKL${USE_MKL}-${TAG_DOCKERFILE}-${TAG_SPACK}-${TAG_REPO}-${TAG_ENVIRONMENT}
-    - docker build -t $BUILD_IMAGE:$TAG -t $BUILD_IMAGE:latest --cache-from $BUILD_IMAGE:$TAG --cache-from $BUILD_IMAGE:latest --build-arg BASE_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg SPACK_SHA --build-arg EXTRA_APTGET --build-arg COMPILER --build-arg CXXSTD --build-arg SPACK_ENVIRONMENT --build-arg SPACK_DLAF_REPO --build-arg USE_MKL -f $BUILD_DOCKER_FILE --network=host .
+    - (docker pull $BUILD_IMAGE:$TAG && docker tag $BUILD_IMAGE:$TAG $BUILD_IMAGE:latest) || docker build -t $BUILD_IMAGE:$TAG -t $BUILD_IMAGE:latest --cache-from $BUILD_IMAGE:latest --build-arg BASE_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg SPACK_SHA --build-arg EXTRA_APTGET --build-arg COMPILER --build-arg CXXSTD --build-arg SPACK_ENVIRONMENT --build-arg SPACK_DLAF_REPO --build-arg USE_MKL -f $BUILD_DOCKER_FILE --network=host .
     - docker push $BUILD_IMAGE:$TAG
     - docker push $BUILD_IMAGE:latest
     - docker build -t $DEPLOY_IMAGE --build-arg BUILD_IMAGE=$BUILD_IMAGE:$TAG --build-arg DEPLOY_BASE_IMAGE --build-arg EXTRA_APTGET_DEPLOY --build-arg USE_MKL --build-arg USE_ROCBLAS -f $DEPLOY_DOCKER_FILE --network=host .
@@ -67,6 +67,8 @@ cpu release build gcc11:
 
 cpu release build clang12:
   extends: .build_spack_common
+  needs:
+    - cpu release build gcc11
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
@@ -88,6 +90,8 @@ cpu release build clang12:
 
 cpu release build clang13 cxx20:
   extends: .build_spack_common
+  needs:
+    - cpu release build clang12
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
@@ -109,6 +113,8 @@ cpu release build clang13 cxx20:
 
 cpu codecov build gcc11:
   extends: .build_spack_common
+  needs:
+    - cpu release build clang13 cxx20
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
@@ -149,28 +155,10 @@ cuda release build gcc11:
     THREADS_PER_NODE: 24
     USE_CODECOV: "false"
 
-cuda release build clang10:
-  extends: .build_spack_common
-  variables:
-    BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
-    DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: nvidia/cuda:11.1.1-devel-ubuntu20.04
-    DEPLOY_BASE_IMAGE: ubuntu:20.04
-    EXTRA_APTGET: clang-10
-    EXTRA_APTGET_DEPLOY: ""
-    COMPILER: clang@10.0.0
-    CXXSTD: 17
-    USE_MKL: "ON"
-    USE_ROCBLAS: "OFF"
-    SPACK_ENVIRONMENT: ci/docker/gpu-release.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/release-cuda-clang10/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_IMAGE/release-cuda-clang10/deploy:$CI_COMMIT_SHA
-    SLURM_CONSTRAINT: gpu
-    THREADS_PER_NODE: 24
-    USE_CODECOV: "false"
-
 cuda codecov build gcc11:
   extends: .build_spack_common
+  needs:
+    - cuda release build gcc11
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/codecov.Dockerfile
@@ -192,6 +180,8 @@ cuda codecov build gcc11:
 
 amdgpu release build clang10+rocm-5.1.3:
   extends: .build_spack_common
+  needs:
+    - cuda codecov build gcc11
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy-amdgpu.Dockerfile
@@ -276,15 +266,6 @@ cuda release test gcc11:
     include:
       - artifact: pipeline.yml
         job: cuda release build gcc11
-
-cuda release test clang10:
-  extends: .run_common
-  needs:
-    - cuda release build clang10
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cuda release build clang10
 
 cuda codecov test gcc11:
   extends: .run_common


### PR DESCRIPTION
3 tricks are used to speed CI up:
1) Force using image if the given tag exists:
  - Pro: Unnecessary (and inexplicable) rebuilding of build image are avoided.
  - Cons: Changes which do not modify the tag do not trigger a rebuild. (Note: this should happen in no or extremely rare cases, and can be solved removing manually the previous image from jfrog)
  
2) Insert dependencies to reduce the amount of build task running concurrently.
  (I noticed that a full (i.e. the build image has been rebuilt from scratch) cpu release gcc11 build phase took only 60 min when run alone, while the same task without the full build image building took 1h30min when run together with other tasks. Therefore I suspect we overload the build system)

3) remove the CUDA + clang10 test:
  As this test use an old CUDA + a compiler which doesn't support C++20 (will be needed in the near future by pika), and generates some problems with the tridiagonal solver PR #617 we remove it.
  It will be reintroduced when we find a working combination of CUDA + clang (see #607)