### PR TITLE
algo: Distributed sub-Gemm (trisolver use-case)

### DIFF
--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -75,9 +75,9 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
 }
 
 template <Backend B, Device D, class T>
-void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const SizeType b, const T alpha,
-                       Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
-                       Matrix<T, D>& mat_c) {
+void generalSubMatrix(comm::CommunicatorGrid grid, const SizeType a, const SizeType b, const T alpha,
+                      Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                      Matrix<T, D>& mat_c) {
   DLAF_ASSERT(equal_process_grid(mat_a, grid), mat_a, grid);
   DLAF_ASSERT(equal_process_grid(mat_b, grid), mat_a, grid);
   DLAF_ASSERT(equal_process_grid(mat_c, grid), mat_a, grid);
@@ -100,7 +100,7 @@ void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const Size
   DLAF_ASSERT(a <= b, a, b);
   DLAF_ASSERT(a >= 0 && a < m, a, m);
 
-  internal::GeneralSubK<B, D, T>::callNN(grid, a, b, alpha, mat_a, mat_b, beta, mat_c);
+  internal::GeneralSub<B, D, T>::callNN(grid, a, b, alpha, mat_a, mat_b, beta, mat_c);
 }
 
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -69,8 +69,8 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
 }
 
 template <Backend B, Device D, class T>
-void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const SizeType b, const SizeType k,
-                       const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const SizeType b, const T alpha,
+                       Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
                        Matrix<T, D>& mat_c) {
   // TODO check about grid distribution
   DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_a), mat_a);
@@ -88,7 +88,7 @@ void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const Size
 
   // TODO add check about k
 
-  internal::GeneralSubK<B, D, T>::call(grid, a, b, k, alpha, mat_a, mat_b, beta, mat_c);
+  internal::GeneralSubK<B, D, T>::call(grid, a, b, alpha, mat_a, mat_b, beta, mat_c);
 }
 
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -82,10 +82,6 @@ void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const Size
   DLAF_ASSERT(dlaf::matrix::square_size(mat_b), mat_b);
   DLAF_ASSERT(dlaf::matrix::square_size(mat_c), mat_c);
 
-  DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
-  DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
-  DLAF_ASSERT(matrix::local_matrix(mat_c), mat_c);
-
   const SizeType m = mat_a.nrTiles().rows();
   DLAF_ASSERT(a <= b, a, b);
   DLAF_ASSERT(a >= 0 && a < m, a, m);

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -86,9 +86,7 @@ void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const Size
   DLAF_ASSERT(a <= b, a, b);
   DLAF_ASSERT(a >= 0 && a < m, a, m);
 
-  // TODO add check about k
-
-  internal::GeneralSubK<B, D, T>::call(grid, a, b, alpha, mat_a, mat_b, beta, mat_c);
+  internal::GeneralSubK<B, D, T>::callNN(grid, a, b, alpha, mat_a, mat_b, beta, mat_c);
 }
 
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -13,6 +13,7 @@
 #include <blas.hh>
 
 #include "dlaf/common/assert.h"
+#include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/multiplication/general/api.h"
 #include "dlaf/util_matrix.h"
@@ -66,4 +67,32 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
   else
     DLAF_UNIMPLEMENTED(opA, opB);
 }
+
+template <Backend B, Device D, class T>
+void generalSubMatrixK(comm::CommunicatorGrid grid, const SizeType a, const SizeType b, const SizeType k,
+                       const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                       Matrix<T, D>& mat_c) {
+  // TODO check about grid distribution
+  DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_a), mat_a);
+  DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_b), mat_b);
+  DLAF_ASSERT(dlaf::matrix::square_blocksize(mat_c), mat_c);
+
+  // TODO check assertions. these are superflous
+  DLAF_ASSERT(dlaf::matrix::square_size(mat_a), mat_a);
+  DLAF_ASSERT(dlaf::matrix::square_size(mat_b), mat_b);
+  DLAF_ASSERT(dlaf::matrix::square_size(mat_c), mat_c);
+
+  DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
+  DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
+  DLAF_ASSERT(matrix::local_matrix(mat_c), mat_c);
+
+  const SizeType m = mat_a.nrTiles().rows();
+  DLAF_ASSERT(a <= b, a, b);
+  DLAF_ASSERT(a >= 0 && a < m, a, m);
+
+  // TODO add check about k
+
+  internal::GeneralSubK<B, D, T>::call(grid, a, b, k, alpha, mat_a, mat_b, beta, mat_c);
+}
+
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -38,7 +38,7 @@ namespace dlaf::multiplication {
 ///         overwritten with the result, while others are left untouched.
 ///         Only tiles whose both row and col tile coords are in the closed range [a,b] are accessed.
 /// @pre mat_a, mat_b and mat_c have the same square block size,
-/// @pre mat_a, mat_b and mat_c have the same square size,
+/// @pre mat_a, mat_b and mat_c have the same size,
 /// @pre mat_a, mat_b and mat_c are not distributed,
 /// @pre a <= b < mat_a.nrTiles().rows()
 template <Backend B, Device D, class T>
@@ -74,6 +74,21 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
     DLAF_UNIMPLEMENTED(opA, opB);
 }
 
