### PR TITLE
Remove explicit use of futures in tridiagonal solver

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/impl.h
+++ b/include/dlaf/eigensolver/tridiag_solver/impl.h
@@ -290,7 +290,7 @@ void TridiagSolver<B, D, T>::call(comm::CommunicatorGrid grid, Matrix<T, D>& tri
   matrix::util::set0<B, T, D>(pika::execution::thread_priority::normal, evecs);
 
   // Cuppen's decomposition
-  std::vector<pika::shared_future<T>> offdiag_vals = cuppensDecomposition(tridiag);
+  auto offdiag_vals = cuppensDecomposition(tridiag);
 
   common::Pipeline<comm::Communicator> full_task_chain(grid.fullCommunicator().clone());
   common::Pipeline<comm::Communicator> row_task_chain(grid.rowCommunicator().clone());

--- a/include/dlaf/eigensolver/tridiag_solver/impl.h
+++ b/include/dlaf/eigensolver/tridiag_solver/impl.h
@@ -11,7 +11,8 @@
 
 #include <algorithm>
 
-#include <pika/future.hpp>
+#include <pika/execution.hpp>
+#include <pika/thread.hpp>
 
 #ifdef DLAF_WITH_GPU
 #include <whip.hpp>
@@ -67,18 +68,24 @@ inline std::vector<std::tuple<SizeType, SizeType, SizeType>> generateSubproblemI
 }
 
 template <class T, Device D>
-std::vector<pika::shared_future<T>> cuppensDecomposition(Matrix<T, D>& tridiag) {
+auto cuppensDecomposition(Matrix<T, D>& tridiag) {
+  namespace ex = pika::execution::experimental;
+  using sender_type = decltype(ex::split(
+      cuppensDecompAsync<T, D>(tridiag.readwrite_sender(std::declval<LocalTileIndex>()),
+                               tridiag.readwrite_sender(std::declval<LocalTileIndex>()))));
+  using vector_type = std::vector<sender_type>;
+
   if (tridiag.nrTiles().rows() == 0)
-    return {};
+    return vector_type{};
 
   const SizeType i_end = tridiag.nrTiles().rows() - 1;
-  std::vector<pika::shared_future<T>> offdiag_vals;
+  vector_type offdiag_vals;
   offdiag_vals.reserve(to_sizet(i_end));
 
   for (SizeType i_split = 0; i_split < i_end; ++i_split) {
     offdiag_vals.push_back(
-        cuppensDecompAsync<T, D>(tridiag.readwrite_sender(LocalTileIndex(i_split, 0)),
-                                 tridiag.readwrite_sender(LocalTileIndex(i_split + 1, 0))));
+        ex::split(cuppensDecompAsync<T, D>(tridiag.readwrite_sender(LocalTileIndex(i_split, 0)),
+                                           tridiag.readwrite_sender(LocalTileIndex(i_split + 1, 0)))));
   }
   return offdiag_vals;
 }
