### PR TITLE
Fix requirement mismatch in applyGivenRotations (and improve doc)

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/rot.h
+++ b/include/dlaf/eigensolver/tridiag_solver/rot.h
@@ -119,9 +119,9 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, comm::Inde
   const matrix::Distribution dist_sub({range_size, range_size}, dist.blockSize(), dist.commGridSize(),
                                       dist.rankIndex(), dist.rankGlobalTile({i_begin, i_begin}));
 
-  auto givens_rots_fn = [comm_row, tag, dist_sub, i_begin, mb](std::vector<GivensRotation<T>> rots,
-                                                               std::vector<matrix::Tile<T, D>> tiles,
-                                                               std::vector<matrix::Tile<T, D>> all_ws) {
+  auto givens_rots_fn = [comm_row, tag, dist_sub, mb](std::vector<GivensRotation<T>> rots,
+                                                      std::vector<matrix::Tile<T, D>> tiles,
+                                                      std::vector<matrix::Tile<T, D>> all_ws) {
     // Note:
     // It would have been enough to just get the first tile from the beginning, and it would have
     // worked anyway (thanks to the fact that panel has its own memorychunk and the first tile would
@@ -149,12 +149,6 @@ void applyGivensRotationsToMatrixColumns(comm::Communicator comm_row, comm::Inde
       }
       return tile_ws.ptr({0, 0});
     };
-
-    // Change SoR for the rotations to just the range, by removing the offset
-    std::transform(rots.begin(), rots.end(), rots.begin(),
-                   [offset = i_begin * mb](const GivensRotation<T>& rot) {
-                     return GivensRotation<T>{rot.i - offset, rot.j - offset, rot.c, rot.s};
-                   });
 
     const SizeType m = dist_sub.localSize().rows();
 


### PR DESCRIPTION
With @teonnik we realised that there was a mismatch between what tridiagonal solver is going to pass, i.e. columns indices relative to the sub-matrix range, compared to what applyGivenRotation function was expecting, i.e. global columns indices.

This PR fixes that (as tridiagonal solver expect it to use, i.e. with relative indices) and adapt relative test.

Moreover, I realised that documentation was not helping at all, so I tried to improve that. Have a look at that, once we converge on one, there is also the [local version one](https://github.com/eth-cscs/DLA-Future/blob/cd760bee66797830b0f48842994dde1eb50f7f3f/include/dlaf/eigensolver/tridiag_solver/merge.h#L560-L571) to be fixed accordingly.