### PR TITLE
algo: applyGivenRotations Distributed (MC)

### DIFF
--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -70,7 +70,7 @@ template <class CommSender, class Sender>
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
 
-  auto recv = [dest, tag, pcomm = std::forward<CommSender>(pcomm)](auto const& tile_comm) mutable {
+  auto send = [dest, tag, pcomm = std::forward<CommSender>(pcomm)](auto const& tile_comm) mutable {
     return whenAllLift(std::move(pcomm), dest, tag, std::cref(tile_comm)) | transformMPI(send_o);
   };
 
@@ -78,7 +78,7 @@ template <class CommSender, class Sender>
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;
 
   return withTemporaryTile<comm_device_type, CopyToDestination::Yes, CopyFromDestination::No,
-                           RequireContiguous::No>(std::forward<Sender>(tile), std::move(recv));
+                           RequireContiguous::No>(std::forward<Sender>(tile), std::move(send));
 }
 
 template <class CommSender, class Sender>

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -225,33 +225,37 @@ pika::future<T> calcTolerance(SizeType i_begin, SizeType i_end, Matrix<const T, 
          di::transform(di::Policy<Backend::MC>(), std::move(tol_fn)) | ex::make_future();
 }
 
-struct TileCollector {
+/// TileCollector is an helper that, given included boundaries of a range [idx_begin, idx_last],
+/// allows to obtain access to all tiles in that range for a matrix.
+///
+/// The range specified is generally considered a square, i.e. the range is applied to both rows and
+/// columns.
+/// Instead, if the matrix has a single column of tiles, the range is considered linear over rows.
+class TileCollector {
   SizeType idx_begin;
   SizeType idx_last;
 
-private:
-  std::pair<GlobalTileIndex, GlobalTileSize> getRange(const matrix::Distribution& dist) const {
-    SizeType ntiles = idx_last - idx_begin + 1;
-    bool is_col_matrix = dist.size().cols() == 1;
-    SizeType col_begin = (is_col_matrix) ? 0 : idx_begin;
-    SizeType col_sz = (is_col_matrix) ? 1 : ntiles;
-
-    return std::make_pair(GlobalTileIndex{idx_begin, col_begin}, GlobalTileSize{ntiles, col_sz});
-  }
-
-public:
   auto iteratorLocal(const matrix::Distribution& dist) const {
-    auto [g_begin, g_size] = getRange(dist);
+    const bool is_col_matrix = dist.nrTiles().cols() == 1;
+
+    const GlobalTileIndex g_begin(idx_begin, is_col_matrix ? 0 : idx_begin);
+    const GlobalTileIndex g_end(idx_last + 1, is_col_matrix ? 1 : idx_last + 1);
+
     const LocalTileIndex begin{
         dist.template nextLocalTileFromGlobalTile<Coord::Row>(g_begin.row()),
         dist.template nextLocalTileFromGlobalTile<Coord::Col>(g_begin.col()),
     };
-    const LocalTileSize size{
-        dist.template nextLocalTileFromGlobalTile<Coord::Row>(g_size.rows()),
-        dist.template nextLocalTileFromGlobalTile<Coord::Col>(g_size.cols()),
+    const LocalTileIndex end{
+        dist.template nextLocalTileFromGlobalTile<Coord::Row>(g_end.row()),
+        dist.template nextLocalTileFromGlobalTile<Coord::Col>(g_end.col()),
     };
+    const LocalTileSize size = end - begin;
+
     return std::make_pair(begin, size);
   }
+
+public:
+  TileCollector(SizeType i_begin, SizeType i_last) : idx_begin(i_begin), idx_last(i_last) {}
 
   template <class T, Device D>
   auto read(Matrix<const T, D>& mat) const {

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -10,64 +10,132 @@
 #pragma once
 
 #include "dlaf/common/assert.h"
+#include "dlaf/common/range2d.h"
+#include "dlaf/common/round_robin.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/communication/kernels/p2p.h"
 #include "dlaf/eigensolver/tridiag_solver/merge.h"
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/index.h"
+#include "dlaf/matrix/matrix.h"
+#include "dlaf/matrix/panel.h"
 #include "dlaf/sender/when_all_lift.h"
 
 namespace dlaf::eigensolver::internal {
 
 // Assumption: the memory layout of the matrix from which the tiles are coming is column major.
 //
-// `tiles`: The tiles of the matrix between tile indices `(i_begin, i_begin)` and `(i_end, i_end)` that
-// are potentially affected by the Givens rotations. `n` : column size
+// @param tiles The tiles of the matrix between tile indices `(i_begin, i_begin)` and `(i_end, i_end)`
+// that are potentially affected by the Givens rotations.
+// @param n column size
 //
 // Note: a column index may be paired to more than one other index, this may lead to a race condition if
 //       parallelized trivially. Current implementation is serial.
-//
-template <class T, Device D>
+template <class T, Device D, class GRSender>
 void applyGivensRotationsToMatrixColumns(comm::CommunicatorGrid grid, SizeType i_begin, SizeType i_last,
-                                         pika::future<std::vector<GivensRotation<T>>> rots_fut,
-                                         Matrix<T, D>& mat) {
+                                         GRSender&& rots_fut, Matrix<T, D>& mat) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
-  SizeType n = problemSize(i_begin, i_last, mat.distribution());
-  SizeType nb = mat.distribution().blockSize().rows();
+  // TODO grid pipeline?
 
-  auto givens_rots_fn = [n, nb](comm::CommunicatorGrid grid, const std::vector<GivensRotation<T>>& rots,
-                                const std::vector<matrix::Tile<T, D>>& tiles,
-                                [[maybe_unused]] auto&&... ts) {
-    // TODO replace this with implementation
-    dlaf::internal::silenceUnusedWarningFor(grid, rots, tiles, ts...);
+  // const SizeType m = problemSize(i_begin, i_last, mat.distribution());
+  const SizeType mb = mat.distribution().blockSize().rows();
 
-    //   // Distribution of the merged subproblems
-    //   matrix::Distribution distr(LocalElementSize(n, n), TileElementSize(nb, nb));
+  const matrix::Distribution& dist = mat.distribution();
 
-    for (const GivensRotation<T>& rot : rots) {
-      //     // Get the index of the tile that has column `rot.i` and the the index of the column within
-      //     the tile. SizeType i_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.i));
-      //     SizeType i_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.i); T* x =
-      //     tiles[to_sizet(i_tile)].ptr(TileElementIndex(0, i_el));
+  auto givens_rots_fn =
+      [mb, dist,
+       i_begin](comm::CommunicatorGrid grid, const std::vector<GivensRotation<T>>& rots,
+                // const std::vector<std::pair<LocalTileIndex, matrix::Tile<T, D>>>& tiles_with_indices,
+                auto tile_indices, auto&& tiles, [[maybe_unused]] auto&&... ts) {
+        // TODO replace this with implementation
+        dlaf::internal::silenceUnusedWarningFor(grid, rots, tiles, ts...);
 
-      //     // Get the index of the tile that has column `rot.j` and the the index of the column within
-      //     the tile. SizeType j_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.j));
-      //     SizeType j_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.j); T* y =
-      //     tiles[to_sizet(j_tile)].ptr(TileElementIndex(0, j_el));
+        // TODO workspace
+        constexpr SizeType n_workspaces = 2;
+        common::RoundRobin<matrix::Panel<Coord::Col, T, D>> workspace(n_workspaces, dist);
 
-      //     // Apply Givens rotations
-      //     if constexpr (D == Device::CPU) {
-      //       blas::rot(n, x, 1, y, 1, rot.c, rot.s);
-      //     }
-      //     else {
-      //       givensRotationOnDevice(n, x, y, rot.c, rot.s, ts...);
-      //     }
-    }
-  };
+        // Distribution of the merged subproblems
+        // matrix::Distribution distr(LocalElementSize(n, n), TileElementSize(nb, nb));
 
-  TileCollector tc{i_begin, i_last};
+        for (const GivensRotation<T>& rot : rots) {
+          // TODO compute if this rank is in a x or y column
+          const SizeType j_x = i_begin + rot.i / mb;
+          const SizeType j_y = i_begin + rot.j / mb;
 
-  auto sender = di::whenAllLift(grid, std::move(rots_fut), ex::when_all_vector(tc.readwrite(mat)));
-  di::transformDetach(di::Policy<DefaultBackend_v<D>>(), std::move(givens_rots_fn), std::move(sender));
+          // TODO assume column layout and operate on the full column? also workspace must obey
+
+          // local, just on columns of x/y
+          for (std::size_t index = 0; index < tile_indices.size(); ++index) {
+            auto&& tile = tiles[index];
+            const LocalTileIndex ij(tile_indices[index]);
+            const SizeType j = dist.template globalTileFromLocalTile<Coord::Col>(ij.col());
+
+            const bool hasX = j == j_x;
+            const bool hasY = j == j_y;
+
+            if (j != j_x && j != j_y)
+              continue;
+
+            const comm::IndexT_MPI rankColX = dist.template rankGlobalTile<Coord::Col>(j_x);
+            const comm::IndexT_MPI rankColY = dist.template rankGlobalTile<Coord::Col>(j_y);
+
+            // Get the index of the tile that has column `rot.i` and the the index of the column
+            // within the tile.
+
+            // SizeType i_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.i));
+            // SizeType i_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.i);
+            // T* x = tiles[to_sizet(i_tile)].ptr(TileElementIndex(0, i_el));
+
+            // Get the index of the tile that has column `rot.j` and the the index of the column
+            // within the tile.
+
+            // SizeType j_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.j));
+            // SizeType j_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.j);
+            // T* y = tiles[to_sizet(j_tile)].ptr(TileElementIndex(0, j_el));
+
+            const bool hasBothXY = hasX && hasY;
+            if (hasBothXY) {
+              // no communication, they all have everything locally
+            }
+            else {
+              const comm::IndexT_MPI rank_partner = hasX ? rankColY : rankColX;
+
+              // TODO one is sent, the other is received
+              // TODO splitTile destination + get right workspace
+              // TODO possible optimization, check if it is zero or not
+              // comm::scheduleSend(CommSender && pcomm, IndexT_MPI dest, IndexT_MPI tag, Sender && tile);
+              // comm::scheduleRecv(CommSender && pcomm, IndexT_MPI dest, IndexT_MPI tag, Sender && tile);
+            }
+
+            // TODO each one computes his own, but just stores either x or y (or both if are on the
+            // same rank)
+
+            if (hasBothXY) {
+              // TODO check if dist can be used
+              T* x = tile.ptr(TileElementIndex(0, rot.i % mb));
+              T* y = tile.ptr(TileElementIndex(0, rot.j % mb));
+
+              // Apply Givens rotations
+              if constexpr (D == Device::CPU) {
+                blas::rot(mb, x, 1, y, 1, rot.c, rot.s);
+              }
+              else {
+                givensRotationOnDevice(mb, x, y, rot.c, rot.s, ts...);
+              }
+            }
+          }
+        }
+      };
+
+  const TileCollector tc{i_begin, i_last};
+  const auto [begin, size] = tc.iteratorLocal(mat.distribution());
+  const auto range = common::iterate_range2d(begin, size);
+  auto sender =
+      di::whenAllLift(grid, std::forward<GRSender>(rots_fut), std::vector(range.begin(), range.end()),
+                      ex::when_all_vector(tc.readwrite(mat)));
+  di::transformDetach(di::Policy<DefaultBackend_v<D>>(), givens_rots_fn, std::move(sender));
 }
 
 }

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -37,7 +37,7 @@ void sendCol(comm::Communicator& comm, comm::IndexT_MPI rank_dest, comm::IndexT_
   }
   else {
     dlaf::internal::silenceUnusedWarningFor(comm, rank_dest, tag, col_data, n, req);
-    DLAF_STATIC_UNIMPLEMENTED(D);
+    DLAF_STATIC_UNIMPLEMENTED(T);
   }
 }
 
@@ -50,7 +50,7 @@ void recvCol(comm::Communicator& comm, comm::IndexT_MPI rank_dest, comm::IndexT_
   }
   else {
     dlaf::internal::silenceUnusedWarningFor(comm, rank_dest, tag, col_data, n, req);
-    DLAF_STATIC_UNIMPLEMENTED(D);
+    DLAF_STATIC_UNIMPLEMENTED(T);
   }
 }
 

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -157,9 +157,9 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, SizeType i
           di::transform(di::Policy<DefaultBackend_v<D>>(), [rot, m, col_x, col_y](auto&&... ts) {
             if constexpr (D == Device::CPU)
               blas::rot(m, col_x, 1, col_y, 1, rot.c, rot.s);
-            // TODO GPU NOT IMPLEMENTED
-            // else
-            //   givensRotationOnDevice(m, x, y, rot.c, rot.s, ts...);
+            else
+              // givensRotationOnDevice(m, x, y, rot.c, rot.s, ts...);
+              DLAF_STATIC_UNIMPLEMENTED(T);
           });
     }
     tt::sync_wait(std::move(serializer));

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -10,8 +10,10 @@
 #pragma once
 
 #include "dlaf/common/assert.h"
