### PR TITLE
algo: BackTransformation Band Distributed GPU (and computeTFactor)

### DIFF
--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -23,6 +23,7 @@
 #include "dlaf/communication/message.h"
 #include "dlaf/communication/rdma.h"
 #include "dlaf/matrix/tile.h"
+#include "dlaf/sender/traits.h"
 #include "dlaf/sender/transform_mpi.h"
 #include "dlaf/sender/with_temporary_tile.h"
 
@@ -31,7 +32,6 @@ namespace internal {
 template <class T, Device D>
 auto allReduce(const Communicator& comm, MPI_Op reduce_op, const matrix::Tile<const T, D>& tile_in,
                const matrix::Tile<T, D>& tile_out, MPI_Request* req) {
-  static_assert(D == Device::CPU, "allReduce requires CPU memory");
   DLAF_ASSERT(tile_in.is_contiguous(), "");
   DLAF_ASSERT(tile_out.is_contiguous(), "");
 
@@ -46,7 +46,6 @@ DLAF_MAKE_CALLABLE_OBJECT(allReduce);
 template <class T, Device D>
 auto allReduceInPlace(const Communicator& comm, MPI_Op reduce_op, const matrix::Tile<T, D>& tile,
                       MPI_Request* req) {
-  static_assert(D == Device::CPU, "allReduceInPlace requires CPU memory");
   DLAF_ASSERT(tile.is_contiguous(), "");
 
   auto msg = comm::make_message(common::make_data(tile));
@@ -66,13 +65,18 @@ DLAF_MAKE_CALLABLE_OBJECT(allReduceInPlace);
 template <class CommSender, class TileInSender, class TileOutSender>
 [[nodiscard]] auto scheduleAllReduce(CommSender&& pcomm, MPI_Op reduce_op, TileInSender&& tile_in,
                                      TileOutSender&& tile_out) {
+  using dlaf::comm::CommunicationDevice_v;
   using dlaf::comm::internal::allReduce_o;
   using dlaf::comm::internal::transformMPI;
   using dlaf::internal::CopyFromDestination;
   using dlaf::internal::CopyToDestination;
   using dlaf::internal::RequireContiguous;
+  using dlaf::internal::SenderSingleValueType;
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
+
+  constexpr static auto D_IN = dlaf::internal::SenderSingleValueType<TileInSender>::D;
+  constexpr static auto D_OUT = dlaf::internal::SenderSingleValueType<TileOutSender>::D;
 
   // We create two nested scopes for the input and output tiles with
   // withTemporaryTile. The output tile is in the outer scope as the output tile
@@ -89,19 +93,16 @@ template <class CommSender, class TileInSender, class TileOutSender>
     // The input tile must be copied to the temporary tile used for the
     // reduction, but the temporary tile does not need to be copied back to the
     // input since the data is not changed by the reduction (the result is
-    // written into the output tile instead).  The reduction is explicitly done
-    // on CPU memory so that we can manage potential asynchronous copies between
-    // CPU and GPU. A reduction requires contiguous memory.
-    return withTemporaryTile<Device::CPU, CopyToDestination::Yes, CopyFromDestination::No,
-                             RequireContiguous::Yes>(std::move(tile_in), std::move(all_reduce));
+    // written into the output tile instead).
+    return withTemporaryTile<CommunicationDevice_v<D_IN>, CopyToDestination::Yes,
+                             CopyFromDestination::No, RequireContiguous::Yes>(std::move(tile_in),
+                                                                              std::move(all_reduce));
   };
 
   // The output tile does not need to be copied to the temporary tile since it
   // is only written to. The written data is copied back from the temporary tile
-  // to the output tile. The reduction is explicitly done on CPU memory so that
-  // we can manage potential asynchronous copies between CPU and GPU. A
-  // reduction requires contiguous memory.
-  return withTemporaryTile<Device::CPU, CopyToDestination::No, CopyFromDestination::Yes,
+  // to the output tile.
+  return withTemporaryTile<CommunicationDevice_v<D_OUT>, CopyToDestination::No, CopyFromDestination::Yes,
                            RequireContiguous::Yes>(std::forward<TileOutSender>(tile_out),
                                                    std::move(all_reduce_final));
 }
@@ -113,6 +114,7 @@ template <class CommSender, class TileInSender, class TileOutSender>
 /// written to it. The tile is sent by the returned sender.
 template <class CommSender, class TileSender>
 [[nodiscard]] auto scheduleAllReduceInPlace(CommSender&& pcomm, MPI_Op reduce_op, TileSender&& tile) {
+  using dlaf::comm::CommunicationDevice_v;
   using dlaf::comm::internal::allReduceInPlace_o;
   using dlaf::comm::internal::transformMPI;
   using dlaf::internal::CopyFromDestination;
@@ -121,6 +123,8 @@ template <class CommSender, class TileSender>
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
 
+  constexpr static auto D = dlaf::internal::SenderSingleValueType<TileSender>::D;
+
   auto all_reduce_in_place = [reduce_op,
                               pcomm = std::forward<CommSender>(pcomm)](auto const& tile_comm) mutable {
     return whenAllLift(std::move(pcomm), reduce_op, std::cref(tile_comm)) |
@@ -128,10 +132,8 @@ template <class CommSender, class TileSender>
   };
 
   // The tile has to be copied both to and from the temporary tile since the
-  // reduction is done in-place. The reduction is explicitly done on CPU memory
-  // so that we can manage potential asynchronous copies between CPU and GPU. A
-  // reduction requires contiguous memory.
-  return withTemporaryTile<Device::CPU, CopyToDestination::Yes, CopyFromDestination::Yes,
+  // reduction is done in-place.
+  return withTemporaryTile<CommunicationDevice_v<D>, CopyToDestination::Yes, CopyFromDestination::Yes,
                            RequireContiguous::Yes>(std::forward<TileSender>(tile),
                                                    std::move(all_reduce_in_place));
 }

--- a/include/dlaf/factorization/qr/t_factor_impl.h
+++ b/include/dlaf/factorization/qr/t_factor_impl.h
@@ -291,9 +291,6 @@ void QR_Tfactor<backend, device, T>::call(matrix::Panel<Coord::Col, T, device>& 
   namespace ex = pika::execution::experimental;
 
   using Helpers = tfactor_l::Helpers<backend, device, T>;
-  if constexpr (backend != Backend::MC) {
-    DLAF_STATIC_UNIMPLEMENTED(T);
-  }
 
   // Fast return in case of no reflectors
   if (hh_panel.getWidth() == 0)

--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -7,6 +7,7 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
+
 #include "dlaf/eigensolver/bt_reduction_to_band.h"
 
 #include <functional>
@@ -16,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <pika/runtime.hpp>
 
+#include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
 #include "dlaf/communication/communicator_grid.h"
 #include "dlaf/matrix/copy.h"
@@ -232,10 +234,26 @@ TYPED_TEST(BackTransformationReductionToBandEigenSolverTestMC, CorrectnessDistri
   for (const auto& comm_grid : this->commGrids()) {
     for (const auto& [m, n, mb, nb, b] : sizes) {
       // b != mb is currently not supported by the implementation yet.
-      (void) mb;
+      dlaf::internal::silenceUnusedWarningFor(b);
 
-      testBackTransformationReductionToBand<TypeParam, Backend::MC, Device::CPU>(comm_grid, m, n, b, nb);
+      testBackTransformationReductionToBand<TypeParam, Backend::MC, Device::CPU>(comm_grid, m, n, mb,
+                                                                                 nb);
       pika::threads::get_thread_manager().wait();
     }
   }
 }
+
+#ifdef DLAF_WITH_GPU
+TYPED_TEST(BackTransformationReductionToBandEigenSolverTestGPU, CorrectnessDistributed) {
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& [m, n, mb, nb, b] : sizes) {
+      // b != mb is currently not supported by the implementation yet.
+      dlaf::internal::silenceUnusedWarningFor(b);
+
+      testBackTransformationReductionToBand<TypeParam, Backend::GPU, Device::GPU>(comm_grid, m, n, mb,
+                                                                                  nb);
+      pika::threads::get_thread_manager().wait();
+    }
+  }
+}
+#endif

--- a/test/unit/factorization/test_compute_t_factor.cpp
+++ b/test/unit/factorization/test_compute_t_factor.cpp
@@ -414,4 +414,13 @@ TYPED_TEST(ComputeTFactorTestGPU, CorrectnessLocal) {
     testComputeTFactor<TypeParam, Backend::GPU, Device::GPU>(m, k, mb, nb, v_start);
   }
 }
+
+TYPED_TEST(ComputeTFactorTestGPU, CorrectnessDistributed) {
+  for (auto comm_grid : this->commGrids()) {
+    for (const auto& [m, k, mb, nb, v_start] : configs) {
+      testComputeTFactor<TypeParam, Backend::GPU, Device::GPU>(comm_grid, m, k, mb, nb, v_start);
+    }
+  }
+}
+
 #endif


### PR DESCRIPTION
Adapt algorithm `BackTransformationReductionToBand ` to use `Device::GPU` memory and add test for it.

Changelog:
- Generalize `scheduleAllReduce*` to work also with GPU tiles.
- Remove constraint for `computeTFactor` and add test on GPU
- minor changes in `BackTransformationReductionToBand` (renaming + use sender where possible)