### PR TITLE
Revert spack commit hash bump

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -20,8 +20,8 @@ stages:
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     # Custom spack sha used to make an umpire fix available
-    # (https://github.com/msimberg/spack/commit/715f222173c7dc309d2cf687ea18bce84b75ac3e)
-    SPACK_SHA: 715f222173c7dc309d2cf687ea18bce84b75ac3e
+    # (https://github.com/aurianer/spack/commit/e4f4b70ed153167c06aa63eefa41d975394af066)
+    SPACK_SHA: e4f4b70ed153167c06aa63eefa41d975394af066
     SPACK_DLAF_REPO: ./spack
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY


### PR DESCRIPTION
The newer version of spack breaks some workarounds in the CI configuration (@rasolca can hopefully fill in details; it's related to this piece of code: https://github.com/eth-cscs/DLA-Future/blob/master/ci/docker/deploy.Dockerfile#L22-L29).

This reverts the spack commit hash back to the previous hash (which means that we won't have pika 0.10.0 available, but it's not required for anything so it's ok to go back right now), i.e. reverts #695.