### PR TITLE
Make DLA-Future install/build verbose in CI

### DIFF
--- a/ci/ctest_to_gitlab.sh
+++ b/ci/ctest_to_gitlab.sh
@@ -41,7 +41,7 @@ allocate:
   extends: .daint_alloc
   variables:
     PULL_IMAGE: 'YES'
-    SLURM_TIMELIMIT: '40:00'
+    SLURM_TIMELIMIT: '1:00:00'
 
 {{JOBS}}
 
@@ -67,7 +67,7 @@ JOB_TEMPLATE="
   variables:
     SLURM_CPUS_PER_TASK: {{CPUS_PER_TASK}}
     SLURM_NTASKS: {{NTASKS}}
-    SLURM_TIMELIMIT: '10:00'
+    SLURM_TIMELIMIT: '15:00'
     PULL_IMAGE: 'NO'
     USE_MPI: 'YES'
     DISABLE_AFTER_SCRIPT: 'YES'
@@ -100,7 +100,7 @@ allocate:
   extends: .daint_alloc
   variables:
     PULL_IMAGE: 'YES'
-    SLURM_TIMELIMIT: '15:00'
+    SLURM_TIMELIMIT: '40:00'
 
 {{JOBS}}
 
@@ -116,7 +116,7 @@ JOB_TEMPLATE="
   variables:
     SLURM_CPUS_PER_TASK: {{CPUS_PER_TASK}}
     SLURM_NTASKS: {{NTASKS}}
-    SLURM_TIMELIMIT: '5:00'
+    SLURM_TIMELIMIT: '10:00'
     PULL_IMAGE: 'NO'
     USE_MPI: 'YES'
     DISABLE_AFTER_SCRIPT: 'YES'

--- a/ci/docker/codecov.Dockerfile
+++ b/ci/docker/codecov.Dockerfile
@@ -29,7 +29,7 @@ RUN spack repo rm --scope site dlaf && \
     spack -e ci concretize -f && \
     mkdir ${BUILD} && \
     ln -s ${BUILD} `spack -e ci location -b dla-future` && \
-    spack -e ci install --keep-stage
+    spack -e ci install --keep-stage --verbose
 
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \

--- a/ci/docker/deploy-amdgpu.Dockerfile
+++ b/ci/docker/deploy-amdgpu.Dockerfile
@@ -29,7 +29,7 @@ RUN spack repo rm --scope site dlaf && \
     spack -e ci concretize -f && \
     mkdir ${BUILD} && \
     ln -s ${BUILD} `spack -e ci location -b dla-future` && \
-    spack -e ci install --keep-stage
+    spack -e ci install --keep-stage --verbose
 
 WORKDIR ${BUILD}
 

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -26,7 +26,7 @@ RUN spack repo rm --scope site dlaf && \
     spack -e ci concretize -f && \
     mkdir ${BUILD} && \
     ln -s ${BUILD} `spack -e ci location -b dla-future` && \
-    spack -e ci install --keep-stage
+    spack -e ci install --keep-stage --verbose
 
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \


### PR DESCRIPTION
I'm doing this in the hope that build errors will be printed slightly more nicely. This targets specifically build errors from building DLA-Future itself. What I'm hoping to improve is e.g. this kind of formatting: https://gitlab.com/cscs-ci/eth-cscs/DLA-Future/-/jobs/3157080069#L393. However, adding `--verbose` may not help and spack may still decide to wrap everything to 80 columns (or whatever it is there). If that's the case I will instead update this to print `spack-build-out.txt` on failure.