### PR TITLE
Always compress debug symbols

### DIFF
--- a/cmake/DLAF_AddMiniapp.cmake
+++ b/cmake/DLAF_AddMiniapp.cmake
@@ -47,7 +47,9 @@ function(DLAF_addMiniapp miniapp_target_name)
 
   ### Miniapp executable target
   add_executable(${miniapp_target_name} ${DLAF_AM_SOURCES})
-  target_link_libraries(${miniapp_target_name} PRIVATE DLAF_miniapp ${DLAF_AM_LIBRARIES})
+  target_link_libraries(
+    ${miniapp_target_name} PRIVATE DLAF_miniapp ${DLAF_AM_LIBRARIES} dlaf.prop_private
+  )
   target_compile_definitions(${miniapp_target_name} PRIVATE ${DLAF_AM_COMPILE_DEFINITIONS})
   target_include_directories(${miniapp_target_name} PRIVATE ${DLAF_AM_INCLUDE_DIRS})
   target_add_warnings(${miniapp_target_name})

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -182,7 +182,9 @@ function(DLAF_addTest test_target_name)
 
   ### Test executable target
   add_executable(${test_target_name} ${DLAF_AT_SOURCES})
-  target_link_libraries(${test_target_name} PRIVATE ${_gtest_tgt} DLAF_test ${DLAF_AT_LIBRARIES})
+  target_link_libraries(
+    ${test_target_name} PRIVATE ${_gtest_tgt} DLAF_test ${DLAF_AT_LIBRARIES} dlaf.prop_private
+  )
   target_compile_definitions(
     ${test_target_name} PRIVATE ${DLAF_AT_COMPILE_DEFINITIONS} $<$<BOOL:${IS_AN_MPI_TEST}>:
                                 NUM_MPI_RANKS=${DLAF_AT_MPIRANKS}>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,11 @@ option(DLAF_ASSERT_ENABLE "Enable low impact assertions" ${DLAF_ASSERT_DEFAULT})
 option(DLAF_ASSERT_MODERATE_ENABLE "Enable medium impact assertions" ${DLAF_ASSERT_MODERATE_DEFAULT})
 option(DLAF_ASSERT_HEAVY_ENABLE "Enable high impact assertions" ${DLAF_ASSERT_HEAVY_DEFAULT})
 
+# Define DLAF's PRIVATE properties
+add_library(dlaf.prop_private INTERFACE)
+target_compile_options(dlaf.prop_private INTERFACE -gz)
+target_link_options(dlaf.prop_private INTERFACE -gz)
+
 # Define DLAF's PUBLIC properties
 add_library(dlaf.prop INTERFACE)
 target_include_directories(
@@ -101,11 +106,11 @@ if(DLAF_WITH_PRECOMPILED_HEADERS)
   # for libraries and one for executables. Separate targets are needed because
   # the compilation flags for executables and libraries may differ.
   add_library(dlaf.pch_lib OBJECT dummy.cpp)
-  target_link_libraries(dlaf.pch_lib PRIVATE dlaf.prop)
+  target_link_libraries(dlaf.pch_lib PRIVATE dlaf.prop dlaf.prop_private)
   target_add_warnings(dlaf.pch_lib)
 
   add_executable(dlaf.pch_exe dummy.cpp)
-  target_link_libraries(dlaf.pch_exe PRIVATE dlaf.prop)
+  target_link_libraries(dlaf.pch_exe PRIVATE dlaf.prop dlaf.prop_private)
   target_add_warnings(dlaf.pch_exe)
 
   set(precompiled_headers
@@ -157,12 +162,13 @@ function(DLAF_addSublibrary name)
   endif()
 
   target_compile_options(${object_lib_name} PRIVATE ${DLAF_ASL_COMPILE_OPTIONS})
-  target_link_libraries(${object_lib_name} PRIVATE dlaf.prop)
+  target_link_libraries(${object_lib_name} PRIVATE dlaf.prop dlaf.prop_private)
   target_add_warnings(${object_lib_name})
   DLAF_addPrecompiledHeaders(${object_lib_name})
   add_library(${lib_name} $<TARGET_OBJECTS:${object_lib_name}>)
   target_link_libraries(${lib_name} PUBLIC dlaf.prop)
   target_link_libraries(${lib_name} PUBLIC ${DLAF_ASL_LIBRARIES})
+  target_link_libraries(${lib_name} PRIVATE dlaf.prop_private)
 endfunction()
 
 # Define DLAF's CORE library
@@ -265,13 +271,14 @@ add_library(
   $<TARGET_OBJECTS:dlaf.solver_object>
 )
 target_link_libraries(DLAF PUBLIC dlaf.prop)
+target_link_libraries(DLAF PRIVATE dlaf.prop_private)
 target_add_warnings(DLAF)
 
 # ----- DEPLOY
 include(GNUInstallDirs)
 
 install(
-  TARGETS DLAF dlaf.prop
+  TARGETS DLAF dlaf.prop dlaf.prop_private
   EXPORT DLAF-Targets
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
~This is very much a draft because I don't know how portable `-gz` is. However, with gcc it does help quite a lot.~