### PR TITLE
Reduce debug bloat part 1

### DIFF
--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -370,11 +370,8 @@ template <class T, Device D>
 pika::future<Tile<T, D>> createSubTile(const pika::shared_future<Tile<T, D>>& tile,
                                        const SubTileSpec& spec) {
   namespace ex = pika::execution::experimental;
-  auto f = [](pika::shared_future<Tile<T, D>>&& tile, SubTileSpec&& spec) {
-    return Tile<T, D>(std::move(tile), std::move(spec));
-  };
-  return dlaf::internal::whenAllLift(ex::keep_future(tile), spec) | ex::then(std::move(f)) |
-         ex::make_future();
+  auto f = [spec](pika::shared_future<Tile<T, D>>&& tile) { return Tile<T, D>(std::move(tile), spec); };
+  return ex::keep_future(tile) | ex::then(std::move(f)) | ex::make_future();
 }
 
 template <class T, Device D>


### PR DESCRIPTION
Part 1 of hopefully a few more PRs to reduce debug bloat.

Skip using `when_all` since it's not strictly required in `createSubTile`. `when_all` is one of the most expensive adaptors. Selected before and after:
```
# on current master
> ls -lah miniapp/miniapp_cholesky src/libDLAF.a
-rwxr-xr-x 1 mjs users 112M Oct 12 12:14 miniapp/miniapp_cholesky
-rw-r--r-- 1 mjs users 949M Oct 12 12:13 src/libDLAF.a
# on this branch
> command ls -lah miniapp/miniapp_cholesky src/libDLAF.a
-rwxr-xr-x 1 mjs users 109M Oct 12 12:08 miniapp/miniapp_cholesky
-rw-r--r-- 1 mjs users 931M Oct 12 12:08 src/libDLAF.a
```