### PR TITLE
algo: Reduction to band Distributed GPU

### DIFF
--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -7,6 +7,7 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
+
 #pragma once
 
 #include "dlaf/common/vector.h"

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -134,19 +134,13 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> reduc
 }
 
 /// ---- ETI
-#define DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(KWORD, BACKEND, DEVICE, DATATYPE)             \
+#define DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(KWORD, BACKEND, DEVICE, DATATYPE)                   \
   KWORD template common::internal::vector<pika::shared_future<common::internal::vector<DATATYPE>>> \
   reductionToBand<BACKEND, DEVICE, DATATYPE>(Matrix<DATATYPE, DEVICE> & mat_a,                     \
-                                             const SizeType band_size);
-
-#define DLAF_EIGENSOLVER_REDUCTION_TO_BAND_DISTR_ETI(KWORD, BACKEND, DEVICE, DATATYPE)             \
+                                             const SizeType band_size);                            \
   KWORD template common::internal::vector<pika::shared_future<common::internal::vector<DATATYPE>>> \
   reductionToBand<BACKEND, DEVICE, DATATYPE>(comm::CommunicatorGrid grid,                          \
                                              Matrix<DATATYPE, DEVICE> & mat_a);
-
-#define DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  DLAF_EIGENSOLVER_REDUCTION_TO_BAND_DISTR_ETI(KWORD, BACKEND, DEVICE, DATATYPE)
 
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, float)
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, double)
@@ -154,9 +148,9 @@ DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::co
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
 
 #ifdef DLAF_WITH_GPU
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, float)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, double)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, float)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, double)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
 }

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -46,8 +46,6 @@
 namespace dlaf::eigensolver::internal {
 
 namespace red2band {
-using matrix::SubMatrixView;
-using matrix::SubPanelView;
 
 // Extract x0 and compute local cumulative sum of squares of the reflector column
 template <Device D, class T>
@@ -264,7 +262,8 @@ void updateTrailingPanelWithReflector(const std::vector<matrix::Tile<T, D>>& pan
 }
 
 template <class MatrixLike>
-auto computePanelReflectors(MatrixLike& mat_a, const SubPanelView& panel_view, const SizeType nrefls) {
+auto computePanelReflectors(MatrixLike& mat_a, const matrix::SubPanelView& panel_view,
+                            const SizeType nrefls) {
   static Device constexpr D = MatrixLike::device;
   using T = typename MatrixLike::ElementType;
   namespace ex = pika::execution::experimental;
@@ -296,7 +295,7 @@ auto computePanelReflectors(MatrixLike& mat_a, const SubPanelView& panel_view, c
 }
 
 template <Backend B, Device D, class T, bool force_copy = false>
-void setupReflectorPanelV(bool has_head, const SubPanelView& panel_view, const SizeType nrefls,
+void setupReflectorPanelV(bool has_head, const matrix::SubPanelView& panel_view, const SizeType nrefls,
                           matrix::Panel<Coord::Col, T, D>& v, matrix::Matrix<const T, D>& mat_a) {
   namespace ex = pika::execution::experimental;
 
@@ -389,7 +388,7 @@ void gemmUpdateX(matrix::Panel<Coord::Col, T, D>& x, matrix::Matrix<const T, D>&
 }
 
 template <Backend B, Device D, class T>
-void hemmComputeX(matrix::Panel<Coord::Col, T, D>& x, const SubMatrixView& view,
+void hemmComputeX(matrix::Panel<Coord::Col, T, D>& x, const matrix::SubMatrixView& view,
                   matrix::Matrix<const T, D>& a, matrix::Panel<Coord::Col, const T, D>& w) {
   using pika::execution::thread_priority;
   namespace ex = pika::execution::experimental;
@@ -467,7 +466,7 @@ void gemmComputeW2(matrix::Matrix<T, D>& w2, matrix::Panel<Coord::Col, const T, 
 }
 
 template <Backend B, Device D, class T>
-void her2kUpdateTrailingMatrix(const SubMatrixView& view, matrix::Matrix<T, D>& a,
+void her2kUpdateTrailingMatrix(const matrix::SubMatrixView& view, matrix::Matrix<T, D>& a,
                                matrix::Panel<Coord::Col, const T, D>& x,
                                matrix::Panel<Coord::Col, const T, D>& v) {
   static_assert(std::is_signed_v<BaseType<T>>, "alpha in computations requires to be -1");
@@ -556,7 +555,7 @@ void updateTrailingPanelWithReflector(const bool has_head, comm::Communicator& c
 template <class MatrixLike, class TriggerSender, class CommSender>
 auto computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
                             CommSender&& mpi_col_chain_panel, MatrixLike& mat_a,
-                            const SubPanelView& panel_view, const SizeType nrefls) {
+                            const matrix::SubPanelView& panel_view, const SizeType nrefls) {
   using T = typename MatrixLike::ElementType;
   namespace ex = pika::execution::experimental;
 
@@ -789,7 +788,7 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
 
   template <Device D, class CommSender, class TriggerSender>
   auto call(TriggerSender&& trigger, comm::IndexT_MPI rank_v0, CommSender&& mpi_col_chain_panel,
-            Matrix<T, D>& mat_a, const SubPanelView& panel_view, const SizeType nrefls) {
+            Matrix<T, D>& mat_a, const matrix::SubPanelView& panel_view, const SizeType nrefls) {
     auto& v = panels_v.nextResource();
 
     // copy to CPU
@@ -810,7 +809,7 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
 protected:
   common::RoundRobin<matrix::Panel<Coord::Col, T, Device::CPU>> panels_v;
 
-  void copyToCPU(const SubPanelView panel_view, matrix::Matrix<T, Device::GPU>& mat_a,
+  void copyToCPU(const matrix::SubPanelView panel_view, matrix::Matrix<T, Device::GPU>& mat_a,
                  matrix::Panel<Coord::Col, T, Device::CPU>& v) {
     namespace ex = pika::execution::experimental;
 
@@ -827,7 +826,7 @@ protected:
     }
   }
 
-  void copyFromCPU(const SubPanelView panel_view, matrix::Panel<Coord::Col, T, Device::CPU>& v,
+  void copyFromCPU(const matrix::SubPanelView panel_view, matrix::Panel<Coord::Col, T, Device::CPU>& v,
                    matrix::Matrix<T, Device::GPU>& mat_a) {
     namespace ex = pika::execution::experimental;
 

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -861,8 +861,7 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
 
   const auto dist_a = mat_a.distribution();
   const matrix::Distribution dist({mat_a.size().rows(), band_size},
-                                  {dist_a.blockSize().rows(), band_size}, dist_a.commGridSize(),
-                                  dist_a.rankIndex(), dist_a.sourceRankIndex());
+                                  {dist_a.blockSize().rows(), band_size});
 
   // Note:
   // Reflector of size = 1 is not considered whatever T is (i.e. neither real nor complex)

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -802,7 +802,7 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
     //                            nrefls);
     // TODO copy back to GPU
     // return taus;
-    return {};
+    return pika::shared_future<common::internal::vector<T>>{};
   }
 
 protected:

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -265,7 +265,7 @@ void updateTrailingPanelWithReflector(const std::vector<matrix::Tile<T, D>>& pan
 
 template <class MatrixLike>
 auto computePanelReflectors(MatrixLike& mat_a, const SubPanelView& panel_view, const SizeType nrefls) {
-  static auto constexpr D = MatrixLike::D;
+  static Device constexpr D = MatrixLike::device;
   using T = typename MatrixLike::ElementType;
   namespace ex = pika::execution::experimental;
 

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -57,6 +57,7 @@ template <class T, Device D>
 class Matrix : public Matrix<const T, D> {
 public:
   static constexpr Device device = D;
+
   using ElementType = T;
   using TileType = Tile<ElementType, D>;
   using ConstTileType = Tile<const ElementType, D>;
@@ -150,6 +151,8 @@ private:
 template <class T, Device D>
 class Matrix<const T, D> : public internal::MatrixBase {
 public:
+  static constexpr Device device = D;
+
   using ElementType = T;
   using TileType = Tile<ElementType, D>;
   using ConstTileType = Tile<const ElementType, D>;

--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -56,6 +56,7 @@ auto selectGeneric(Func&& f, common::IterableRange2D<SizeType, LocalTile_TAG> ra
 template <class T, Device D>
 class Matrix : public Matrix<const T, D> {
 public:
+  static constexpr Device device = D;
   using ElementType = T;
   using TileType = Tile<ElementType, D>;
   using ConstTileType = Tile<const ElementType, D>;

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -443,6 +443,7 @@ protected:
 
 template <Coord axis, class T, Device D>
 struct Panel : public Panel<axis, const T, D> {
+  constexpr static Coord coord = orthogonal(axis);
   constexpr static Device device = D;
 
   using TileType = Tile<T, D>;

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -42,7 +42,7 @@ struct Panel<axis, const T, D> {
   // moreover allows the casting between references (i.e. Panel<const T>& = Panel<T>)
 
   constexpr static Coord coord = orthogonal(axis);
-  constexpr static Device D = device;
+  constexpr static Device device = D;
 
   using TileType = Tile<T, D>;
   using ConstTileType = Tile<const T, D>;

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -42,6 +42,7 @@ struct Panel<axis, const T, D> {
   // moreover allows the casting between references (i.e. Panel<const T>& = Panel<T>)
 
   constexpr static Coord coord = orthogonal(axis);
+  constexpr static Device D = device;
 
   using TileType = Tile<T, D>;
   using ConstTileType = Tile<const T, D>;
@@ -442,6 +443,8 @@ protected:
 
 template <Coord axis, class T, Device D>
 struct Panel : public Panel<axis, const T, D> {
+  constexpr static Device device = D;
+
   using TileType = Tile<T, D>;
   using ConstTileType = Tile<const T, D>;
   using ElementType = T;

--- a/src/eigensolver/reduction_to_band/gpu.cpp
+++ b/src/eigensolver/reduction_to_band/gpu.cpp
@@ -12,9 +12,9 @@
 
 namespace dlaf::eigensolver {
 
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, float)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, double)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, float)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, double)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
 
 }

--- a/test/unit/eigensolver/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_reduction_to_band.cpp
@@ -372,42 +372,43 @@ TYPED_TEST(ReductionToBandTestGPU, CorrectnessLocalSubBand) {
 }
 #endif
 
+template <class T, Device D, Backend B>
+void testReductionToBand(comm::CommunicatorGrid grid, const LocalElementSize size,
+                         const TileElementSize block_size, const SizeType band_size) {
+  const SizeType k_reflectors = std::max(SizeType(0), size.rows() - band_size - 1);
+  DLAF_ASSERT(block_size.rows() % band_size == 0, block_size.rows(), band_size);
+
+  Distribution distribution({size.rows(), size.cols()}, block_size, grid.size(), grid.rank(), {0, 0});
+
+  // setup the reference input matrix
+  Matrix<const T, D> reference = [&]() {
+    Matrix<T, D> reference(distribution);
+    matrix::util::set_random_hermitian(reference);
+    return reference;
+  }();
+
+  Matrix<T, D> matrix_a(distribution);
+  copy(reference, matrix_a);
+
+  auto local_taus = eigensolver::reductionToBand<Backend::MC>(grid, matrix_a);
+  pika::threads::get_thread_manager().wait();
+
+  checkUpperPartUnchanged(reference, matrix_a);
+
+  auto mat_v = allGather(blas::Uplo::Lower, matrix_a, grid);
+  auto mat_b = makeLocal(matrix_a);
+  splitReflectorsAndBand(mat_v, mat_b, band_size);
+
+  auto taus = allGatherTaus(k_reflectors, block_size.cols(), local_taus, grid);
+  DLAF_ASSERT(to_SizeType(taus.size()) == k_reflectors, taus.size(), k_reflectors);
+
+  checkResult(k_reflectors, band_size, reference, mat_v, mat_b, taus);
+}
+
 TYPED_TEST(ReductionToBandTestMC, CorrectnessDistributed) {
-  constexpr Device device = Device::CPU;
-
   for (auto&& comm_grid : this->commGrids()) {
-    for (const auto& config : configs) {
-      const auto& [size, block_size, band_size] = config;
-
-      const SizeType k_reflectors = std::max(SizeType(0), size.rows() - band_size - 1);
-      DLAF_ASSERT(block_size.rows() % band_size == 0, block_size.rows(), band_size);
-
-      Distribution distribution({size.rows(), size.cols()}, block_size, comm_grid.size(),
-                                comm_grid.rank(), {0, 0});
-
-      // setup the reference input matrix
-      Matrix<const TypeParam, device> reference = [&]() {
-        Matrix<TypeParam, device> reference(distribution);
-        matrix::util::set_random_hermitian(reference);
-        return reference;
-      }();
-
-      Matrix<TypeParam, device> matrix_a(distribution);
-      copy(reference, matrix_a);
-
-      auto local_taus = eigensolver::reductionToBand<Backend::MC>(comm_grid, matrix_a);
-      pika::threads::get_thread_manager().wait();
-
-      checkUpperPartUnchanged(reference, matrix_a);
-
-      auto mat_v = allGather(blas::Uplo::Lower, matrix_a, comm_grid);
-      auto mat_b = makeLocal(matrix_a);
-      splitReflectorsAndBand(mat_v, mat_b, band_size);
-
-      auto taus = allGatherTaus(k_reflectors, block_size.cols(), local_taus, comm_grid);
-      DLAF_ASSERT(to_SizeType(taus.size()) == k_reflectors, taus.size(), k_reflectors);
-
-      checkResult(k_reflectors, band_size, reference, mat_v, mat_b, taus);
+    for (const auto& [size, block_size, band_size] : configs) {
+      testReductionToBand<TypeParam, Device::CPU, Backend::MC>(comm_grid, size, block_size, band_size);
     }
   }
 }

--- a/test/unit/eigensolver/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_reduction_to_band.cpp
@@ -412,3 +412,13 @@ TYPED_TEST(ReductionToBandTestMC, CorrectnessDistributed) {
     }
   }
 }
+
+#ifdef DLAF_WITH_GPU
+TYPED_TEST(ReductionToBandTestGPU, CorrectnessDistributed) {
+  for (auto&& comm_grid : this->commGrids()) {
+    for (const auto& [size, block_size, band_size] : configs) {
+      testReductionToBand<TypeParam, Device::GPU, Backend::GPU>(comm_grid, size, block_size, band_size);
+    }
+  }
+}
+#endif


### PR DESCRIPTION
Adapt current implementation to work in GPU too.

Changes:
- Refactor and extend `ComputePanelHelper` to work with GPU (as for local, it will compute the panel on CPU)
- Algorithm trigger preventing deadlocks had to be adapted for the GPU implementation (notes and doc will come later)
- introduce `D` static attribute for both `Matrix` and `Panel`
- adapt test facility to GPU and add Distributed GPU test

TODO
- [x] Check necessity of `D` static attribute introduction
- [x] Document trigger problem (both for GPU and CPU)
- [x] Differentiate trigger configuration between implementations (due to different requirements)/