### PR TITLE
Fix template parameters in `transform` call in `DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS`

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/kernels.h
+++ b/include/dlaf/eigensolver/tridiag_solver/kernels.h
@@ -29,9 +29,7 @@ void stedcAsync(DiagTileSenderIn&& in, DiagTileSenderOut&& out) {
   namespace di = dlaf::internal;
 
   auto sender = ex::when_all(std::forward<DiagTileSenderIn>(in), std::forward<DiagTileSenderOut>(out));
-  ex::start_detached(di::transform<di::TransformDispatchType::Lapack>(di::Policy<DefaultBackend_v<D>>(),
-                                                                      tile::internal::stedc_o,
-                                                                      std::move(sender)));
+  ex::start_detached(tile::stedc(di::Policy<DefaultBackend_v<D>>(), std::move(sender)));
 }
 
 template <class T>

--- a/include/dlaf/sender/make_sender_algorithm_overloads.h
+++ b/include/dlaf/sender/make_sender_algorithm_overloads.h
@@ -36,7 +36,7 @@
   template <Backend B, typename Sender,                                                            \
             typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>       \
   auto fname(const dlaf::internal::Policy<B> p, Sender&& s) {                                      \
-    return dlaf::internal::transform<B, tag>(p, callable, std::forward<Sender>(s));                \
+    return dlaf::internal::transform<tag>(p, callable, std::forward<Sender>(s));                   \
   }                                                                                                \
                                                                                                    \
   template <Backend B>                                                                             \


### PR DESCRIPTION
This was not called anywhere so the bug never came up. Fixing it allows calling `stedc` as a sender adaptor in `stedcAsync` in the tridiagonal solver.