### PR TITLE
Enable gpu backend for tridiagonal eigensolver

### DIFF
--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -22,6 +22,7 @@
 #include "dlaf/eigensolver/reduction_to_band.h"
 #include "dlaf/eigensolver/tridiag_solver.h"
 #include "dlaf/lapack/tile.h"
+#include "dlaf/matrix/copy.h"
 #include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
@@ -43,38 +44,31 @@ EigensolverResult<T, D> Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>
   auto taus = reductionToBand<B>(mat_a, band_size);
   auto ret = bandToTridiag<Backend::MC>(uplo, band_size, mat_a);
 
-  matrix::Matrix<BaseType<T>, Device::CPU> evals(LocalElementSize(size, 1),
-                                                 TileElementSize(mat_a.blockSize().rows(), 1));
-  matrix::Matrix<T, Device::CPU> mat_e(LocalElementSize(size, size), mat_a.blockSize());
-
-  eigensolver::tridiagSolver<Backend::MC>(ret.tridiagonal, evals, mat_e);
-
-  // Note: This is just a temporary workaround. It will be removed as soon as we will have our
-  // tridiagonal eigensolver implementation both on CPU and GPU.
-  Matrix<BaseType<T>, D> evals_device = [&]() {
-    if constexpr (D == Device::CPU)
-      return std::move(evals);
+  // Note:
+  // Since reduction from band to tridiagonal happens on MC for all backends, but eigensolver
+  // requires tridiagonal matrix to be on CPU or GPU depending on the backend used, next snippet
+  // ensures that tridiagonal matrix gets copied if needed (i.e. just for GPU backend).
+  matrix::Matrix<BaseType<T>, D> tridiagonal = [&ret]() {
+    if constexpr (B == Backend::MC) {
+      return std::move(ret.tridiagonal);
+    }
     else {
-      Matrix<BaseType<T>, D> evals_device(evals.distribution());
-      dlaf::matrix::copy(evals, evals_device);
-      return evals_device;
+      matrix::Matrix<BaseType<T>, D> tridiagonal(ret.tridiagonal.distribution());
+      copy(ret.tridiagonal, tridiagonal);
+      return tridiagonal;
     }
   }();
 
-  Matrix<T, D> mat_e_device = [&]() {
-    if constexpr (D == Device::CPU)
-      return std::move(mat_e);
-    else {
-      Matrix<T, D> e(mat_e.distribution());
-      dlaf::matrix::copy(mat_e, e);
-      return e;
-    }
-  }();
+  matrix::Matrix<BaseType<T>, D> evals(LocalElementSize(size, 1),
+                                       TileElementSize(mat_a.blockSize().rows(), 1));
+  matrix::Matrix<T, D> mat_e(LocalElementSize(size, size), mat_a.blockSize());
 
-  backTransformationBandToTridiag<B>(band_size, mat_e_device, ret.hh_reflectors);
-  backTransformationReductionToBand<B>(band_size, mat_e_device, mat_a, taus);
+  eigensolver::tridiagSolver<B>(tridiagonal, evals, mat_e);
 
-  return {std::move(evals_device), std::move(mat_e_device)};
+  backTransformationBandToTridiag<B>(band_size, mat_e, ret.hh_reflectors);
+  backTransformationReductionToBand<B>(band_size, mat_e, mat_a, taus);
+
+  return {std::move(evals), std::move(mat_e)};
 }
 
 }

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -27,9 +27,13 @@ DLAF_addMiniapp(miniapp_reduction_to_band SOURCES miniapp_reduction_to_band.cpp 
 
 DLAF_addMiniapp(miniapp_band_to_tridiag SOURCES miniapp_band_to_tridiag.cpp LIBRARIES DLAF)
 
-DLAF_addMiniapp(miniapp_eigensolver SOURCES miniapp_eigensolver.cpp LIBRARIES DLAF)
-
-DLAF_addMiniapp(miniapp_gen_eigensolver SOURCES miniapp_gen_eigensolver.cpp LIBRARIES DLAF)
+# Note:
+# HIP is not yet supported. Disabling this miniapp for HIP means that we don't have also the MC one...
+# ...but it is a shortcut in the meanwhile we get HIP support.
+if (NOT DLAF_WITH_HIP)
+  DLAF_addMiniapp(miniapp_eigensolver SOURCES miniapp_eigensolver.cpp LIBRARIES DLAF)
+  DLAF_addMiniapp(miniapp_gen_eigensolver SOURCES miniapp_gen_eigensolver.cpp LIBRARIES DLAF)
+endif()
 
 DLAF_addMiniapp(miniapp_bt_band_to_tridiag SOURCES miniapp_bt_band_to_tridiag.cpp LIBRARIES DLAF)
 

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -30,7 +30,7 @@ DLAF_addMiniapp(miniapp_band_to_tridiag SOURCES miniapp_band_to_tridiag.cpp LIBR
 # Note:
 # HIP is not yet supported. Disabling this miniapp for HIP means that we don't have also the MC one...
 # ...but it is a shortcut in the meanwhile we get HIP support.
-if (NOT DLAF_WITH_HIP)
+if(NOT DLAF_WITH_HIP)
   DLAF_addMiniapp(miniapp_eigensolver SOURCES miniapp_eigensolver.cpp LIBRARIES DLAF)
   DLAF_addMiniapp(miniapp_gen_eigensolver SOURCES miniapp_gen_eigensolver.cpp LIBRARIES DLAF)
 endif()

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -39,7 +39,7 @@ using EigensolverTestMC = EigensolverTest<T>;
 
 TYPED_TEST_SUITE(EigensolverTestMC, MatrixElementTypes);
 
-#ifdef DLAF_WITH_GPU
+#ifdef DLAF_WITH_CUDA
 template <class T>
 using EigensolverTestGPU = EigensolverTest<T>;
 
@@ -125,7 +125,7 @@ TYPED_TEST(EigensolverTestMC, CorrectnessLocal) {
   }
 }
 
-#ifdef DLAF_WITH_GPU
+#ifdef DLAF_WITH_CUDA
 TYPED_TEST(EigensolverTestGPU, CorrectnessLocal) {
   for (auto uplo : blas_uplos) {
     for (auto sz : sizes) {

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -37,7 +37,7 @@ using GenEigensolverTestMC = GenEigensolverTest<T>;
 
 TYPED_TEST_SUITE(GenEigensolverTestMC, MatrixElementTypes);
 
-#ifdef DLAF_WITH_GPU
+#ifdef DLAF_WITH_CUDA
 template <class T>
 using GenEigensolverTestGPU = GenEigensolverTest<T>;
 
@@ -138,7 +138,7 @@ TYPED_TEST(GenEigensolverTestMC, CorrectnessLocal) {
   }
 }
 
-#ifdef DLAF_WITH_GPU
+#ifdef DLAF_WITH_CUDA
 TYPED_TEST(GenEigensolverTestGPU, CorrectnessLocal) {
   for (auto uplo : blas_uplos) {
     for (auto sz : sizes) {


### PR DESCRIPTION
For some reason the pipeline was not yet updated to use the tridiagonal solver on GPU.

Due to a mismatch between output of reduction from band to tridiagonal (happening on MC) and the eigensolver (MC/GPU), an additional copy is needed when running on GPU.