+#include "dlaf/common/pipeline.h"
 #include "dlaf/common/range2d.h"
 #include "dlaf/common/round_robin.h"
+#include "dlaf/communication/communicator.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/communication/kernels/p2p.h"
 #include "dlaf/eigensolver/tridiag_solver/merge.h"
@@ -19,123 +21,126 @@
 #include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/matrix/panel.h"
+#include "dlaf/sender/transform_mpi.h"
 #include "dlaf/sender/when_all_lift.h"
 
 namespace dlaf::eigensolver::internal {
 
-// Assumption: the memory layout of the matrix from which the tiles are coming is column major.
-//
 // @param tiles The tiles of the matrix between tile indices `(i_begin, i_begin)` and `(i_end, i_end)`
 // that are potentially affected by the Givens rotations.
 // @param n column size
 //
+// @pre the memory layout of the matrix from which the tiles are coming is column major.
+//
 // Note: a column index may be paired to more than one other index, this may lead to a race condition if
 //       parallelized trivially. Current implementation is serial.
 template <class T, Device D, class GRSender>
-void applyGivensRotationsToMatrixColumns(comm::CommunicatorGrid grid, SizeType i_begin, SizeType i_last,
+void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, SizeType i_begin, SizeType i_last,
                                          GRSender&& rots_fut, Matrix<T, D>& mat) {
   namespace ex = pika::execution::experimental;
+  namespace tt = pika::this_thread::experimental;
   namespace di = dlaf::internal;
-
-  // TODO grid pipeline?
-
-  // const SizeType m = problemSize(i_begin, i_last, mat.distribution());
-  const SizeType mb = mat.distribution().blockSize().rows();
 
   const matrix::Distribution& dist = mat.distribution();
 
-  auto givens_rots_fn =
-      [mb, dist,
-       i_begin](comm::CommunicatorGrid grid, const std::vector<GivensRotation<T>>& rots,
-                // const std::vector<std::pair<LocalTileIndex, matrix::Tile<T, D>>>& tiles_with_indices,
-                auto tile_indices, auto&& tiles, [[maybe_unused]] auto&&... ts) {
-        // TODO replace this with implementation
-        dlaf::internal::silenceUnusedWarningFor(grid, rots, tiles, ts...);
+  const SizeType mb = mat.distribution().blockSize().rows();
 
-        // TODO workspace
-        constexpr SizeType n_workspaces = 2;
-        common::RoundRobin<matrix::Panel<Coord::Col, T, D>> workspace(n_workspaces, dist);
+  const matrix::Distribution dist_sub = [=]() {
+    const SizeType size = (i_last + 1 - i_begin) * mb;
+    return matrix::Distribution({size, size}, dist.blockSize(), dist.commGridSize(), dist.rankIndex(),
+                                dist.rankGlobalTile({i_begin, i_begin}));
+  }();
 
-        // Distribution of the merged subproblems
-        // matrix::Distribution distr(LocalElementSize(n, n), TileElementSize(nb, nb));
+  const SizeType n = dist_sub.localSize().rows();
 
-        for (const GivensRotation<T>& rot : rots) {
-          // TODO compute if this rank is in a x or y column
-          const SizeType j_x = i_begin + rot.i / mb;
-          const SizeType j_y = i_begin + rot.j / mb;
+  auto givens_rots_fn = [comm_row, n, mb, dist, dist_sub](const std::vector<GivensRotation<T>>& rots,
+                                                          auto&& tiles, [[maybe_unused]] auto&&... ts) {
+    const matrix::Distribution dist_ws({dist.size().rows(), 1}, dist.blockSize(), dist.commGridSize(),
+                                       dist.rankIndex(), dist.sourceRankIndex());
+    // TODO allocate just sub-range
+    matrix::Panel<Coord::Col, T, D> workspace(dist_ws);
 
-          // TODO assume column layout and operate on the full column? also workspace must obey
+    for (const GivensRotation<T>& rot : rots) {
+      const SizeType j_x = rot.i / mb;
+      const SizeType j_y = rot.j / mb;
 
-          // local, just on columns of x/y
-          for (std::size_t index = 0; index < tile_indices.size(); ++index) {
-            auto&& tile = tiles[index];
-            const LocalTileIndex ij(tile_indices[index]);
-            const SizeType j = dist.template globalTileFromLocalTile<Coord::Col>(ij.col());
+      const comm::IndexT_MPI rankColX = dist_sub.template rankGlobalTile<Coord::Col>(j_x);
+      const comm::IndexT_MPI rankColY = dist_sub.template rankGlobalTile<Coord::Col>(j_y);
 
-            const bool hasX = j == j_x;
-            const bool hasY = j == j_y;
+      const bool hasX = dist.rankIndex().col() == rankColX;
+      const bool hasY = dist.rankIndex().col() == rankColY;
 
-            if (j != j_x && j != j_y)
-              continue;
+      if (!hasX && !hasY)
+        continue;
 
-            const comm::IndexT_MPI rankColX = dist.template rankGlobalTile<Coord::Col>(j_x);
-            const comm::IndexT_MPI rankColY = dist.template rankGlobalTile<Coord::Col>(j_y);
-
-            // Get the index of the tile that has column `rot.i` and the the index of the column
-            // within the tile.
-
-            // SizeType i_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.i));
-            // SizeType i_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.i);
-            // T* x = tiles[to_sizet(i_tile)].ptr(TileElementIndex(0, i_el));
-
-            // Get the index of the tile that has column `rot.j` and the the index of the column
-            // within the tile.
-
-            // SizeType j_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.j));
-            // SizeType j_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.j);
-            // T* y = tiles[to_sizet(j_tile)].ptr(TileElementIndex(0, j_el));
-
-            const bool hasBothXY = hasX && hasY;
-            if (hasBothXY) {
-              // no communication, they all have everything locally
-            }
-            else {
-              const comm::IndexT_MPI rank_partner = hasX ? rankColY : rankColX;
-
-              // TODO one is sent, the other is received
-              // TODO splitTile destination + get right workspace
-              // TODO possible optimization, check if it is zero or not
-              // comm::scheduleSend(CommSender && pcomm, IndexT_MPI dest, IndexT_MPI tag, Sender && tile);
-              // comm::scheduleRecv(CommSender && pcomm, IndexT_MPI dest, IndexT_MPI tag, Sender && tile);
-            }
-
-            // TODO each one computes his own, but just stores either x or y (or both if are on the
-            // same rank)
-
-            if (hasBothXY) {
-              // TODO check if dist can be used
-              T* x = tile.ptr(TileElementIndex(0, rot.i % mb));
-              T* y = tile.ptr(TileElementIndex(0, rot.j % mb));
-
-              // Apply Givens rotations
-              if constexpr (D == Device::CPU) {
-                blas::rot(mb, x, 1, y, 1, rot.c, rot.s);
-              }
-              else {
-                givensRotationOnDevice(mb, x, y, rot.c, rot.s, ts...);
-              }
-            }
-          }
+      // TODO assume column layout and operate on the full column? also workspace must obey
+      auto&& tile_ws = workspace({0, 0}).get();
+      const auto& tile_x = [&]() -> matrix::Tile<T, Device::CPU> const& {
+        if (hasX) {
+          const LocalTileIndex loc_tile{dist_sub.nextLocalTileFromGlobalElement<Coord::Row>(0),
+                                        dist_sub.nextLocalTileFromGlobalElement<Coord::Col>(rot.i)};
+          const std::size_t idx_x = to_sizet(dist_sub.localTileLinearIndex(loc_tile));
+          return tiles[idx_x];
         }
-      };
+        return tile_ws;
+      }();
+      const auto& tile_y = [&]() -> matrix::Tile<T, Device::CPU> const& {
+        if (hasY) {
+          const LocalTileIndex loc_tile{dist_sub.nextLocalTileFromGlobalElement<Coord::Row>(0),
+                                        dist_sub.nextLocalTileFromGlobalElement<Coord::Col>(rot.j)};
+          const std::size_t idx_y = to_sizet(dist_sub.localTileLinearIndex(loc_tile));
+          return tiles[idx_y];
+        }
+        return tile_ws;
+      }();
 
-  const TileCollector tc{i_begin, i_last};
-  const auto [begin, size] = tc.iteratorLocal(mat.distribution());
-  const auto range = common::iterate_range2d(begin, size);
+      const bool hasBothXY = hasX && hasY;
+
+      const TileElementIndex idx_x(0, rot.i % mb);  // TODO check if dist can be used
+      const TileElementIndex idx_y(0, rot.j % mb);
+
+      std::vector<ex::unique_any_sender<>> cps;
+      if (!hasBothXY) {
+        // TODO compute TAG
+
+        const comm::IndexT_MPI rank_partner = hasX ? rankColY : rankColX;
+
+        // TODO possible optimization, check if it is zero or not
+
+        auto sender = [idx = hasX ? idx_x : idx_y, n](comm::Communicator& comm,
+                                                      comm::IndexT_MPI rank_dest, comm::IndexT_MPI tag,
+                                                      const auto& tile, MPI_Request* req) {
+          DLAF_MPI_CHECK_ERROR(MPI_Isend(tile.ptr(idx), static_cast<int>(n),
+                                         dlaf::comm::mpi_datatype<T>::type, rank_dest, tag, comm, req));
+        };
+        auto cp_send =
+            dlaf::internal::whenAllLift(comm_row, rank_partner, 0, std::cref(hasX ? tile_x : tile_y)) |
+            dlaf::comm::internal::transformMPI(sender);
+
+        auto receiver = [n](comm::Communicator& comm, comm::IndexT_MPI rank_dest, comm::IndexT_MPI tag,
+                            const matrix::Tile<T, Device::CPU>& tile, MPI_Request* req) {
+          DLAF_MPI_CHECK_ERROR(MPI_Irecv(tile.ptr({0, 0}), static_cast<int>(n),
+                                         dlaf::comm::mpi_datatype<T>::type, rank_dest, tag, comm, req));
+        };
+        auto cp_recv = dlaf::internal::whenAllLift(comm_row, rank_partner, 0, std::cref(tile_ws)) |
+                       dlaf::comm::internal::transformMPI(receiver);
+        cps.emplace_back(std::move(cp_send));
+        cps.emplace_back(std::move(cp_recv));
+      }
+
+      // each one computes his own, but just stores either x or y
+      // (or both if are on the same rank)
+      T* x = hasX ? tile_x.ptr(idx_x) : tile_ws.ptr({0, 0});
+      T* y = hasY ? tile_y.ptr(idx_y) : tile_ws.ptr({0, 0});
+
+      tt::sync_wait(ex::when_all_vector(std::move(cps)) |
+                    ex::then([rot, n, x, y]() { blas::rot(n, x, 1, y, 1, rot.c, rot.s); }));
+    }
+  };
+
+  TileCollector tc{i_begin, i_last};
   auto sender =
-      di::whenAllLift(grid, std::forward<GRSender>(rots_fut), std::vector(range.begin(), range.end()),
-                      ex::when_all_vector(tc.readwrite(mat)));
+      di::whenAllLift(std::forward<GRSender>(rots_fut), ex::when_all_vector(tc.readwrite(mat)));
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), givens_rots_fn, std::move(sender));
 }
