### PR TITLE
More build dependencies from apt-get

### DIFF
--- a/ci/docker/amdgpu-release-rocm523.yaml
+++ b/ci/docker/amdgpu-release-rocm523.yaml
@@ -37,6 +37,10 @@ spack:
       - ~hwloc
       - device=ch3
       - netmod=tcp
+      - ~libxml2
+    hwloc:
+      variants:
+      - ~libxml2
     git:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040

--- a/ci/docker/build.Dockerfile
+++ b/ci/docker/build.Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -yqq update && \
     apt-get -yqq install --no-install-recommends \
     software-properties-common \
     build-essential gfortran \
-    autoconf automake \
+    autoconf automake ninja-build pkg-config \
     ${EXTRA_APTGET} \
     gawk \
     python3 python3-distutils \
@@ -68,10 +68,12 @@ RUN spack external find \
     diffutils \
     findutils \
     git \
+    ninja \
     m4 \
     ncurses \
     openssl \
     perl \
+    pkg-config \
     python \
     xz && \
     if [ "$USE_MKL" = "ON" ]; then \

--- a/ci/docker/cpu-debug.yaml
+++ b/ci/docker/cpu-debug.yaml
@@ -34,6 +34,10 @@ spack:
         - 3.4.2
       variants:
         - '~fortran'
+        - '~libxml2'
+    hwloc:
+      variants:
+        - '~libxml2'
     git:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040

--- a/ci/docker/cpu-release.yaml
+++ b/ci/docker/cpu-release.yaml
@@ -33,6 +33,10 @@ spack:
         - 3.4.2
       variants:
         - '~fortran'
+        - '~libxml2'
+    hwloc:
+      variants:
+        - '~libxml2'
     git:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040

--- a/ci/docker/gpu-debug.yaml
+++ b/ci/docker/gpu-debug.yaml
@@ -34,6 +34,10 @@ spack:
         - 3.4.2
       variants:
         - '~fortran'
+        - '~libxml2'
+    hwloc:
+      variants:
+        - '~libxml2'
     git:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040

--- a/ci/docker/gpu-release.yaml
+++ b/ci/docker/gpu-release.yaml
@@ -33,6 +33,10 @@ spack:
         - 3.4.2
       variants:
         - '~fortran'
+        - '~libxml2'
+    hwloc:
+      variants:
+        - '~libxml2'
     git:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040


### PR DESCRIPTION
Closes #699.

Note: as `hwloc` and `mpich` both depends on `libpciaccess` it make little difference to set `hwloc` external (only the compilation of `hwloc`) and I'm not confident about possible problems arising from multiple libpciaccess used. (@msimberg what do you think?)