+/// General sub-matrix distributed multiplication, computing
+/// C[a:b][a:b] = alpha * A[a:b][a:b] * B[a:b][a:b] + beta * C[a:b][a:b]
+/// where [a:b] is the range of tiles starting from tile index @p a to tile index @p b (included)
+///
+/// @param  mat_a contains the input matrix A. Only tiles whose both row and col tile coords are in
+///         the closed range [a,b] are accessed in read-only mode (elements are not modified)
+/// @param  mat_b contains the input matrix B. Only tiles whose both row and col tile coords are in
+///         the closed range [a,b] are accessed in read-only mode (elements are not modified)
+/// @param  mat_c On entry it contains the input matrix C. On exit matrix tiles in the range will be
+///         overwritten with the result, while others are left untouched.
+///         Only tiles whose both row and col tile coords are in the closed range [a,b] are accessed.
+/// @pre mat_a, mat_b and mat_c are distributed in the same way,
+/// @pre mat_a, mat_b and mat_c have the same square block size,
+/// @pre mat_a, mat_b and mat_c have the same size,
+/// @pre a <= b < mat_a.nrTiles().rows()
 template <Backend B, Device D, class T>
 void generalSubMatrix(comm::CommunicatorGrid grid, const SizeType a, const SizeType b, const T alpha,
                       Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -43,9 +43,9 @@ DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<
 
 template <Backend B, Device D, class T>
 struct GeneralSubK {
-  static void call(comm::CommunicatorGrid grid, const SizeType i_tile_from, const SizeType i_tile_to,
-                   const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
-                   Matrix<T, D>& mat_c);
+  static void callNN(comm::CommunicatorGrid grid, const SizeType i_tile_from, const SizeType i_tile_to,
+                     const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                     Matrix<T, D>& mat_c);
 };
 
 #define DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -56,5 +56,12 @@ DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, double)
 DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
 
+#ifdef DLAF_WITH_GPU
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, float)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, double)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
+#endif
+
 }
 }

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -23,6 +23,9 @@ struct GeneralSub {
   static void callNN(const SizeType i_tile_from, const SizeType i_tile_to, const blas::Op opA,
                      const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
                      Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c);
+  static void callNN(comm::CommunicatorGrid grid, const SizeType i_tile_from, const SizeType i_tile_to,
+                     const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                     Matrix<T, D>& mat_c);
 };
 
 /// ---- ETI
@@ -39,28 +42,6 @@ DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, float)
 DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, double)
 DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
-#endif
-
-template <Backend B, Device D, class T>
-struct GeneralSubK {
-  static void callNN(comm::CommunicatorGrid grid, const SizeType i_tile_from, const SizeType i_tile_to,
-                     const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
-                     Matrix<T, D>& mat_c);
-};
-
-#define DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  KWORD template struct GeneralSubK<BACKEND, DEVICE, DATATYPE>;
-
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, float)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, double)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
-
-#ifdef DLAF_WITH_GPU
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, float)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, double)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
 
 }

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -44,8 +44,8 @@ DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<
 template <Backend B, Device D, class T>
 struct GeneralSubK {
   static void call(comm::CommunicatorGrid grid, const SizeType i_tile_from, const SizeType i_tile_to,
-                   const SizeType k, const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b,
-                   const T beta, Matrix<T, D>& mat_c);
+                   const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                   Matrix<T, D>& mat_c);
 };
 
 #define DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -40,5 +40,21 @@ DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, double)
 DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