-
 }

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -37,7 +37,7 @@ void sendCol(comm::Communicator& comm, comm::IndexT_MPI rank_dest, comm::IndexT_
   }
   else {
     dlaf::internal::silenceUnusedWarningFor(comm, rank_dest, tag, col_data, n, req);
-    DLAF_UNIMPLEMENTED(D);
+    DLAF_STATIC_UNIMPLEMENTED(D);
   }
 }
 
@@ -50,7 +50,7 @@ void recvCol(comm::Communicator& comm, comm::IndexT_MPI rank_dest, comm::IndexT_
   }
   else {
     dlaf::internal::silenceUnusedWarningFor(comm, rank_dest, tag, col_data, n, req);
-    DLAF_UNIMPLEMENTED(D);
+    DLAF_STATIC_UNIMPLEMENTED(D);
   }
 }
 

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -1,0 +1,73 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include "dlaf/common/assert.h"
+#include "dlaf/communication/communicator_grid.h"
+#include "dlaf/eigensolver/tridiag_solver/merge.h"
+#include "dlaf/sender/when_all_lift.h"
+
+namespace dlaf::eigensolver::internal {
+
+// Assumption: the memory layout of the matrix from which the tiles are coming is column major.
+//
+// `tiles`: The tiles of the matrix between tile indices `(i_begin, i_begin)` and `(i_end, i_end)` that
+// are potentially affected by the Givens rotations. `n` : column size
+//
+// Note: a column index may be paired to more than one other index, this may lead to a race condition if
+//       parallelized trivially. Current implementation is serial.
+//
+template <class T, Device D>
+void applyGivensRotationsToMatrixColumns(comm::CommunicatorGrid grid, SizeType i_begin, SizeType i_last,
+                                         pika::future<std::vector<GivensRotation<T>>> rots_fut,
+                                         Matrix<T, D>& mat) {
+  namespace ex = pika::execution::experimental;
+  namespace di = dlaf::internal;
+
+  SizeType n = problemSize(i_begin, i_last, mat.distribution());
+  SizeType nb = mat.distribution().blockSize().rows();
+
+  auto givens_rots_fn = [n, nb](comm::CommunicatorGrid grid, const std::vector<GivensRotation<T>>& rots,
+                                const std::vector<matrix::Tile<T, D>>& tiles,
+                                [[maybe_unused]] auto&&... ts) {
+    // TODO replace this with implementation
+    dlaf::internal::silenceUnusedWarningFor(grid, rots, tiles, ts...);
+
+    //   // Distribution of the merged subproblems
+    //   matrix::Distribution distr(LocalElementSize(n, n), TileElementSize(nb, nb));
+
+    for (const GivensRotation<T>& rot : rots) {
+      //     // Get the index of the tile that has column `rot.i` and the the index of the column within
+      //     the tile. SizeType i_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.i));
+      //     SizeType i_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.i); T* x =
+      //     tiles[to_sizet(i_tile)].ptr(TileElementIndex(0, i_el));
+
+      //     // Get the index of the tile that has column `rot.j` and the the index of the column within
+      //     the tile. SizeType j_tile = distr.globalTileLinearIndex(GlobalElementIndex(0, rot.j));
+      //     SizeType j_el = distr.tileElementFromGlobalElement<Coord::Col>(rot.j); T* y =
+      //     tiles[to_sizet(j_tile)].ptr(TileElementIndex(0, j_el));
+
+      //     // Apply Givens rotations
+      //     if constexpr (D == Device::CPU) {
+      //       blas::rot(n, x, 1, y, 1, rot.c, rot.s);
+      //     }
+      //     else {
+      //       givensRotationOnDevice(n, x, y, rot.c, rot.s, ts...);
+      //     }
+    }
+  };
+
+  TileCollector tc{i_begin, i_last};
+
+  auto sender = di::whenAllLift(grid, std::move(rots_fut), ex::when_all_vector(tc.readwrite(mat)));
+  di::transformDetach(di::Policy<DefaultBackend_v<D>>(), std::move(givens_rots_fn), std::move(sender));
+}
+
+}

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -90,7 +90,8 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, comm::Inde
 
   const SizeType mb = dist.blockSize().rows();
   const SizeType i_end = i_last + 1;
