### PR TITLE
Make sure split communicators in `CommunicatorGrid6RanksEnvironment` are freed by making them managed

### DIFF
--- a/test/include/dlaf_test/comm_grids/grids_6_ranks.h
+++ b/test/include/dlaf_test/comm_grids/grids_6_ranks.h
@@ -56,7 +56,7 @@ public:
       MPI_Comm split_comm;
       DLAF_MPI_CHECK_ERROR(MPI_Comm_split(world, color, world.rank(), &split_comm));
 
-      comm::Communicator comm(split_comm);
+      auto comm = comm::make_communicator_managed(split_comm);
       comm_grids.emplace_back(comm, rows, cols, common::Ordering::ColumnMajor);
     }
   }


### PR DESCRIPTION
Fixes #712.

The split communicator was previously unmanaged and thus not freed when the vector `comm_grids` was cleared. This makes it managed to make sure it's freed.

I checked for other uses of `MPI_Comm_split` and as far as I can tell they're all ok uses of unmanaged communicators (i.e. the communicators are explicitly freed). Do you see any reason to avoid a managed communicator in this instance and instead explicitly free the communicators that need freeing in the `TearDown` function?

As for adding a test, we could of course add @albestro's test from https://github.com/eth-cscs/DLA-Future/issues/712, but since that would only check one test environment I don't know if there's much value in that. So thinking about how we can avoid this situation in the API instead, I wonder if we could make managed communicators the default when constructing one with the regular `Communicator` constructor (with an exception for `MPI_COMM_WORLD`), and instead make the unmanaged case the verbose case. Currently managed communicators have to be constructed with the more verbose `make_managed_communicator`. What do you think?