+
+template <Backend B, Device D, class T>
+struct GeneralSubK {
+  static void call(comm::CommunicatorGrid grid, const SizeType i_tile_from, const SizeType i_tile_to,
+                   const SizeType k, const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b,
+                   const T beta, Matrix<T, D>& mat_c);
+};
+
+#define DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct GeneralSubK<BACKEND, DEVICE, DATATYPE>;
+
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, float)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, double)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
+
 }
 }

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -49,46 +49,55 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
 
 template <Backend B, Device D, class T>
 void GeneralSubK<B, D, T>::call(comm::CommunicatorGrid grid, const SizeType idx_begin,
-                                const SizeType idx_end, const SizeType k, const T alpha,
+                                const SizeType idx_last, const SizeType k, const T alpha,
                                 Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
                                 Matrix<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
+  const auto& dist_a = mat_a.distribution();
   const auto& dist_c = mat_c.distribution();
   const auto rank = dist_c.rankIndex();
 
   common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
   common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
 
+  // TODO minimize panel memory allocation (in order to reduce also communications)
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<matrix::Panel<Coord::Col, T, D>> col_panels(n_workspaces, dist_c);
   common::RoundRobin<matrix::Panel<Coord::Row, T, D>> row_panels(n_workspaces, dist_c);
 
-  // TODO compute correctly the range to work on
+  const SizeType idx_end = std::min(idx_last + 1, dist_a.nrTiles().rows());
+  const SizeType i_beg = dist_a.template nextLocalTileFromGlobalTile<Coord::Row>(idx_begin);
+  const SizeType i_end = dist_a.template nextLocalTileFromGlobalTile<Coord::Row>(idx_end);
 
-  for (SizeType k = 0; k < mat_a.nrTiles().cols(); ++k) {
+  const SizeType j_beg = dist_a.template nextLocalTileFromGlobalTile<Coord::Col>(idx_begin);
+  const SizeType j_end = dist_a.template nextLocalTileFromGlobalTile<Coord::Col>(idx_end);
+
+  for (SizeType k = idx_begin; k <= idx_last; ++k) {
     auto& col_panel = col_panels.nextResource();
     auto& row_panel = row_panels.nextResource();
 
-    const auto rank_k = mat_a.distribution().template rankGlobalTile<Coord::Col>(k);
+    const auto rank_k = dist_a.template rankGlobalTile<Coord::Col>(k);
     if (rank_k == rank.col()) {
-      for (SizeType i = 0; i < mat_a.distribution().localNrTiles().rows(); ++i) {
+      const auto k_local = dist_a.template localTileFromGlobalTile<Coord::Col>(k);
+      for (SizeType i = i_beg; i < i_end; ++i) {
         const LocalTileIndex i0(i, 0);
-        col_panel.setTile(i0, mat_a.read(i0));
+        col_panel.setTile(i0, mat_a.read(LocalTileIndex{i, k_local}));
       }
     }
     if (rank_k == rank.row()) {
-      for (SizeType j = 0; j < mat_a.distribution().localNrTiles().cols(); ++j) {
+      const auto k_local = dist_a.template localTileFromGlobalTile<Coord::Row>(k);
+      for (SizeType j = j_beg; j < j_end; ++j) {
         const LocalTileIndex j0(0, j);
-        row_panel.setTile(j0, mat_b.read(j0));
+        row_panel.setTile(j0, mat_b.read(LocalTileIndex{k_local, j}));
       }
     }
 
     broadcast(rank.col(), col_panel, mpi_row_task_chain);
     broadcast(rank.row(), row_panel, mpi_col_task_chain);
 
-    for (SizeType i = 0; i < dist_c.localNrTiles().rows(); ++i) {
-      for (SizeType j = 0; j < dist_c.localNrTiles().cols(); ++j) {
+    for (SizeType i = i_beg; i < i_end; ++i) {
+      for (SizeType j = j_beg; j < j_end; ++j) {
         // TODO split last tile if not all elements are used
 
         ex::start_detached(dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha,

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -12,10 +12,16 @@
 
 #include "dlaf/multiplication/general/api.h"
 
-#include "dlaf/blas/enum_output.h"
 #include "dlaf/blas/tile.h"
+#include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
-#include "dlaf/sender/transform.h"
+#include "dlaf/common/pipeline.h"
+#include "dlaf/common/round_robin.h"
+#include "dlaf/communication/broadcast_panel.h"
+#include "dlaf/communication/communicator_grid.h"
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/index.h"
+#include "dlaf/matrix/panel.h"
 #include "dlaf/sender/when_all_lift.h"
 
 namespace dlaf::multiplication {
@@ -38,6 +44,64 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
                            tile::gemm(dlaf::internal::Policy<B>()));
       }
     }
+  }
+}
+
+template <Backend B, Device D, class T>
+void GeneralSubK<B, D, T>::call(comm::CommunicatorGrid grid, const SizeType idx_begin,
+                                const SizeType idx_end, const SizeType k, const T alpha,
+                                Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
+                                Matrix<T, D>& mat_c) {
+  namespace ex = pika::execution::experimental;
+
+  const auto& dist_c = mat_c.distribution();
+  const auto rank = dist_c.rankIndex();
+
+  common::Pipeline<comm::Communicator> mpi_row_task_chain(grid.rowCommunicator().clone());
+  common::Pipeline<comm::Communicator> mpi_col_task_chain(grid.colCommunicator().clone());
+
+  constexpr std::size_t n_workspaces = 2;
+  common::RoundRobin<matrix::Panel<Coord::Col, T, D>> col_panels(n_workspaces, dist_c);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> row_panels(n_workspaces, dist_c);
+
+  // TODO compute correctly the range to work on
+
+  for (SizeType k = 0; k < mat_a.nrTiles().cols(); ++k) {
+    auto& col_panel = col_panels.nextResource();
+    auto& row_panel = row_panels.nextResource();
+
+    const auto rank_k = mat_a.distribution().template rankGlobalTile<Coord::Col>(k);
+    if (rank_k == rank.col()) {
+      for (SizeType i = 0; i < mat_a.distribution().localNrTiles().rows(); ++i) {
+        const LocalTileIndex i0(i, 0);
+        col_panel.setTile(i0, mat_a.read(i0));
+      }
+    }
+    if (rank_k == rank.row()) {
+      for (SizeType j = 0; j < mat_a.distribution().localNrTiles().cols(); ++j) {
+        const LocalTileIndex j0(0, j);
+        row_panel.setTile(j0, mat_b.read(j0));
+      }
+    }
+
+    broadcast(rank.col(), col_panel, mpi_row_task_chain);
+    broadcast(rank.row(), row_panel, mpi_col_task_chain);
+
+    for (SizeType i = 0; i < dist_c.localNrTiles().rows(); ++i) {
+      for (SizeType j = 0; j < dist_c.localNrTiles().cols(); ++j) {
+        // TODO split last tile if not all elements are used
+
+        ex::start_detached(dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha,
+                                                       col_panel.read_sender(LocalTileIndex{i, 0}),
+                                                       row_panel.read_sender(LocalTileIndex{0, j}),
+                                                       k == idx_begin ? beta : T(1),
+                                                       mat_c.readwrite_sender(LocalTileIndex(i, j))) |
+                           tile::gemm(dlaf::internal::Policy<B>()));
+      }
+    }
+
+    col_panel.reset();
+    row_panel.reset();
   }
 }
 }

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -53,9 +53,9 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
 // SUMMA: Scalable universal matrix multiplication algorithm.
 // Concurrency: Practice and Experience 9.4 (1997): 255-274
 template <Backend B, Device D, class T>
-void GeneralSubK<B, D, T>::callNN(comm::CommunicatorGrid grid, const SizeType idx_begin,
-                                  const SizeType idx_last, const T alpha, Matrix<const T, D>& mat_a,
-                                  Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
+void GeneralSub<B, D, T>::callNN(comm::CommunicatorGrid grid, const SizeType idx_begin,
+                                 const SizeType idx_last, const T alpha, Matrix<const T, D>& mat_a,
+                                 Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
   const auto& dist_a = mat_a.distribution();

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -49,7 +49,7 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
 
 template <Backend B, Device D, class T>
 void GeneralSubK<B, D, T>::call(comm::CommunicatorGrid grid, const SizeType idx_begin,
-                                const SizeType idx_last, const SizeType k, const T alpha,
+                                const SizeType idx_last, const SizeType nrefls, const T alpha,
                                 Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta,
                                 Matrix<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -47,15 +47,15 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
   }
 }
 
-// This implementations is based on
+// This implementation is based on
 //
 // Van De Geijn, Robert A., and Jerrell Watts.
 // SUMMA: Scalable universal matrix multiplication algorithm.
 // Concurrency: Practice and Experience 9.4 (1997): 255-274
 template <Backend B, Device D, class T>
-void GeneralSubK<B, D, T>::call(comm::CommunicatorGrid grid, const SizeType idx_begin,
-                                const SizeType idx_last, const T alpha, Matrix<const T, D>& mat_a,
-                                Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
+void GeneralSubK<B, D, T>::callNN(comm::CommunicatorGrid grid, const SizeType idx_begin,
+                                  const SizeType idx_last, const T alpha, Matrix<const T, D>& mat_a,
+                                  Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
   const auto& dist_a = mat_a.distribution();

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -147,8 +147,8 @@ void GeneralSubK<B, D, T>::call(comm::CommunicatorGrid grid, const SizeType idx_
     }
 
     // Broadcast both column and row panel from root to others (row-wise and col-wise, respectively)
-    broadcast(rank.col(), panelA, mpi_row_task_chain);
-    broadcast(rank.row(), panelB, mpi_col_task_chain);
+    broadcast(rank_k.col(), panelA, mpi_row_task_chain);
+    broadcast(rank_k.row(), panelB, mpi_col_task_chain);
 
     // This is the core loop where the k step performs the update step over the full local matrix
     // using the col and row workspaces.

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -47,6 +47,11 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
   }
 }
 
+// This implementations is based on
+//
+// Van De Geijn, Robert A., and Jerrell Watts.
+// SUMMA: Scalable universal matrix multiplication algorithm.
+// Concurrency: Practice and Experience 9.4 (1997): 255-274
 template <Backend B, Device D, class T>
 void GeneralSubK<B, D, T>::call(comm::CommunicatorGrid grid, const SizeType idx_begin,
                                 const SizeType idx_last, const SizeType nrefls, const T alpha,

--- a/src/multiplication/general/gpu.cpp
+++ b/src/multiplication/general/gpu.cpp
@@ -17,9 +17,4 @@ DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::GPU, Device::GPU, double)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
 
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, float)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, double)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
-
 }

--- a/src/multiplication/general/gpu.cpp
+++ b/src/multiplication/general/gpu.cpp
@@ -17,4 +17,9 @@ DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::GPU, Device::GPU, double)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
 
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, float)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, double)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
+
 }

