### PR TITLE
Fix P2P Send on GPU

### DIFF
--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -77,7 +77,7 @@ template <class CommSender, class Sender>
   constexpr Device in_device_type = SenderSingleValueType<std::decay_t<Sender>>::D;
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;
 
-  return withTemporaryTile<comm_device_type, CopyToDestination::No, CopyFromDestination::Yes,
+  return withTemporaryTile<comm_device_type, CopyToDestination::Yes, CopyFromDestination::No,
                            RequireContiguous::No>(std::forward<Sender>(tile), std::move(recv));
 }
 


### PR DESCRIPTION
`scheduleSend` was using incorrectly the `withTemporaryTile` helper, which resulted in a build error with a GPU tile as input.

The build problem was due to `CopyFromDestination::Yes`, which was asking to copy back the result of the communication to the original tile, which was a readonly one (since we are sending it). The other problem was that actually the sent tile was not getting copied to the destination device before being sent due to `CopyFromDestination::No`.

In the end, we actually need the opposite configuration, as it has been fixed in https://github.com/eth-cscs/DLA-Future/commit/199c0f7d1d72460fd8778f295c4c00e7217172c0.

Why the problem was triggered just with GPU? because `CopyToDestination` and `CopyFromDestination` parameters are used just when source and destination device are different, and that's not the case for CPU but it is for GPU when CUDA_MPI_RDMA is not enabled.

I took the chance to extend `test_comm_p2p` by testing also the use-case described above (it will be tested just in case the project is configured with `DLAF_WITH_CUDA_MPI_RDMA=off`).

I adapted just the basic test-cases in there, but if you would prefer to see extended also "MixedTags" ones, just comment below (it should be easy).