### PR TITLE
Fix pika flags in CMake

### DIFF
--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -160,7 +160,8 @@ function(DLAF_addTest test_target_name)
   if(IS_AN_PIKA_TEST)
     separate_arguments(_PIKA_EXTRA_ARGS_LIST UNIX_COMMAND ${DLAF_PIKATEST_EXTRA_ARGS})
 
-    if(NOT DLAF_TEST_THREAD_BINDING_ENABLED)
+    # --pika:bind=none is useful just in case more ranks are going to be allocated on the same node.
+    if(IS_AN_MPI_TEST AND (DLAF_AT_MPIRANKS GREATER 1) AND (NOT DLAF_TEST_THREAD_BINDING_ENABLED))
       _set_element_to_fallback_value(_PIKA_EXTRA_ARGS_LIST "--pika:bind" "--pika:bind=none")
     endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,12 @@ option(DLAF_TEST_THREAD_BINDING_ENABLED "If OFF disables pika thread binding." O
 
 set(DLAF_PIKATEST_EXTRA_ARGS "" CACHE STRING "Extra arguments for tests with pika")
 
+# If DLAF_CI_RUNNER_USES_MPIRUN=on we don't want to use any preset, so we just go for the custom one
+# without setting any variable.
+if(DLAF_CI_RUNNER_USES_MPIRUN)
+  set(DLAF_MPI_PRESET "custom" CACHE STRING "" FORCE)
+endif()
+
 # if a preset has been selected and it has been changed from previous configurations
 if(NOT DLAF_MPI_PRESET STREQUAL _DLAF_MPI_PRESET)
 


### PR DESCRIPTION
This is a fix for #582.

In particular:
- With `DLAF_CI_RUNNER_USES_MPIRUN=on` do not use any MPI preset
- Since `--pika:bind=none` is a workaround for avoiding multiple ranks on the same node to bind to the same resources, do not use it when there is just a single rank