### PR TITLE
Renaming D <-> Device (mainly for Matrix and similar/related)

### DIFF
--- a/include/dlaf/communication/broadcast_panel.h
+++ b/include/dlaf/communication/broadcast_panel.h
@@ -49,8 +49,8 @@ std::pair<SizeType, comm::IndexT_MPI> transposedOwner(const matrix::Distribution
 ///                     on other ranks it is the destination panel
 /// @param serial_comm  where to pipeline the tasks for communications.
 /// @pre Communicator in @p serial_comm must be orthogonal to panel axis
-template <class T, Device device, Coord axis, class = std::enable_if_t<!std::is_const_v<T>>>
-void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, device>& panel,
+template <class T, Device D, Coord axis, class = std::enable_if_t<!std::is_const_v<T>>>
+void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
                common::Pipeline<comm::Communicator>& serial_comm) {
   constexpr auto comm_coord = axis;
 
@@ -98,9 +98,9 @@ void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, device>& panel
 /// @pre both panels are child of a matrix (even not the same) with the same Distribution
 /// @pre both panels parent matrices should be square matrices with square blocksizes
 /// @pre both panels offsets should lay on the main diagonal of the parent matrix
-template <class T, Device device, Coord axis, class = std::enable_if_t<!std::is_const_v<T>>>
-void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, device>& panel,
-               matrix::Panel<orthogonal(axis), T, device>& panelT,
+template <class T, Device D, Coord axis, class = std::enable_if_t<!std::is_const_v<T>>>
+void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
+               matrix::Panel<orthogonal(axis), T, D>& panelT,
                common::Pipeline<comm::Communicator>& row_task_chain,
                common::Pipeline<comm::Communicator>& col_task_chain) {
   constexpr Coord axisT = orthogonal(axis);

--- a/include/dlaf/communication/kernels/all_reduce.h
+++ b/include/dlaf/communication/kernels/all_reduce.h
@@ -92,7 +92,7 @@ template <class CommSender, class TileInSender, class TileOutSender>
     // reduction, but the temporary tile does not need to be copied back to the
     // input since the data is not changed by the reduction (the result is
     // written into the output tile instead).
-    constexpr static Device in_device = SenderSingleValueType<TileInSender>::D;
+    constexpr static Device in_device = SenderSingleValueType<TileInSender>::device;
     constexpr static Device in_comm_device = CommunicationDevice_v<in_device>;
 
     return withTemporaryTile<in_comm_device, CopyToDestination::Yes, CopyFromDestination::No,
@@ -102,7 +102,7 @@ template <class CommSender, class TileInSender, class TileOutSender>
   // The output tile does not need to be copied to the temporary tile since it
   // is only written to. The written data is copied back from the temporary tile
   // to the output tile.
-  constexpr static Device out_device = SenderSingleValueType<TileOutSender>::D;
+  constexpr static Device out_device = SenderSingleValueType<TileOutSender>::device;
   constexpr static Device out_comm_device = CommunicationDevice_v<out_device>;
 
   return withTemporaryTile<out_comm_device, CopyToDestination::No, CopyFromDestination::Yes,
@@ -126,7 +126,7 @@ template <class CommSender, class TileSender>
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
 
-  constexpr static auto D = dlaf::internal::SenderSingleValueType<TileSender>::D;
+  constexpr static auto D = dlaf::internal::SenderSingleValueType<TileSender>::device;
 
   auto all_reduce_in_place = [reduce_op,
                               pcomm = std::forward<CommSender>(pcomm)](auto const& tile_comm) mutable {

--- a/include/dlaf/communication/kernels/broadcast.h
+++ b/include/dlaf/communication/kernels/broadcast.h
@@ -73,7 +73,7 @@ template <class CommSender, class TileSender>
     return whenAllLift(std::move(pcomm), std::cref(tile_comm)) | transformMPI(sendBcast_o);
   };
 
-  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<TileSender>>::D;
+  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<TileSender>>::device;
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;
 
   // The input tile must be copied to the temporary tile used for the send, but
@@ -103,7 +103,7 @@ template <class CommSender, class TileSender>
     return whenAllLift(std::move(pcomm), root_rank, std::cref(tile_comm)) | transformMPI(recvBcast_o);
   };
 
-  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<TileSender>>::D;
+  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<TileSender>>::device;
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;
 
   // Since this is a receive we don't need to copy the input to the temporary

--- a/include/dlaf/communication/kernels/p2p.h
+++ b/include/dlaf/communication/kernels/p2p.h
@@ -74,7 +74,7 @@ template <class CommSender, class Sender>
     return whenAllLift(std::move(pcomm), dest, tag, std::cref(tile_comm)) | transformMPI(send_o);
   };
 
-  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<Sender>>::D;
+  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<Sender>>::device;
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;
 
   return withTemporaryTile<comm_device_type, CopyToDestination::Yes, CopyFromDestination::No,
@@ -96,7 +96,7 @@ template <class CommSender, class Sender>
     return whenAllLift(std::move(pcomm), source, tag, std::cref(tile_comm)) | transformMPI(recv_o);
   };
 
-  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<Sender>>::D;
+  constexpr Device in_device_type = SenderSingleValueType<std::decay_t<Sender>>::device;
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;
 
   return withTemporaryTile<comm_device_type, CopyToDestination::No, CopyFromDestination::Yes,

