### PR TITLE
Remove `mpi_invoke`, `mpi_serialized` and only allow initializing MPI with `MPI_THREAD_MULTIPLE`

### DIFF
--- a/include/dlaf/communication/init.h
+++ b/include/dlaf/communication/init.h
@@ -20,60 +20,16 @@
 namespace dlaf {
 namespace comm {
 
-enum class mpi_thread_level { serialized, multiple };
-
-/// Checks if MPI was initialized with MPI_THREAD_SERIALIZED.
-inline bool mpi_serialized() noexcept {
-  // This is executed only once and is thread safe.
-  // Note that the lambda is called at the end.
-  static bool is_serialized = []() {
-    int provided;
-    MPI_Query_thread(&provided);
-    if (provided == MPI_THREAD_SERIALIZED)
-      return true;
-    else if (provided == MPI_THREAD_MULTIPLE)
-      return false;
-    else {
-      std::cerr << "MPI must be initialized to either `MPI_THREAD_SERIALIZED` or `MPI_THREAD_MULTIPLE`!";
-      MPI_Abort(MPI_COMM_WORLD, 1);
-      return false;  // unreachable - here to avoid compiler warnings
-    }
-  }();
-  return is_serialized;
-}
-
-/// Serializes the MPI call if `MPI_THREAD_SERIALIZED` is used.
-///
-/// Note: pika mutex is used instead of std::mutex to avoid stalling the pika scheduler as the function may
-///       be called from a pika thread/task.
-/// Note: This function should only be called after pika has been initialized, otherwise the pika mutex may
-///       error out.
-template <class F, class... Ts>
-void mpi_invoke(F f, Ts... ts) noexcept {
-  if (mpi_serialized()) {
-    static pika::lcos::local::mutex mt;
-    std::lock_guard<pika::lcos::local::mutex> lk(mt);
-    DLAF_MPI_CHECK_ERROR(f(ts...));
-  }
-  else {
-    DLAF_MPI_CHECK_ERROR(f(ts...));
-  }
-}
-
 struct mpi_init {
-  /// Initialize MPI to either MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE
-  mpi_init(int argc, char** argv, mpi_thread_level thd_level) noexcept {
-    int required_threading;
-    if (thd_level == mpi_thread_level::serialized)
-      required_threading = MPI_THREAD_SERIALIZED;
-    else
-      required_threading = MPI_THREAD_MULTIPLE;
-
+  /// Initialize MPI to MPI_THREAD_MULTIPLE
+  mpi_init(int argc, char** argv) noexcept {
+    int required_threading = MPI_THREAD_MULTIPLE;
     int provided_threading;
     MPI_Init_thread(&argc, &argv, required_threading, &provided_threading);
 
     if (provided_threading != required_threading) {
-      std::cerr << "Provided MPI threading model does not match the required one." << std::endl;
+      std::cerr << "Provided MPI threading model does not match the required one (MPI_THREAD_MULTIPLE)."
+                << std::endl;
       MPI_Abort(MPI_COMM_WORLD, 1);
     }
   }

--- a/miniapp/miniapp_band_to_tridiag.cpp
+++ b/miniapp/miniapp_band_to_tridiag.cpp
@@ -171,7 +171,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 
 int main(int argc, char** argv) {
   // Init MPI
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -169,7 +169,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 
 int main(int argc, char** argv) {
   // Init MPI
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -186,7 +186,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 
 int main(int argc, char** argv) {
   // Init MPI
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -154,7 +154,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 
 int main(int argc, char** argv) {
   // Init MPI
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -167,7 +167,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 
 int main(int argc, char** argv) {
   // Init MPI
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_gen_to_std.cpp
+++ b/miniapp/miniapp_gen_to_std.cpp
@@ -179,7 +179,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 
 int main(int argc, char** argv) {
   // Init MPI
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -181,7 +181,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 int main(int argc, char** argv) {
   using dlaf::SizeType;
 
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -187,7 +187,7 @@ int pika_main(pika::program_options::variables_map& vm) {
 }
 
 int main(int argc, char** argv) {
-  dlaf::comm::mpi_init mpi_initter(argc, argv, dlaf::comm::mpi_thread_level::multiple);
+  dlaf::comm::mpi_init mpi_initter(argc, argv);
 
   // options
   using namespace pika::program_options;


### PR DESCRIPTION
Fixes #623.