-  const SizeType range_size = std::min(dist.size().rows(), i_end * mb) - i_begin * mb;
+  const SizeType range_size_limit = std::min(dist.size().rows(), i_end * mb);
+  const SizeType range_size = range_size_limit - i_begin * mb;
 
   // Note:
   // Some ranks might not participate to the application of given rotations. This logic checks which
@@ -228,7 +229,7 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, comm::Inde
   // Note:
   // Using a combination of shrinked distribution and an offset given to the panel, the workspace
   // is allocated just for the part strictly needed by the range [i_begin, i_last]
-  const matrix::Distribution dist_ws({i_end * mb, 1}, dist.blockSize(), dist.commGridSize(),
+  const matrix::Distribution dist_ws({range_size_limit, 1}, dist.blockSize(), dist.commGridSize(),
                                      dist.rankIndex(), dist.sourceRankIndex());
   matrix::Panel<Coord::Col, T, D> workspace(dist_ws, GlobalTileIndex(i_begin, i_begin));
 

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -90,8 +90,7 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, comm::Inde
 
   const SizeType mb = dist.blockSize().rows();
   const SizeType i_end = i_last + 1;
-  const SizeType range_tile_size = i_end - i_begin;
-  const SizeType range_size = range_tile_size * mb;
+  const SizeType range_size = std::min(dist.size().rows(), i_end * mb) - i_begin * mb;
 
   // Note:
   // Some ranks might not participate to the application of given rotations. This logic checks which

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -181,8 +181,6 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, SizeType i
 
         const comm::IndexT_MPI rank_partner = hasX ? rankColY : rankColX;
 
-        // TODO possible optimization, check if it is zero or not
-
         const T* col_send = hasX ? col_x : col_y;
         T* col_recv = hasX ? col_y : col_x;
 

--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -235,8 +235,8 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, comm::Inde
 
   const TileCollector tc(i_begin, i_last);
 
-  di::whenAllLift(std::forward<GRSender>(rots_fut), ex::when_all_vector(tc.readwrite(mat)),
-                  select(workspace, workspace.iteratorLocal())) |
+  ex::when_all(std::forward<GRSender>(rots_fut), ex::when_all_vector(tc.readwrite(mat)),
+               ex::when_all_vector(select(workspace, workspace.iteratorLocal()))) |
       di::transformDetach(di::Policy<Backend::MC>(), givens_rots_fn);
 }
 }