--- a/src/multiplication/general/mc.cpp
+++ b/src/multiplication/general/mc.cpp
@@ -16,4 +16,9 @@ DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, float)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, double)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, std::complex<double>)
+
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, float)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, double)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, std::complex<double>)
 }

--- a/src/multiplication/general/mc.cpp
+++ b/src/multiplication/general/mc.cpp
@@ -17,8 +17,4 @@ DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, double)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_MULTIPLICATION_GENERAL_ETI(, Backend::MC, Device::CPU, std::complex<double>)
 
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, float)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, double)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_MULTIPLICATION_GENERAL_SUBK_ETI(, Backend::MC, Device::CPU, std::complex<double>)
 }

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -35,6 +35,8 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
   if (opB != blas::Op::NoTrans)
     DLAF_UNIMPLEMENTED(opB);
 
+  const auto sub = b - a + 1;
+
   DLAF_ASSERT(a >= 0 and a < m and a < n, a, m, n);
   DLAF_ASSERT(b >= 0 and b < m and b < n, b, m, n);
   DLAF_ASSERT(a <= b, a, b);
@@ -69,14 +71,14 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
     return TypeUtilities<T>::polar((i + k + 1) / (j + 5), i + j + k);
   };
 
-  auto elR = [a, b, k, alpha, beta](const GlobalElementIndex ij) {
+  auto elR = [a, b, sub, k, alpha, beta](const GlobalElementIndex ij) {
     if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
       return -TypeUtilities<T>::polar(99, 99);
 
     const double i = ij.row();
     const double j = ij.col();
 
-    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * (b - a + 1), (2 * i) + j) +
+    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * sub, (2 * i) + j) +
            beta * TypeUtilities<T>::polar((i + k + 1) / (j + 5), k + i + j);
   };
 

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -61,7 +61,7 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
 
   auto elC = [a, b, k](const GlobalElementIndex ij) {
     if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
-      return TypeUtilities<T>::polar(-99, 99);
+      return -TypeUtilities<T>::polar(99, 99);
 
     const double i = ij.row();
     const double j = ij.col();
@@ -71,7 +71,7 @@ auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const 
 
   auto elR = [a, b, k, alpha, beta](const GlobalElementIndex ij) {
     if (ij.row() < a || ij.row() > b || ij.col() < a || ij.col() > b)
-      return TypeUtilities<T>::polar(13, -26);
+      return -TypeUtilities<T>::polar(99, 99);
 
     const double i = ij.row();
     const double j = ij.col();

--- a/test/include/dlaf_test/util_types.h
+++ b/test/include/dlaf_test/util_types.h
@@ -53,6 +53,7 @@ struct TypeUtilities<std::complex<T>> {
   ///
   /// @pre r > 0.
   static constexpr std::complex<T> polar(double r, double theta) {
+    assert(r >= 0 && "Magnitude must be a positive value.");
     return std::polar<T>(static_cast<T>(r), static_cast<T>(theta));
   }
 

--- a/test/unit/multiplication/CMakeLists.txt
+++ b/test/unit/multiplication/CMakeLists.txt
@@ -12,7 +12,8 @@ DLAF_addTest(
   test_multiplication_general
   SOURCES test_multiplication_general.cpp
   LIBRARIES dlaf.multiplication dlaf.core
-  USE_MAIN PIKA
+  USE_MAIN MPIPIKA
+  MPIRANKS 6
 )
 
 DLAF_addTest(

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -180,8 +180,12 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, S
         // partial tile, all reflectors
         {9, 9, 9, 3, 1, 2, 6},
         {21, 21, 21, 3, 3, 6, 12},
-        // TODO full tile, partial reflectors
-        // TODO partial tile, partial reflectors
+        // full tile, partial reflectors
+        {9, 9, 9, 3, 0, 2, 8},
+        {6, 6, 6, 2, 0, 2, 5},
+        // partial tile, partial reflectors
+        {9, 9, 9, 3, 1, 2, 5},
+        // TODO incomplete tiles
 };
 
 TYPED_TEST(GeneralSubKMultiplicationTestMC, CorrectnessDistributed) {

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -144,8 +144,9 @@ TYPED_TEST_SUITE(GeneralSubMultiplicationDistTestGPU, MatrixElementTypes);
 template <class T, Backend B, Device D>
 void testGeneralSubMultiplication(comm::CommunicatorGrid grid, const SizeType a, const SizeType b,
                                   const T alpha, const T beta, const SizeType m, const SizeType mb) {
-  // TODO source_rank_index
-  matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});
+  const comm::Index2D src_rank_index(std::max(0, grid.size().rows() - 1),
+                                     std::min(1, grid.size().cols() - 1));
+  matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), src_rank_index);
 
   const SizeType a_el = a * mb;
   const SizeType b_el = std::min((b + 1) * mb - 1, m - 1);

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -7,6 +7,7 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
+#include "dlaf/communication/communicator_grid.h"
 #include "dlaf/multiplication/general.h"
 
 #include <gtest/gtest.h>
@@ -17,6 +18,7 @@
 #include "dlaf/matrix/matrix_mirror.h"
 #include "dlaf/util_matrix.h"
 
+#include "dlaf_test/comm_grids/grids_6_ranks.h"
 #include "dlaf_test/matrix/util_generic_blas.h"
 #include "dlaf_test/matrix/util_matrix.h"
 #include "dlaf_test/util_types.h"
@@ -123,3 +125,65 @@ TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocal) {
   }
 }
 #endif
