### PR TITLE
Pass the `amdgpu_target` and `cuda_arch` variants to DLAF dependencies

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -68,6 +68,17 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts("+cuda", when="+rocm")
 
+    with when("+rocm"):
+        for val in ROCmPackage.amdgpu_targets:
+            depends_on("pika amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
+            depends_on("rocsolver amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
+            depends_on("rocblas amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
+            depends_on("umpire amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
+
     def cmake_args(self):
         spec = self.spec
 

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -79,6 +79,13 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
             depends_on("umpire amdgpu_target={0}".format(val),
                 when="amdgpu_target={0}".format(val))
 
+    with when("+cuda"):
+        for val in CudaPackage.cuda_arch_values:
+            depends_on("pika cuda_arch={0}".format(val),
+                when="cuda_arch={0}".format(val))
+            depends_on("umpire cuda_arch={0}".format(val),
+                when="cuda_arch={0}".format(val))
+
     def cmake_args(self):
         spec = self.spec
 

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -110,6 +110,11 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
             if "none" not in archs:
                 arch_str = ";".join(archs)
                 args.append(self.define("CMAKE_HIP_ARCHITECTURES", arch_str))
+        if "+cuda" in spec:
+            archs = self.spec.variants["cuda_arch"].value
+            if "none" not in archs:
+                arch_str = ";".join(archs)
+                args.append(self.define("CMAKE_CUDA_ARCHITECTURES", arch_str))
 
         # DOC
         args.append(self.define_from_variant("DLAF_BUILD_DOC", "doc"))


### PR DESCRIPTION
Fix #684