--- a/include/dlaf/matrix/distribution.h
+++ b/include/dlaf/matrix/distribution.h
@@ -316,6 +316,11 @@ public:
     return tileSizeFromGlobalElement<rc>(i_gl) - tileElementFromGlobalElement<rc>(i_gl);
   }
 
+  /// Returns a local linear column-major index of the tile that contains @p ij
+  SizeType localTileLinearIndex(LocalTileIndex ij) const noexcept {
+    return ij.row() + ij.col() * local_nr_tiles_.rows();
+  }
+
   /// Returns a global linear column-major index of the tile that contains @p i_gl
   SizeType globalTileLinearIndex(GlobalElementIndex i_gl) const noexcept {
     GlobalTileIndex i_tile = globalTileIndex(i_gl);

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -132,14 +132,14 @@ void Permutations<B, D, T, C>::call(SizeType i_begin, SizeType i_end, Matrix<con
   matrix::Distribution subm_distr(LocalElementSize(m, n), distr.blockSize());
   SizeType ntiles = i_end - i_begin + 1;
 
-  auto sender = ex::when_all(ex::when_all_vector(ut::collectReadTiles(GlobalTileIndex(i_begin, 0),
-                                                                      GlobalTileSize(ntiles, 1), perms)),
-                             ex::when_all_vector(
-                                 ut::collectReadWriteTiles(GlobalTileIndex(i_begin, i_begin),
-                                                           GlobalTileSize(ntiles, ntiles), mat_in)),
-                             ex::when_all_vector(
-                                 ut::collectReadWriteTiles(GlobalTileIndex(i_begin, i_begin),
-                                                           GlobalTileSize(ntiles, ntiles), mat_out)));
+  auto sender =
+      ex::when_all(ex::when_all_vector(ut::collectReadTiles(LocalTileIndex(i_begin, 0),
+                                                            LocalTileSize(ntiles, 1), perms)),
+                   ex::when_all_vector(ut::collectReadWriteTiles(LocalTileIndex(i_begin, i_begin),
+                                                                 LocalTileSize(ntiles, ntiles), mat_in)),
+                   ex::when_all_vector(ut::collectReadWriteTiles(LocalTileIndex(i_begin, i_begin),
+                                                                 LocalTileSize(ntiles, ntiles),
+                                                                 mat_out)));
 
   auto permute_fn = [subm_distr](const auto& index_tile_futs, const auto& mat_in_tiles,
                                  const auto& mat_out_tiles, auto&&... ts) {

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -389,7 +389,7 @@ void set_random_hermitian_positive_definite(Matrix<T, Device::CPU>& matrix) {
 
 /// The tiles are returned in column major order
 template <class T, Device D>
-auto collectReadWriteTiles(GlobalTileIndex begin, GlobalTileSize sz, Matrix<T, D>& mat) {
+auto collectReadWriteTiles(LocalTileIndex begin, LocalTileSize sz, Matrix<T, D>& mat) {
   std::vector<decltype(mat.readwrite_sender(std::declval<LocalTileIndex>()))> tiles;
   tiles.reserve(to_sizet(sz.linear_size()));
   for (auto idx : iterate_range2d(begin, sz)) {
@@ -400,7 +400,7 @@ auto collectReadWriteTiles(GlobalTileIndex begin, GlobalTileSize sz, Matrix<T, D
 
 /// The tiles are returned in column major order
 template <class T, Device D>
-auto collectReadTiles(GlobalTileIndex begin, GlobalTileSize sz, Matrix<const T, D>& mat) {
+auto collectReadTiles(LocalTileIndex begin, LocalTileSize sz, Matrix<const T, D>& mat) {
   std::vector<decltype(mat.read_sender(std::declval<LocalTileIndex>()))> tiles;
   tiles.reserve(to_sizet(sz.linear_size()));
   for (auto idx : iterate_range2d(begin, sz)) {

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -74,3 +74,11 @@ DLAF_addTest(
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
+
+DLAF_addTest(
+  test_tridiag_solver_rot
+  SOURCES test_tridiag_solver_rot.cpp
+  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  USE_MAIN MPIPIKA
+  MPIRANKS 6
+)

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -78,7 +78,7 @@ DLAF_addTest(
 DLAF_addTest(
   test_tridiag_solver_rot
   SOURCES test_tridiag_solver_rot.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.core dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -15,6 +15,7 @@
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
+#include "dlaf/matrix/matrix_mirror.h"
 
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
 #include "dlaf_test/matrix/matrix_local.h"
@@ -32,11 +33,26 @@ namespace di = dlaf::eigensolver::internal;
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
 template <typename T>
-class TridiagEigensolverRotTest : public TestWithCommGrids {};
+struct TridiagEigensolverRotTest : public TestWithCommGrids {
+  template <class U>
+  struct config_t {
+    SizeType m;
+    SizeType mb;
+    SizeType i_begin;
+    SizeType i_last;
+    std::vector<di::GivensRotation<U>> rots;
+  };
 
-TYPED_TEST_SUITE(TridiagEigensolverRotTest, RealMatrixElementTypes);
+  const std::vector<config_t<T>> configs{
+      {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}}};
+};
 
-template <class T>
+template <typename T>
+using TridiagEigensolverRotMCTest = TridiagEigensolverRotTest<T>;
+
+TYPED_TEST_SUITE(TridiagEigensolverRotMCTest, RealMatrixElementTypes);
+
+template <class T, Device D>
 void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, const SizeType mb,
                              const SizeType idx_begin, const SizeType idx_last,
                              std::vector<di::GivensRotation<T>> rots) {
@@ -46,12 +62,16 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
 
   matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});
 
-  matrix::Matrix<T, Device::CPU> mat(dist);
-  matrix::util::set_random(mat);
+  matrix::Matrix<T, Device::CPU> mat_h(dist);
+  matrix::util::set_random(mat_h);
 
-  matrix::test::MatrixLocal<T> mat_loc = matrix::test::allGather(blas::Uplo::General, mat, grid);
+  matrix::test::MatrixLocal<T> mat_loc = matrix::test::allGather(blas::Uplo::General, mat_h, grid);
 
-  applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), idx_begin, idx_last, ex::just(rots), mat);
+  {
+    matrix::MatrixMirror<T, D, Device::CPU> mat(mat_h);
+    applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), idx_begin, idx_last, ex::just(rots),
+                                        mat.get());
+  }
 
   // Apply Given Rotations
   for (auto rot : rots) {
@@ -61,35 +81,19 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
     blas::rot(n, x, 1, y, 1, rot.c, rot.s);
   }
 
-  auto result = [&dist = mat.distribution(), &mat_local = mat_loc](const GlobalElementIndex& element) {
+  auto result = [&dist = mat_h.distribution(), &mat_local = mat_loc](const GlobalElementIndex& element) {
     const auto tile_index = dist.globalTileIndex(element);
     const auto tile_element = dist.tileElementIndex(element);
     return mat_local.tile_read(tile_index)(tile_element);
   };
 
-  CHECK_MATRIX_NEAR(result, mat, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
+  CHECK_MATRIX_NEAR(result, mat_h, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
 }
 
-template <class T>
-struct config_t {
-  SizeType m;
-  SizeType mb;
-  SizeType i_begin;
-  SizeType i_last;
-  std::vector<di::GivensRotation<T>> rots;
-};
-
-TYPED_TEST(TridiagEigensolverRotTest, ApplyGivenRotations) {
-  std::vector<config_t<TypeParam>> configs = {{9,
-                                               3,
-                                               0,
-                                               2,
-                                               {di::GivensRotation<TypeParam>{0, 8, 0.5f, 0.5f},
-                                                di::GivensRotation<TypeParam>{0, 2, 0.5f, 0.5f}}}};
-
+TYPED_TEST(TridiagEigensolverRotMCTest, ApplyGivenRotations) {
   for (const auto& grid : this->commGrids()) {
-    for (const auto& [m, mb, idx_begin, idx_last, rots] : configs) {
-      testApplyGivenRotations<TypeParam>(grid, m, mb, idx_begin, idx_last, rots);
+    for (const auto& [m, mb, idx_begin, idx_last, rots] : this->configs) {
+      testApplyGivenRotations<TypeParam, Device::CPU>(grid, m, mb, idx_begin, idx_last, rots);
     }
   }
 }

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -1,0 +1,31 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2022, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "dlaf/eigensolver/tridiag_solver/rot.h"
+
+#include <gtest/gtest.h>
+
+#include "dlaf_test/comm_grids/grids_6_ranks.h"
+#include "dlaf_test/util_types.h"
+
+using namespace dlaf;
+using namespace dlaf::test;
+
+::testing::Environment* const comm_grids_env =
+    ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
+
+template <typename Type>
+class TridiagEigensolverRotTest : public TestWithCommGrids {};
+
+TYPED_TEST_SUITE(TridiagEigensolverRotTest, MatrixElementTypes);
+
+TYPED_TEST(TridiagEigensolverRotTest, ApplyGivenRotations) {
+  using dlaf::eigensolver::internal::applyGivensRotationsToMatrixColumns;
+}

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -8,24 +8,74 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include "dlaf/communication/communicator_grid.h"
+#include "dlaf/eigensolver/tridiag_solver/merge.h"
 #include "dlaf/eigensolver/tridiag_solver/rot.h"
 
 #include <gtest/gtest.h>
 
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/matrix.h"
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
 #include "dlaf_test/util_types.h"
 
 using namespace dlaf;
 using namespace dlaf::test;
 
+namespace ex = pika::execution::experimental;
+namespace di = dlaf::eigensolver::internal;
+
 ::testing::Environment* const comm_grids_env =
     ::testing::AddGlobalTestEnvironment(new CommunicatorGrid6RanksEnvironment);
 
-template <typename Type>
+template <typename T>
 class TridiagEigensolverRotTest : public TestWithCommGrids {};
 
-TYPED_TEST_SUITE(TridiagEigensolverRotTest, MatrixElementTypes);
+// TODO use MatrixElementTypes
+using JustThisType = ::testing::Types<float>;
+
+TYPED_TEST_SUITE(TridiagEigensolverRotTest, JustThisType);
+
+template <class T>
+void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, const SizeType mb,
+                             const SizeType idx_begin, const SizeType idx_last,
+                             std::vector<di::GivensRotation<T>> rots) {
+  using dlaf::eigensolver::internal::applyGivensRotationsToMatrixColumns;
+
+  matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});
+
+  // TODO initialize matrix randomly
+  matrix::Matrix<T, Device::CPU> matrix(dist);
+
+  auto rots_fut = ex::just(rots);
+
+  applyGivensRotationsToMatrixColumns(grid, idx_begin, idx_last, std::move(rots_fut), matrix);
+
+  // TODO collect locally mat
+  // TODO apply blas::rot
+  // TODO check equality
+}
+
+template <class T>
+struct config_t {
+  SizeType m;
+  SizeType mb;
+  SizeType i_begin;
+  SizeType i_last;
+  std::vector<di::GivensRotation<T>> rots;
+};
 
 TYPED_TEST(TridiagEigensolverRotTest, ApplyGivenRotations) {
-  using dlaf::eigensolver::internal::applyGivensRotationsToMatrixColumns;
+  std::vector<config_t<TypeParam>> configs = {{9,
+                                               3,
+                                               0,
+                                               2,
+                                               {di::GivensRotation<TypeParam>{0, 8, 0.5f, 0.5f},
+                                                di::GivensRotation<TypeParam>{0, 2, 0.5f, 0.5f}}}};
+
+  for (const auto& grid : this->commGrids()) {
+    for (const auto& [m, mb, idx_begin, idx_last, rots] : configs) {
+      testApplyGivenRotations<TypeParam>(grid, m, mb, idx_begin, idx_last, rots);
+    }
+  }
 }

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -8,15 +8,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/communication/communicator_grid.h"
-#include "dlaf/eigensolver/tridiag_solver/merge.h"
 #include "dlaf/eigensolver/tridiag_solver/rot.h"
 
 #include <gtest/gtest.h>
 
+#include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
+
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
+#include "dlaf_test/matrix/matrix_local.h"
+#include "dlaf_test/matrix/util_matrix.h"
+#include "dlaf_test/matrix/util_matrix_local.h"
 #include "dlaf_test/util_types.h"
 
 using namespace dlaf;
@@ -40,20 +43,34 @@ template <class T>
 void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, const SizeType mb,
                              const SizeType idx_begin, const SizeType idx_last,
                              std::vector<di::GivensRotation<T>> rots) {
+  // TODO check about "independent" rots?
+
   using dlaf::eigensolver::internal::applyGivensRotationsToMatrixColumns;
 
   matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});
 
-  // TODO initialize matrix randomly
-  matrix::Matrix<T, Device::CPU> matrix(dist);
+  matrix::Matrix<T, Device::CPU> mat(dist);
+  matrix::util::set_random(mat);
 
-  auto rots_fut = ex::just(rots);
+  matrix::test::MatrixLocal<T> mat_loc = matrix::test::allGather(blas::Uplo::General, mat, grid);
 
-  applyGivensRotationsToMatrixColumns(grid, idx_begin, idx_last, std::move(rots_fut), matrix);
+  applyGivensRotationsToMatrixColumns(grid, idx_begin, idx_last, ex::just(rots), mat);
 
-  // TODO collect locally mat
-  // TODO apply blas::rot
-  // TODO check equality
+  // Apply Given Rotations
+  for (auto rot : rots) {
+    const SizeType n = mat_loc.size().rows();
+    T* x = mat_loc.ptr({0, rot.i});
+    T* y = mat_loc.ptr({0, rot.j});
+    blas::rot(n, x, 1, y, 1, rot.c, rot.s);
+  }
+
+  auto result = [&dist = mat.distribution(), &mat_local = mat_loc](const GlobalElementIndex& element) {
+    const auto tile_index = dist.globalTileIndex(element);
+    const auto tile_element = dist.tileElementIndex(element);
+    return mat_local.tile_read(tile_index)(tile_element);
+  };
+
+  CHECK_MATRIX_NEAR(result, mat, m * TypeUtilities<T>::error, m * TypeUtilities<T>::error);
 }
 
 template <class T>
@@ -70,7 +87,7 @@ TYPED_TEST(TridiagEigensolverRotTest, ApplyGivenRotations) {
                                                3,
                                                0,
                                                2,
-                                               {di::GivensRotation<TypeParam>{0, 8, 0.5f, 0.5f},
+                                               {// di::GivensRotation<TypeParam>{0, 8, 0.5f, 0.5f},
                                                 di::GivensRotation<TypeParam>{0, 2, 0.5f, 0.5f}}}};
 
   for (const auto& grid : this->commGrids()) {

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -34,10 +34,7 @@ namespace di = dlaf::eigensolver::internal;
 template <typename T>
 class TridiagEigensolverRotTest : public TestWithCommGrids {};
 
-// TODO use MatrixElementTypes
-using JustThisType = ::testing::Types<float>;
-
-TYPED_TEST_SUITE(TridiagEigensolverRotTest, JustThisType);
+TYPED_TEST_SUITE(TridiagEigensolverRotTest, RealMatrixElementTypes);
 
 template <class T>
 void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, const SizeType mb,
@@ -54,7 +51,7 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
 
   matrix::test::MatrixLocal<T> mat_loc = matrix::test::allGather(blas::Uplo::General, mat, grid);
 
-  applyGivensRotationsToMatrixColumns(grid, idx_begin, idx_last, ex::just(rots), mat);
+  applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), idx_begin, idx_last, ex::just(rots), mat);
 
   // Apply Given Rotations
   for (auto rot : rots) {
@@ -87,7 +84,7 @@ TYPED_TEST(TridiagEigensolverRotTest, ApplyGivenRotations) {
                                                3,
                                                0,
                                                2,
-                                               {// di::GivensRotation<TypeParam>{0, 8, 0.5f, 0.5f},
+                                               {di::GivensRotation<TypeParam>{0, 8, 0.5f, 0.5f},
                                                 di::GivensRotation<TypeParam>{0, 2, 0.5f, 0.5f}}}};
 
   for (const auto& grid : this->commGrids()) {

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include "dlaf/communication/communicator.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
@@ -72,6 +73,7 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
                              std::vector<di::GivensRotation<T>> rots) {
   using dlaf::eigensolver::internal::applyGivensRotationsToMatrixColumns;
 
+  constexpr comm::IndexT_MPI tag = 0;
   matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});
 
   matrix::Matrix<T, Device::CPU> mat_h(dist);
@@ -81,7 +83,7 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
 
   {
     matrix::MatrixMirror<T, D, Device::CPU> mat(mat_h);
-    applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), idx_begin, idx_last, ex::just(rots),
+    applyGivensRotationsToMatrixColumns(grid.rowCommunicator(), tag, idx_begin, idx_last, ex::just(rots),
                                         mat.get());
   }
 

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -52,13 +52,14 @@ struct TridiagEigensolverRotTest : public TestWithCommGrids {
   const std::vector<config_t> configs{
       // range with one-sided margin
       {9, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}}},
+      {8, 3, 1, 2, {GRot{3, 7, rot_c, rot_s}}},  // incomplete tile
       {9, 3, 0, 1, {GRot{2, 4, rot_c, rot_s}}},
       // range fully in-bound
       {12, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}}},
-      // incomplete tile
-      {8, 3, 1, 2, {GRot{3, 7, rot_c, rot_s}}},
+      {11, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}}},  // incomplete tile
       // full-range, multiple rotations
       {9, 3, 0, 2, {GRot{0, 8, rot_c, rot_s}, GRot{0, 2, rot_c, rot_s}}},