--- a/include/dlaf/matrix/internal/tile_future_manager.h
+++ b/include/dlaf/matrix/internal/tile_future_manager.h
@@ -65,12 +65,12 @@ pika::future<ReturnTileType> getTileFuture(
 
 // TileFutureManager manages the futures and promises for tiles in the Matrix object.
 // See misc/synchronization.md for details.
-template <class T, Device device>
+template <class T, Device D>
 class TileFutureManager {
 public:
-  using TileType = Tile<T, device>;
-  using ConstTileType = Tile<const T, device>;
-  using TileDataType = internal::TileData<T, device>;
+  using TileType = Tile<T, D>;
+  using ConstTileType = Tile<const T, D>;
+  using TileDataType = internal::TileData<T, D>;
 
   TileFutureManager() {}
 

--- a/include/dlaf/matrix/matrix.tpp
+++ b/include/dlaf/matrix/matrix.tpp
@@ -11,17 +11,17 @@
 namespace dlaf {
 namespace matrix {
 
-template <class T, Device device>
-Matrix<T, device>::Matrix(const LocalElementSize& size, const TileElementSize& block_size)
-    : Matrix<T, device>(Distribution(size, block_size)) {}
+template <class T, Device D>
+Matrix<T, D>::Matrix(const LocalElementSize& size, const TileElementSize& block_size)
+    : Matrix<T, D>(Distribution(size, block_size)) {}
 
-template <class T, Device device>
-Matrix<T, device>::Matrix(const GlobalElementSize& size, const TileElementSize& block_size,
-                          const comm::CommunicatorGrid& comm)
-    : Matrix<T, device>(Distribution(size, block_size, comm.size(), comm.rank(), {0, 0})) {}
+template <class T, Device D>
+Matrix<T, D>::Matrix(const GlobalElementSize& size, const TileElementSize& block_size,
+                     const comm::CommunicatorGrid& comm)
+    : Matrix<T, D>(Distribution(size, block_size, comm.size(), comm.rank(), {0, 0})) {}
 
-template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution distribution) : Matrix<const T, device>(std::move(distribution)) {
+template <class T, Device D>
+Matrix<T, D>::Matrix(Distribution distribution) : Matrix<const T, D>(std::move(distribution)) {
   const SizeType alignment = 64;
   const SizeType ld =
       std::max<SizeType>(1,
@@ -30,35 +30,34 @@ Matrix<T, device>::Matrix(Distribution distribution) : Matrix<const T, device>(s
   auto layout = colMajorLayout(this->distribution().localSize(), this->blockSize(), ld);
 
   SizeType memory_size = layout.minMemSize();
-  memory::MemoryView<ElementType, device> mem(memory_size);
+  memory::MemoryView<ElementType, D> mem(memory_size);
 
   setUpTiles(mem, layout);
 }
 
-template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution distribution, const LayoutInfo& layout) noexcept
-    : Matrix<const T, device>(std::move(distribution)) {
+template <class T, Device D>
+Matrix<T, D>::Matrix(Distribution distribution, const LayoutInfo& layout) noexcept
+    : Matrix<const T, D>(std::move(distribution)) {
   DLAF_ASSERT(this->distribution().localSize() == layout.size(),
               "Size of distribution does not match layout size!", distribution.localSize(),
               layout.size());
   DLAF_ASSERT(this->distribution().blockSize() == layout.blockSize(), distribution.blockSize(),
               layout.blockSize());
 
-  memory::MemoryView<ElementType, device> mem(layout.minMemSize());
+  memory::MemoryView<ElementType, D> mem(layout.minMemSize());
 
   setUpTiles(mem, layout);
 }
 
-template <class T, Device device>
-Matrix<T, device>::Matrix(Distribution distribution, const LayoutInfo& layout, ElementType* ptr) noexcept
-    : Matrix<const T, device>(std::move(distribution), layout, ptr) {}
+template <class T, Device D>
+Matrix<T, D>::Matrix(Distribution distribution, const LayoutInfo& layout, ElementType* ptr) noexcept
+    : Matrix<const T, D>(std::move(distribution), layout, ptr) {}
 
-template <class T, Device device>
-Matrix<T, device>::Matrix(const LayoutInfo& layout, ElementType* ptr)
-    : Matrix<const T, device>(layout, ptr) {}
+template <class T, Device D>
+Matrix<T, D>::Matrix(const LayoutInfo& layout, ElementType* ptr) : Matrix<const T, D>(layout, ptr) {}
 
-template <class T, Device device>
-pika::future<Tile<T, device>> Matrix<T, device>::operator()(const LocalTileIndex& index) noexcept {
+template <class T, Device D>
+pika::future<Tile<T, D>> Matrix<T, D>::operator()(const LocalTileIndex& index) noexcept {
   const auto i = tileLinearIndex(index);
   return tile_managers_[i].getRWTileFuture();
 }

--- a/include/dlaf/matrix/matrix_view.h
+++ b/include/dlaf/matrix/matrix_view.h
@@ -25,19 +25,19 @@
 namespace dlaf {
 namespace matrix {
 
-template <class T, Device device>
+template <class T, Device D>
 class MatrixView;
 
-template <class T, Device device>
-class MatrixView<const T, device> : public internal::MatrixBase {
+template <class T, Device D>
+class MatrixView<const T, D> : public internal::MatrixBase {
 public:
   using ElementType = T;
-  using TileType = Tile<ElementType, device>;
-  using ConstTileType = Tile<const ElementType, device>;
+  using TileType = Tile<ElementType, D>;
+  using ConstTileType = Tile<const ElementType, D>;
 
   template <template <class, Device> class MatrixType, class T2,
             std::enable_if_t<std::is_same_v<T, std::remove_const_t<T2>>, int> = 0>
-  MatrixView(blas::Uplo uplo, MatrixType<T2, device>& matrix);
+  MatrixView(blas::Uplo uplo, MatrixType<T2, D>& matrix);
 
   MatrixView(const MatrixView& rhs) = delete;
   MatrixView(MatrixView&& rhs) = default;
@@ -82,18 +82,18 @@ public:
 private:
   template <template <class, Device> class MatrixType, class T2,
             std::enable_if_t<std::is_same_v<T, std::remove_const_t<T2>>, int> = 0>
-  void setUpTiles(MatrixType<T2, device>& matrix) noexcept;
+  void setUpTiles(MatrixType<T2, D>& matrix) noexcept;
 
   std::vector<pika::shared_future<ConstTileType>> tile_shared_futures_;
 };
 
-template <template <class, Device> class MatrixType, class T, Device device>
-MatrixView<std::add_const_t<T>, device> getConstView(blas::Uplo uplo, MatrixType<T, device>& matrix) {
-  return MatrixView<std::add_const_t<T>, device>(uplo, matrix);
+template <template <class, Device> class MatrixType, class T, Device D>
+MatrixView<std::add_const_t<T>, D> getConstView(blas::Uplo uplo, MatrixType<T, D>& matrix) {
+  return MatrixView<std::add_const_t<T>, D>(uplo, matrix);
 }
 
-template <template <class, Device> class MatrixType, class T, Device device>
-MatrixView<std::add_const_t<T>, device> getConstView(MatrixType<T, device>& matrix) {
+template <template <class, Device> class MatrixType, class T, Device D>
+MatrixView<std::add_const_t<T>, D> getConstView(MatrixType<T, D>& matrix) {
   return getConstView(blas::Uplo::General, matrix);
 }
 

--- a/include/dlaf/matrix/matrix_view_const.tpp
+++ b/include/dlaf/matrix/matrix_view_const.tpp
@@ -13,33 +13,31 @@
 namespace dlaf {
 namespace matrix {
 
-template <class T, Device device>
+template <class T, Device D>
 template <template <class, Device> class MatrixType, class T2,
           std::enable_if_t<std::is_same_v<T, std::remove_const_t<T2>>, int>>
-MatrixView<const T, device>::MatrixView(blas::Uplo uplo, MatrixType<T2, device>& matrix)
-    : MatrixBase(matrix) {
+MatrixView<const T, D>::MatrixView(blas::Uplo uplo, MatrixType<T2, D>& matrix) : MatrixBase(matrix) {
   if (uplo != blas::Uplo::General)
     DLAF_UNIMPLEMENTED(uplo);
   setUpTiles(matrix);
 }
 
-template <class T, Device device>
-pika::shared_future<Tile<const T, device>> MatrixView<const T, device>::read(
-    const LocalTileIndex& index) noexcept {
+template <class T, Device D>
+pika::shared_future<Tile<const T, D>> MatrixView<const T, D>::read(const LocalTileIndex& index) noexcept {
   const auto i = tileLinearIndex(index);
   return tile_shared_futures_[i];
 }
 
-template <class T, Device device>
-void MatrixView<const T, device>::done(const LocalTileIndex& index) noexcept {
+template <class T, Device D>
+void MatrixView<const T, D>::done(const LocalTileIndex& index) noexcept {
   const auto i = tileLinearIndex(index);
   tile_shared_futures_[i] = {};
 }
 
-template <class T, Device device>
+template <class T, Device D>
 template <template <class, Device> class MatrixType, class T2,
           std::enable_if_t<std::is_same_v<T, std::remove_const_t<T2>>, int>>
-void MatrixView<const T, device>::setUpTiles(MatrixType<T2, device>& matrix) noexcept {
+void MatrixView<const T, D>::setUpTiles(MatrixType<T2, D>& matrix) noexcept {
   const auto& nr_tiles = matrix.distribution().localNrTiles();
   tile_shared_futures_.reserve(futureVectorSize(nr_tiles));
 

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -440,14 +440,14 @@ protected:
   std::set<SizeType> internal_;
 };
 
-template <Coord axis, class T, Device device>
-struct Panel : public Panel<axis, const T, device> {
-  using TileType = Tile<T, device>;
-  using ConstTileType = Tile<const T, device>;
+template <Coord axis, class T, Device D>
+struct Panel : public Panel<axis, const T, D> {
+  using TileType = Tile<T, D>;
+  using ConstTileType = Tile<const T, D>;
   using ElementType = T;
 
   explicit Panel(matrix::Distribution distribution, GlobalTileIndex start = {0, 0})
-      : Panel<axis, const T, device>(std::move(distribution), std::move(start)) {}
+      : Panel<axis, const T, D>(std::move(distribution), std::move(start)) {}
 
   /// Access tile at specified index in readwrite mode
   ///
@@ -474,7 +474,7 @@ struct Panel : public Panel<axis, const T, device> {
   }
 
 protected:
-  using BaseT = Panel<axis, const T, device>;
+  using BaseT = Panel<axis, const T, D>;
   using BaseT::dim_;
   using BaseT::has_been_used_;
   using BaseT::isFirstGlobalTile;

--- a/include/dlaf/matrix/print_numpy.h
+++ b/include/dlaf/matrix/print_numpy.h
@@ -79,8 +79,8 @@ void print(format::numpy, const Tile<const T, Device::CPU>& tile, std::ostream& 
      << ".reshape" << transposed(tile.size()) << ".T\n";
 }
 
-template <class T, Device device, template <class, Device> class MatrixLikeT>
-void print(format::numpy, std::string sym, MatrixLikeT<const T, device>& matrix,
+template <class T, Device D, template <class, Device> class MatrixLikeT>
+void print(format::numpy, std::string sym, MatrixLikeT<const T, D>& matrix,
            std::ostream& os = std::cout) {
   using common::iterate_range2d;
 

--- a/include/dlaf/memory/memory_chunk.h
+++ b/include/dlaf/memory/memory_chunk.h
@@ -33,7 +33,7 @@ umpire::Allocator& getUmpireDeviceAllocator();
 }
 
 /// The class @c MemoryChunk represents a layer of abstraction over the underlying device memory.
-template <class T, Device device>
+template <class T, Device D>
 class MemoryChunk {
 public:
   using ElementType = T;
@@ -54,14 +54,14 @@ public:
 
     std::size_t mem_size = static_cast<std::size_t>(size_) * sizeof(T);
 #ifdef DLAF_WITH_GPU
-    if (device == Device::CPU) {
+    if (D == Device::CPU) {
       ptr_ = static_cast<T*>(internal::getUmpireHostAllocator().allocate(mem_size));
     }
     else {
       ptr_ = static_cast<T*>(internal::getUmpireDeviceAllocator().allocate(mem_size));
     }
 #else
-    if (device == Device::CPU) {
+    if (D == Device::CPU) {
       ptr_ = static_cast<T*>(internal::getUmpireHostAllocator().allocate(mem_size));
     }
     else {
@@ -143,14 +143,14 @@ private:
   void deallocate() {
     if (allocated_) {
 #ifdef DLAF_WITH_GPU
-      if (device == Device::CPU) {
+      if (D == Device::CPU) {
         internal::getUmpireHostAllocator().deallocate(ptr_);
       }
       else {
         internal::getUmpireDeviceAllocator().deallocate(ptr_);
       }
 #else
-      if (device == Device::CPU) {
+      if (D == Device::CPU) {
         internal::getUmpireHostAllocator().deallocate(ptr_);
       }
 #endif

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -161,10 +161,12 @@ DLAF_MEMVIEW_ETI(extern, double, Device::CPU)
 DLAF_MEMVIEW_ETI(extern, std::complex<float>, Device::CPU)
 DLAF_MEMVIEW_ETI(extern, std::complex<double>, Device::CPU)
 
+#ifdef DLAF_WITH_GPU
 DLAF_MEMVIEW_ETI(extern, float, Device::GPU)
 DLAF_MEMVIEW_ETI(extern, double, Device::GPU)
 DLAF_MEMVIEW_ETI(extern, std::complex<float>, Device::GPU)
 DLAF_MEMVIEW_ETI(extern, std::complex<double>, Device::GPU)
+#endif
 
 }
 }

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -25,11 +25,11 @@ namespace memory {
 /// Two levels of constness exist for @c MemoryView analogously to pointer semantics:
 /// the constness of the view and the constness of the data referenced by the view.
 /// Implicit conversion is allowed from views of non-const elements to views of const elements.
-template <class T, Device device>
+template <class T, Device D>
 class MemoryView {
 public:
   using ElementType = std::remove_const_t<T>;
-  friend MemoryView<const ElementType, device>;
+  friend MemoryView<const ElementType, D>;
 
   /// Creates a MemoryView of size 0.
   MemoryView() : memory_(), offset_(0), size_(0) {}
@@ -41,8 +41,8 @@ public:
   /// Memory of @p size elements of type @c T is allocated on the given device.
   template <class U = T, class = typename std::enable_if_t<!std::is_const_v<U> && std::is_same_v<T, U>>>
   explicit MemoryView(SizeType size)
-      : memory_(size > 0 ? std::make_shared<MemoryChunk<ElementType, device>>(size) : nullptr),
-        offset_(0), size_(size) {
+      : memory_(size > 0 ? std::make_shared<MemoryChunk<ElementType, D>>(size) : nullptr), offset_(0),
+        size_(size) {
     DLAF_ASSERT(size >= 0, size);
   }
 
@@ -52,14 +52,14 @@ public:
   /// @param size The size (in number of elements of type @c T) of the existing allocation,
   /// @pre @p ptr+i can be deferenced for 0 < @c i < @p size.
   MemoryView(T* ptr, SizeType size)
-      : memory_(std::make_shared<MemoryChunk<ElementType, device>>(const_cast<ElementType*>(ptr), size)),
+      : memory_(std::make_shared<MemoryChunk<ElementType, D>>(const_cast<ElementType*>(ptr), size)),
         offset_(0), size_(size) {
     DLAF_ASSERT(size >= 0, size);
   }
 
   MemoryView(const MemoryView&) = default;
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
-  MemoryView(const MemoryView<ElementType, device>& rhs)
+  MemoryView(const MemoryView<ElementType, D>& rhs)
       : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {}
 
   MemoryView(MemoryView&& rhs)
@@ -69,9 +69,9 @@ public:
   }
 
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
-  MemoryView(MemoryView<ElementType, device>&& rhs)
+  MemoryView(MemoryView<ElementType, D>&& rhs)
       : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {
-    rhs.memory_ = std::make_shared<MemoryChunk<ElementType, device>>();
+    rhs.memory_ = std::make_shared<MemoryChunk<ElementType, D>>();
     rhs.size_ = 0;
     rhs.offset_ = 0;
   }
@@ -88,7 +88,7 @@ public:
     DLAF_ASSERT(offset + size <= memory_view.size_, offset + size, memory_view.size_);
   }
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
-  MemoryView(const MemoryView<ElementType, device>& memory_view, SizeType offset, SizeType size)
+  MemoryView(const MemoryView<ElementType, D>& memory_view, SizeType offset, SizeType size)
       : memory_(size > 0 ? memory_view.memory_ : nullptr),
         offset_(size > 0 ? offset + memory_view.offset_ : 0), size_(size) {
     DLAF_ASSERT(offset + size <= memory_view.size_, offset + size, memory_view.size_);
@@ -96,7 +96,7 @@ public:
 
   MemoryView& operator=(const MemoryView&) = default;
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
-  MemoryView& operator=(const MemoryView<ElementType, device>& rhs) {
+  MemoryView& operator=(const MemoryView<ElementType, D>& rhs) {
     memory_ = rhs.memory_;
     offset_ = rhs.offset_;
     size_ = rhs.size_;
@@ -115,7 +115,7 @@ public:
     return *this;
   }
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
-  MemoryView& operator=(MemoryView<ElementType, device>&& rhs) {
+  MemoryView& operator=(MemoryView<ElementType, D>&& rhs) {
     memory_ = std::move(rhs.memory_);
     offset_ = rhs.offset_;
     size_ = rhs.size_;
@@ -147,7 +147,7 @@ public:
   }
 
 private:
-  std::shared_ptr<MemoryChunk<ElementType, device>> memory_;
+  std::shared_ptr<MemoryChunk<ElementType, D>> memory_;
   SizeType offset_;
   SizeType size_;
 };
@@ -161,10 +161,10 @@ DLAF_MEMVIEW_ETI(extern, double, Device::CPU)
 DLAF_MEMVIEW_ETI(extern, std::complex<float>, Device::CPU)
 DLAF_MEMVIEW_ETI(extern, std::complex<double>, Device::CPU)
 
-// DLAF_MEMVIEW_ETI(extern, float, Device::GPU)
-// DLAF_MEMVIEW_ETI(extern, double, Device::GPU)
-// DLAF_MEMVIEW_ETI(extern, std::complex<float>, Device::GPU)
-// DLAF_MEMVIEW_ETI(extern, std::complex<double>, Device::GPU)
+DLAF_MEMVIEW_ETI(extern, float, Device::GPU)
+DLAF_MEMVIEW_ETI(extern, double, Device::GPU)
+DLAF_MEMVIEW_ETI(extern, std::complex<float>, Device::GPU)
+DLAF_MEMVIEW_ETI(extern, std::complex<double>, Device::GPU)
 
 }
 }

--- a/include/dlaf/sender/with_temporary_tile.h
+++ b/include/dlaf/sender/with_temporary_tile.h
@@ -99,7 +99,7 @@ auto withTemporaryTile(InSender&& in_sender, F&& f) {
          // Start a new asynchronous scope for keeping the input tile alive
          // until all asynchronous operations are done.
          ex::let_value(pika::unwrapping([f = std::forward<F>(f)](auto& in) mutable {
-           constexpr Device in_device_type = std::decay_t<decltype(in)>::D;
+           constexpr Device in_device_type = std::decay_t<decltype(in)>::device;
            constexpr Backend copy_backend = CopyBackend_v<in_device_type, destination_device>;
 
            // In cases that we cannot use the input tile as the temporary tile we need to:

--- a/include/dlaf/types.h
+++ b/include/dlaf/types.h
@@ -89,7 +89,7 @@ template <Backend backend>
 inline constexpr Device DefaultDevice_v = DefaultDevice<backend>::value;
 
 /// Default backend given a device.
-template <Device device>
+template <Device D>
 struct DefaultBackend;
 
 template <>
@@ -102,8 +102,8 @@ struct DefaultBackend<Device::GPU> {
   static constexpr Backend value = Backend::GPU;
 };
 
-template <Device device>
-inline constexpr Backend DefaultBackend_v = DefaultBackend<device>::value;
+template <Device D>
+inline constexpr Backend DefaultBackend_v = DefaultBackend<D>::value;
 
 template <class T>
 struct TypeInfo;

--- a/include/dlaf/util_blas.h
+++ b/include/dlaf/util_blas.h
@@ -27,11 +27,9 @@ struct gemmSizes {
   const SizeType k;
 };
 
-template <typename T, Device device>
-gemmSizes getGemmSizes(const blas::Op op_a, const blas::Op op_b,
-                       const dlaf::matrix::Tile<const T, device>& a,
-                       const dlaf::matrix::Tile<const T, device>& b,
-                       const dlaf::matrix::Tile<T, device>& c) {
+template <typename T, Device D>
+gemmSizes getGemmSizes(const blas::Op op_a, const blas::Op op_b, const dlaf::matrix::Tile<const T, D>& a,
+                       const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
   SizeType m;
   SizeType n;
   SizeType k;
@@ -67,10 +65,9 @@ struct hemmSizes {
   const SizeType n;
 };
 
-template <typename T, Device device>
-hemmSizes getHemmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, device>& a,
-                       const dlaf::matrix::Tile<const T, device>& b,
-                       const dlaf::matrix::Tile<T, device>& c) {
+template <typename T, Device D>
+hemmSizes getHemmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
+                       const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
   const hemmSizes s{c.size().rows(), c.size().cols()};
 
   if (side == blas::Side::Left) {
@@ -92,10 +89,9 @@ struct her2kSizes {
   const SizeType k;
 };
 
-template <typename T, Device device>
-her2kSizes getHer2kSizes(blas::Op op, const dlaf::matrix::Tile<const T, device>& a,
-                         const dlaf::matrix::Tile<const T, device>& b,
-                         const dlaf::matrix::Tile<T, device>& c) {
+template <typename T, Device D>
+her2kSizes getHer2kSizes(blas::Op op, const dlaf::matrix::Tile<const T, D>& a,
+                         const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
   const SizeType rows = a.size().rows();
   const SizeType cols = a.size().cols();
   const auto s = (op == blas::Op::NoTrans) ? her2kSizes{rows, cols} : her2kSizes{cols, rows};
@@ -114,9 +110,9 @@ struct herkSizes {
   const SizeType k;
 };
 
-template <typename T, Device device>
-herkSizes getHerkSizes(const blas::Op op, const dlaf::matrix::Tile<const T, device>& a,
-                       const dlaf::matrix::Tile<T, device>& c) {
+template <typename T, Device D>
+herkSizes getHerkSizes(const blas::Op op, const dlaf::matrix::Tile<const T, D>& a,
+                       const dlaf::matrix::Tile<T, D>& c) {
   const SizeType rows = a.size().rows();
   const SizeType cols = a.size().cols();
   const auto s = (op == blas::Op::NoTrans) ? herkSizes{rows, cols} : herkSizes{cols, rows};
@@ -133,9 +129,9 @@ struct trmmSizes {
   const SizeType n;
 };
 
-template <typename T, Device device>
-trmmSizes getTrmmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, device>& a,
-                       const dlaf::matrix::Tile<T, device>& b) {
+template <typename T, Device D>
+trmmSizes getTrmmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
+                       const dlaf::matrix::Tile<T, D>& b) {
   trmmSizes s{b.size().rows(), b.size().cols()};
   const auto b_side = (side == blas::Side::Left ? s.m : s.n);
 
@@ -145,10 +141,9 @@ trmmSizes getTrmmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, 
   return s;
 }
 
-template <typename T, Device device>
-trmmSizes getTrmm3Sizes(const blas::Side side, const dlaf::matrix::Tile<const T, device>& a,
-                        const dlaf::matrix::Tile<const T, device>& b,
-                        const dlaf::matrix::Tile<T, device>& c) {
+template <typename T, Device D>
+trmmSizes getTrmm3Sizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
+                        const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
   DLAF_ASSERT(b.size() == c.size(), b, c);
   return getTrmmSizes(side, a, c);
 }
@@ -158,9 +153,9 @@ struct trsmSizes {
   const SizeType n;
 };
 
-template <typename T, Device device>
-trsmSizes getTrsmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, device>& a,
-                       const dlaf::matrix::Tile<T, device>& b) {
+template <typename T, Device D>
+trsmSizes getTrsmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
+                       const dlaf::matrix::Tile<T, D>& b) {
   trsmSizes s{b.size().rows(), b.size().cols()};
 
   DLAF_ASSERT(square_size(a), a);

--- a/miniapp/include/dlaf/miniapp/work_tiles.h
+++ b/miniapp/include/dlaf/miniapp/work_tiles.h
@@ -23,10 +23,10 @@ namespace dlaf::miniapp {
 /// Creates a set of tiles that can be used to benchmark kernels.
 ///
 /// It helps removing the cache effect when the same tile is used multiple times.
-template <class T, Device device>
+template <class T, Device D>
 class WorkTiles {
 public:
-  using TileType = matrix::Tile<T, device>;
+  using TileType = matrix::Tile<T, D>;
 
   WorkTiles(SizeType count, SizeType m, SizeType n, SizeType ld) noexcept {
     DLAF_ASSERT(count > 0, count);
@@ -37,12 +37,11 @@ public:
     const SizeType chunk_size = ld * n;
     const SizeType chunks = util::ceilDiv(count, tiles_in_chunk);
 
-    memory::MemoryView<T, device> mem(chunks * chunk_size);
+    memory::MemoryView<T, D> mem(chunks * chunk_size);
 
     for (SizeType i = 0; i < count; ++i) {
-      memory::MemoryView<T, device> sub_mem(mem,
-                                            i % tiles_in_chunk * m + i / tiles_in_chunk * chunk_size,
-                                            ld * (n - 1) + m);
+      memory::MemoryView<T, D> sub_mem(mem, i % tiles_in_chunk * m + i / tiles_in_chunk * chunk_size,
+                                       ld * (n - 1) + m);
       tiles_.emplace_back(TileElementSize(m, n), std::move(sub_mem), ld);
     }
   }

--- a/src/memory/memory_view.cpp
+++ b/src/memory/memory_view.cpp
@@ -18,10 +18,12 @@ DLAF_MEMVIEW_ETI(, double, Device::CPU)
 DLAF_MEMVIEW_ETI(, std::complex<float>, Device::CPU)
 DLAF_MEMVIEW_ETI(, std::complex<double>, Device::CPU)
 
-// DLAF_MEMVIEW_ETI(, float, Device::GPU)
-// DLAF_MEMVIEW_ETI(, double, Device::GPU)
-// DLAF_MEMVIEW_ETI(, std::complex<float>, Device::GPU)
-// DLAF_MEMVIEW_ETI(, std::complex<double>, Device::GPU)
+#ifdef DLAF_WITH_GPU
+DLAF_MEMVIEW_ETI(, float, Device::GPU)
+DLAF_MEMVIEW_ETI(, double, Device::GPU)
+DLAF_MEMVIEW_ETI(, std::complex<float>, Device::GPU)
+DLAF_MEMVIEW_ETI(, std::complex<double>, Device::GPU)
+#endif
 
 }
 }

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -36,14 +36,14 @@ namespace test {
 template <class MatrixType>
 struct matrix_traits;
 
-template <template <class, Device> class MatrixLike, class T, Device device>
-struct matrix_traits<MatrixLike<T, device>> {
+template <template <class, Device> class MatrixLike, class T, Device D>
+struct matrix_traits<MatrixLike<T, D>> {
   using ElementT = std::remove_cv_t<T>;
   using has_distribution = std::true_type;
 };
 
-template <class T, Device device>
-struct matrix_traits<Tile<T, device>> {
+template <class T, Device D>
+struct matrix_traits<Tile<T, D>> {
   using ElementT = std::remove_cv_t<T>;
   using has_distribution = std::false_type;
 };

--- a/test/include/dlaf_test/matrix/util_matrix_futures.h
+++ b/test/include/dlaf_test/matrix/util_matrix_futures.h
@@ -28,11 +28,11 @@ namespace test {
 ///
 /// The futures are created using the matrix method operator()(const LocalTileIndex&).
 /// Note: This function is interchangeable with getFuturesUsingGlobalIndex.
-template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<pika::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<T, device>& mat) {
+template <template <class, Device> class MatrixType, class T, Device D>
+std::vector<pika::future<Tile<T, D>>> getFuturesUsingLocalIndex(MatrixType<T, D>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<pika::future<Tile<T, device>>> result;
+  std::vector<pika::future<Tile<T, D>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.localNrTiles().cols(); ++j) {
@@ -48,11 +48,11 @@ std::vector<pika::future<Tile<T, device>>> getFuturesUsingLocalIndex(MatrixType<
 ///
 /// The futures are created using the matrix method operator()(const GlobalTileIndex&).
 /// Note: This function is interchangeable with getFuturesUsingLocalIndex.
-template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<pika::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType<T, device>& mat) {
+template <template <class, Device> class MatrixType, class T, Device D>
+std::vector<pika::future<Tile<T, D>>> getFuturesUsingGlobalIndex(MatrixType<T, D>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<pika::future<Tile<T, device>>> result;
+  std::vector<pika::future<Tile<T, D>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {
@@ -73,12 +73,12 @@ std::vector<pika::future<Tile<T, device>>> getFuturesUsingGlobalIndex(MatrixType
 ///
 /// The futures are created using the matrix method read(const LocalTileIndex&).
 /// Note: This function is interchangeable with getSharedFuturesUsingGlobalIndex.
-template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<pika::shared_future<Tile<const T, device>>> getSharedFuturesUsingLocalIndex(
-    MatrixType<T, device>& mat) {
+template <template <class, Device> class MatrixType, class T, Device D>
+std::vector<pika::shared_future<Tile<const T, D>>> getSharedFuturesUsingLocalIndex(
+    MatrixType<T, D>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<pika::shared_future<Tile<const T, device>>> result;
+  std::vector<pika::shared_future<Tile<const T, D>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.localNrTiles().cols(); ++j) {
@@ -95,12 +95,12 @@ std::vector<pika::shared_future<Tile<const T, device>>> getSharedFuturesUsingLoc
 ///
 /// The futures are created using the matrix method read(const GlobalTileIndex&).
 /// Note: This function is interchangeable with getSharedFuturesUsingLocalIndex.
-template <template <class, Device> class MatrixType, class T, Device device>
-std::vector<pika::shared_future<Tile<const T, device>>> getSharedFuturesUsingGlobalIndex(
-    MatrixType<T, device>& mat) {
+template <template <class, Device> class MatrixType, class T, Device D>
+std::vector<pika::shared_future<Tile<const T, D>>> getSharedFuturesUsingGlobalIndex(
+    MatrixType<T, D>& mat) {
   const matrix::Distribution& dist = mat.distribution();
 
-  std::vector<pika::shared_future<Tile<const T, device>>> result;
+  std::vector<pika::shared_future<Tile<const T, D>>> result;
   result.reserve(static_cast<std::size_t>(dist.localNrTiles().linear_size()));
 
   for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {

--- a/test/unit/communication/test_comm_p2p.cpp
+++ b/test/unit/communication/test_comm_p2p.cpp
@@ -56,7 +56,7 @@ using P2PTestGPU = P2PTest<Device::GPU>;
 
 template <class T, class SenderTile>
 auto setTileTo(SenderTile&& tile, const T input_value) {
-  constexpr auto D = internal::SenderSingleValueType<SenderTile>::D;
+  constexpr auto D = internal::SenderSingleValueType<SenderTile>::device;
   return internal::whenAllLift(blas::Uplo::General, input_value, input_value,
                                std::forward<SenderTile>(tile)) |
          tile::laset(internal::Policy<DefaultBackend_v<D>>());
@@ -64,7 +64,7 @@ auto setTileTo(SenderTile&& tile, const T input_value) {
 
 template <class SenderTile, class TileLike>
 auto checkTileEq(TileLike&& ref_tile, SenderTile&& tile) {
-  constexpr auto D = internal::SenderSingleValueType<SenderTile>::D;
+  constexpr auto D = internal::SenderSingleValueType<SenderTile>::device;
   return std::forward<SenderTile>(tile) |
          internal::transform(internal::Policy<DefaultBackend_v<D>>(), matrix::Duplicate<Device::CPU>{}) |
          ex::then([&](const auto& tile_cpu) { CHECK_TILE_EQ(ref_tile, tile_cpu); });

--- a/test/unit/communication/test_comm_p2p.cpp
+++ b/test/unit/communication/test_comm_p2p.cpp
@@ -118,8 +118,8 @@ TEST_F(P2PTestGPU, SendRecv) {
 }
 #endif
 
-template <class T, Device device>
-void testSendRecvMixTags(comm::Communicator world, matrix::Matrix<T, device> matrix) {
+template <class T, Device D>
+void testSendRecvMixTags(comm::Communicator world, matrix::Matrix<T, D> matrix) {
   // This test involves just 2 ranks, where rank_src sends all tiles allowing to "mirror" the
   // entire matrix on rank_dst. P2P communications are issued by the different ranks in different
   // orders, linking them using the tag of the MPI communication.

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -73,24 +73,25 @@ GlobalElementSize globalTestSize(const LocalElementSize& size, const Size2D& gri
 }
 
 TYPED_TEST(MatrixLocalTest, StaticAPI) {
-  constexpr Device D = Device::CPU;
+  constexpr Device device = Device::CPU;
 
-  using matrix_t = Matrix<TypeParam, D>;
+  using matrix_t = Matrix<TypeParam, device>;
 
   static_assert(std::is_same_v<TypeParam, typename matrix_t::ElementType>, "wrong ElementType");
-  static_assert(std::is_same_v<Tile<TypeParam, D>, typename matrix_t::TileType>, "wrong TileType");
-  static_assert(std::is_same_v<Tile<const TypeParam, D>, typename matrix_t::ConstTileType>,
+  static_assert(std::is_same_v<Tile<TypeParam, device>, typename matrix_t::TileType>, "wrong TileType");
+  static_assert(std::is_same_v<Tile<const TypeParam, device>, typename matrix_t::ConstTileType>,
                 "wrong ConstTileType");
 }
 
 TYPED_TEST(MatrixLocalTest, StaticAPIConst) {
-  constexpr Device D = Device::CPU;
+  constexpr Device device = Device::CPU;
 
-  using const_matrix_t = Matrix<const TypeParam, D>;
+  using const_matrix_t = Matrix<const TypeParam, device>;
 
   static_assert(std::is_same_v<TypeParam, typename const_matrix_t::ElementType>, "wrong ElementType");
-  static_assert(std::is_same_v<Tile<TypeParam, D>, typename const_matrix_t::TileType>, "wrong TileType");
-  static_assert(std::is_same_v<Tile<const TypeParam, D>, typename const_matrix_t::ConstTileType>,
+  static_assert(std::is_same_v<Tile<TypeParam, device>, typename const_matrix_t::TileType>,
+                "wrong TileType");
+  static_assert(std::is_same_v<Tile<const TypeParam, device>, typename const_matrix_t::ConstTileType>,
                 "wrong ConstTileType");
 }
 
@@ -1230,7 +1231,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadwrite) {
 // usage, but they are just meant to test that the Matrix does not wait on destruction for any left
 // task on one of its tiles.
 
-constexpr Device D = dlaf::Device::CPU;
+constexpr Device device = dlaf::Device::CPU;
 using T = std::complex<float>;  // randomly chosen element type for matrix
 
 // wait for guard to become true
@@ -1243,13 +1244,13 @@ auto try_waiting_guard = [](auto& guard) {
 
 // Create a single-element matrix
 template <class T>
-auto createMatrix() -> Matrix<T, D> {
+auto createMatrix() -> Matrix<T, device> {
   return {{1, 1}, {1, 1}};
 }
 
 // Create a single-element matrix with user-provided memory
 template <class T>
-auto createMatrix(T& data) -> Matrix<T, D> {
+auto createMatrix(T& data) -> Matrix<T, device> {
   return createMatrixFromColMajor<Device::CPU>({1, 1}, {1, 1}, 1, &data);
 }
 

--- a/test/unit/matrix/test_matrix_view.cpp
+++ b/test/unit/matrix/test_matrix_view.cpp
@@ -92,8 +92,8 @@ TYPED_TEST(MatrixLocalViewTest, StaticAPIConst) {
 //}
 
 // TODO (Upper and Lower cases NOT yet implemented)
-template <template <class, Device> class MatrixType, class T, Device device, class ElementGetter>
-void checkConstructorConst(MatrixType<T, device>& matrix, ElementGetter el) {
+template <template <class, Device> class MatrixType, class T, Device D, class ElementGetter>
+void checkConstructorConst(MatrixType<T, D>& matrix, ElementGetter el) {
   const auto& distribution = matrix.distribution();
 
   for (const auto& uplo : blas_uplos) {

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -44,8 +44,8 @@ SizeType elIndex(TileElementIndex index, SizeType ld) {
 
 using TileSizes = std::tuple<TileElementSize, SizeType>;
 
-template <class T, Device device>
-TileSizes getSizes(const Tile<T, device>& tile) {
+template <class T, Device D>
+TileSizes getSizes(const Tile<T, D>& tile) {
   return TileSizes(tile.size(), tile.ld());
 }
 

--- a/test/unit/sender/test_with_temporary_tile.cpp
+++ b/test/unit/sender/test_with_temporary_tile.cpp
@@ -21,24 +21,24 @@ using namespace dlaf;
 namespace ex = pika::execution::experimental;
 namespace tt = pika::this_thread::experimental;
 
-template <class T, Device device>
+template <class T, Device D>
 auto newBlockMatrixContiguous() {
   auto layout = matrix::colMajorLayout({13, 13}, {13, 13}, 13);
   auto dist = matrix::Distribution({13, 13}, {13, 13});
 
-  auto matrix = matrix::Matrix<T, device>(dist, layout);
+  auto matrix = matrix::Matrix<T, D>(dist, layout);
 
   EXPECT_TRUE(data_iscontiguous(common::make_data(matrix.read(LocalTileIndex(0, 0)).get())));
 
   return matrix;
 }
 
-template <class T, Device device>
+template <class T, Device D>
 auto newBlockMatrixStrided() {
   auto layout = matrix::colMajorLayout({13, 13}, {13, 13}, 26);
   auto dist = matrix::Distribution({13, 13}, {13, 13});
 
-  auto matrix = matrix::Matrix<T, device>(dist, layout);
+  auto matrix = matrix::Matrix<T, D>(dist, layout);
 
   EXPECT_FALSE(data_iscontiguous(common::make_data(matrix.read(LocalTileIndex(0, 0)).get())));
 


### PR DESCRIPTION
Following https://github.com/eth-cscs/DLA-Future/pull/683#discussion_r1003142943

I tried to keep it as "minimal" as possible, since I don't want to interfere much with others PRs, and moreover there is no need to actually fully address this issue right now.

Main points:
- Rename `device` to `D` as template parameter for Matrix, Tile, Panel and related
- Normalize Device D template in `util_blas`
- MatrixMemory ETI for GPU

Template naming will still not be fully consistent after this PR.

Just a couple of examples:
- not all algorithms follow the `Device D` template parameter naming
- `Backend backend` has not been yet addressed

Moreover, as a side discussion, it might be relevant to define (for a later PR), if we want to accomunate also `using T = Matrix::ElementType` to the snake_case convention (as we are apparently aiming for `constexpr Device device = Matrix::device`).