### PR TITLE
 bandtotridiagonal from GPU memory

### DIFF
--- a/include/dlaf/eigensolver/band_to_tridiag.h
+++ b/include/dlaf/eigensolver/band_to_tridiag.h
@@ -152,7 +152,7 @@ TridiagResult<T, Device::CPU> bandToTridiag(comm::CommunicatorGrid grid, blas::U
 
   switch (uplo) {
     case blas::Uplo::Lower:
-      return internal::BandToTridiagDistr<backend, device, T>::call_L(grid, band_size, mat_a);
+      return internal::BandToTridiag<backend, device, T>::call_L(grid, band_size, mat_a);
       break;
     case blas::Uplo::Upper:
       DLAF_UNIMPLEMENTED(uplo);

--- a/include/dlaf/eigensolver/band_to_tridiag/api.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/api.h
@@ -41,13 +41,6 @@ struct BandToTridiag;
 template <Device D, class T>
 struct BandToTridiag<Backend::MC, D, T> {
   static TridiagResult<T, Device::CPU> call_L(const SizeType b, Matrix<const T, D>& mat_a) noexcept;
-};
-
-template <Backend B, Device D, class T>
-struct BandToTridiagDistr;
-
-template <Device D, class T>
-struct BandToTridiagDistr<Backend::MC, D, T> {
   static TridiagResult<T, Device::CPU> call_L(comm::CommunicatorGrid grid, const SizeType b,
                                               Matrix<const T, D>& mat_a) noexcept;
 };
@@ -62,11 +55,6 @@ DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, float)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, double)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
-
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(extern, Backend::MC, Device::CPU, float)
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(extern, Backend::MC, Device::CPU, double)
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
 
 #ifdef DLAF_WITH_GPU
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, float)

--- a/include/dlaf/eigensolver/band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/mc.h
@@ -1091,12 +1091,12 @@ TridiagResult<T, Device::CPU> BandToTridiag<Backend::MC, D, T>::call_L(
                                              TileElementSize{nb, nb});
 
     auto copy_diag = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType j, auto source) {
-      constexpr Device device = dlaf::internal::SenderElementDevice<decltype(source)>;
+      constexpr Device device = dlaf::internal::SenderDevice<decltype(source)>;
       return a_block->template copyDiag<device>(j, std::move(source));
     };
 
     auto copy_offdiag = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType j, auto source) {
-      constexpr Device device = dlaf::internal::SenderElementDevice<decltype(source)>;
+      constexpr Device device = dlaf::internal::SenderDevice<decltype(source)>;
       return a_block->template copyOffDiag<device>(j, std::move(source));
     };
 

--- a/include/dlaf/eigensolver/band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/mc.h
@@ -1091,12 +1091,12 @@ TridiagResult<T, Device::CPU> BandToTridiag<Backend::MC, D, T>::call_L(
                                              TileElementSize{nb, nb});
 
     auto copy_diag = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType j, auto source) {
-      constexpr Device device = dlaf::internal::SenderDevice<decltype(source)>;
+      constexpr Device device = dlaf::internal::sender_device<decltype(source)>;
       return a_block->template copyDiag<device>(j, std::move(source));
     };
 
     auto copy_offdiag = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType j, auto source) {
-      constexpr Device device = dlaf::internal::SenderDevice<decltype(source)>;
+      constexpr Device device = dlaf::internal::sender_device<decltype(source)>;
       return a_block->template copyOffDiag<device>(j, std::move(source));
     };
 

--- a/include/dlaf/eigensolver/band_to_tridiag/mc.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/mc.h
@@ -34,6 +34,7 @@
 #include "dlaf/matrix/copy_tile.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/memory/memory_view.h"