+      {8, 3, 0, 2, {GRot{0, 7, rot_c, rot_s}, GRot{0, 2, rot_c, rot_s}}},  // incomplete tile
       // range fully in-bound, independent rotations from same tiles
       {12, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}, GRot{4, 7, rot_c, rot_s}}},
       // range fully in-bound, non-independent rotations, between same pair of tiles

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -53,6 +53,11 @@ struct TridiagEigensolverRotTest : public TestWithCommGrids {
       {8, 3, 1, 2, {di::GivensRotation<T>{3, 7, 0.5f, 0.5f}}},
       // full-range, multiple rotations
       {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}},
+      // range fully in-bound, independent rotations from same tiles
+      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}, di::GivensRotation<T>{4, 7, 0.5f, 0.5f}}},
+      // range fully in-bound, non-independent rotations, between same pair of tiles
+      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}, di::GivensRotation<T>{3, 7, 0.5f, 0.5f}}},
+      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}, di::GivensRotation<T>{4, 8, 0.5f, 0.5f}}},
   };
 };
 

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -35,30 +35,31 @@ namespace di = dlaf::eigensolver::internal;
 
 template <typename T>
 struct TridiagEigensolverRotTest : public TestWithCommGrids {
-  template <class U>
+  using GRot = di::GivensRotation<T>;
+
   struct config_t {
     SizeType m;
     SizeType mb;
     SizeType i_begin;
     SizeType i_last;
-    std::vector<di::GivensRotation<U>> rots;
+    std::vector<GRot> rots;
   };
 
-  const std::vector<config_t<T>> configs{
+  const std::vector<config_t> configs{
       // range with one-sided margin
-      {9, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
-      {9, 3, 0, 1, {di::GivensRotation<T>{2, 4, 0.5f, 0.5f}}},
+      {9, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}}},
+      {9, 3, 0, 1, {GRot{2, 4, cos(2.6f), sin(2.6f)}}},
       // range fully in-bound
-      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
+      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}}},
       // incomplete tile