+
+::testing::Environment* const comm_grids_env =
+    ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
+
+template <class T>
+struct GeneralSubKMultiplicationTestMC : public TestWithCommGrids {};
+
+TYPED_TEST_SUITE(GeneralSubKMultiplicationTestMC, MatrixElementTypes);
+
+template <class T, Backend B, Device D>
+void testGeneralSubKMultiplication(comm::CommunicatorGrid grid, const SizeType a, const SizeType b,
+                                   const SizeType nrefls, const T alpha, const T beta, const SizeType m,
+                                   const SizeType n, const SizeType k, const SizeType mb) {
+  const SizeType a_el = a * mb;
+  const SizeType b_el = std::min((b + 1) * mb - 1, m - 1);  // TODO use r
+
+  auto [refA, refB, refC, refResult] =
+      matrix::test::getSubMatrixMatrixMultiplication(a_el, b_el, m, n, k, alpha, beta, blas::Op::NoTrans,
+                                                     blas::Op::NoTrans);
+
+  auto setMatrix = [&](auto elSetter, const LocalElementSize size, const TileElementSize block_size) {
+    Matrix<T, Device::CPU> matrix(size, block_size);
+    dlaf::matrix::util::set(matrix, elSetter);
+    return matrix;
+  };
+
+  Matrix<const T, Device::CPU> mat_ah = setMatrix(refA, {m, k}, {mb, mb});
+  Matrix<const T, Device::CPU> mat_bh = setMatrix(refB, {k, n}, {mb, mb});
+  Matrix<T, Device::CPU> mat_ch = setMatrix(refC, {m, n}, {mb, mb});
+
+  {
+    MatrixMirror<const T, D, Device::CPU> mat_a(mat_ah);
+    MatrixMirror<const T, D, Device::CPU> mat_b(mat_bh);
+    MatrixMirror<T, D, Device::CPU> mat_c(mat_ch);
+
+    multiplication::generalSubMatrixK<B>(grid, a, b, nrefls, alpha, mat_a.get(), mat_b.get(), beta,
+                                         mat_c.get());
+  }
+
+  CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,
+                    40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error);
+}
+
+const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, SizeType, SizeType>>
+    subk_sizes = {
+        // m, n, k, mb, a, b, r
+        {3, 3, 3, 1, 0, 2, 3}, {3, 3, 3, 3, 0, 0, 0},     {6, 6, 6, 3, 0, 1, 3},
+        {9, 9, 9, 3, 0, 2, 9}, {21, 21, 21, 3, 0, 6, 21},
+        // TODO test for partial tiles
+        // TODO test for partial tiles and less nrefls
+};
+
+TYPED_TEST(GeneralSubKMultiplicationTestMC, CorrectnessDistributed) {
+  for (auto comm_grid : this->commGrids()) {
+    for (const auto& [m, n, k, mb, a, b, nrefls] : subk_sizes) {
+      const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
+      const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+      testGeneralSubKMultiplication<TypeParam, Backend::MC, Device::CPU>(comm_grid, a, b, nrefls, alpha,
+                                                                         beta, m, n, k, mb);
+    }
+  }
+}

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -134,6 +134,13 @@ struct GeneralSubKMultiplicationTestMC : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(GeneralSubKMultiplicationTestMC, MatrixElementTypes);
 
