### PR TITLE
Reformat all `CMakeLists.txt` and fix `format.sh` script

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -28,7 +28,7 @@ do
       # Check if tab are present.
       egrep -Hn $'\t' $FILE && TAB_FOUND=1 || true
       ;;
-    *.cmake|CMakeList.txt|*.cmake.in)
+    *.cmake|*CMakeLists.txt|*.cmake.in)
       cmake-format -i $FILE
       # Check if tab are present.
       egrep -Hn $'\t' $FILE && TAB_FOUND=1 || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,12 +56,13 @@ enable_language(C)
 enable_language(CXX)
 
 # ---- CUDA/HIP
-if (DLAF_WITH_CUDA AND DLAF_WITH_HIP)
+if(DLAF_WITH_CUDA AND DLAF_WITH_HIP)
   message(FATAL_ERROR "DLAF_WITH_CUDA=ON and DLAF_WITH_HIP=ON. Only one of "
-    "them can be enabled at the same time.")
+                      "them can be enabled at the same time."
+  )
 endif()
-if (DLAF_WITH_CUDA)
-  if (NOT CMAKE_CUDA_ARCHITECTURES)
+if(DLAF_WITH_CUDA)
+  if(NOT CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES "60;70;80" CACHE STRING "Cuda architectures" FORCE)
   endif()
   enable_language(CUDA)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,39 +60,37 @@ option(DLAF_ASSERT_HEAVY_ENABLE "Enable high impact assertions" ${DLAF_ASSERT_HE
 
 # Define DLAF's PUBLIC properties
 add_library(dlaf.prop INTERFACE)
-target_include_directories(dlaf.prop
-  INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  dlaf.prop INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                      $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(dlaf.prop
-  INTERFACE
-    MPI::MPI_CXX
-    DLAF::LAPACK
-    pika::pika
-    lapackpp
-    blaspp
-    umpire
-    $<$<BOOL:${DLAF_WITH_CUDA}>:CUDA::cublas>
-    $<$<BOOL:${DLAF_WITH_CUDA}>:CUDA::cudart>
-    $<$<BOOL:${DLAF_WITH_CUDA}>:CUDA::cusolver>
-    $<$<BOOL:${DLAF_WITH_HIP}>:roc::hipblas>
-    $<$<BOOL:${DLAF_WITH_HIP}>:roc::rocblas>
-    $<$<BOOL:${DLAF_WITH_HIP}>:roc::rocsolver>
-    $<$<BOOL:${DLAF_WITH_GPU}>:whip::whip>
+target_link_libraries(
+  dlaf.prop
+  INTERFACE MPI::MPI_CXX
+            DLAF::LAPACK
+            pika::pika
+            lapackpp
+            blaspp
+            umpire
+            $<$<BOOL:${DLAF_WITH_CUDA}>:CUDA::cublas>
+            $<$<BOOL:${DLAF_WITH_CUDA}>:CUDA::cudart>
+            $<$<BOOL:${DLAF_WITH_CUDA}>:CUDA::cusolver>
+            $<$<BOOL:${DLAF_WITH_HIP}>:roc::hipblas>
+            $<$<BOOL:${DLAF_WITH_HIP}>:roc::rocblas>
+            $<$<BOOL:${DLAF_WITH_HIP}>:roc::rocsolver>
+            $<$<BOOL:${DLAF_WITH_GPU}>:whip::whip>
 )
-target_compile_definitions(dlaf.prop
-  INTERFACE
-    $<$<BOOL:${DLAF_ASSERT_ENABLE}>:DLAF_ASSERT_ENABLE>
-    $<$<BOOL:${DLAF_ASSERT_MODERATE_ENABLE}>:DLAF_ASSERT_MODERATE_ENABLE>
-    $<$<BOOL:${DLAF_ASSERT_HEAVY_ENABLE}>:DLAF_ASSERT_HEAVY_ENABLE>
-    DLAF_FUNCTION_NAME=$<IF:$<BOOL:is_pretty_function_available>,__PRETTY_FUNCTION__,__func__>
-    $<$<BOOL:${DLAF_WITH_GPU}>:DLAF_WITH_GPU>
-    $<$<BOOL:${DLAF_WITH_CUDA}>:DLAF_WITH_CUDA>
-    $<$<BOOL:${DLAF_WITH_HIP}>:DLAF_WITH_HIP>
-    $<$<BOOL:${DLAF_WITH_HIP}>:ROCM_MATHLIBS_API_USE_HIP_COMPLEX>
-    $<$<BOOL:${DLAF_WITH_CUDA_MPI_RDMA}>:DLAF_WITH_CUDA_MPI_RDMA>
+target_compile_definitions(
+  dlaf.prop
+  INTERFACE $<$<BOOL:${DLAF_ASSERT_ENABLE}>:DLAF_ASSERT_ENABLE>
+            $<$<BOOL:${DLAF_ASSERT_MODERATE_ENABLE}>:DLAF_ASSERT_MODERATE_ENABLE>
+            $<$<BOOL:${DLAF_ASSERT_HEAVY_ENABLE}>:DLAF_ASSERT_HEAVY_ENABLE>
+            DLAF_FUNCTION_NAME=$<IF:$<BOOL:is_pretty_function_available>,__PRETTY_FUNCTION__,__func__>
+            $<$<BOOL:${DLAF_WITH_GPU}>:DLAF_WITH_GPU>
+            $<$<BOOL:${DLAF_WITH_CUDA}>:DLAF_WITH_CUDA>
+            $<$<BOOL:${DLAF_WITH_HIP}>:DLAF_WITH_HIP>
+            $<$<BOOL:${DLAF_WITH_HIP}>:ROCM_MATHLIBS_API_USE_HIP_COMPLEX>
+            $<$<BOOL:${DLAF_WITH_CUDA_MPI_RDMA}>:DLAF_WITH_CUDA_MPI_RDMA>
 )
 
 # Precompiled headers

--- a/test/unit/sender/CMakeLists.txt
+++ b/test/unit/sender/CMakeLists.txt
@@ -8,7 +8,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-DLAF_addTest(test_with_temporary_tile
+DLAF_addTest(
+  test_with_temporary_tile
   SOURCES test_with_temporary_tile.cpp
   LIBRARIES dlaf.core
   USE_MAIN PIKA


### PR DESCRIPTION
This fixes the `format.sh` script to correctly check formatting in  `CMakeLists.txt` files. It also reformats the files according to `cmake-format`.