### PR TITLE
Build static libraries of all the intermediate DLA-Future object libraries

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -32,6 +32,16 @@ with section("parse"):
         "MPIRANKS": '1',
       }
     },
+    "DLAF_addSublibrary": {
+      "pargs": 1,
+      "flags": [],
+      "kwargs": {
+        "SOURCES": '*',
+        "GPU_SOURCES": '*',
+        "COMPILE_OPTIONS": '*',
+        "LIBRARIES": '*',
+      }
+    },
     "DLAF_addPrecompiledHeaders": {
       "pargs": 1,
     },

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,152 +135,131 @@ if(DLAF_WITH_PRECOMPILED_HEADERS)
   target_precompile_headers(dlaf.pch_exe PRIVATE ${precompiled_headers})
 endif()
 
-# Define DLAF's CORE library
-add_library(dlaf.core_obj
-  OBJECT
-    communication/communicator_impl.cpp
-    communication/communicator.cpp
-    communication/communicator_grid.cpp
-    communication/datatypes.cpp
-    init.cpp
-    matrix/distribution.cpp
-    matrix/layout_info.cpp
-    matrix/tile.cpp
-    matrix.cpp
-    matrix_mirror.cpp
-    memory/memory_view.cpp
-    memory/memory_chunk.cpp
-)
+# Helper function for creating sub-libraries that libDLAF consists of. It
+# creates two variants of the library: one object library with the name
+# dlaf.${name}_object and one static/shared library with the name dlaf.${name}.
+# The object libraries are only meant for creating libDLAF. The static/shared
+# libraries are meant for internal use in tests and miniapps.
+function(DLAF_addSublibrary name)
+  set(options "")
+  set(oneValueArgs "")
+  set(multiValueArgs SOURCES GPU_SOURCES COMPILE_OPTIONS LIBRARIES)
+  cmake_parse_arguments(DLAF_ASL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-if(DLAF_WITH_GPU)
-  set(dlaf_core_gpu_source_files
-    cusolver/assert_info.cu
-    cusolver/stedc.cu
-    lapack/gpu/lacpy.cu
-    lapack/gpu/laset.cu
-  )
-  target_sources(dlaf.core_obj PRIVATE ${dlaf_core_gpu_source_files})
-  if(DLAF_WITH_HIP)
-    set_source_files_properties(${dlaf_core_gpu_source_files} PROPERTIES LANGUAGE HIP)
+  set(object_lib_name dlaf.${name}_object)
+  set(lib_name dlaf.${name})
+
+  add_library(${object_lib_name} OBJECT ${DLAF_ASL_SOURCES})
+  if(DLAF_WITH_GPU)
+    target_sources(${object_lib_name} PRIVATE ${DLAF_ASL_GPU_SOURCES})
+    if(DLAF_WITH_HIP)
+      set_source_files_properties(${DLAF_ASL_GPU_SOURCES} PROPERTIES LANGUAGE HIP)
+    endif()
   endif()
-endif()
 
-target_compile_options(dlaf.core_obj PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
-target_link_libraries(dlaf.core_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.core_obj)
-DLAF_addPrecompiledHeaders(dlaf.core_obj)
-add_library(dlaf.core $<TARGET_OBJECTS:dlaf.core_obj>)
-target_link_libraries(dlaf.core PUBLIC dlaf.prop)
+  target_compile_options(${object_lib_name} PRIVATE ${DLAF_ASL_COMPILE_OPTIONS})
+  target_link_libraries(${object_lib_name} PRIVATE dlaf.prop)
+  target_add_warnings(${object_lib_name})
+  DLAF_addPrecompiledHeaders(${object_lib_name})
+  add_library(${lib_name} $<TARGET_OBJECTS:${object_lib_name}>)
+  target_link_libraries(${lib_name} PUBLIC dlaf.prop)
+  target_link_libraries(${lib_name} PUBLIC ${DLAF_ASL_LIBRARIES})
+endfunction()
+
+# Define DLAF's CORE library
+DLAF_addSublibrary(
+  core
+  SOURCES communication/communicator_impl.cpp
+          communication/communicator.cpp
+          communication/communicator_grid.cpp
+          communication/datatypes.cpp
+          init.cpp
+          matrix/distribution.cpp
+          matrix/layout_info.cpp
+          matrix/tile.cpp
+          matrix.cpp
+          matrix_mirror.cpp
+          memory/memory_view.cpp
+          memory/memory_chunk.cpp
+  GPU_SOURCES cusolver/assert_info.cu cusolver/stedc.cu lapack/gpu/lacpy.cu lapack/gpu/laset.cu
+  COMPILE_OPTIONS $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>
+)
 
 # Define DLAF's auxiliary library
-add_library(dlaf.auxiliary_obj OBJECT auxiliary/norm/mc.cpp)
-target_link_libraries(dlaf.auxiliary_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.auxiliary_obj)
-DLAF_addPrecompiledHeaders(dlaf.auxiliary_obj)
-add_library(dlaf.auxiliary $<TARGET_OBJECTS:dlaf.auxiliary_obj>)
-target_link_libraries(dlaf.auxiliary PUBLIC dlaf.core dlaf.prop)
+DLAF_addSublibrary(auxiliary SOURCES auxiliary/norm/mc.cpp LIBRARIES dlaf.core)
 
 # Define DLAF's eigensolver library
-add_library(
-  dlaf.eigensolver_obj OBJECT
-  eigensolver/band_to_tridiag/mc.cpp
-  eigensolver/bt_band_to_tridiag/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/bt_band_to_tridiag/gpu.cpp>
-  eigensolver/bt_reduction_to_band/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/bt_reduction_to_band/gpu.cpp>
-  eigensolver/eigensolver/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/eigensolver/gpu.cpp>
-  eigensolver/gen_eigensolver/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/gen_eigensolver/gpu.cpp>
-  eigensolver/gen_to_std/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/gen_to_std/gpu.cpp>
-  eigensolver/reduction_to_band/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/reduction_to_band/gpu.cpp>
+DLAF_addSublibrary(
+  eigensolver
+  SOURCES eigensolver/band_to_tridiag/mc.cpp
+          eigensolver/bt_band_to_tridiag/mc.cpp
+          $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/bt_band_to_tridiag/gpu.cpp>
+          eigensolver/bt_reduction_to_band/mc.cpp
+          $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/bt_reduction_to_band/gpu.cpp>
+          eigensolver/eigensolver/mc.cpp
+          $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/eigensolver/gpu.cpp>
+          eigensolver/gen_eigensolver/mc.cpp
+          $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/gen_eigensolver/gpu.cpp>
+          eigensolver/gen_to_std/mc.cpp
+          $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/gen_to_std/gpu.cpp>
+          eigensolver/reduction_to_band/mc.cpp
+          $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/reduction_to_band/gpu.cpp>
+  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.solver dlaf.factorization dlaf.core
 )
-target_link_libraries(dlaf.eigensolver_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.eigensolver_obj)
-DLAF_addPrecompiledHeaders(dlaf.eigensolver_obj)
-add_library(dlaf.eigensolver $<TARGET_OBJECTS:dlaf.eigensolver_obj>)
-target_link_libraries(dlaf.eigensolver PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's tridiagonal eigensolver library
-add_library(
-  dlaf.tridiagonal_eigensolver_obj OBJECT
-  eigensolver/tridiag_solver/mc.cpp
-  eigensolver/tridiag_solver/kernels.cpp
-  $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/tridiag_solver/gpu.cpp>
-  $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/tridiag_solver/kernels.cu>
+DLAF_addSublibrary(
+  tridiagonal_eigensolver
+  SOURCES eigensolver/tridiag_solver/mc.cpp
+          eigensolver/tridiag_solver/kernels.cpp
+          $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/tridiag_solver/gpu.cpp>
+          # TODO: This should be moved to GPU_SOURCES once HIP is supported for the
+          # tridiagonal solver.
+          $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/tridiag_solver/kernels.cu>
+  LIBRARIES dlaf.factorization dlaf.multiplication dlaf.permutations dlaf.solver dlaf.core
 )
-if (DLAF_WITH_HIP)
-    set_source_files_properties(eigensolver/tridiag_solver/kernels.cu PROPERTIES LANGUAGE HIP)
-endif()
-target_link_libraries(dlaf.tridiagonal_eigensolver_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.tridiagonal_eigensolver_obj)
-DLAF_addPrecompiledHeaders(dlaf.tridiagonal_eigensolver_obj)
-add_library(dlaf.tridiagonal_eigensolver $<TARGET_OBJECTS:dlaf.tridiagonal_eigensolver_obj>)
-target_link_libraries(dlaf.tridiagonal_eigensolver PUBLIC dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.core dlaf.prop)
 
 # Define DLAF's factorization library
-add_library(dlaf.factorization_obj OBJECT
-  factorization/cholesky/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:factorization/cholesky/gpu.cpp>
-  factorization/qr/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:factorization/qr/gpu.cpp>
+DLAF_addSublibrary(
+  factorization
+  SOURCES factorization/cholesky/mc.cpp $<$<BOOL:${DLAF_WITH_GPU}>:factorization/cholesky/gpu.cpp>
+          factorization/qr/mc.cpp $<$<BOOL:${DLAF_WITH_GPU}>:factorization/qr/gpu.cpp>
+  LIBRARIES dlaf.core
 )
-target_link_libraries(dlaf.factorization_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.factorization_obj)
-DLAF_addPrecompiledHeaders(dlaf.factorization_obj)
-add_library(dlaf.factorization $<TARGET_OBJECTS:dlaf.factorization_obj>)
-target_link_libraries(dlaf.factorization PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's multiplication library
-add_library(dlaf.multiplication_obj OBJECT
-  multiplication/general/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:multiplication/general/gpu.cpp>
-  multiplication/triangular/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:multiplication/triangular/gpu.cpp>)
-target_link_libraries(dlaf.multiplication_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.multiplication_obj)
-DLAF_addPrecompiledHeaders(dlaf.multiplication_obj)
-add_library(dlaf.multiplication $<TARGET_OBJECTS:dlaf.multiplication_obj>)
-target_link_libraries(dlaf.multiplication PUBLIC dlaf.core dlaf.prop)
+DLAF_addSublibrary(
+  multiplication
+  SOURCES multiplication/general/mc.cpp $<$<BOOL:${DLAF_WITH_GPU}>:multiplication/general/gpu.cpp>
+          multiplication/triangular/mc.cpp $<$<BOOL:${DLAF_WITH_GPU}>:multiplication/triangular/gpu.cpp>
+  LIBRARIES dlaf.core
+)
 
 # Define DLAF's permutations library
-add_library(
-  dlaf.permutations_obj OBJECT permutations/general/mc.cpp
-                           $<$<BOOL:${DLAF_WITH_GPU}>:permutations/general/gpu.cpp>
-                           $<$<BOOL:${DLAF_WITH_GPU}>:permutations/general/perms.cu>
+DLAF_addSublibrary(
+  permutations
+  SOURCES permutations/general/mc.cpp $<$<BOOL:${DLAF_WITH_GPU}>:permutations/general/gpu.cpp>
+  GPU_SOURCES permutations/general/perms.cu
+  LIBRARIES dlaf.core
 )
-if (DLAF_WITH_HIP)
-    set_source_files_properties(permutations/general/perms.cu PROPERTIES LANGUAGE HIP)
-endif()
-target_link_libraries(dlaf.permutations_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.permutations_obj)
-DLAF_addPrecompiledHeaders(dlaf.permutations_obj)
-add_library(dlaf.permutations $<TARGET_OBJECTS:dlaf.permutations_obj>)
-target_link_libraries(dlaf.permutations PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's solver library
-add_library(dlaf.solver_obj OBJECT
-  solver/triangular/mc.cpp
-  $<$<BOOL:${DLAF_WITH_GPU}>:solver/triangular/gpu.cpp>)
-target_link_libraries(dlaf.solver_obj PUBLIC dlaf.prop)
-target_add_warnings(dlaf.solver_obj)
-DLAF_addPrecompiledHeaders(dlaf.solver_obj)
-add_library(dlaf.solver $<TARGET_OBJECTS:dlaf.solver_obj>)
-target_link_libraries(dlaf.solver PUBLIC dlaf.core dlaf.prop)
+DLAF_addSublibrary(
+  solver SOURCES solver/triangular/mc.cpp $<$<BOOL:${DLAF_WITH_GPU}>:solver/triangular/gpu.cpp>
+  LIBRARIES dlaf.core
+)
 
 # Define DLAF's complete library
 add_library(
   DLAF
-  $<TARGET_OBJECTS:dlaf.core_obj>
-  $<TARGET_OBJECTS:dlaf.auxiliary_obj>
-  $<TARGET_OBJECTS:dlaf.eigensolver_obj>
-  $<TARGET_OBJECTS:dlaf.tridiagonal_eigensolver_obj>
-  $<TARGET_OBJECTS:dlaf.factorization_obj>
-  $<TARGET_OBJECTS:dlaf.multiplication_obj>
-  $<TARGET_OBJECTS:dlaf.permutations_obj>
-  $<TARGET_OBJECTS:dlaf.solver_obj>
+  $<TARGET_OBJECTS:dlaf.core_object>
+  $<TARGET_OBJECTS:dlaf.auxiliary_object>
+  $<TARGET_OBJECTS:dlaf.eigensolver_object>
+  $<TARGET_OBJECTS:dlaf.tridiagonal_eigensolver_object>
+  $<TARGET_OBJECTS:dlaf.factorization_object>
+  $<TARGET_OBJECTS:dlaf.multiplication_object>
+  $<TARGET_OBJECTS:dlaf.permutations_object>
+  $<TARGET_OBJECTS:dlaf.solver_object>
 )
 target_link_libraries(DLAF PUBLIC dlaf.prop)
 target_add_warnings(DLAF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,7 +136,7 @@ if(DLAF_WITH_PRECOMPILED_HEADERS)
 endif()
 
 # Define DLAF's CORE library
-add_library(dlaf.core
+add_library(dlaf.core_obj
   OBJECT
     communication/communicator_impl.cpp
     communication/communicator.cpp
@@ -159,26 +159,30 @@ if(DLAF_WITH_GPU)
     lapack/gpu/lacpy.cu
     lapack/gpu/laset.cu
   )
-  target_sources(dlaf.core PRIVATE ${dlaf_core_gpu_source_files})
+  target_sources(dlaf.core_obj PRIVATE ${dlaf_core_gpu_source_files})
   if(DLAF_WITH_HIP)
     set_source_files_properties(${dlaf_core_gpu_source_files} PROPERTIES LANGUAGE HIP)
   endif()
 endif()
 
-target_compile_options(dlaf.core PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
+target_compile_options(dlaf.core_obj PRIVATE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>)
+target_link_libraries(dlaf.core_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.core_obj)
+DLAF_addPrecompiledHeaders(dlaf.core_obj)
+add_library(dlaf.core $<TARGET_OBJECTS:dlaf.core_obj>)
 target_link_libraries(dlaf.core PUBLIC dlaf.prop)
-target_add_warnings(dlaf.core)
-DLAF_addPrecompiledHeaders(dlaf.core)
 
 # Define DLAF's auxiliary library
-add_library(dlaf.auxiliary OBJECT auxiliary/norm/mc.cpp)
-target_link_libraries(dlaf.auxiliary PUBLIC dlaf.prop)
-target_add_warnings(dlaf.auxiliary)
-DLAF_addPrecompiledHeaders(dlaf.auxiliary)
+add_library(dlaf.auxiliary_obj OBJECT auxiliary/norm/mc.cpp)
+target_link_libraries(dlaf.auxiliary_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.auxiliary_obj)
+DLAF_addPrecompiledHeaders(dlaf.auxiliary_obj)
+add_library(dlaf.auxiliary $<TARGET_OBJECTS:dlaf.auxiliary_obj>)
+target_link_libraries(dlaf.auxiliary PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's eigensolver library
 add_library(
-  dlaf.eigensolver OBJECT
+  dlaf.eigensolver_obj OBJECT
   eigensolver/band_to_tridiag/mc.cpp
   eigensolver/bt_band_to_tridiag/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/bt_band_to_tridiag/gpu.cpp>
@@ -193,13 +197,15 @@ add_library(
   eigensolver/reduction_to_band/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:eigensolver/reduction_to_band/gpu.cpp>
 )
-target_link_libraries(dlaf.eigensolver PUBLIC dlaf.prop)
-target_add_warnings(dlaf.eigensolver)
-DLAF_addPrecompiledHeaders(dlaf.eigensolver)
+target_link_libraries(dlaf.eigensolver_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.eigensolver_obj)
+DLAF_addPrecompiledHeaders(dlaf.eigensolver_obj)
+add_library(dlaf.eigensolver $<TARGET_OBJECTS:dlaf.eigensolver_obj>)
+target_link_libraries(dlaf.eigensolver PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's tridiagonal eigensolver library
 add_library(
-  dlaf.tridiagonal_eigensolver OBJECT
+  dlaf.tridiagonal_eigensolver_obj OBJECT
   eigensolver/tridiag_solver/mc.cpp
   eigensolver/tridiag_solver/kernels.cpp
   $<$<BOOL:${DLAF_WITH_CUDA}>:eigensolver/tridiag_solver/gpu.cpp>
@@ -208,63 +214,73 @@ add_library(
 if (DLAF_WITH_HIP)
     set_source_files_properties(eigensolver/tridiag_solver/kernels.cu PROPERTIES LANGUAGE HIP)
 endif()
-target_link_libraries(dlaf.tridiagonal_eigensolver PUBLIC dlaf.prop)
-target_add_warnings(dlaf.tridiagonal_eigensolver)
-DLAF_addPrecompiledHeaders(dlaf.tridiagonal_eigensolver)
+target_link_libraries(dlaf.tridiagonal_eigensolver_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.tridiagonal_eigensolver_obj)
+DLAF_addPrecompiledHeaders(dlaf.tridiagonal_eigensolver_obj)
+add_library(dlaf.tridiagonal_eigensolver $<TARGET_OBJECTS:dlaf.tridiagonal_eigensolver_obj>)
+target_link_libraries(dlaf.tridiagonal_eigensolver PUBLIC dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.core dlaf.prop)
 
 # Define DLAF's factorization library
-add_library(dlaf.factorization OBJECT
+add_library(dlaf.factorization_obj OBJECT
   factorization/cholesky/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:factorization/cholesky/gpu.cpp>
   factorization/qr/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:factorization/qr/gpu.cpp>
 )
-target_link_libraries(dlaf.factorization PUBLIC dlaf.prop)
-target_add_warnings(dlaf.factorization)
-DLAF_addPrecompiledHeaders(dlaf.factorization)
+target_link_libraries(dlaf.factorization_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.factorization_obj)
+DLAF_addPrecompiledHeaders(dlaf.factorization_obj)
+add_library(dlaf.factorization $<TARGET_OBJECTS:dlaf.factorization_obj>)
+target_link_libraries(dlaf.factorization PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's multiplication library
-add_library(dlaf.multiplication OBJECT
+add_library(dlaf.multiplication_obj OBJECT
   multiplication/general/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:multiplication/general/gpu.cpp>
   multiplication/triangular/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:multiplication/triangular/gpu.cpp>)
-target_link_libraries(dlaf.multiplication PUBLIC dlaf.prop)
-target_add_warnings(dlaf.multiplication)
-DLAF_addPrecompiledHeaders(dlaf.multiplication)
+target_link_libraries(dlaf.multiplication_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.multiplication_obj)
+DLAF_addPrecompiledHeaders(dlaf.multiplication_obj)
+add_library(dlaf.multiplication $<TARGET_OBJECTS:dlaf.multiplication_obj>)
+target_link_libraries(dlaf.multiplication PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's permutations library
 add_library(
-  dlaf.permutations OBJECT permutations/general/mc.cpp
+  dlaf.permutations_obj OBJECT permutations/general/mc.cpp
                            $<$<BOOL:${DLAF_WITH_GPU}>:permutations/general/gpu.cpp>
                            $<$<BOOL:${DLAF_WITH_GPU}>:permutations/general/perms.cu>
 )
 if (DLAF_WITH_HIP)
     set_source_files_properties(permutations/general/perms.cu PROPERTIES LANGUAGE HIP)
 endif()
-target_link_libraries(dlaf.permutations PUBLIC dlaf.prop)
-target_add_warnings(dlaf.permutations)
-DLAF_addPrecompiledHeaders(dlaf.permutations)
+target_link_libraries(dlaf.permutations_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.permutations_obj)
+DLAF_addPrecompiledHeaders(dlaf.permutations_obj)
+add_library(dlaf.permutations $<TARGET_OBJECTS:dlaf.permutations_obj>)
+target_link_libraries(dlaf.permutations PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's solver library
-add_library(dlaf.solver OBJECT
+add_library(dlaf.solver_obj OBJECT
   solver/triangular/mc.cpp
   $<$<BOOL:${DLAF_WITH_GPU}>:solver/triangular/gpu.cpp>)
-target_link_libraries(dlaf.solver PUBLIC dlaf.prop)
-target_add_warnings(dlaf.solver)
-DLAF_addPrecompiledHeaders(dlaf.solver)
+target_link_libraries(dlaf.solver_obj PUBLIC dlaf.prop)
+target_add_warnings(dlaf.solver_obj)
+DLAF_addPrecompiledHeaders(dlaf.solver_obj)
+add_library(dlaf.solver $<TARGET_OBJECTS:dlaf.solver_obj>)
+target_link_libraries(dlaf.solver PUBLIC dlaf.core dlaf.prop)
 
 # Define DLAF's complete library
 add_library(
   DLAF
-  $<TARGET_OBJECTS:dlaf.core>
-  $<TARGET_OBJECTS:dlaf.auxiliary>
-  $<TARGET_OBJECTS:dlaf.eigensolver>
-  $<TARGET_OBJECTS:dlaf.tridiagonal_eigensolver>
-  $<TARGET_OBJECTS:dlaf.factorization>
-  $<TARGET_OBJECTS:dlaf.multiplication>
-  $<TARGET_OBJECTS:dlaf.permutations>
-  $<TARGET_OBJECTS:dlaf.solver>
+  $<TARGET_OBJECTS:dlaf.core_obj>
+  $<TARGET_OBJECTS:dlaf.auxiliary_obj>
+  $<TARGET_OBJECTS:dlaf.eigensolver_obj>
+  $<TARGET_OBJECTS:dlaf.tridiagonal_eigensolver_obj>
+  $<TARGET_OBJECTS:dlaf.factorization_obj>
+  $<TARGET_OBJECTS:dlaf.multiplication_obj>
+  $<TARGET_OBJECTS:dlaf.permutations_obj>
+  $<TARGET_OBJECTS:dlaf.solver_obj>
 )
 target_link_libraries(DLAF PUBLIC dlaf.prop)
 target_add_warnings(DLAF)

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -11,14 +11,14 @@
 DLAF_addTest(
   test_band_to_tridiag
   SOURCES test_band_to_tridiag.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_bt_band_to_tridiag
   SOURCES test_bt_band_to_tridiag.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
@@ -26,35 +26,35 @@ DLAF_addTest(
 DLAF_addTest(
   test_tridiag_solver_full
   SOURCES test_tridiag_solver.cpp
-  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_tridiag_solver_merge
   SOURCES test_tridiag_solver_merge.cpp
-  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_eigensolver
   SOURCES test_eigensolver.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_gen_eigensolver
   SOURCES test_gen_eigensolver.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_reduction_to_band
   SOURCES test_reduction_to_band.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
@@ -62,7 +62,7 @@ DLAF_addTest(
 DLAF_addTest(
   test_bt_reduction_to_band
   SOURCES test_bt_reduction_to_band.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
@@ -70,7 +70,7 @@ DLAF_addTest(
 DLAF_addTest(
   test_gen_to_std
   SOURCES test_gen_to_std.cpp
-  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
+  LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -11,14 +11,14 @@
 DLAF_addTest(
   test_band_to_tridiag
   SOURCES test_band_to_tridiag.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_bt_band_to_tridiag
   SOURCES test_bt_band_to_tridiag.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
@@ -26,35 +26,35 @@ DLAF_addTest(
 DLAF_addTest(
   test_tridiag_solver_full
   SOURCES test_tridiag_solver.cpp
-  LIBRARIES dlaf.core dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_tridiag_solver_merge
   SOURCES test_tridiag_solver_merge.cpp
-  LIBRARIES dlaf.core dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_eigensolver
   SOURCES test_eigensolver.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_gen_eigensolver
   SOURCES test_gen_eigensolver.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN PIKA
 )
 
 DLAF_addTest(
   test_reduction_to_band
   SOURCES test_reduction_to_band.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
@@ -62,7 +62,7 @@ DLAF_addTest(
 DLAF_addTest(
   test_bt_reduction_to_band
   SOURCES test_bt_reduction_to_band.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
@@ -70,7 +70,7 @@ DLAF_addTest(
 DLAF_addTest(
   test_gen_to_std
   SOURCES test_gen_to_std.cpp
-  LIBRARIES dlaf.core dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
+  LIBRARIES dlaf.eigensolver dlaf.factorization dlaf.solver dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )


### PR DESCRIPTION
This fixes #487.

This is down the rabbit hole of #674. In its current state (i.e. without this PR) #674 reduces the binary size of _some_ binaries, but increases it for many. The reason for this is that object libraries are unconditionally included in executables and libraries taking no regard to whether or not they're needed. Since communication kernels were added to `dlaf.core`, the size of `dlaf.core` increased noticeably, and as a result everything that links to `dlaf.core` but doesn't use the newly added instantiations of communication kernels will end up massively bloated.

When linking to static libraries, unlike object libraries, only required symbols are actually included by the linker. This means that e.g. a test that doesn't use communication kernels and links to a static library `dlaf.core` will not end up bloated by the communication kernels.

This PR fixes #487 and as a side-effect also significantly reduces the binary size of most executables.

Still to do:
- [x] remove unnecessary dependencies from tests (now that dependencies are transitively linked)
- [x] add CMake helper function for creating the `dlaf.X` libraries

For comparison, these are the sizes of tests and static libraries on current master:
```
21G     total
2.0G    src/libDLAF.a
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_reduction_to_band
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_gen_to_std
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_gen_eigensolver
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_eigensolver
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_bt_reduction_to_band
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_bt_band_to_tridiag
1.7G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_band_to_tridiag
651M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_tridiag_solver_merge
650M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_tridiag_solver_full
425M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/sender/test_with_temporary_tile
414M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/solver/test_triangular
306M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/multiplication/test_multiplication_triangular
306M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/multiplication/test_multiplication_general
298M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/factorization/test_compute_t_factor
293M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/factorization/test_cholesky
160M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/permutations/test_permutations
99M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_p2p
94M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_panel
89M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_panel
77M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix
76M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_collective_async
74M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_util_matrix
62M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_tile
54M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/auxiliary/mc/test_norm
52M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_blas_tile
49M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_mirror
47M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_matrix
46M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_sender
45M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_lapack_tile
45M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_transform_mpi
45M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_pipeline
44M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_output
44M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_data_descriptor
43M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_views
43M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_view
43M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_local
42M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/memory/test_memory_view
42M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_matrix
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_util_math
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_util_cuda
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_types
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/memory/test_memory_chunk
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_layout_info
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_distribution
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/lapack/gpu/test_lacpy
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/init/test_init
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_reduce
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_message
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_communicator_grid
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_communicator
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_tile
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_all_reduce
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_size2d
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_range2d
41M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_index2d
40M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_util_distribution
37M     test/src/libDLAF_gtest_mpipika_main.a
36M     test/src/libDLAF_gtest_pika_main.a
560K    test/src/libDLAF_gtest_mpi_main.a
```

These are the sizes on this PR (note the addition of a more static libraries, so the total size is also a bit inflated):
```
12G     total
2.0G    src/libDLAF.a
1.5G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_gen_eigensolver
1.1G    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_eigensolver
984M    src/libdlaf.eigensolver.a
420M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_tridiag_solver_full
415M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/solver/test_triangular
414M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/sender/test_with_temporary_tile
405M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_bt_band_to_tridiag
399M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_reduction_to_band
284M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/multiplication/test_multiplication_triangular
272M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_gen_to_std
258M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_bt_reduction_to_band
257M    src/libdlaf.solver.a
242M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/factorization/test_cholesky
221M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_band_to_tridiag
219M    src/libdlaf.tridiagonal_eigensolver.a
204M    src/libdlaf.factorization.a
186M    src/libdlaf.multiplication.a
161M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/permutations/test_permutations
134M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_tridiag_solver_merge
109M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/factorization/test_compute_t_factor
88M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_p2p
82M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_panel
78M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_panel
76M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix
75M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/multiplication/test_multiplication_general
63M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_util_matrix
62M     src/libdlaf.permutations.a
50M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_mirror
49M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_collective_async
44M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_output
42M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/auxiliary/mc/test_norm
40M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_tile
36M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_matrix
35M     src/libdlaf.core.a
32M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_view
32M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_local
31M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_matrix
29M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_blas_tile
22M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_lapack_tile
19M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_transform_mpi
19M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_sender
18M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/lapack/gpu/test_lacpy
18M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_pipeline
17M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_tile
16M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_views
14M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/memory/test_memory_view
14M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/init/test_init
13M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/memory/test_memory_chunk
7.3M    src/libdlaf.auxiliary.a
6.2M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_data_descriptor
3.8M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_util_math
3.8M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_communicator_grid
3.8M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_index2d
3.7M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_message
3.5M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_reduce
3.4M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast
3.4M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_all_reduce
3.3M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_distribution
3.2M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_layout_info
3.1M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_util_cuda
3.1M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_communicator
3.1M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_size2d
3.0M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_types
2.9M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_range2d
2.8M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_util_distribution
1.3M    test/src/libDLAF_gtest_mpipika_main.a
680K    test/src/libDLAF_gtest_pika_main.a
560K    test/src/libDLAF_gtest_mpi_main.a
```

Finally, one can also build DLA-Future with `BUILD_SHARED_LIBS=ON`. The sizes are then:
```
5.7G    total
2.0G    src/libDLAF.so
1.2G    src/libdlaf.eigensolver.so
434M    src/libdlaf.solver.so
387M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/sender/test_with_temporary_tile
307M    src/libdlaf.multiplication.so
303M    src/libdlaf.factorization.so
295M    src/libdlaf.tridiagonal_eigensolver.so
122M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_tridiag_solver_merge
106M    src/libdlaf.permutations.so
61M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_p2p
57M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_panel
53M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix
52M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_panel
47M     src/libdlaf.core.so
38M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_util_matrix
36M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/permutations/test_permutations
36M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_collective_async
32M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_tridiag_solver_full
25M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_tile
24M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_mirror
22M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/factorization/test_compute_t_factor
18M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_gen_eigensolver
18M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_eigensolver
18M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_bt_band_to_tridiag
16M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/multiplication/test_multiplication_general
16M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_reduction_to_band
15M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_blas_tile
14M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_bt_reduction_to_band
12M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/solver/test_triangular
12M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/multiplication/test_multiplication_triangular
12M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_band_to_tridiag
11M     /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_output
8.8M    src/libdlaf.auxiliary.so
8.8M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/auxiliary/mc/test_norm
7.6M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_matrix
6.6M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_lapack_tile
5.8M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_comm_sender
5.4M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_transform_mpi
5.3M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_pipeline
4.3M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_view
4.1M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/eigensolver/test_gen_to_std
4.0M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_matrix_local
3.9M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/factorization/test_cholesky
3.9M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_data_descriptor
3.4M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/lapack/gpu/test_lacpy
3.0M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_views
2.7M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/memory/test_memory_view
2.2M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_matrix
1.7M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/init/test_init
1.5M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_util_math
1.5M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_index2d
1.4M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_message
1.4M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_communicator_grid
1.3M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast_tile
1.1M    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_broadcast
976K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/memory/test_memory_chunk
968K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_reduce
904K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_all_reduce
784K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_distribution
776K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_util_cuda
768K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_size2d
736K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_layout_info
720K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/communication/test_communicator
544K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/test_types
512K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/common/test_range2d
336K    /apps/daint/UES/simbergm/src/DLA-Future/build/spack/test/unit/matrix/test_util_distribution
```