-      {8, 3, 1, 2, {di::GivensRotation<T>{3, 7, 0.5f, 0.5f}}},
+      {8, 3, 1, 2, {GRot{3, 7, cos(2.6f), sin(2.6f)}}},
       // full-range, multiple rotations
-      {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}},
+      {9, 3, 0, 2, {GRot{0, 8, cos(2.6f), sin(2.6f)}, GRot{0, 2, cos(2.6f), sin(2.6f)}}},
       // range fully in-bound, independent rotations from same tiles
-      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}, di::GivensRotation<T>{4, 7, 0.5f, 0.5f}}},
+      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}, GRot{4, 7, cos(2.6f), sin(2.6f)}}},
       // range fully in-bound, non-independent rotations, between same pair of tiles
-      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}, di::GivensRotation<T>{3, 7, 0.5f, 0.5f}}},
-      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}, di::GivensRotation<T>{4, 8, 0.5f, 0.5f}}},
+      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}, GRot{3, 7, cos(2.6f), sin(2.6f)}}},
+      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}, GRot{4, 8, cos(2.6f), sin(2.6f)}}},
   };
 };
 

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -44,7 +44,10 @@ struct TridiagEigensolverRotTest : public TestWithCommGrids {
   };
 
   const std::vector<config_t<T>> configs{
-      {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}}};
+      {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}},
+      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
+      {9, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
+  };
 };
 
 template <typename T>
