### PR TITLE
Check required MPI thread level in `dlaf::initialize`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -197,6 +197,17 @@ void initialize(pika::program_options::variables_map const& vm, configuration co
     std::exit(0);
   }
 
+  int mpi_initialized;
+  DLAF_MPI_CHECK_ERROR(MPI_Initialized(&mpi_initialized));
+  if (mpi_initialized) {
+    int provided;
+    DLAF_MPI_CHECK_ERROR(MPI_Query_thread(&provided));
+    if (provided < MPI_THREAD_MULTIPLE) {
+      std::cerr << "MPI must be initialized to `MPI_THREAD_MULTIPLE` for DLA-Future!\n";
+      MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+  }
+
   DLAF_ASSERT(!internal::initialized(), "");
   internal::Init<Backend::MC>::initialize(cfg);
 #ifdef DLAF_WITH_GPU


### PR DESCRIPTION
To avoid unpleasant debugging when something other than DLAF initializes MPI with the wrong level of threading, I propose we check the level during initialization. This is the minimal required changed, but this is a draft because if I understand correctly we could remove the support for `MPI_THREAD_SERIALIZED`? Is that required for something? Related issue: #623.