### PR TITLE
Bump spack commit hash to get pika 0.10.0 (again)

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -20,8 +20,8 @@ stages:
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     # Custom spack sha used to make an umpire fix available
-    # (https://github.com/aurianer/spack/commit/e4f4b70ed153167c06aa63eefa41d975394af066)
-    SPACK_SHA: e4f4b70ed153167c06aa63eefa41d975394af066
+    # (https://github.com/msimberg/spack/commit/770d71dff6428876f2cc996f8a0551df36a59e4f)
+    SPACK_SHA: 770d71dff6428876f2cc996f8a0551df36a59e4f
     SPACK_DLAF_REPO: ./spack
   before_script:
     - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY


### PR DESCRIPTION
~This is a draft PR to reapply the spack commit hash bump from #695. However, it requires https://github.com/spack/spack/issues/33785 to be resolved first (and then the spack commit hash has to be bumped in this PR again).~