@@ -75,9 +78,9 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
 
   // Apply Given Rotations
   for (auto rot : rots) {
-    const SizeType n = mat_loc.size().rows();
-    T* x = mat_loc.ptr({0, rot.i});
-    T* y = mat_loc.ptr({0, rot.j});
+    const SizeType n = (idx_last + 1 - idx_begin) * mb;
+    T* x = mat_loc.ptr({idx_begin * mb, rot.i});
+    T* y = mat_loc.ptr({idx_begin * mb, rot.j});
     blas::rot(n, x, 1, y, 1, rot.c, rot.s);
   }
 

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -44,9 +44,15 @@ struct TridiagEigensolverRotTest : public TestWithCommGrids {
   };
 
   const std::vector<config_t<T>> configs{
-      {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}},
-      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
+      // range with one-sided margin
       {9, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
+      {9, 3, 0, 1, {di::GivensRotation<T>{2, 4, 0.5f, 0.5f}}},
+      // range fully in-bound
+      {12, 3, 1, 2, {di::GivensRotation<T>{3, 8, 0.5f, 0.5f}}},
+      // incomplete tile
+      {8, 3, 1, 2, {di::GivensRotation<T>{3, 7, 0.5f, 0.5f}}},
+      // full-range, multiple rotations
+      {9, 3, 0, 2, {di::GivensRotation<T>{0, 8, 0.5f, 0.5f}, di::GivensRotation<T>{0, 2, 0.5f, 0.5f}}},
   };
 };
 
@@ -77,8 +83,9 @@ void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, cons
   }
 
   // Apply Given Rotations
+  const SizeType n = std::min((idx_last + 1) * mb, m) - idx_begin * mb;
+
   for (auto rot : rots) {
-    const SizeType n = (idx_last + 1 - idx_begin) * mb;
     T* x = mat_loc.ptr({idx_begin * mb, rot.i});
     T* y = mat_loc.ptr({idx_begin * mb, rot.j});
     blas::rot(n, x, 1, y, 1, rot.c, rot.s);

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -70,8 +70,6 @@ template <class T, Device D>
 void testApplyGivenRotations(comm::CommunicatorGrid grid, const SizeType m, const SizeType mb,
                              const SizeType idx_begin, const SizeType idx_last,
                              std::vector<di::GivensRotation<T>> rots) {
-  // TODO check about "independent" rots?
-
   using dlaf::eigensolver::internal::applyGivensRotationsToMatrixColumns;
 
   matrix::Distribution dist({m, m}, {mb, mb}, grid.size(), grid.rank(), {0, 0});

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -35,6 +35,10 @@ namespace di = dlaf::eigensolver::internal;
 
 template <typename T>
 struct TridiagEigensolverRotTest : public TestWithCommGrids {
+  static constexpr T angle = static_cast<T>(2.6);
+  static constexpr T rot_c = std::cos(angle);
+  static constexpr T rot_s = std::sin(angle);
+
   using GRot = di::GivensRotation<T>;
 
   struct config_t {
@@ -47,19 +51,19 @@ struct TridiagEigensolverRotTest : public TestWithCommGrids {
 
   const std::vector<config_t> configs{
       // range with one-sided margin
-      {9, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}}},
-      {9, 3, 0, 1, {GRot{2, 4, cos(2.6f), sin(2.6f)}}},
+      {9, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}}},
+      {9, 3, 0, 1, {GRot{2, 4, rot_c, rot_s}}},
       // range fully in-bound
-      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}}},
+      {12, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}}},
       // incomplete tile
-      {8, 3, 1, 2, {GRot{3, 7, cos(2.6f), sin(2.6f)}}},
+      {8, 3, 1, 2, {GRot{3, 7, rot_c, rot_s}}},
       // full-range, multiple rotations
-      {9, 3, 0, 2, {GRot{0, 8, cos(2.6f), sin(2.6f)}, GRot{0, 2, cos(2.6f), sin(2.6f)}}},
+      {9, 3, 0, 2, {GRot{0, 8, rot_c, rot_s}, GRot{0, 2, rot_c, rot_s}}},
       // range fully in-bound, independent rotations from same tiles
-      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}, GRot{4, 7, cos(2.6f), sin(2.6f)}}},
+      {12, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}, GRot{4, 7, rot_c, rot_s}}},
       // range fully in-bound, non-independent rotations, between same pair of tiles
-      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}, GRot{3, 7, cos(2.6f), sin(2.6f)}}},
-      {12, 3, 1, 2, {GRot{3, 8, cos(2.6f), sin(2.6f)}, GRot{4, 8, cos(2.6f), sin(2.6f)}}},
+      {12, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}, GRot{3, 7, rot_c, rot_s}}},
+      {12, 3, 1, 2, {GRot{3, 8, rot_c, rot_s}, GRot{4, 8, rot_c, rot_s}}},
   };
 };
 

--- a/test/unit/eigensolver/test_tridiag_solver_rot.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_rot.cpp
@@ -36,8 +36,8 @@ namespace di = dlaf::eigensolver::internal;
 template <typename T>
 struct TridiagEigensolverRotTest : public TestWithCommGrids {
   static constexpr T angle = static_cast<T>(2.6);
-  static constexpr T rot_c = std::cos(angle);
-  static constexpr T rot_s = std::sin(angle);
+  const T rot_c = std::cos(angle);
+  const T rot_s = std::sin(angle);
 
   using GRot = di::GivensRotation<T>;
 


### PR DESCRIPTION
This is an implementation for one of the sub-tasks needed by #601.

At the time of writing is still in the early phases and I will refine it in the next days, but I hope that this premature publication might help in the integration with the rest of the code @teonnik.

Main points:
- `TileCollector` has been adapted to work also with distributed ranges
- `applyGivensRotationsToMatrixColumns` accepts a `Communicator` of the row, because it is up to the caller the correct management of multiple calls and ensure their independency (this is something we might want to discuss @teonnik)
- minor fix: naming of lambda function in communication kernel

TODO:
- [ ] ? Move implementation together with the other into `tridiag_solver_merge` (and the test too)
- [x] ~Evaluate how easy it is to extend to GPU~ (it will be topic for a separate PR)
- [x] Check if sub-tasking is implemented correctly
- [x] Add more test-cases
- [x] Check it works with incomplete tiles
- [x] Cleanup and refinement