+#include "dlaf/sender/traits.h"
 #include "dlaf/traits.h"
 
 namespace dlaf::eigensolver::internal {
@@ -948,7 +949,7 @@ private:
 
 // Distributed implementation of bandToTridiag.
 template <Device D, class T>
-TridiagResult<T, Device::CPU> BandToTridiagDistr<Backend::MC, D, T>::call_L(
+TridiagResult<T, Device::CPU> BandToTridiag<Backend::MC, D, T>::call_L(
     comm::CommunicatorGrid grid, const SizeType b, Matrix<const T, D>& mat_a) noexcept {
   // Note on the algorithm, data distribution and dependency tracking:
   // The band matrix is redistribuited in 1D block cyclic. The new block size is a multiple of the
@@ -990,8 +991,6 @@ TridiagResult<T, Device::CPU> BandToTridiagDistr<Backend::MC, D, T>::call_L(
   using pika::resource::get_num_threads;
 
   namespace ex = pika::execution::experimental;
-
-  static_assert(D == Device::CPU);
 
   // Should be dispatched to local implementation if (1x1) grid.
   DLAF_ASSERT(grid.size() != comm::Size2D(1, 1), grid);
@@ -1088,14 +1087,17 @@ TridiagResult<T, Device::CPU> BandToTridiagDistr<Backend::MC, D, T>::call_L(
 
   {
     constexpr std::size_t n_workspaces = 4;
-    RoundRobin<Matrix<T, D>> temps(n_workspaces, LocalElementSize{nb, nb}, TileElementSize{nb, nb});
+    RoundRobin<Matrix<T, Device::CPU>> temps(n_workspaces, LocalElementSize{nb, nb},
+                                             TileElementSize{nb, nb});
 
     auto copy_diag = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType j, auto source) {
-      return a_block->template copyDiag<D>(j, std::move(source));
+      constexpr Device device = dlaf::internal::SenderElementDevice<decltype(source)>;
+      return a_block->template copyDiag<device>(j, std::move(source));
     };
 
     auto copy_offdiag = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType j, auto source) {
-      return a_block->template copyOffDiag<D>(j, std::move(source));
+      constexpr Device device = dlaf::internal::SenderElementDevice<decltype(source)>;
+      return a_block->template copyOffDiag<device>(j, std::move(source));
     };
 
     // Copy the band matrix
@@ -1171,7 +1173,7 @@ TridiagResult<T, Device::CPU> BandToTridiagDistr<Backend::MC, D, T>::call_L(
   // of nb * tiles_per_block, we use a local distribution and we manage the computation of the
   // local panel index with VAccessHelper.
   matrix::Distribution dist_panel({dist.localSize().cols(), b}, {nb, b});
-  common::RoundRobin<matrix::Panel<Coord::Col, T, D>> v_panels(n_workspaces, dist_panel);
+  common::RoundRobin<matrix::Panel<Coord::Col, T, Device::CPU>> v_panels(n_workspaces, dist_panel);
 
   auto init_sweep = [](std::shared_ptr<BandBlock<T, true>> a_block, SizeType sweep,
                        PromiseGuard<SweepWorkerDist<T>> worker) {
@@ -1335,7 +1337,7 @@ TridiagResult<T, Device::CPU> BandToTridiagDistr<Backend::MC, D, T>::call_L(
                   if (rank == rank_v) {
                     auto tile_v = splitTile(mat_v(index_v), spec_v);
                     ex::start_detached(ex::when_all(std::move(tile_v_panel), std::move(tile_v)) |
-                                       copy(Policy<CopyBackend_v<Device::CPU, D>>{}));
+                                       copy(Policy<CopyBackend_v<Device::CPU, Device::CPU>>{}));
                   }
                   else {
                     ex::start_detached(comm::scheduleSend(comm, rank_v, compute_v_tag(index_v.row()),

--- a/include/dlaf/sender/traits.h
+++ b/include/dlaf/sender/traits.h
@@ -55,7 +55,7 @@ using SenderElementType = typename SenderSingleValueType<Sender>::ElementType;
 // The value of an embedded device in the value_types of Sender, if it
 // exists and Sender sends exactly one type.
 template <typename Sender>
-inline constexpr Device SenderElementDevice = SenderSingleValueType<Sender>::device;
+inline constexpr Device SenderDevice = SenderSingleValueType<Sender>::device;
 
 template <typename T>
 struct IsSharedFuture : std::false_type {};

--- a/include/dlaf/sender/traits.h
+++ b/include/dlaf/sender/traits.h
@@ -55,7 +55,7 @@ using SenderElementType = typename SenderSingleValueType<Sender>::ElementType;
 // The value of an embedded device in the value_types of Sender, if it
 // exists and Sender sends exactly one type.
 template <typename Sender>
-inline constexpr Device SenderDevice = SenderSingleValueType<Sender>::device;
+inline constexpr Device sender_device = SenderSingleValueType<Sender>::device;
 
 template <typename T>
 struct IsSharedFuture : std::false_type {};

--- a/include/dlaf/sender/traits.h
+++ b/include/dlaf/sender/traits.h
@@ -52,6 +52,11 @@ using SenderSingleValueType =
 template <typename Sender>
 using SenderElementType = typename SenderSingleValueType<Sender>::ElementType;
 
+// The value of an embedded device in the value_types of Sender, if it
+// exists and Sender sends exactly one type.
+template <typename Sender>
+inline constexpr Device SenderElementDevice = SenderSingleValueType<Sender>::device;
+
 template <typename T>
 struct IsSharedFuture : std::false_type {};
 

--- a/src/eigensolver/band_to_tridiag/mc.cpp
+++ b/src/eigensolver/band_to_tridiag/mc.cpp
@@ -17,11 +17,6 @@ DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, double)
 DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, std::complex<float>)
 DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::CPU, std::complex<double>)
 
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(, Backend::MC, Device::CPU, float)
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(, Backend::MC, Device::CPU, double)
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_EIGENSOLVER_B2T_DISTR_ETI(, Backend::MC, Device::CPU, std::complex<double>)
-
 #ifdef DLAF_WITH_GPU
 DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, float)
 DLAF_EIGENSOLVER_B2T_ETI(, Backend::MC, Device::GPU, double)

--- a/test/unit/eigensolver/test_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_band_to_tridiag.cpp
@@ -178,3 +178,15 @@ TYPED_TEST(EigensolverBandToTridiagTest, CorrectnessDistributed) {
     }
   }
 }
+
+#ifdef DLAF_WITH_GPU
+TYPED_TEST(EigensolverBandToTridiagTest, CorrectnessDistributedFromGPU) {
+  const blas::Uplo uplo = blas::Uplo::Lower;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& [m, mb, b] : sizes) {
+      testBandToTridiag<Device::GPU, TypeParam>(comm_grid, uplo, b, m, mb);
+    }
+  }
+}
+#endif


### PR DESCRIPTION
Enabled the case where the matrix is on GPU for the GPU eigensolver.

Depends on #698.