### PR TITLE
Fix band to tridiagonal backtransformation

### DIFF
--- a/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag/impl.h
@@ -504,13 +504,13 @@ struct HHManager<Backend::GPU, Device::GPU, T> {
                                  matrix::Tile<const T, D>(std::move(tile_w)));
         };
 
-    auto tup2 = ex::when_all(ex::keep_future(std::move(tile_v_h)), ex::keep_future(std::move(tile_t_h)),
-                             splitTile(mat_v(ij), helper.specHH()), splitTile(mat_t(ij_t), t_spec),
-                             splitTile(mat_w(ij), helper.specHH())) |
-                dlaf::internal::transform<
-                    dlaf::internal::TransformDispatchType::Blas>(dlaf::internal::Policy<Backend::GPU>(),
-                                                                 copyVTandComputeW) |
-                ex::make_future();
+    auto tup2 =
+        ex::when_all(std::move(tile_v_h), std::move(tile_t_h), splitTile(mat_v(ij), helper.specHH()),
+                     splitTile(mat_t(ij_t), t_spec), splitTile(mat_w(ij), helper.specHH())) |
+        dlaf::internal::transform<
+            dlaf::internal::TransformDispatchType::Blas>(dlaf::internal::Policy<Backend::GPU>(),
+                                                         copyVTandComputeW) |
+        ex::make_future();
 
     return pika::split_future(std::move(tup2));
   }


### PR DESCRIPTION
The cause was two `keep_future`s on `pika::future`s which, as we've already seen in https://github.com/eth-cscs/DLA-Future/pull/409, leads to wrong behaviour. As a reminder, with `keep_future` the full `future` (rather than its wrapped value) gets passed to `unwrapping` and the wrapped value is consumed in the `unwrapping` call. The value (tile in this case) is then released without waiting for the GPU kernel to finish.

Fixes #643.