@@ -189,7 +196,7 @@ void TridiagSolver<B, D, T>::call(Matrix<T, D>& tridiag, Matrix<T, D>& evals, Ma
   matrix::util::set0<B, T, D>(pika::execution::thread_priority::normal, evecs);
 
   // Cuppen's decomposition
-  std::vector<pika::shared_future<T>> offdiag_vals = cuppensDecomposition(tridiag);
+  auto offdiag_vals = cuppensDecomposition(tridiag);
 
   // Solve with stedc for each tile of `tridiag` (nb x 2) and save eigenvectors in diagonal tiles of
   // `evecs` (nb x nb)

--- a/include/dlaf/eigensolver/tridiag_solver/impl.h
+++ b/include/dlaf/eigensolver/tridiag_solver/impl.h
@@ -70,9 +70,9 @@ inline std::vector<std::tuple<SizeType, SizeType, SizeType>> generateSubproblemI
 template <class T, Device D>
 auto cuppensDecomposition(Matrix<T, D>& tridiag) {
   namespace ex = pika::execution::experimental;
-  using sender_type = decltype(ex::split(
-      cuppensDecompAsync<T, D>(tridiag.readwrite_sender(std::declval<LocalTileIndex>()),
-                               tridiag.readwrite_sender(std::declval<LocalTileIndex>()))));
+  using sender_type = decltype(
+      ex::split(cuppensDecompAsync<T, D>(tridiag.readwrite_sender(std::declval<LocalTileIndex>()),
+                                         tridiag.readwrite_sender(std::declval<LocalTileIndex>()))));
   using vector_type = std::vector<sender_type>;
 
   if (tridiag.nrTiles().rows() == 0)

--- a/include/dlaf/eigensolver/tridiag_solver/kernels.h
+++ b/include/dlaf/eigensolver/tridiag_solver/kernels.h
@@ -109,8 +109,7 @@ auto cuppensDecompAsync(TopTileSender&& top, BottomTileSender&& bottom) {
   namespace di = dlaf::internal;
 
   auto sender = ex::when_all(std::forward<TopTileSender>(top), std::forward<BottomTileSender>(bottom));
-  return di::transform(di::Policy<DefaultBackend_v<D>>(), cuppensDecomp_o, std::move(sender)) |
-         ex::make_future();
+  return di::transform(di::Policy<DefaultBackend_v<D>>(), cuppensDecomp_o, std::move(sender));
 }
 
 template <class T>
@@ -191,12 +190,13 @@ DLAF_GPU_ASSEMBLE_RANK1_UPDATE_VECTOR_TILE_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(assembleRank1UpdateVectorTile);
 
-template <class T, Device D, class EvecsTileSender, class Rank1TileSender>
-void assembleRank1UpdateVectorTileAsync(bool top_tile, pika::shared_future<T> rho_fut,
-                                        EvecsTileSender&& evecs, Rank1TileSender&& rank1) {
+template <class T, Device D, class RhoSender, class EvecsTileSender, class Rank1TileSender>
+void assembleRank1UpdateVectorTileAsync(bool top_tile, RhoSender&& rho, EvecsTileSender&& evecs,
+                                        Rank1TileSender&& rank1) {
   namespace di = dlaf::internal;
-  auto sender = di::whenAllLift(top_tile, rho_fut, std::forward<EvecsTileSender>(evecs),
-                                std::forward<Rank1TileSender>(rank1));
+  auto sender =
+      di::whenAllLift(top_tile, std::forward<RhoSender>(rho), std::forward<EvecsTileSender>(evecs),
+                      std::forward<Rank1TileSender>(rank1));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), assembleRank1UpdateVectorTile_o,
                       std::move(sender));
 }
@@ -308,15 +308,14 @@ DLAF_GPU_DIVIDE_EVECS_BY_DIAGONAL_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(divideEvecsByDiagonal);
 
-template <Device D, class DiagRowsTileSender, class DiagColsTileSender, class EvecsTileSender,
-          class TempTileSender>
-void divideEvecsByDiagonalAsync(pika::shared_future<SizeType> k_fut, SizeType i_subm_el,
-                                SizeType j_subm_el, DiagRowsTileSender&& diag_rows,
-                                DiagColsTileSender&& diag_cols, EvecsTileSender&& evecs,
-                                TempTileSender&& temp) {
+template <Device D, class KSender, class DiagRowsTileSender, class DiagColsTileSender,
+          class EvecsTileSender, class TempTileSender>
+void divideEvecsByDiagonalAsync(KSender&& k, SizeType i_subm_el, SizeType j_subm_el,
+                                DiagRowsTileSender&& diag_rows, DiagColsTileSender&& diag_cols,
+                                EvecsTileSender&& evecs, TempTileSender&& temp) {
   namespace di = dlaf::internal;
   auto sender =
-      di::whenAllLift(std::move(k_fut), i_subm_el, j_subm_el,
+      di::whenAllLift(std::forward<KSender>(k), i_subm_el, j_subm_el,
                       std::forward<DiagRowsTileSender>(diag_rows),
                       std::forward<DiagColsTileSender>(diag_cols), std::forward<EvecsTileSender>(evecs),
                       std::forward<TempTileSender>(temp));
@@ -354,11 +353,11 @@ DLAF_GPU_MULTIPLY_FIRST_COLUMNS_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(multiplyFirstColumns);
 
-template <Device D, class InTileSender, class OutTileSender>
-void multiplyFirstColumnsAsync(pika::shared_future<SizeType> k_fut, SizeType row, SizeType col,
-                               InTileSender&& in, OutTileSender&& out) {
+template <Device D, class KSender, class InTileSender, class OutTileSender>
+void multiplyFirstColumnsAsync(KSender&& k, SizeType row, SizeType col, InTileSender&& in,
+                               OutTileSender&& out) {
   namespace di = dlaf::internal;
-  auto sender = di::whenAllLift(std::move(k_fut), row, col, std::forward<InTileSender>(in),
+  auto sender = di::whenAllLift(std::forward<KSender>(k), row, col, std::forward<InTileSender>(in),
                                 std::forward<OutTileSender>(out));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), multiplyFirstColumns_o, std::move(sender));
 }
@@ -400,14 +399,13 @@ DLAF_GPU_CALC_EVECS_FROM_WEIGHT_VEC_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(calcEvecsFromWeightVec);
 
-template <Device D, class Rank1TileSender, class TempTileSender, class EvecsTileSender>
-void calcEvecsFromWeightVecAsync(pika::shared_future<SizeType> k_fut, SizeType row, SizeType col,
-                                 Rank1TileSender&& rank1, TempTileSender&& temp,
-                                 EvecsTileSender&& evecs) {
+template <Device D, class KSender, class Rank1TileSender, class TempTileSender, class EvecsTileSender>
+void calcEvecsFromWeightVecAsync(KSender&& k, SizeType row, SizeType col, Rank1TileSender&& rank1,
+                                 TempTileSender&& temp, EvecsTileSender&& evecs) {
   namespace di = dlaf::internal;
 
   auto sender =
-      di::whenAllLift(std::move(k_fut), row, col, std::forward<Rank1TileSender>(rank1),
+      di::whenAllLift(std::forward<KSender>(k), row, col, std::forward<Rank1TileSender>(rank1),
                       std::forward<TempTileSender>(temp), std::forward<EvecsTileSender>(evecs));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), calcEvecsFromWeightVec_o, std::move(sender));
 }
@@ -442,12 +440,12 @@ DLAF_GPU_SUMSQ_COLS_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(sumsqCols);
 
-template <Device D, class EvecsTileSender, class TempTileSender>
-void sumsqColsAsync(pika::shared_future<SizeType> k_fut, SizeType row, SizeType col,
-                    EvecsTileSender&& evecs, TempTileSender&& temp) {
+template <Device D, class KSender, class EvecsTileSender, class TempTileSender>
+void sumsqColsAsync(KSender&& k, SizeType row, SizeType col, EvecsTileSender&& evecs,
+                    TempTileSender&& temp) {
   namespace di = dlaf::internal;
 
-  auto sender = di::whenAllLift(std::move(k_fut), row, col, std::forward<EvecsTileSender>(evecs),
+  auto sender = di::whenAllLift(std::forward<KSender>(k), row, col, std::forward<EvecsTileSender>(evecs),
                                 std::forward<TempTileSender>(temp));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), sumsqCols_o, std::move(sender));
 }
@@ -481,12 +479,11 @@ DLAF_GPU_ADD_FIRST_ROWS_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(addFirstRows);
 
-template <Device D, class InTileSender, class OutTileSender>
-void addFirstRowsAsync(pika::shared_future<SizeType> k_fut, SizeType row, SizeType col,
-                       InTileSender&& in, OutTileSender&& out) {
+template <Device D, class KSender, class InTileSender, class OutTileSender>
+void addFirstRowsAsync(KSender&& k, SizeType row, SizeType col, InTileSender&& in, OutTileSender&& out) {
   namespace di = dlaf::internal;
 
-  auto sender = di::whenAllLift(std::move(k_fut), row, col, std::forward<InTileSender>(in),
+  auto sender = di::whenAllLift(std::forward<KSender>(k), row, col, std::forward<InTileSender>(in),
                                 std::forward<OutTileSender>(out));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), addFirstRows_o, std::move(sender));
 }
@@ -522,12 +519,12 @@ DLAF_GPU_DIVIDE_COLS_BY_FIRST_ROW_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(divideColsByFirstRow);
 
-template <Device D, class InTileSender, class OutTileSender>
-void divideColsByFirstRowAsync(pika::shared_future<SizeType> k_fut, SizeType row, SizeType col,
-                               InTileSender&& in, OutTileSender&& out) {
+template <Device D, class KSender, class InTileSender, class OutTileSender>
+void divideColsByFirstRowAsync(KSender&& k, SizeType row, SizeType col, InTileSender&& in,
+                               OutTileSender&& out) {
   namespace di = dlaf::internal;
 
-  auto sender = di::whenAllLift(std::move(k_fut), row, col, std::forward<InTileSender>(in),
+  auto sender = di::whenAllLift(std::forward<KSender>(k), row, col, std::forward<InTileSender>(in),
                                 std::forward<OutTileSender>(out));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), divideColsByFirstRow_o, std::move(sender));
 }

--- a/include/dlaf/eigensolver/tridiag_solver/kernels.h
+++ b/include/dlaf/eigensolver/tridiag_solver/kernels.h
@@ -557,10 +557,10 @@ DLAF_GPU_SET_UNIT_DIAGONAL_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(setUnitDiagonal);
 
-template <Device D, class TileSender>
-void setUnitDiagonalAsync(pika::shared_future<SizeType> k_fut, SizeType tile_begin, TileSender&& tile) {
+template <Device D, class KSender, class TileSender>
+void setUnitDiagonalAsync(KSender&& k, SizeType tile_begin, TileSender&& tile) {
   namespace di = dlaf::internal;
-  auto sender = di::whenAllLift(std::move(k_fut), tile_begin, std::forward<TileSender>(tile));
+  auto sender = di::whenAllLift(std::forward<KSender>(k), tile_begin, std::forward<TileSender>(tile));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), setUnitDiagonal_o, std::move(sender));
 }
 
@@ -601,13 +601,14 @@ DLAF_GPU_COPY_1D_ETI(extern, double);
 
 DLAF_MAKE_CALLABLE_OBJECT(copy1D);
 
-template <Device D, class InTileSender, class OutTileSender>
-void copy1DAsync(pika::shared_future<SizeType> k_fut, SizeType row, SizeType col, Coord in_coord,
-                 InTileSender&& in, Coord out_coord, OutTileSender&& out) {
+template <Device D, class KSender, class InTileSender, class OutTileSender>
+void copy1DAsync(KSender&& k, SizeType row, SizeType col, Coord in_coord, InTileSender&& in,
+                 Coord out_coord, OutTileSender&& out) {
   namespace di = dlaf::internal;
   namespace ex = pika::execution::experimental;
-  auto sender = di::whenAllLift(std::move(k_fut), row, col, in_coord, std::forward<InTileSender>(in),
-                                out_coord, std::forward<OutTileSender>(out));
+  auto sender =
+      di::whenAllLift(std::forward<KSender>(k), row, col, in_coord, std::forward<InTileSender>(in),
+                      out_coord, std::forward<OutTileSender>(out));
   ex::start_detached(di::transform<di::TransformDispatchType::Blas>(di::Policy<DefaultBackend_v<D>>(),
                                                                     copy1D_o, std::move(sender)));
 }

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -223,7 +223,12 @@ auto calcTolerance(SizeType i_begin, SizeType i_end, Matrix<const T, D>& d, Matr
   };
 
   return ex::when_all(std::move(dmax), std::move(zmax)) |
-         di::transform(di::Policy<Backend::MC>(), std::move(tol_fn));
+         di::transform(di::Policy<Backend::MC>(), std::move(tol_fn)) |
+         // TODO: This releases the tiles that are kept in the operation state.
+         // This is a temporary fix and needs to be replaced by a different
+         // adaptor or different lifetime guarantees. This is tracked in
+         // https://github.com/pika-org/pika/issues/479.
+         ex::ensure_started();
 }
 
 // Sorts an index `in_index_tiles` based on values in `vals_tiles` in ascending order into the index

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -499,7 +499,12 @@ auto applyDeflation(SizeType i_begin, SizeType i_end, RhoSender&& rho, TolSender
                              ex::when_all_vector(tc.read(index)), ex::when_all_vector(tc.readwrite(d)),
                              ex::when_all_vector(tc.readwrite(z)), ex::when_all_vector(tc.readwrite(c)));
 
-  return di::transform(di::Policy<Backend::MC>(), std::move(deflate_fn), std::move(sender));
+  return di::transform(di::Policy<Backend::MC>(), std::move(deflate_fn), std::move(sender)) |
+         // TODO: This releases the tiles that are kept in the operation state.
+         // This is a temporary fix and needs to be replaced by a different
+         // adaptor or different lifetime guarantees. This is tracked in
+         // https://github.com/pika-org/pika/issues/479.
+         ex::ensure_started();
 }
 
 // Apply GivenRotations to tiles of the square sub-matrix identified by tile in range [i_begin, i_last].

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -10,8 +10,7 @@
 #pragma once
 
 #include <pika/algorithm.hpp>
-#include <pika/future.hpp>
-#include <pika/parallel/algorithms/for_each.hpp>
+#include <pika/execution.hpp>
 
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/kernels.h"
@@ -157,8 +156,8 @@ inline void initIndex(SizeType i_begin, SizeType i_end, Matrix<SizeType, D>& ind
 //
 // Note that the norm of `z` is sqrt(2) because it is a concatination of two normalized vectors. Hence
 // to normalize `z` we have to divide by sqrt(2).
-template <class T, Device D>
-void assembleZVec(SizeType i_begin, SizeType i_split, SizeType i_end, pika::shared_future<T> rho_fut,
+template <class T, Device D, class RhoSender>
+void assembleZVec(SizeType i_begin, SizeType i_split, SizeType i_end, RhoSender&& rho,
                   Matrix<const T, D>& evecs, Matrix<T, D>& z) {
   // Iterate over tiles of Q1 and Q2 around the split row `i_middle`.
   for (SizeType i = i_begin; i <= i_end; ++i) {
@@ -171,20 +170,19 @@ void assembleZVec(SizeType i_begin, SizeType i_split, SizeType i_end, pika::shar
     GlobalTileIndex z_idx(i, 0);
 
     // Copy the row into the column vector `z`
-    assembleRank1UpdateVectorTileAsync<T, D>(top_tile, rho_fut, evecs.read_sender(idx_evecs),
+    assembleRank1UpdateVectorTileAsync<T, D>(top_tile, rho, evecs.read_sender(idx_evecs),
                                              z.readwrite_sender(z_idx));
   }
 }
 
 // Multiply by factor 2 to account for the normalization of `z` vector and make sure rho > 0 f
 //
-template <class T>
-pika::future<T> scaleRho(pika::shared_future<T> rho_fut) {
+template <class RhoSender>
+auto scaleRho(RhoSender&& rho) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
-  return std::move(rho_fut) |
-         di::transform(di::Policy<Backend::MC>(), [](T rho) { return 2 * std::abs(rho); }) |
-         ex::make_future();
+  return std::forward<RhoSender>(rho) |
+         di::transform(di::Policy<Backend::MC>(), [](auto rho) { return 2 * std::abs(rho); });
 }
 
 // Returns the maximum element of a portion of a column vector from tile indices `i_begin` to `i_end`
@@ -213,30 +211,28 @@ auto maxVectorElement(SizeType i_begin, SizeType i_end, Matrix<const T, D>& vec)
 //
 // [1] LAPACK 3.10.0, file dlaed2.f, line 315, variable TOL
 template <class T, Device D>
-pika::future<T> calcTolerance(SizeType i_begin, SizeType i_end, Matrix<const T, D>& d,
-                              Matrix<const T, D>& z) {
+auto calcTolerance(SizeType i_begin, SizeType i_end, Matrix<const T, D>& d, Matrix<const T, D>& z) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
-  auto dmax_fut = maxVectorElement(i_begin, i_end, d);
-  auto zmax_fut = maxVectorElement(i_begin, i_end, z);
+  auto dmax = maxVectorElement(i_begin, i_end, d);
+  auto zmax = maxVectorElement(i_begin, i_end, z);
 
   auto tol_fn = [](T dmax, T zmax) {
     return 8 * std::numeric_limits<T>::epsilon() * std::max(dmax, zmax);
   };
 
-  return ex::when_all(std::move(dmax_fut), std::move(zmax_fut)) |
-         di::transform(di::Policy<Backend::MC>(), std::move(tol_fn)) | ex::make_future();
+  return ex::when_all(std::move(dmax), std::move(zmax)) |
+         di::transform(di::Policy<Backend::MC>(), std::move(tol_fn));
 }
 
 // Sorts an index `in_index_tiles` based on values in `vals_tiles` in ascending order into the index
 // `out_index_tiles` where `vals_tiles` is composed of two pre-sorted ranges in ascending order that
 // are merged, the first is [0, k) and the second is [k, n).
 //
-template <class T, Device D>
-void sortIndex(SizeType i_begin, SizeType i_end, pika::shared_future<SizeType> k_fut,
-               Matrix<const T, D>& vec, Matrix<const SizeType, D>& in_index,
-               Matrix<SizeType, D>& out_index) {
+template <class T, Device D, class KSender>
+void sortIndex(SizeType i_begin, SizeType i_end, KSender&& k, Matrix<const T, D>& vec,
+               Matrix<const SizeType, D>& in_index, Matrix<SizeType, D>& out_index) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -267,7 +263,7 @@ void sortIndex(SizeType i_begin, SizeType i_end, pika::shared_future<SizeType> k
 
   TileCollector tc{i_begin, i_end};
 
-  auto sender = ex::when_all(std::move(k_fut), ex::when_all_vector(tc.read<T, D>(vec)),
+  auto sender = ex::when_all(std::forward<KSender>(k), ex::when_all_vector(tc.read<T, D>(vec)),
                              ex::when_all_vector(tc.read<SizeType, D>(in_index)),
                              ex::when_all_vector(tc.readwrite<SizeType, D>(out_index)));
 
@@ -363,10 +359,8 @@ inline SizeType stablePartitionIndexForDeflationArrays(SizeType n, const ColType
 }
 
 template <Device D>
-inline pika::future<SizeType> stablePartitionIndexForDeflation(SizeType i_begin, SizeType i_end,
-                                                               Matrix<const ColType, D>& c,
-                                                               Matrix<const SizeType, D>& in,
-                                                               Matrix<SizeType, D>& out) {
+auto stablePartitionIndexForDeflation(SizeType i_begin, SizeType i_end, Matrix<const ColType, D>& c,
+                                      Matrix<const SizeType, D>& in, Matrix<SizeType, D>& out) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -390,8 +384,7 @@ inline pika::future<SizeType> stablePartitionIndexForDeflation(SizeType i_begin,
   auto sender = ex::when_all(ex::when_all_vector(tc.read(c)), ex::when_all_vector(tc.read(in)),
                              ex::when_all_vector(tc.readwrite(out)));
 
-  return ex::make_future(
-      di::transform(di::Policy<DefaultBackend_v<D>>(), std::move(part_fn), std::move(sender)));
+  return di::transform(di::Policy<DefaultBackend_v<D>>(), std::move(part_fn), std::move(sender));
 }
 
 template <Device D>
@@ -476,11 +469,10 @@ std::vector<GivensRotation<T>> applyDeflationToArrays(T rho, T tol, SizeType len
   return rots;
 }
 
-template <class T>
-pika::future<std::vector<GivensRotation<T>>> applyDeflation(
-    SizeType i_begin, SizeType i_end, pika::shared_future<T> rho_fut, pika::shared_future<T> tol_fut,
-    Matrix<const SizeType, Device::CPU>& index, Matrix<T, Device::CPU>& d, Matrix<T, Device::CPU>& z,
-    Matrix<ColType, Device::CPU>& c) {
+template <class T, class RhoSender, class TolSender>
+auto applyDeflation(SizeType i_begin, SizeType i_end, RhoSender&& rho, TolSender&& tol,
+                    Matrix<const SizeType, Device::CPU>& index, Matrix<T, Device::CPU>& d,
+                    Matrix<T, Device::CPU>& z, Matrix<ColType, Device::CPU>& c) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -498,26 +490,24 @@ pika::future<std::vector<GivensRotation<T>>> applyDeflation(
 
   TileCollector tc{i_begin, i_end};
 
-  auto sender = ex::when_all(std::move(rho_fut), std::move(tol_fut), ex::when_all_vector(tc.read(index)),
-                             ex::when_all_vector(tc.readwrite(d)), ex::when_all_vector(tc.readwrite(z)),
-                             ex::when_all_vector(tc.readwrite(c)));
+  auto sender = ex::when_all(std::forward<RhoSender>(rho), std::forward<TolSender>(tol),
+                             ex::when_all_vector(tc.read(index)), ex::when_all_vector(tc.readwrite(d)),
+                             ex::when_all_vector(tc.readwrite(z)), ex::when_all_vector(tc.readwrite(c)));
 
-  return ex::make_future(
-      di::transform(di::Policy<Backend::MC>(), std::move(deflate_fn), std::move(sender)));
+  return di::transform(di::Policy<Backend::MC>(), std::move(deflate_fn), std::move(sender));
 }
 
 // Apply GivenRotations to tiles of the square sub-matrix identified by tile in range [i_begin, i_last].
 //
 // @param i_begin global tile index for both row and column identifying the start of the sub-matrix
 // @param i_last global tile index for both row and column identifying the end of the sub-matrix (inclusive)
-// @param rots_fut GivenRotations to apply (element column indices of rotations are relative to the sub-matrix)
+// @param rots GivenRotations to apply (element column indices of rotations are relative to the sub-matrix)
 // @param mat matrix where the sub-matrix is located
 //
 // @pre mat is not distributed
 // @pre memory layout of @p mat is column major.
-template <class T, Device D>
-void applyGivensRotationsToMatrixColumns(SizeType i_begin, SizeType i_end,
-                                         pika::future<std::vector<GivensRotation<T>>> rots_fut,
+template <class T, Device D, class RotsSender>
+void applyGivensRotationsToMatrixColumns(SizeType i_begin, SizeType i_end, RotsSender&& rots,
                                          Matrix<T, D>& mat) {
   // Note:
   // a column index may be paired to more than one other index, this may lead to a race
@@ -556,15 +546,14 @@ void applyGivensRotationsToMatrixColumns(SizeType i_begin, SizeType i_end,
 
   TileCollector tc{i_begin, i_end};
 
-  auto sender = ex::when_all(std::move(rots_fut), ex::when_all_vector(tc.readwrite(mat)));
+  auto sender = ex::when_all(std::forward<RotsSender>(rots), ex::when_all_vector(tc.readwrite(mat)));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), std::move(givens_rots_fn), std::move(sender));
 }
 
-template <class T>
-void solveRank1Problem(SizeType i_begin, SizeType i_end, pika::shared_future<SizeType> k_fut,
-                       pika::shared_future<T> rho_fut, Matrix<const T, Device::CPU>& d,
-                       Matrix<const T, Device::CPU>& z, Matrix<T, Device::CPU>& evals,
-                       Matrix<T, Device::CPU>& evecs) {
+template <class T, class KSender, class RhoSender>
+void solveRank1Problem(SizeType i_begin, SizeType i_end, KSender&& k, RhoSender&& rho,
+                       Matrix<const T, Device::CPU>& d, Matrix<const T, Device::CPU>& z,
+                       Matrix<T, Device::CPU>& evals, Matrix<T, Device::CPU>& evecs) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -595,9 +584,10 @@ void solveRank1Problem(SizeType i_begin, SizeType i_end, pika::shared_future<Siz
 
   TileCollector tc{i_begin, i_end};
 
-  auto sender = ex::when_all(std::move(k_fut), std::move(rho_fut), ex::when_all_vector(tc.read(d)),
-                             ex::when_all_vector(tc.read(z)), ex::when_all_vector(tc.readwrite(evals)),
-                             ex::when_all_vector(tc.readwrite(evecs)));
+  auto sender =
+      ex::when_all(std::forward<KSender>(k), std::forward<RhoSender>(rho),
+                   ex::when_all_vector(tc.read(d)), ex::when_all_vector(tc.read(z)),
+                   ex::when_all_vector(tc.readwrite(evals)), ex::when_all_vector(tc.readwrite(evecs)));
 
   ex::start_detached(di::transform(di::Policy<Backend::MC>(), std::move(rank1_fn), std::move(sender)));
 }
@@ -614,10 +604,10 @@ void solveRank1Problem(SizeType i_begin, SizeType i_end, pika::shared_future<Siz
 // - lapack 3.10.0, dlaed3.f, line 293
 // - LAPACK Working Notes: lawn132, Parallelizing the Divide and Conquer Algorithm for the Symmetric
 //   Tridiagonal Eigenvalue Problem on Distributed Memory Architectures, 4.2 Orthogonality
-template <class T, Device D>
+template <class T, Device D, class KSender>
 void initWeightVector(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin,
-                      LocalTileSize sz_loc_tiles, pika::shared_future<SizeType> k_fut,
-                      Matrix<const T, D>& diag, Matrix<const T, D>& evecs, Matrix<T, D>& ws) {
+                      LocalTileSize sz_loc_tiles, KSender&& k, Matrix<const T, D>& diag,
+                      Matrix<const T, D>& evecs, Matrix<T, D>& ws) {
   const matrix::Distribution& dist = evecs.distribution();
 
   // Reduce by multiplication into the first local column of each tile of the workspace matrix `ws`
@@ -626,7 +616,7 @@ void initWeightVector(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin
     auto sz_gl_el = dist.globalTileElementDistance(idx_gl_begin, idx_gl_tile);
     // Divide the eigenvectors of the rank1 update problem `evecs` by it's diagonal matrix `diag` and
     // reduce multiply into the first column of each tile of the workspace matrix `ws`
-    divideEvecsByDiagonalAsync<D>(k_fut, sz_gl_el.rows(), sz_gl_el.cols(),
+    divideEvecsByDiagonalAsync<D>(k, sz_gl_el.rows(), sz_gl_el.cols(),
                                   diag.read_sender(GlobalTileIndex(idx_gl_tile.row(), 0)),
                                   diag.read_sender(GlobalTileIndex(idx_gl_tile.col(), 0)),
                                   evecs.read_sender(idx_loc_tile), ws.readwrite_sender(idx_loc_tile));
@@ -638,7 +628,7 @@ void initWeightVector(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin
     // reduce-multiply the first column of each local tile of the workspace matrix into the first local
     // column of the matrix
     LocalTileIndex idx_ws_first_col_tile(idx_loc_tile.row(), idx_loc_begin.col());
-    multiplyFirstColumnsAsync<D>(k_fut, sz_gl_el.rows(), sz_gl_el.cols(), ws.read_sender(idx_loc_tile),
+    multiplyFirstColumnsAsync<D>(k, sz_gl_el.rows(), sz_gl_el.cols(), ws.read_sender(idx_loc_tile),
                                  ws.readwrite_sender(idx_ws_first_col_tile));
   }
 }
@@ -647,10 +637,10 @@ void initWeightVector(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin
 // - lapack 3.10.0, dlaed3.f, line 293
 // - LAPACK Working Notes: lawn132, Parallelizing the Divide and Conquer Algorithm for the Symmetric
 //   Tridiagonal Eigenvalue Problem on Distributed Memory Architectures, 4.2 Orthogonality
-template <class T, Device D>
+template <class T, Device D, class KSender>
 void formEvecsUsingWeightVec(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin,
-                             LocalTileSize sz_loc_tiles, pika::shared_future<SizeType> k_fut,
-                             Matrix<const T, D>& z, Matrix<const T, D>& ws, Matrix<T, D>& evecs) {
+                             LocalTileSize sz_loc_tiles, KSender&& k, Matrix<const T, D>& z,
+                             Matrix<const T, D>& ws, Matrix<T, D>& evecs) {
   const matrix::Distribution& dist = evecs.distribution();
 
   for (auto idx_loc_tile : common::iterate_range2d(idx_loc_begin, sz_loc_tiles)) {
@@ -658,7 +648,7 @@ void formEvecsUsingWeightVec(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_lo
     auto sz_gl_el = dist.globalTileElementDistance(idx_gl_begin, idx_gl_tile);
     LocalTileIndex idx_ws_first_local_column(idx_loc_tile.row(), idx_loc_begin.col());
 
-    calcEvecsFromWeightVecAsync<D>(k_fut, sz_gl_el.rows(), sz_gl_el.cols(),
+    calcEvecsFromWeightVecAsync<D>(k, sz_gl_el.rows(), sz_gl_el.cols(),
                                    z.read_sender(GlobalTileIndex(idx_gl_tile.row(), 0)),
                                    ws.read_sender(idx_ws_first_local_column),
                                    evecs.readwrite_sender(idx_loc_tile));
@@ -666,15 +656,15 @@ void formEvecsUsingWeightVec(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_lo
 }
 
 // Sum of squares of columns of @p evecs into the first row of @p ws
-template <class T, Device D>
+template <class T, Device D, class KSender>
 void sumsqEvecs(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin, LocalTileSize sz_loc_tiles,
-                pika::shared_future<SizeType> k_fut, Matrix<const T, D>& evecs, Matrix<T, D>& ws) {
+                KSender&& k, Matrix<const T, D>& evecs, Matrix<T, D>& ws) {
   const matrix::Distribution& dist = evecs.distribution();
 
   for (auto idx_loc_tile : common::iterate_range2d(idx_loc_begin, sz_loc_tiles)) {
     auto idx_gl_tile = dist.globalTileIndex(idx_loc_tile);
     auto sz_gl_el = dist.globalTileElementDistance(idx_gl_begin, idx_gl_tile);
-    sumsqColsAsync<D>(k_fut, sz_gl_el.rows(), sz_gl_el.cols(), evecs.read_sender(idx_loc_tile),
+    sumsqColsAsync<D>(k, sz_gl_el.rows(), sz_gl_el.cols(), evecs.read_sender(idx_loc_tile),
                       ws.readwrite_sender(idx_loc_tile));
 
     // skip the first local row
@@ -682,7 +672,7 @@ void sumsqEvecs(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin, Loca
       continue;
 
     LocalTileIndex idx_ws_first_row_tile(idx_loc_begin.row(), idx_loc_tile.col());
-    addFirstRowsAsync<D>(k_fut, sz_gl_el.rows(), sz_gl_el.cols(), ws.read_sender(idx_loc_tile),
+    addFirstRowsAsync<D>(k, sz_gl_el.rows(), sz_gl_el.cols(), ws.read_sender(idx_loc_tile),
                          ws.readwrite_sender(idx_ws_first_row_tile));
   }
 }
@@ -690,34 +680,33 @@ void sumsqEvecs(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin, Loca
 // Normalize column vectors
 template <class T, Device D>
 void normalizeEvecs(GlobalTileIndex idx_gl_begin, LocalTileIndex idx_loc_begin,
-                    LocalTileSize sz_loc_tiles, pika::shared_future<SizeType> k_fut,
-                    Matrix<const T, D>& ws, Matrix<T, D>& evecs) {
+                    LocalTileSize sz_loc_tiles, KSender&& k, Matrix<const T, D>& ws,
+                    Matrix<T, D>& evecs) {
   const matrix::Distribution& dist = evecs.distribution();
 
   for (auto idx_loc_tile : common::iterate_range2d(idx_loc_begin, sz_loc_tiles)) {
     auto idx_gl_tile = dist.globalTileIndex(idx_loc_tile);
     auto sz_gl_el = dist.globalTileElementDistance(idx_gl_begin, idx_gl_tile);
     LocalTileIndex idx_ws_first_local_row(idx_loc_begin.row(), idx_loc_tile.col());
-    divideColsByFirstRowAsync<D>(k_fut, sz_gl_el.rows(), sz_gl_el.cols(),
+    divideColsByFirstRowAsync<D>(k, sz_gl_el.rows(), sz_gl_el.cols(),
                                  ws.read_sender(idx_ws_first_local_row),
                                  evecs.readwrite_sender(idx_loc_tile));
   }
 }
 
-template <class T, Device D>
-void setUnitDiag(SizeType i_begin, SizeType i_end, pika::shared_future<SizeType> k_fut,
-                 Matrix<T, D>& mat) {
+template <class T, Device D, class KSender>
+void setUnitDiag(SizeType i_begin, SizeType i_end, KSender&& k, Matrix<T, D>& mat) {
   // Iterate over diagonal tiles
   const matrix::Distribution& distr = mat.distribution();
   for (SizeType i_tile = i_begin; i_tile <= i_end; ++i_tile) {
     SizeType tile_begin = distr.globalTileElementDistance<Coord::Row>(i_begin, i_tile);
 
-    setUnitDiagonalAsync<D>(k_fut, tile_begin, mat.readwrite_sender(GlobalTileIndex(i_tile, i_tile)));
+    setUnitDiagonalAsync<D>(k, tile_begin, mat.readwrite_sender(GlobalTileIndex(i_tile, i_tile)));
   }
 }
 
-template <Backend backend, Device device, class T>
-void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::shared_future<T> rho_fut,
+template <Backend backend, Device device, class T, class RhoSender>
+void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, RhoSender&& rho,
                       WorkSpace<T, device>& ws, WorkSpaceHostMirror<T, device>& ws_h,
                       Matrix<T, device>& evals, Matrix<T, device>& evecs) {
   GlobalTileIndex idx_gl_begin(i_begin, i_begin);
@@ -728,17 +717,19 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
   LocalTileIndex idx_begin_tiles_vec(i_begin, 0);
   LocalTileSize sz_tiles_vec(nrtiles, 1);
 
+  namespace ex = pika::execution::experimental;
+
   // Calculate the size of the upper subproblem
   SizeType n1 = problemSize(i_begin, i_split, evecs.distribution());
 
   // Assemble the rank-1 update vector `z` from the last row of Q1 and the first row of Q2
-  assembleZVec(i_begin, i_split, i_end, rho_fut, evecs, ws.z);
+  assembleZVec(i_begin, i_split, i_end, rho, evecs, ws.z);
 
   // Double `rho` to account for the normalization of `z` and make sure `rho > 0` for the root solver laed4
-  rho_fut = scaleRho(std::move(rho_fut));
+  auto scaled_rho = scaleRho(std::move(rho)) | ex::split();
 
   // Calculate the tolerance used for deflation
-  pika::shared_future<T> tol_fut = calcTolerance(i_begin, i_end, evals, ws.z);
+  auto tol = calcTolerance(i_begin, i_end, evals, ws.z);
 
   // Initialize the column types vector `c`
   initColTypes(i_begin, i_split, i_end, ws.c);
@@ -752,7 +743,7 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
   // - apply Givens rotations to `Q` - `evecs`
   //
   initIndex(i_begin, i_end, ws.i1);
-  sortIndex(i_begin, i_end, pika::make_ready_future(n1), evals, ws.i1, ws.i2);
+  sortIndex(i_begin, i_end, ex::just(n1), evals, ws.i1, ws.i2);
 
   // --- copy from GPU to CPU if on GPU
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws.i2, ws_h.i2);
@@ -760,15 +751,15 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws.c, ws_h.c);
   copy(idx_begin_tiles_vec, sz_tiles_vec, evals, ws_h.evals);
 
-  pika::future<std::vector<GivensRotation<T>>> rots_fut =
-      applyDeflation(i_begin, i_end, rho_fut, tol_fut, ws_h.i2, ws_h.evals, ws_h.z, ws_h.c);
+  auto rots =
+      applyDeflation(i_begin, i_end, scaled_rho, std::move(tol), ws_h.i2, ws_h.evals, ws_h.z, ws_h.c);
 
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.z, ws.z);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.c, ws.c);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.evals, evals);
   // ---
 
-  applyGivensRotationsToMatrixColumns(i_begin, i_end, std::move(rots_fut), evecs);
+  applyGivensRotationsToMatrixColumns(i_begin, i_end, std::move(rots), evecs);
 
   // Step #2
   //
@@ -779,8 +770,7 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
   // - solve the rank-1 problem and save eigenvalues in `dtmp` and eigenvectors in `mat1`.
   // - set deflated diagonal entries of `U` to 1 (temporary solution until optimized GEMM is implemented)
   //
-  pika::shared_future<SizeType> k_fut =
-      stablePartitionIndexForDeflation(i_begin, i_end, ws.c, ws.i2, ws.i3);
+  auto k = stablePartitionIndexForDeflation(i_begin, i_end, ws.c, ws.i2, ws.i3) | ex::split();
   applyIndex(i_begin, i_end, ws.i3, evals, ws.dtmp);
   applyIndex(i_begin, i_end, ws.i3, ws.z, ws.ztmp);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws.dtmp, evals);
@@ -792,18 +782,18 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
 
   matrix::util::set0<Backend::MC>(pika::execution::thread_priority::normal, idx_loc_begin, sz_loc_tiles,
                                   ws_h.mat1);
-  solveRank1Problem(i_begin, i_end, k_fut, rho_fut, ws_h.evals, ws_h.ztmp, ws_h.dtmp, ws_h.mat1);
+  solveRank1Problem(i_begin, i_end, k, scaled_rho, ws_h.evals, ws_h.ztmp, ws_h.dtmp, ws_h.mat1);
 
   copy(idx_loc_begin, sz_loc_tiles, ws_h.mat1, ws.mat1);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.dtmp, ws.dtmp);
   // ---
 
-  // formEvecs(i_begin, i_end, k_fut, evals, ws.ztmp, ws.mat2, ws.mat1);
-  initWeightVector(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, evals, ws.mat1, ws.mat2);
-  formEvecsUsingWeightVec(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, ws.ztmp, ws.mat2, ws.mat1);
-  sumsqEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, ws.mat1, ws.mat2);
-  normalizeEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, ws.mat2, ws.mat1);
-  setUnitDiag(i_begin, i_end, k_fut, ws.mat1);
+  // formEvecs(i_begin, i_end, k, evals, ws.ztmp, ws.mat2, ws.mat1);
+  initWeightVector(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, evals, ws.mat1, ws.mat2);
+  formEvecsUsingWeightVec(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, ws.ztmp, ws.mat2, ws.mat1);
+  sumsqEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, ws.mat1, ws.mat2);
+  normalizeEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, ws.mat2, ws.mat1);
+  setUnitDiag(i_begin, i_end, k, ws.mat1);
 
   // Step #3: Eigenvectors of the tridiagonal system: Q * U
   //
@@ -828,7 +818,7 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
   //   ascending order
   // - reorder columns in `evecs` using `i2` such that eigenvectors match eigenvalues
   //
-  sortIndex(i_begin, i_end, k_fut, ws.dtmp, ws.i1, ws.i2);
+  sortIndex(i_begin, i_end, std::move(k), ws.dtmp, ws.i1, ws.i2);
   applyIndex(i_begin, i_end, ws.i2, ws.dtmp, evals);
   dlaf::permutations::permute<backend, device, T, Coord::Col>(i_begin, i_end, ws.i2, ws.mat1, evecs);
 }
@@ -837,9 +827,9 @@ void mergeSubproblems(SizeType i_begin, SizeType i_split, SizeType i_end, pika::
 //
 // Note that the norm of `z` is sqrt(2) because it is a concatination of two normalized vectors. Hence
 // to normalize `z` we have to divide by sqrt(2).
-template <class T, Device D>
+template <class T, Device D, class RhoSender>
 void assembleDistZVec(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& full_task_chain,
-                      SizeType i_begin, SizeType i_split, SizeType i_end, pika::shared_future<T> rho_fut,
+                      SizeType i_begin, SizeType i_split, SizeType i_end, RhoSender&& rho,
                       Matrix<const T, D>& evecs, Matrix<T, D>& z) {
   namespace ex = pika::execution::experimental;
 
@@ -859,7 +849,7 @@ void assembleDistZVec(comm::CommunicatorGrid grid, common::Pipeline<comm::Commun
     comm::Index2D evecs_tile_rank = dist.rankGlobalTile(idx_evecs);
     if (evecs_tile_rank == this_rank) {
       // Copy the row into the column vector `z`
-      assembleRank1UpdateVectorTileAsync<T, D>(top_tile, rho_fut, evecs.read_sender(idx_evecs),
+      assembleRank1UpdateVectorTileAsync<T, D>(top_tile, rho, evecs.read_sender(idx_evecs),
                                                z.readwrite_sender(z_idx));
       ex::start_detached(comm::scheduleSendBcast(ex::make_unique_any_sender(full_task_chain()),
                                                  ex::make_unique_any_sender(z.read_sender(z_idx))));
@@ -873,9 +863,8 @@ void assembleDistZVec(comm::CommunicatorGrid grid, common::Pipeline<comm::Commun
   }
 }
 
-template <class T, Device D>
-void setUnitDiagDist(SizeType i_begin, SizeType i_end, pika::shared_future<SizeType> k_fut,
-                     Matrix<T, D>& mat) {
+template <class T, Device D, class KSender>
+void setUnitDiagDist(SizeType i_begin, SizeType i_end, KSender&& k, Matrix<T, D>& mat) {
   // Iterate over diagonal tiles
   const matrix::Distribution& dist = mat.distribution();
   comm::Index2D this_rank = dist.rankIndex();
@@ -885,18 +874,17 @@ void setUnitDiagDist(SizeType i_begin, SizeType i_end, pika::shared_future<SizeT
     if (diag_tile_rank == this_rank) {
       SizeType tile_begin = dist.globalTileElementDistance<Coord::Row>(i_begin, i_tile);
 
-      setUnitDiagonalAsync<D>(k_fut, tile_begin, mat.readwrite_sender(ii_tile));
+      setUnitDiagonalAsync<D>(k, tile_begin, mat.readwrite_sender(ii_tile));
     }
   }
 }
 
 // (All)Reduce-multiply row-wise the first local columns of the distributed matrix @p mat of size (n, n).
 // The local column on each rank is first offloaded to a local communication buffer @p comm_vec of size (n, 1).
-template <class T, Device D>
+template <class T, Device D, class KSender>
 void reduceMultiplyWeightVector(common::Pipeline<comm::Communicator>& row_task_chain, SizeType i_begin,
                                 SizeType i_end, LocalTileIndex idx_loc_begin, LocalTileSize sz_loc_tiles,
-                                pika::shared_future<SizeType> k_fut, Matrix<T, D>& mat,
-                                Matrix<T, D>& comm_vec) {
+                                KSender&& k, Matrix<T, D>& mat, Matrix<T, D>& comm_vec) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -934,7 +922,7 @@ void reduceMultiplyWeightVector(common::Pipeline<comm::Communicator>& row_task_c
         tile::laset(di::Policy<DefaultBackend_v<D>>()));
 
     // copy the first column of the matrix tile into the column tile of the buffer
-    copy1DAsync<D>(k_fut, sz_subm.rows(), sz_subm.cols(), Coord::Col, mat.read_sender(idx_loc_tile),
+    copy1DAsync<D>(k, sz_subm.rows(), sz_subm.cols(), Coord::Col, mat.read_sender(idx_loc_tile),
                    Coord::Col, comm_vec.readwrite_sender(idx_gl_comm));
 
     ex::start_detached(comm::scheduleAllReduceInPlace(ex::make_unique_any_sender(row_task_chain()),
@@ -943,18 +931,17 @@ void reduceMultiplyWeightVector(common::Pipeline<comm::Communicator>& row_task_c
                                                           comm_vec.readwrite_sender(idx_gl_comm))));
 
     // copy the column tile of the buffer into the first column of the matrix tile
-    copy1DAsync<D>(k_fut, sz_subm.rows(), sz_subm.cols(), Coord::Col, comm_vec.read_sender(idx_gl_comm),
+    copy1DAsync<D>(k, sz_subm.rows(), sz_subm.cols(), Coord::Col, comm_vec.read_sender(idx_gl_comm),
                    Coord::Col, mat.readwrite_sender(idx_loc_tile));
   }
 }
 
 // (All)Reduce-sum column-wise the first local rows of the distributed matrix @p mat of size (n, n).
 // The local row on each rank is first offloaded to a local communication buffer @p comm_vec of size (n, 1).
-template <class T, Device D>
+template <class T, Device D, class KSender>
 void reduceSumScalingVector(common::Pipeline<comm::Communicator>& col_task_chain, SizeType i_begin,
                             SizeType i_end, LocalTileIndex idx_loc_begin, LocalTileSize sz_loc_tiles,
-                            pika::shared_future<SizeType> k_fut, Matrix<T, D>& mat,
-                            Matrix<T, D>& comm_vec) {
+                            KSender&& k, Matrix<T, D>& mat, Matrix<T, D>& comm_vec) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -990,7 +977,7 @@ void reduceSumScalingVector(common::Pipeline<comm::Communicator>& col_task_chain
                        tile::set0(di::Policy<DefaultBackend_v<D>>()));
 
     // copy the first row of the matrix tile into the column tile of the buffer
-    copy1DAsync<D>(k_fut, sz_subm.rows(), sz_subm.cols(), Coord::Row, mat.read_sender(idx_loc_tile),
+    copy1DAsync<D>(k, sz_subm.rows(), sz_subm.cols(), Coord::Row, mat.read_sender(idx_loc_tile),
                    Coord::Col, comm_vec.readwrite_sender(idx_gl_comm));
 
     ex::start_detached(comm::scheduleAllReduceInPlace(ex::make_unique_any_sender(col_task_chain()),
@@ -999,17 +986,17 @@ void reduceSumScalingVector(common::Pipeline<comm::Communicator>& col_task_chain
                                                           comm_vec.readwrite_sender(idx_gl_comm))));
 
     // copy the column tile of the buffer into the first column of the matrix tile
-    copy1DAsync<D>(k_fut, sz_subm.rows(), sz_subm.cols(), Coord::Col, comm_vec.read_sender(idx_gl_comm),
+    copy1DAsync<D>(k, sz_subm.rows(), sz_subm.cols(), Coord::Col, comm_vec.read_sender(idx_gl_comm),
                    Coord::Row, mat.readwrite_sender(idx_loc_tile));
   }
 }
 
-template <class T>
+template <class T, class KSender, class RhoSender>
 void solveRank1ProblemDist(SizeType i_begin, SizeType i_end, LocalTileIndex idx_loc_begin,
-                           LocalTileSize sz_loc_tiles, pika::shared_future<SizeType> k_fut,
-                           pika::shared_future<T> rho_fut, Matrix<const T, Device::CPU>& d,
-                           Matrix<const T, Device::CPU>& z, Matrix<T, Device::CPU>& evals,
-                           Matrix<T, Device::CPU>& delta, Matrix<T, Device::CPU>& evecs) {
+                           LocalTileSize sz_loc_tiles, KSender&& k, RhoSender&& rho,
+                           Matrix<const T, Device::CPU>& d, Matrix<const T, Device::CPU>& z,
+                           Matrix<T, Device::CPU>& evals, Matrix<T, Device::CPU>& delta,
+                           Matrix<T, Device::CPU>& evecs) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
@@ -1080,9 +1067,10 @@ void solveRank1ProblemDist(SizeType i_begin, SizeType i_end, LocalTileIndex idx_
   TileCollector tc{i_begin, i_end};
 
   auto sender =
-      ex::when_all(std::move(k_fut), std::move(rho_fut), ex::when_all_vector(tc.read(d)),
-                   ex::when_all_vector(tc.read(z)), ex::when_all_vector(tc.readwrite(evals)),
-                   ex::when_all_vector(tc.readwrite(delta)), ex::when_all_vector(tc.readwrite(evecs)));
+      ex::when_all(std::forward<KSender>(k), std::forward<RhoSender>(rho),
+                   ex::when_all_vector(tc.read(d)), ex::when_all_vector(tc.read(z)),
+                   ex::when_all_vector(tc.readwrite(evals)), ex::when_all_vector(tc.readwrite(delta)),
+                   ex::when_all_vector(tc.readwrite(evecs)));
 
   ex::start_detached(di::transform(di::Policy<Backend::MC>(), std::move(rank1_fn), std::move(sender)));
 }
@@ -1112,14 +1100,13 @@ void assembleDistEvalsVec(common::Pipeline<comm::Communicator>& row_task_chain, 
 }
 
 // Distributed version of the tridiagonal solver on CPUs
-template <Backend B, class T, Device D>
+template <Backend B, class T, Device D, class RhoSender>
 void mergeDistSubproblems(comm::CommunicatorGrid grid,
                           common::Pipeline<comm::Communicator>& full_task_chain,
                           common::Pipeline<comm::Communicator>& row_task_chain,
                           common::Pipeline<comm::Communicator>& col_task_chain, SizeType i_begin,
-                          SizeType i_split, SizeType i_end, pika::shared_future<T> rho_fut,
-                          WorkSpace<T, D>& ws, WorkSpaceHostMirror<T, D>& ws_h, Matrix<T, D>& evals,
-                          Matrix<T, D>& evecs) {
+                          SizeType i_split, SizeType i_end, RhoSender&& rho, WorkSpace<T, D>& ws,
+                          WorkSpaceHostMirror<T, D>& ws_h, Matrix<T, D>& evals, Matrix<T, D>& evecs) {
   const matrix::Distribution& dist_evecs = evecs.distribution();
 
   // Calculate the size of the upper subproblem
@@ -1137,13 +1124,13 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   LocalTileSize sz_tiles_vec(i_end - i_begin + 1, 1);
 
   // Assemble the rank-1 update vector `z` from the last row of Q1 and the first row of Q2
-  assembleDistZVec(grid, full_task_chain, i_begin, i_split, i_end, rho_fut, evecs, ws.z);
+  assembleDistZVec(grid, full_task_chain, i_begin, i_split, i_end, rho, evecs, ws.z);
 
   // Calculate the tolerance used for deflation
   pika::shared_future<T> tol_fut = calcTolerance(i_begin, i_end, evals, ws.z);
 
   // Double `rho` to account for the normalization of `z` and make sure `rho > 0` for the root solver laed4
-  rho_fut = scaleRho(std::move(rho_fut));
+  auto scaled_rho = scaleRho(std::move(rho)) | ex::split();
 
   // Initialize the column types vector `c`
   initColTypes(i_begin, i_split, i_end, ws.c);
@@ -1165,8 +1152,7 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws.c, ws_h.c);
   copy(idx_begin_tiles_vec, sz_tiles_vec, evals, ws_h.evals);
 
-  pika::future<std::vector<GivensRotation<T>>> rots_fut =
-      applyDeflation(i_begin, i_end, rho_fut, tol_fut, ws_h.i2, ws_h.evals, ws_h.z, ws_h.c);
+  auto rots = applyDeflation(i_begin, i_end, scaled_rho, tol_fut, ws_h.i2, ws_h.evals, ws_h.z, ws_h.c);
 
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.z, ws.z);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.c, ws.c);
@@ -1178,7 +1164,7 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   // Note: this is unique because i_[begin|split|end] < nrtiles
   SizeType nrtiles = dist_evecs.nrTiles().rows();
   comm::IndexT_MPI tag = to_int(i_begin + i_split * nrtiles + i_end * nrtiles * nrtiles);
-  applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), tag, i_begin, i_end, std::move(rots_fut),
+  applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), tag, i_begin, i_end, std::move(rots),
                                       evecs);
 
   // Step #2
@@ -1190,8 +1176,7 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   // - solve the rank-1 problem and save eigenvalues in `dtmp` and eigenvectors in `mat1`.
   // - set deflated diagonal entries of `U` to 1 (temporary solution until optimized GEMM is implemented)
   //
-  pika::shared_future<SizeType> k_fut =
-      stablePartitionIndexForDeflation(i_begin, i_end, ws.c, ws.i2, ws.i3);
+  auto k = stablePartitionIndexForDeflation(i_begin, i_end, ws.c, ws.i2, ws.i3);
   applyIndex(i_begin, i_end, ws.i3, evals, ws.dtmp);
   applyIndex(i_begin, i_end, ws.i3, ws.z, ws.ztmp);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws.dtmp, evals);
@@ -1204,8 +1189,8 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   // Note: here ws_h.z is used as a contiguous buffer for the laed4 call
   matrix::util::set0<Backend::MC>(pika::execution::thread_priority::normal, idx_loc_begin, sz_loc_tiles,
                                   ws_h.mat1);
-  solveRank1ProblemDist(i_begin, i_end, idx_loc_begin, sz_loc_tiles, k_fut, rho_fut, ws_h.evals,
-                        ws_h.ztmp, ws_h.dtmp, ws_h.z, ws_h.mat1);
+  solveRank1ProblemDist(i_begin, i_end, idx_loc_begin, sz_loc_tiles, k, std::move(scaled_rho),
+                        ws_h.evals, ws_h.ztmp, ws_h.dtmp, ws_h.z, ws_h.mat1);
 
   copy(idx_loc_begin, sz_loc_tiles, ws_h.mat1, ws.mat1);
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws_h.dtmp, ws.dtmp);
@@ -1214,15 +1199,14 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   assembleDistEvalsVec(row_task_chain, i_begin, i_end, dist_evecs, ws.dtmp);
 
   // Eigenvector formation: `ws.mat1` stores the eigenvectors, `ws.mat2` is used as an additional workspace
-  initWeightVector(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, evals, ws.mat1, ws.mat2);
-  reduceMultiplyWeightVector(row_task_chain, i_begin, i_end, idx_loc_begin, sz_loc_tiles, k_fut, ws.mat2,
+  initWeightVector(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, evals, ws.mat1, ws.mat2);
+  reduceMultiplyWeightVector(row_task_chain, i_begin, i_end, idx_loc_begin, sz_loc_tiles, k, ws.mat2,
                              ws.z);
-  formEvecsUsingWeightVec(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, ws.ztmp, ws.mat2, ws.mat1);
-  sumsqEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, ws.mat1, ws.mat2);
-  reduceSumScalingVector(col_task_chain, i_begin, i_end, idx_loc_begin, sz_loc_tiles, k_fut, ws.mat2,
-                         ws.z);
-  normalizeEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k_fut, ws.mat2, ws.mat1);
-  setUnitDiagDist(i_begin, i_end, k_fut, ws.mat1);
+  formEvecsUsingWeightVec(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, ws.ztmp, ws.mat2, ws.mat1);
+  sumsqEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, ws.mat1, ws.mat2);
+  reduceSumScalingVector(col_task_chain, i_begin, i_end, idx_loc_begin, sz_loc_tiles, k, ws.mat2, ws.z);
+  normalizeEvecs(idx_gl_begin, idx_loc_begin, sz_loc_tiles, k, ws.mat2, ws.mat1);
+  setUnitDiagDist(i_begin, i_end, k, ws.mat1);
 
   // Step #3: Eigenvectors of the tridiagonal system: Q * U
   //
@@ -1253,7 +1237,7 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   //   ascending order
   // - reorder columns in `evecs` using `i2` such that eigenvectors match eigenvalues
   //
-  sortIndex(i_begin, i_end, k_fut, ws.dtmp, ws.i1, ws.i2);
+  sortIndex(i_begin, i_end, std::move(k), ws.dtmp, ws.i1, ws.i2);
   applyIndex(i_begin, i_end, ws.i2, ws.dtmp, evals);
 
   copy(idx_begin_tiles_vec, sz_tiles_vec, ws.i2, ws_h.i2);

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -403,7 +403,7 @@ auto collectReadWriteTiles(LocalTileIndex begin, LocalTileSize sz, Matrix<T, D>&
   std::vector<decltype(mat.readwrite_sender(std::declval<LocalTileIndex>()))> tiles;
   tiles.reserve(to_sizet(sz.linear_size()));
   for (auto idx : iterate_range2d(begin, sz)) {
-    tiles.push_back(mat(idx));
+    tiles.push_back(mat.readwrite_sender(idx));
   }
   return tiles;
 }


### PR DESCRIPTION
Fixes #588. Removes all explicit occurrences of futures, but does not yet get rid of the ones that come implicitly from `Matrix::read` (which returns a keep_future(shared_future)`).

~There's one TODO related to lifetime management of tiles that I haven't yet decided if I'll leave as it is in this PR or try to do something about it. Hence the draft.~ I've left a TODO for something that will be changed separately.