+#ifdef DLAF_WITH_GPU
+template <class T>
+struct GeneralSubKMultiplicationTestGPU : public TestWithCommGrids {};
+
+TYPED_TEST_SUITE(GeneralSubKMultiplicationTestGPU, MatrixElementTypes);
+#endif
+
 template <class T, Backend B, Device D>
 void testGeneralSubKMultiplication(comm::CommunicatorGrid grid, const SizeType a, const SizeType b,
                                    const SizeType nrefls, const T alpha, const T beta, const SizeType m,
@@ -198,3 +205,16 @@ TYPED_TEST(GeneralSubKMultiplicationTestMC, CorrectnessDistributed) {
     }
   }
 }
+
+#ifdef DLAF_WITH_GPU
+TYPED_TEST(GeneralSubKMultiplicationTestGPU, CorrectnessDistributed) {
+  for (auto comm_grid : this->commGrids()) {
+    for (const auto& [m, n, k, mb, a, b, nrefls] : subk_sizes) {
+      const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
+      const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+      testGeneralSubKMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, a, b, nrefls, alpha,
+                                                                          beta, m, n, k, mb);
+    }
+  }
+}
+#endif

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -139,11 +139,11 @@ void testGeneralSubKMultiplication(comm::CommunicatorGrid grid, const SizeType a
                                    const SizeType nrefls, const T alpha, const T beta, const SizeType m,
                                    const SizeType n, const SizeType k, const SizeType mb) {
   const SizeType a_el = a * mb;
-  const SizeType b_el = std::min((b + 1) * mb - 1, m - 1);  // TODO use r
+  const SizeType b_el = std::min(a_el + nrefls - 1, std::min((b + 1) * mb - 1, m - 1));
 
   auto [refA, refB, refC, refResult] =
-      matrix::test::getSubMatrixMatrixMultiplication(a_el, b_el, m, n, k, alpha, beta, blas::Op::NoTrans,
-                                                     blas::Op::NoTrans);
+      matrix::test::getSubMatrixMatrixMultiplication(a_el, b_el, m, n, nrefls, alpha, beta,
+                                                     blas::Op::NoTrans, blas::Op::NoTrans);
 
   auto setMatrix = [&](auto elSetter, const LocalElementSize size, const TileElementSize block_size) {
     Matrix<T, Device::CPU> matrix(size, block_size);
@@ -173,8 +173,8 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, S
         // m, n, k, mb, a, b, r
         // full tile, all reflectors
         {3, 3, 3, 1, 0, 2, 3},
-        {3, 3, 3, 3, 0, 0, 0},
-        {6, 6, 6, 3, 0, 1, 3},
+        {3, 3, 3, 3, 0, 0, 3},
+        {6, 6, 6, 3, 0, 1, 6},
         {9, 9, 9, 3, 0, 2, 9},
         {21, 21, 21, 3, 0, 6, 21},
         // partial tile, all reflectors

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -171,10 +171,17 @@ void testGeneralSubKMultiplication(comm::CommunicatorGrid grid, const SizeType a
 const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, SizeType, SizeType>>
     subk_sizes = {
         // m, n, k, mb, a, b, r
-        {3, 3, 3, 1, 0, 2, 3}, {3, 3, 3, 3, 0, 0, 0},     {6, 6, 6, 3, 0, 1, 3},
-        {9, 9, 9, 3, 0, 2, 9}, {21, 21, 21, 3, 0, 6, 21},
-        // TODO test for partial tiles
-        // TODO test for partial tiles and less nrefls
+        // full tile, all reflectors
+        {3, 3, 3, 1, 0, 2, 3},
+        {3, 3, 3, 3, 0, 0, 0},
+        {6, 6, 6, 3, 0, 1, 3},
+        {9, 9, 9, 3, 0, 2, 9},
+        {21, 21, 21, 3, 0, 6, 21},
+        // partial tile, all reflectors
+        {9, 9, 9, 3, 1, 2, 6},
+        {21, 21, 21, 3, 3, 6, 12},
+        // TODO full tile, partial reflectors
+        // TODO partial tile, partial reflectors
 };
 
 TYPED_TEST(GeneralSubKMultiplicationTestMC, CorrectnessDistributed) {

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -136,7 +136,7 @@ TYPED_TEST_SUITE(GeneralSubMultiplicationDistTestMC, MatrixElementTypes);
 
 #ifdef DLAF_WITH_GPU
 template <class T>
-struct GeneralSubKMultiplicationTestGPU : public TestWithCommGrids {};
+struct GeneralSubMultiplicationDistTestGPU : public TestWithCommGrids {};
 
 TYPED_TEST_SUITE(GeneralSubMultiplicationDistTestGPU, MatrixElementTypes);
 #endif
@@ -207,7 +207,7 @@ TYPED_TEST(GeneralSubMultiplicationDistTestMC, CorrectnessDistributed) {
 #ifdef DLAF_WITH_GPU
 TYPED_TEST(GeneralSubMultiplicationDistTestGPU, CorrectnessDistributed) {
   for (auto comm_grid : this->commGrids()) {
-    for (const auto& [m, mb, a, b, nrefls] : subk_sizes) {
+    for (const auto& [m, mb, a, b] : subk_sizes) {
       const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
       const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
       testGeneralSubMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, a, b, alpha, beta, m,

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -40,8 +40,15 @@ TYPED_TEST_SUITE(GeneralMultiplicationTestGPU, MatrixElementTypes);
 const std::vector<blas::Op> blas_ops({blas::Op::NoTrans, blas::Op::Trans, blas::Op::ConjTrans});
 const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType, SizeType>> sizes = {
     // m, n, k, mb, a, b
-    {3, 3, 3, 1, 0, 2}, {3, 3, 3, 3, 0, 0},    {6, 6, 6, 3, 0, 1},
-    {9, 9, 9, 3, 0, 2}, {21, 21, 21, 3, 0, 6},
+    // full gemm
+    {3, 3, 3, 1, 0, 2},
+    {3, 3, 3, 3, 0, 0},
+    {6, 6, 6, 3, 0, 1},
+    {9, 9, 9, 3, 0, 2},
+    {21, 21, 21, 3, 0, 6},
+    // sub gemm
+    {9, 9, 9, 3, 1, 2},
+    {21, 21, 21, 3, 3, 6},
 };
 
 GlobalElementSize globalTestSize(const LocalElementSize& size) {

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -130,20 +130,20 @@ TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocal) {
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <class T>
-struct GeneralSubKMultiplicationTestMC : public TestWithCommGrids {};
+struct GeneralSubMultiplicationDistTestMC : public TestWithCommGrids {};
 
-TYPED_TEST_SUITE(GeneralSubKMultiplicationTestMC, MatrixElementTypes);
+TYPED_TEST_SUITE(GeneralSubMultiplicationDistTestMC, MatrixElementTypes);
 
 #ifdef DLAF_WITH_GPU
 template <class T>
 struct GeneralSubKMultiplicationTestGPU : public TestWithCommGrids {};
 
-TYPED_TEST_SUITE(GeneralSubKMultiplicationTestGPU, MatrixElementTypes);
+TYPED_TEST_SUITE(GeneralSubMultiplicationDistTestGPU, MatrixElementTypes);
 #endif
 
 template <class T, Backend B, Device D>
-void testGeneralSubKMultiplication(comm::CommunicatorGrid grid, const SizeType a, const SizeType b,
-                                   const T alpha, const T beta, const SizeType m, const SizeType mb) {
+void testGeneralSubMultiplication(comm::CommunicatorGrid grid, const SizeType a, const SizeType b,
+                                  const T alpha, const T beta, const SizeType m, const SizeType mb) {
   // TODO source_rank_index
   matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});
 
@@ -170,7 +170,7 @@ void testGeneralSubKMultiplication(comm::CommunicatorGrid grid, const SizeType a
     MatrixMirror<const T, D, Device::CPU> mat_b(mat_bh);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_ch);
 
-    multiplication::generalSubMatrixK<B>(grid, a, b, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
+    multiplication::generalSubMatrix<B>(grid, a, b, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
   CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,
@@ -192,25 +192,25 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType>> subk_sizes
     {8, 3, 1, 2},
 };
 
-TYPED_TEST(GeneralSubKMultiplicationTestMC, CorrectnessDistributed) {
+TYPED_TEST(GeneralSubMultiplicationDistTestMC, CorrectnessDistributed) {
   for (auto comm_grid : this->commGrids()) {
     for (const auto& [m, mb, a, b] : subk_sizes) {
       const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
       const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
-      testGeneralSubKMultiplication<TypeParam, Backend::MC, Device::CPU>(comm_grid, a, b, alpha, beta, m,
-                                                                         mb);
+      testGeneralSubMultiplication<TypeParam, Backend::MC, Device::CPU>(comm_grid, a, b, alpha, beta, m,
+                                                                        mb);
     }
   }
 }
 
 #ifdef DLAF_WITH_GPU
-TYPED_TEST(GeneralSubKMultiplicationTestGPU, CorrectnessDistributed) {
+TYPED_TEST(GeneralSubMultiplicationDistTestGPU, CorrectnessDistributed) {
   for (auto comm_grid : this->commGrids()) {
     for (const auto& [m, mb, a, b, nrefls] : subk_sizes) {
       const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
       const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
-      testGeneralSubKMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, a, b, alpha, beta,
-                                                                          m, mb);
+      testGeneralSubMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, a, b, alpha, beta, m,
+                                                                         mb);
     }
   }
 }


### PR DESCRIPTION
This is a distributed gemm that covers a use-case needed for the distributed tridiagonal eigensolver. In particular, it allows to multiply two (distributed) square matrices selections of size `k`.

Changelog:
- bug-fix: `getSubMatrixMatrixMultiplication` was returning wrong values for multiplications not covering the full matrix;
- minor bug-fix: `std::polar` (and transitively `TypeUtilities::polar`) gets as first parameter `magnitude` value, which cannot be negative;
- extend test-cases for old test in `test_multiplication_general`, the partial multiplication was not tested.

TODO:
- [x] ~accept k as "future"~ (let's just skip this optimisation for the moment)
- [x] extend and check test for distributed case
- [x] add and verify test-cases for incomplete tiles
- [x] add and check assertions
- [x] enabling GPU (if it is straightforward, as expected)
- [ ] decide name and position for this algorithm