### PR TITLE
Panel StoreTransposed

### DIFF
--- a/include/dlaf/common/index2d.h
+++ b/include/dlaf/common/index2d.h
@@ -83,13 +83,13 @@ public:
 
   /// Return a copy of the row or the col index as specified by @p rc.
   template <Coord rc>
-  constexpr IndexT get() const noexcept {
-    if (rc == Coord::Row)
+  IndexT get() const noexcept {
+    if constexpr (rc == Coord::Row)
       return row_;
     return col_;
   }
 
-  constexpr IndexT get(const Coord rc) const noexcept {
+  IndexT get(const Coord rc) const noexcept {
     if (rc == Coord::Row)
       return row_;
     return col_;

--- a/include/dlaf/communication/broadcast_panel.h
+++ b/include/dlaf/communication/broadcast_panel.h
@@ -12,8 +12,11 @@
 
 /// @file
 
+#include <type_traits>
+
 #include <pika/future.hpp>
 
+#include "dlaf/common/index2d.h"
 #include "dlaf/communication/kernels/broadcast.h"
 #include "dlaf/communication/message.h"
 #include "dlaf/matrix/copy_tile.h"
@@ -36,6 +39,7 @@ std::pair<SizeType, comm::IndexT_MPI> transposedOwner(const matrix::Distribution
   const auto rank_owner = dist.template rankGlobalTile<orthogonal(dst_coord)>(idx_cross);
   return std::make_pair(idx_cross, rank_owner);
 }
+
 }
 
 /// Broadcast
@@ -49,8 +53,9 @@ std::pair<SizeType, comm::IndexT_MPI> transposedOwner(const matrix::Distribution
 ///                     on other ranks it is the destination panel
 /// @param serial_comm  where to pipeline the tasks for communications.
 /// @pre Communicator in @p serial_comm must be orthogonal to panel axis
-template <class T, Device D, Coord axis, class = std::enable_if_t<!std::is_const_v<T>>>
-void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
+template <class T, Device D, Coord axis, matrix::StoreTransposed storage,
+          class = std::enable_if_t<!std::is_const_v<T>>>
+void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D, storage>& panel,
                common::Pipeline<comm::Communicator>& serial_comm) {
   constexpr auto comm_coord = axis;
 
@@ -58,7 +63,7 @@ void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
   if (panel.parentDistribution().commGridSize().get(comm_coord) <= 1)
     return;
 
-  const auto rank = panel.rankIndex().get(comm_coord);
+  const auto rank = panel.parentDistribution().rankIndex().get(comm_coord);
 
   namespace ex = pika::execution::experimental;
   for (const auto& index : panel.iteratorLocal()) {
@@ -98,9 +103,10 @@ void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
 /// @pre both panels are child of a matrix (even not the same) with the same Distribution
 /// @pre both panels parent matrices should be square matrices with square blocksizes
 /// @pre both panels offsets should lay on the main diagonal of the parent matrix
-template <class T, Device D, Coord axis, class = std::enable_if_t<!std::is_const_v<T>>>
-void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
-               matrix::Panel<orthogonal(axis), T, D>& panelT,
+template <class T, Device D, Coord axis, matrix::StoreTransposed storage,
+          matrix::StoreTransposed storageT, class = std::enable_if_t<!std::is_const_v<T>>>
+void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D, storage>& panel,
+               matrix::Panel<orthogonal(axis), T, D, storageT>& panelT,
                common::Pipeline<comm::Communicator>& row_task_chain,
                common::Pipeline<comm::Communicator>& col_task_chain) {
   constexpr Coord axisT = orthogonal(axis);
@@ -189,5 +195,6 @@ void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D>& panel,
     }
   }
 }
+
 }
 }

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -12,7 +12,6 @@
 #include <pika/future.hpp>
 #include <pika/unwrap.hpp>
 
-#include "dlaf/common/assert.h"
 #include "dlaf/common/index2d.h"
 #include "dlaf/common/pipeline.h"
 #include "dlaf/common/range2d.h"
@@ -489,7 +488,7 @@ public:
 
   void setRangeEnd(GlobalTileIndex end_idx) {
     end_idx.transpose();
-    BaseT::setRangeStart(end_idx);
+    BaseT::setRangeEnd(end_idx);
   }
 
   using BaseT::rangeStart;

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -428,7 +428,6 @@ protected:
 
   ///> It represents the offset to use in first global tile
   SizeType start_offset_ = 0;
-
   SizeType offset_element_ = 0;
 
   bool has_been_used_ = false;

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -48,7 +48,7 @@ struct Panel<axis, const T, D, StoreTransposed::No> {
 
   using TileType = Tile<T, D>;
   using ConstTileType = Tile<const T, D>;
-  using ElementType = const T;
+  using ElementType = T;
   using BaseT = Matrix<T, D>;
 
   Panel(Panel&&) = default;

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -497,28 +497,24 @@ public:
   using BaseT::rangeEnd;
   using BaseT::rangeEndLocal;
 
-  // TODO fix setHeight (and setWidth accordingly)
-  template <Coord A = axis, std::enable_if_t<A == axis && Coord::Row == axis, int> = 0>
-  void setHeight(const SizeType height) {
-    BaseT::setWidth(height);
-  }
-
-  // TODO fix setHeight (and setWidth accordingly)
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Col == axis, int> = 0>
   void setWidth(const SizeType width) {
     BaseT::setHeight(width);
   }
 
-  // TODO fix setHeight (and setWidth accordingly)
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Row == axis, int> = 0>
-  SizeType getHeight() const noexcept {
-    return BaseT::getWidth();
+  void setHeight(const SizeType height) {
+    BaseT::setWidth(height);
   }
 
-  // TODO fix setHeight (and setWidth accordingly)
   template <Coord A = axis, std::enable_if_t<A == axis && Coord::Col == axis, int> = 0>
   SizeType getWidth() const noexcept {
     return BaseT::getHeight();
+  }
+
+  template <Coord A = axis, std::enable_if_t<A == axis && Coord::Row == axis, int> = 0>
+  SizeType getHeight() const noexcept {
+    return BaseT::getWidth();
   }
 
   using BaseT::offsetElement;

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -147,8 +147,8 @@ void set0(pika::execution::thread_priority priority, Matrix<T, D>& matrix) {
 }
 
 /// Sets all the elements of all the tiles in the active range to zero
-template <Backend backend, class T, Coord axis, Device D>
-void set0(pika::execution::thread_priority priority, Panel<axis, T, D>& panel) {
+template <Backend backend, class T, Coord axis, Device D, StoreTransposed storage>
+void set0(pika::execution::thread_priority priority, Panel<axis, T, D, storage>& panel) {
   using dlaf::internal::Policy;
   using pika::execution::experimental::start_detached;
 

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -48,7 +48,7 @@ std::vector<config_t> test_params{
     {{26, 13}, {3, 3}, {1, 2}},
 };
 
-template <class TypeParam, Coord panel_axis, StoreTransposed Storage = StoreTransposed::No>
+template <class TypeParam, Coord panel_axis, StoreTransposed Storage>
 void testBroadcast(const config_t& cfg, comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
   using pika::unwrapping;
@@ -85,13 +85,13 @@ void testBroadcast(const config_t& cfg, comm::CommunicatorGrid comm_grid) {
 TYPED_TEST(PanelBcastTest, BroadcastCol) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params)
-      testBroadcast<TypeParam, Coord::Col>(cfg, comm_grid);
+      testBroadcast<TypeParam, Coord::Col, StoreTransposed::No>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastRow) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params)
-      testBroadcast<TypeParam, Coord::Row>(cfg, comm_grid);
+      testBroadcast<TypeParam, Coord::Row, StoreTransposed::No>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastColStoreTransposed) {
@@ -113,7 +113,7 @@ std::vector<config_t> test_params_bcast_transpose{
     {{25, 25}, {5, 5}, {1, 1}},
 };
 
-template <class TypeParam, Coord AxisSrc, StoreTransposed storageT = StoreTransposed::No>
+template <class TypeParam, Coord AxisSrc, StoreTransposed storageT>
 void testBroadcastTranspose(const config_t& cfg, comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
   using pika::unwrapping;
@@ -159,13 +159,13 @@ void testBroadcastTranspose(const config_t& cfg, comm::CommunicatorGrid comm_gri
 TYPED_TEST(PanelBcastTest, BroadcastCol2Row) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params_bcast_transpose)
-      testBroadcastTranspose<TypeParam, Coord::Col>(cfg, comm_grid);
+      testBroadcastTranspose<TypeParam, Coord::Col, StoreTransposed::No>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastRow2Col) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params_bcast_transpose)
-      testBroadcastTranspose<TypeParam, Coord::Row>(cfg, comm_grid);
+      testBroadcastTranspose<TypeParam, Coord::Row, StoreTransposed::No>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastCol2RowStoreTransposed) {

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -114,7 +114,7 @@ std::vector<config_t> test_params_bcast_transpose{
 };
 
 template <class TypeParam, Coord AxisSrc, StoreTransposed storageT = StoreTransposed::No>
-void testBrodcastTranspose(const config_t& cfg, comm::CommunicatorGrid comm_grid) {
+void testBroadcastTranspose(const config_t& cfg, comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
   using pika::unwrapping;
 
@@ -159,23 +159,23 @@ void testBrodcastTranspose(const config_t& cfg, comm::CommunicatorGrid comm_grid
 TYPED_TEST(PanelBcastTest, BroadcastCol2Row) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params_bcast_transpose)
-      testBrodcastTranspose<TypeParam, Coord::Col>(cfg, comm_grid);
+      testBroadcastTranspose<TypeParam, Coord::Col>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastRow2Col) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params_bcast_transpose)
-      testBrodcastTranspose<TypeParam, Coord::Row>(cfg, comm_grid);
+      testBroadcastTranspose<TypeParam, Coord::Row>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastCol2RowStoreTransposed) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params_bcast_transpose)
-      testBrodcastTranspose<TypeParam, Coord::Col, StoreTransposed::Yes>(cfg, comm_grid);
+      testBroadcastTranspose<TypeParam, Coord::Col, StoreTransposed::Yes>(cfg, comm_grid);
 }
 
 TYPED_TEST(PanelBcastTest, BroadcastRow2ColStoreTransposed) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params_bcast_transpose)
-      testBrodcastTranspose<TypeParam, Coord::Row, StoreTransposed::Yes>(cfg, comm_grid);
+      testBroadcastTranspose<TypeParam, Coord::Row, StoreTransposed::Yes>(cfg, comm_grid);
 }

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -15,6 +15,7 @@
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/matrix/distribution.h"
 #include "dlaf/matrix/panel.h"
 
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
@@ -47,20 +48,14 @@ std::vector<config_t> test_params{
     {{26, 13}, {3, 3}, {1, 2}},
 };
 
-template <class TypeParam, Coord panel_axis>
+template <class TypeParam, Coord panel_axis, StoreTransposed Storage = StoreTransposed::No>
 void testBroadcast(const config_t& cfg, comm::CommunicatorGrid comm_grid) {
   using TypeUtil = TypeUtilities<TypeParam>;
   using pika::unwrapping;
 
-  constexpr Coord coord1D = orthogonal(panel_axis);
+  const matrix::Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
 
-  Matrix<TypeParam, dlaf::Device::CPU> matrix(cfg.sz, cfg.blocksz, comm_grid);
-  const auto& dist = matrix.distribution();
-
-  matrix::test::set(matrix, [](const auto& index) { return TypeUtil::element(index.get(coord1D), 26); });
-
-  Panel<panel_axis, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
-  static_assert(coord1D == decltype(panel)::coord, "coord types mismatch");
+  Panel<panel_axis, TypeParam, dlaf::Device::CPU, Storage> panel(dist, cfg.offset);
 
   // select the last available rank as root rank, i.e. it owns the panel to be broadcasted
   const comm::IndexT_MPI root = std::max(0, comm_grid.size().get(panel_axis) - 1);
@@ -97,6 +92,18 @@ TYPED_TEST(PanelBcastTest, BroadcastRow) {
   for (auto comm_grid : this->commGrids())
     for (const auto& cfg : test_params)
       testBroadcast<TypeParam, Coord::Row>(cfg, comm_grid);
+}
+
+TYPED_TEST(PanelBcastTest, BroadcastColStoreTransposed) {
+  for (auto comm_grid : this->commGrids())
+    for (const auto& cfg : test_params)
+      testBroadcast<TypeParam, Coord::Col, StoreTransposed::Yes>(cfg, comm_grid);
+}
+
+TYPED_TEST(PanelBcastTest, BroadcastRowStoreTransposed) {
+  for (auto comm_grid : this->commGrids())
+    for (const auto& cfg : test_params)
+      testBroadcast<TypeParam, Coord::Row, StoreTransposed::Yes>(cfg, comm_grid);
 }
 
 std::vector<config_t> test_params_bcast_transpose{

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -72,27 +72,26 @@ GlobalElementSize globalTestSize(const LocalElementSize& size, const Size2D& gri
   return {size.rows() * grid_size.rows(), size.cols() * grid_size.cols()};
 }
 
-TYPED_TEST(MatrixLocalTest, StaticAPI) {
-  constexpr Device device = Device::CPU;
+template <class T, Device D>
+void testStaticAPI() {
+  using matrix_t = Matrix<T, D>;
 
-  using matrix_t = Matrix<TypeParam, device>;
-
-  static_assert(std::is_same_v<TypeParam, typename matrix_t::ElementType>, "wrong ElementType");
-  static_assert(std::is_same_v<Tile<TypeParam, device>, typename matrix_t::TileType>, "wrong TileType");
-  static_assert(std::is_same_v<Tile<const TypeParam, device>, typename matrix_t::ConstTileType>,
+  // MatrixLike Traits
+  using ncT = std::remove_const_t<T>;
+  static_assert(std::is_same_v<ncT, typename matrix_t::ElementType>, "wrong ElementType");
+  static_assert(std::is_same_v<Tile<ncT, D>, typename matrix_t::TileType>, "wrong TileType");
+  static_assert(std::is_same_v<Tile<const T, D>, typename matrix_t::ConstTileType>,
                 "wrong ConstTileType");
 }
 
+TYPED_TEST(MatrixLocalTest, StaticAPI) {
+  testStaticAPI<TypeParam, Device::CPU>();
+  testStaticAPI<TypeParam, Device::GPU>();
+}
+
 TYPED_TEST(MatrixLocalTest, StaticAPIConst) {
-  constexpr Device device = Device::CPU;
-
-  using const_matrix_t = Matrix<const TypeParam, device>;
-
-  static_assert(std::is_same_v<TypeParam, typename const_matrix_t::ElementType>, "wrong ElementType");
-  static_assert(std::is_same_v<Tile<TypeParam, device>, typename const_matrix_t::TileType>,
-                "wrong TileType");
-  static_assert(std::is_same_v<Tile<const TypeParam, device>, typename const_matrix_t::ConstTileType>,
-                "wrong ConstTileType");
+  testStaticAPI<const TypeParam, Device::CPU>();
+  testStaticAPI<const TypeParam, Device::GPU>();
 }
 
 TYPED_TEST(MatrixLocalTest, Constructor) {

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -634,30 +634,18 @@ void testSetMutable(const GlobalElementSize size, const TileElementSize blocksiz
   checkPanelTileSize<CoordMutable>(default_dim, panel);
 }
 
-TYPED_TEST(PanelTest, SetWidth) {
+TYPED_TEST(PanelTest, SetMutableDim) {
   for (auto& comm_grid : this->commGrids()) {
     const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
-  }
-}
-
-TYPED_TEST(PanelTest, SetHeight) {
-  for (auto& comm_grid : this->commGrids()) {
-    const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
   }
 }
 
-TYPED_TEST(PanelStoreTransposedTest, SetWidth) {
+TYPED_TEST(PanelStoreTransposedTest, SetMutableDim) {
   for (auto& comm_grid : this->commGrids()) {
     const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-  }
-}
-
-TYPED_TEST(PanelStoreTransposedTest, SetHeight) {
-  for (auto& comm_grid : this->commGrids()) {
-    const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
   }
 }

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -46,7 +46,11 @@ using namespace dlaf::comm;
 template <typename Type>
 struct PanelTest : public TestWithCommGrids {};
 
+template <class T>
+using PanelStoreTransposedTest = PanelTest<T>;
+
 TYPED_TEST_SUITE(PanelTest, MatrixElementTypes);
+TYPED_TEST_SUITE(PanelStoreTransposedTest, MatrixElementTypes);
 
 // Helper for checking if current rank, along specific Axis, locally stores just an incomplete tile,
 // i.e. a tile with a size < blocksize
@@ -97,25 +101,33 @@ void testStaticAPI() {
 
 TYPED_TEST(PanelTest, StaticAPI) {
   testStaticAPI<Coord::Row, TypeParam, Device::CPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Row, TypeParam, Device::CPU, StoreTransposed::Yes>();
   testStaticAPI<Coord::Col, TypeParam, Device::CPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Col, TypeParam, Device::CPU, StoreTransposed::Yes>();
 
   testStaticAPI<Coord::Row, TypeParam, Device::GPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Row, TypeParam, Device::GPU, StoreTransposed::Yes>();
   testStaticAPI<Coord::Col, TypeParam, Device::GPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Col, TypeParam, Device::GPU, StoreTransposed::Yes>();
 }
 
 TYPED_TEST(PanelTest, StaticAPIConst) {
   testStaticAPI<Coord::Row, const TypeParam, Device::CPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Row, const TypeParam, Device::CPU, StoreTransposed::Yes>();
   testStaticAPI<Coord::Col, const TypeParam, Device::CPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Col, const TypeParam, Device::CPU, StoreTransposed::Yes>();
 
   testStaticAPI<Coord::Row, const TypeParam, Device::GPU, StoreTransposed::No>();
-  testStaticAPI<Coord::Row, const TypeParam, Device::GPU, StoreTransposed::Yes>();
   testStaticAPI<Coord::Col, const TypeParam, Device::GPU, StoreTransposed::No>();
+}
+
+TYPED_TEST(PanelStoreTransposedTest, StaticAPI) {
+  testStaticAPI<Coord::Row, TypeParam, Device::CPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, TypeParam, Device::CPU, StoreTransposed::Yes>();
+
+  testStaticAPI<Coord::Row, TypeParam, Device::GPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, TypeParam, Device::GPU, StoreTransposed::Yes>();
+}
+
+TYPED_TEST(PanelStoreTransposedTest, StaticAPIConst) {
+  testStaticAPI<Coord::Row, const TypeParam, Device::CPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, const TypeParam, Device::CPU, StoreTransposed::Yes>();
+
+  testStaticAPI<Coord::Row, const TypeParam, Device::GPU, StoreTransposed::Yes>();
   testStaticAPI<Coord::Col, const TypeParam, Device::GPU, StoreTransposed::Yes>();
 }
 
@@ -143,23 +155,33 @@ void testAssignToConstRef(const GlobalElementSize size, const TileElementSize bl
 TYPED_TEST(PanelTest, AssignToConstRefCol) {
   using namespace dlaf;
 
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, _] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, _] : test_params)
       testAssignToConstRef<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
-      testAssignToConstRef<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
-    }
-  }
 }
 
 TYPED_TEST(PanelTest, AssignToConstRefRow) {
   using namespace dlaf;
 
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, _] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, _] : test_params)
       testAssignToConstRef<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, AssignToConstRefCol) {
+  using namespace dlaf;
+
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, _] : test_params)
+      testAssignToConstRef<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, AssignToConstRefRow) {
+  using namespace dlaf;
+
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, _] : test_params)
       testAssignToConstRef<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
-    }
-  }
 }
 
 template <Coord Axis, class T, StoreTransposed Storage>
@@ -185,18 +207,26 @@ void testIterator(const GlobalElementSize size, const TileElementSize blocksize,
 
 TYPED_TEST(PanelTest, IteratorCol) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& [size, blocksize, offset] : test_params) {
+    for (const auto& [size, blocksize, offset] : test_params)
       testIterator<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
-      testIterator<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
 }
 
 TYPED_TEST(PanelTest, IteratorRow) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& [size, blocksize, offset] : test_params) {
+    for (const auto& [size, blocksize, offset] : test_params)
       testIterator<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, IteratorCol) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
+      testIterator<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, IteratorRow) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testIterator<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
 }
 
 template <Coord Axis, class T, StoreTransposed Storage>
@@ -239,18 +269,26 @@ void testAccess(const GlobalElementSize size, const TileElementSize blocksize,
 
 TYPED_TEST(PanelTest, AccessTileCol) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& [size, blocksize, offset] : test_params) {
+    for (const auto& [size, blocksize, offset] : test_params)
       testAccess<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
-      testAccess<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
 }
 
 TYPED_TEST(PanelTest, AccessTileRow) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& [size, blocksize, offset] : test_params) {
+    for (const auto& [size, blocksize, offset] : test_params)
       testAccess<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, AccessTileCol) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
+      testAccess<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, AccessTileRow) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testAccess<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
 }
 
 template <Coord Axis, class T, StoreTransposed Storage>
@@ -348,21 +386,27 @@ void testExternalTile(const GlobalElementSize size, const TileElementSize blocks
 }
 
 TYPED_TEST(PanelTest, ExternalTilesCol) {
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, offset] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testExternalTile<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
-      testExternalTile<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
-  }
 }
 
 TYPED_TEST(PanelTest, ExternalTilesRow) {
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, offset] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testExternalTile<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, ExternalTilesCol) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
+      testExternalTile<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, ExternalTilesRow) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testExternalTile<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
-  }
 }
 
 template <Coord Axis, class T, StoreTransposed Storage>
@@ -491,21 +535,27 @@ void testShrink(const GlobalElementSize size, const TileElementSize blocksize,
 }
 
 TYPED_TEST(PanelTest, ShrinkCol) {
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, offset] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testShrink<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
-      testShrink<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
-  }
 }
 
 TYPED_TEST(PanelTest, ShrinkRow) {
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, offset] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testShrink<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, ShrinkCol) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
+      testShrink<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, ShrinkRow) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testShrink<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
-    }
-  }
 }
 
 template <Coord CoordMutable, Coord Axis, class T, Device D, StoreTransposed Storage>
@@ -588,7 +638,6 @@ TYPED_TEST(PanelTest, SetWidth) {
   for (auto& comm_grid : this->commGrids()) {
     const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
-    testSetMutable<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
   }
 }
 
@@ -596,6 +645,19 @@ TYPED_TEST(PanelTest, SetHeight) {
   for (auto& comm_grid : this->commGrids()) {
     const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+  }
+}
+
+TYPED_TEST(PanelStoreTransposedTest, SetWidth) {
+  for (auto& comm_grid : this->commGrids()) {
+    const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
+    testSetMutable<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+  }
+}
+
+TYPED_TEST(PanelStoreTransposedTest, SetHeight) {
+  for (auto& comm_grid : this->commGrids()) {
+    const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
     testSetMutable<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
   }
 }
@@ -649,19 +711,25 @@ void testOffsetTileUnaligned(const GlobalElementSize size, const TileElementSize
 }
 
 TYPED_TEST(PanelTest, OffsetTileUnalignedRow) {
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, offset] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
       testOffsetTileUnaligned<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
-      testOffsetTileUnaligned<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
-    }
-  }
 }
 
 TYPED_TEST(PanelTest, OffsetTileUnalignedCol) {
-  for (auto& comm_grid : this->commGrids()) {
-    for (const auto& [size, blocksize, _] : test_params) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, _] : test_params)
       testOffsetTileUnaligned<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, OffsetTileUnalignedRow) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, offset] : test_params)
+      testOffsetTileUnaligned<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
+}
+
+TYPED_TEST(PanelStoreTransposedTest, OffsetTileUnalignedCol) {
+  for (auto& comm_grid : this->commGrids())
+    for (const auto& [size, blocksize, _] : test_params)
       testOffsetTileUnaligned<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
-    }
-  }
 }

--- a/test/unit/matrix/test_panel.cpp
+++ b/test/unit/matrix/test_panel.cpp
@@ -8,21 +8,24 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/common/index2d.h"
-#include "dlaf/matrix/distribution.h"
-#include "dlaf/matrix/index.h"
 #include "dlaf/matrix/panel.h"
 
+#include <functional>
+#include <type_traits>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include <pika/unwrap.hpp>
 
+#include "dlaf/common/index2d.h"
 #include "dlaf/common/range2d.h"
 #include "dlaf/communication/communicator.h"
 #include "dlaf/communication/communicator_grid.h"
+#include "dlaf/matrix/distribution.h"
+#include "dlaf/matrix/index.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/sender/transform.h"
+#include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
 
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
@@ -69,52 +72,111 @@ struct config_t {
 
 std::vector<config_t> test_params{
     {{0, 0}, {3, 3}, {0, 0}},  // empty matrix
+    // square blocksize
     {{8, 5}, {3, 3}, {0, 0}},
     {{26, 13}, {3, 3}, {1, 2}},
+    // non-square blocksize
+    {{26, 13}, {5, 4}, {1, 2}},
+    {{13, 26}, {5, 4}, {1, 2}},
 };
 
-TYPED_TEST(PanelTest, AssignToConstRef) {
+template <Coord Axis, class T, Device D, StoreTransposed Storage>
+void testStaticAPI() {
+  using panel_t = Panel<Axis, T, D, Storage>;
+
+  static_assert(panel_t::device == D, "wrong device");
+  static_assert(panel_t::coord == orthogonal(Axis), "wrong coord");
+
+  // MatrixLike Traits
+  using ncT = std::remove_const_t<T>;
+  static_assert(std::is_same_v<ncT, typename panel_t::ElementType>, "wrong ElementType");
+  static_assert(std::is_same_v<Tile<ncT, D>, typename panel_t::TileType>, "wrong TileType");
+  static_assert(std::is_same_v<Tile<const T, D>, typename panel_t::ConstTileType>,
+                "wrong ConstTileType");
+}
+
+TYPED_TEST(PanelTest, StaticAPI) {
+  testStaticAPI<Coord::Row, TypeParam, Device::CPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Row, TypeParam, Device::CPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, TypeParam, Device::CPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Col, TypeParam, Device::CPU, StoreTransposed::Yes>();
+
+  testStaticAPI<Coord::Row, TypeParam, Device::GPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Row, TypeParam, Device::GPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, TypeParam, Device::GPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Col, TypeParam, Device::GPU, StoreTransposed::Yes>();
+}
+
+TYPED_TEST(PanelTest, StaticAPIConst) {
+  testStaticAPI<Coord::Row, const TypeParam, Device::CPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Row, const TypeParam, Device::CPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, const TypeParam, Device::CPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Col, const TypeParam, Device::CPU, StoreTransposed::Yes>();
+
+  testStaticAPI<Coord::Row, const TypeParam, Device::GPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Row, const TypeParam, Device::GPU, StoreTransposed::Yes>();
+  testStaticAPI<Coord::Col, const TypeParam, Device::GPU, StoreTransposed::No>();
+  testStaticAPI<Coord::Col, const TypeParam, Device::GPU, StoreTransposed::Yes>();
+}
+
+template <Coord Axis, class T, StoreTransposed Storage>
+void testAssignToConstRef(const GlobalElementSize size, const TileElementSize blocksize,
+                          const comm::CommunicatorGrid& comm_grid) {
+  const Distribution dist(size, blocksize, comm_grid.size(), comm_grid.rank(), {0, 0});
+
+  Panel<Axis, T, dlaf::Device::CPU, Storage> panel(dist);
+  Panel<Axis, const T, dlaf::Device::CPU, Storage>& ref = panel;
+
+  std::vector<LocalTileIndex> exp_indices(panel.iteratorLocal().begin(), panel.iteratorLocal().end());
+  std::vector<LocalTileIndex> ref_indices(ref.iteratorLocal().begin(), ref.iteratorLocal().end());
+
+  EXPECT_EQ(exp_indices, ref_indices);
+
+  for (const auto& idx : exp_indices) {
+    auto exp_tile_f = panel.read(idx);
+    const auto& exp_tile = exp_tile_f.get();
+    auto get_element_ptr = [&exp_tile](const TileElementIndex& index) { return exp_tile.ptr(index); };
+    CHECK_TILE_PTR(get_element_ptr, ref.read(idx).get());
+  }
+}
+
+TYPED_TEST(PanelTest, AssignToConstRefCol) {
   using namespace dlaf;
 
   for (auto& comm_grid : this->commGrids()) {
-    for (const auto& cfg : test_params) {
-      const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
-
-      Panel<Coord::Col, TypeParam, dlaf::Device::CPU> panel(dist);
-      Panel<Coord::Col, const TypeParam, dlaf::Device::CPU>& ref = panel;
-
-      std::vector<LocalTileIndex> exp_indices(panel.iteratorLocal().begin(),
-                                              panel.iteratorLocal().end());
-      std::vector<LocalTileIndex> ref_indices(ref.iteratorLocal().begin(), ref.iteratorLocal().end());
-
-      EXPECT_EQ(exp_indices, ref_indices);
-
-      for (const auto& idx : exp_indices) {
-        auto exp_tile_f = panel.read(idx);
-        const auto& exp_tile = exp_tile_f.get();
-        auto get_element_ptr = [&exp_tile](const TileElementIndex& index) {
-          return exp_tile.ptr(index);
-        };
-        CHECK_TILE_PTR(get_element_ptr, ref.read(idx).get());
-      }
+    for (const auto& [size, blocksize, _] : test_params) {
+      testAssignToConstRef<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
+      testAssignToConstRef<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
     }
   }
 }
 
-template <class TypeParam, Coord panel_axis>
-void testIterator(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
-  const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
+TYPED_TEST(PanelTest, AssignToConstRefRow) {
+  using namespace dlaf;
 
-  Panel<panel_axis, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
-  constexpr auto CT = decltype(panel)::coord;
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, _] : test_params) {
+      testAssignToConstRef<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
+      testAssignToConstRef<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
+    }
+  }
+}
 
-  const auto offset_loc = dist.template nextLocalTileFromGlobalTile<CT>(cfg.offset.get<CT>());
-  const auto exp_nrTiles = dist.localNrTiles().get<CT>();
+template <Coord Axis, class T, StoreTransposed Storage>
+void testIterator(const GlobalElementSize size, const TileElementSize blocksize,
+                  const GlobalTileIndex offset, const comm::CommunicatorGrid& comm_grid) {
+  const Distribution dist(size, blocksize, comm_grid.size(), comm_grid.rank(), {0, 0});
+
+  Panel<Axis, T, dlaf::Device::CPU, Storage> panel(dist, offset);
+  constexpr Coord coord = decltype(panel)::coord;
+
+  const auto offset_loc = dist.template nextLocalTileFromGlobalTile<coord>(offset.get<coord>());
+  const auto exp_nrTiles = dist.localNrTiles().get<coord>();
 
   std::vector<LocalTileIndex> exp_indices;
   exp_indices.reserve(static_cast<size_t>(exp_nrTiles));
   for (auto index = offset_loc; index < exp_nrTiles; ++index)
-    exp_indices.emplace_back(CT, index, 0);
+    exp_indices.emplace_back(coord, index, 0);
 
   std::vector<LocalTileIndex> indices(panel.iteratorLocal().begin(), panel.iteratorLocal().end());
 
@@ -123,26 +185,30 @@ void testIterator(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) 
 
 TYPED_TEST(PanelTest, IteratorCol) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testIterator<TypeParam, Coord::Col>(cfg, comm_grid);
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testIterator<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testIterator<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
 }
 
 TYPED_TEST(PanelTest, IteratorRow) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testIterator<TypeParam, Coord::Row>(cfg, comm_grid);
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testIterator<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testIterator<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
 }
 
-template <class TypeParam, Coord panel_axis>
-void testAccess(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
-  using TypeUtil = TypeUtilities<TypeParam>;
+template <Coord Axis, class T, StoreTransposed Storage>
+void testAccess(const GlobalElementSize size, const TileElementSize blocksize,
+                const GlobalTileIndex offset, const comm::CommunicatorGrid comm_grid) {
+  using TypeUtil = TypeUtilities<T>;
   using pika::unwrapping;
 
-  const Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
+  const Distribution dist(size, blocksize, comm_grid.size(), comm_grid.rank(), {0, 0});
 
-  using PanelType = Panel<panel_axis, TypeParam, dlaf::Device::CPU>;
-  PanelType panel(dist, cfg.offset);
-  constexpr Coord coord = PanelType::coord;
+  Panel<Axis, T, dlaf::Device::CPU, Storage> panel(dist, offset);
+  constexpr Coord coord = decltype(panel)::coord;
 
   // rw-access
   for (const auto& idx : panel.iteratorLocal()) {
@@ -161,9 +227,7 @@ void testAccess(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
   for (const auto& idx : panel.iteratorLocal()) {
     dlaf::internal::transformDetach(
         dlaf::internal::Policy<dlaf::Backend::MC>(),
-        [idx](typename PanelType::TileType&& tile) {
-          matrix::test::set(tile, TypeUtil::element(idx.get(coord), 42));
-        },
+        [idx](auto&& tile) { matrix::test::set(tile, TypeUtil::element(idx.get(coord), 42)); },
         panel.readwrite_sender(idx));
   }
 
@@ -175,57 +239,90 @@ void testAccess(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
 
 TYPED_TEST(PanelTest, AccessTileCol) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testAccess<TypeParam, Coord::Col>(cfg, comm_grid);
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testAccess<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testAccess<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
 }
 
 TYPED_TEST(PanelTest, AccessTileRow) {
   for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testAccess<TypeParam, Coord::Row>(cfg, comm_grid);
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testAccess<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testAccess<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
 }
 
-template <class TypeParam, Coord panel_axis>
-void testExternalTile(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
-  using TypeUtil = TypeUtilities<TypeParam>;
-  using pika::unwrapping;
+template <Coord Axis, class T, StoreTransposed Storage>
+void testExternalTile(const GlobalElementSize size, const TileElementSize blocksize,
+                      const GlobalTileIndex offset, const comm::CommunicatorGrid comm_grid) {
+  using TypeUtil = TypeUtilities<T>;
+  using dlaf::internal::Policy;
+  using dlaf::internal::transformDetach;
 
-  constexpr Coord coord = orthogonal(panel_axis);
+  namespace tt = pika::this_thread::experimental;
 
-  using MatrixType = Matrix<TypeParam, dlaf::Device::CPU>;
-  MatrixType matrix(cfg.sz, cfg.blocksz, comm_grid);
-  const auto& dist = matrix.distribution();
+  constexpr Coord coord = orthogonal(Axis);
+
+  const comm::Index2D src_rank_idx(0, 0);
+  const matrix::Distribution dist(size, blocksize, comm_grid.size(), comm_grid.rank(), src_rank_idx);
+
+  // Note:
+  // dist_t represents the full transposition of the distribution dist, which is useful when dealing with
+  // StoreTransposed panels.
+  // Indeed, a StoreTransposed panel represents a "classic" panel for a fully  transposed matrix (both
+  // shape and rank distribution). So, passing the straight dist for panel construciton, we can find
+  // work with shape-compatible if we construct the support matrix with dist_t.
+  // It is important to highlight that, due to the transposition, a StoreTransposed::Yes Column panel,
+  // will "match" the transposed matrix along the orthogonal axis, i.e. Row of the matrix, and viceversa.
+  //
+  // For this reason we have to conditionally (depending on StoreTransposed value) use:
+  // - dist_t
+  // - correctIndex helper
+  [[maybe_unused]] const matrix::Distribution dist_t(common::transposed(size),
+                                                     common::transposed(blocksize),
+                                                     common::transposed(comm_grid.size()),
+                                                     common::transposed(comm_grid.rank()),
+                                                     common::transposed(src_rank_idx));
+
+  const auto correctIndex = [](LocalTileIndex panel_ij) {
+    if constexpr (StoreTransposed::Yes == Storage)
+      panel_ij.transpose();
+    return panel_ij;
+  };
+
+  Matrix<T, dlaf::Device::CPU> matrix(StoreTransposed::No == Storage ? dist : dist_t);
+  Panel<Axis, T, dlaf::Device::CPU, Storage> panel(dist, offset);
 
   matrix::test::set(matrix, [](const auto& index) { return TypeUtil::element(index.get(coord), 26); });
 
-  Panel<panel_axis, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
-  static_assert(coord == decltype(panel)::coord, "coord types mismatch");
-
   // if locally there are just incomplete tiles, skip the test (not worth it)
-  if (doesThisRankOwnsJustIncomplete<panel_axis>(dist))
+  if (doesThisRankOwnsJustIncomplete<Axis>(dist))
     return;
 
-  // if there is no local tiles...cannot test external tiles
+  // if there are no local tiles...cannot test external tiles
   if (dist.localNrTiles().isEmpty())
     return;
 
   // Note:
-  // - Even indexed tiles in panel, odd indexed linked to the matrix first column
+  // - Even indexed tiles in panel, odd indexed linked to the matrix first row/column
   // - Even indexed, i.e. the one using panel memory, are set to a different value
-  for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 0)
-      panel(idx).then(unwrapping(
-          [idx](auto&& tile) { matrix::test::set(tile, TypeUtil::element(-idx.get(coord), 13)); }));
+  for (auto idx : panel.iteratorLocal()) {
+    if (idx.template get<coord>() % 2 == 0)
+      panel.readwrite_sender(idx) | transformDetach(Policy<Backend::MC>{}, [idx](auto&& tile) {
+        matrix::test::set(tile, TypeUtil::element(-idx.get(coord), 13));
+      });
     else
-      panel.setTile(idx, matrix.read(idx));
+      panel.setTile(idx, matrix.read(correctIndex(idx)));
   }
 
   // Check that the values are correct, both for internal and externally linked tiles
   for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 0)
-      CHECK_TILE_EQ(TypeUtil::element(-idx.get(coord), 13), panel.read(idx).get());
+    if (idx.template get<coord>() % 2 == 0)
+      CHECK_TILE_EQ(TypeUtil::element(-idx.get(coord), 13), tt::sync_wait(panel.read_sender(idx)).get());
     else
-      CHECK_TILE_EQ(matrix.read(idx).get(), panel.read(idx).get());
+      CHECK_TILE_EQ(tt::sync_wait(matrix.read_sender(correctIndex(idx))).get(),
+                    tt::sync_wait(panel.read_sender(idx)).get());
   }
 
   // Reset external tiles links
@@ -233,138 +330,69 @@ void testExternalTile(const config_t& cfg, const comm::CommunicatorGrid comm_gri
 
   // Invert the "logic" of external tiles: even are linked to matrix, odd are in-panel
   for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 1)
-      panel(idx).then(unwrapping(
-          [idx](auto&& tile) { matrix::test::set(tile, TypeUtil::element(-idx.get(coord), 5)); }));
-    else
-      panel.setTile(idx, matrix.read(idx));
-  }
-
-  for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 1)
-      CHECK_TILE_EQ(TypeUtil::element(-idx.get(coord), 5), panel.read(idx).get());
-    else
-      CHECK_TILE_EQ(matrix.read(idx).get(), panel.read(idx).get());
-  }
-}
-
-template <class TypeParam, Coord panel_axis>
-void testExternalTileWithSenders(const config_t& cfg, const comm::CommunicatorGrid comm_grid) {
-  using TypeUtil = TypeUtilities<TypeParam>;
-  using dlaf::internal::Policy;
-  using dlaf::internal::transformDetach;
-  using pika::this_thread::experimental::sync_wait;
-
-  constexpr Coord coord1D = orthogonal(panel_axis);
-
-  using MatrixType = Matrix<TypeParam, dlaf::Device::CPU>;
-  using TileType = typename MatrixType::TileType;
-  MatrixType matrix(cfg.sz, cfg.blocksz, comm_grid);
-  const auto& dist = matrix.distribution();
-  const Policy<Backend::MC> policy{};
-
-  matrix::test::set(matrix, [](const auto& index) { return TypeUtil::element(index.get(coord1D), 26); });
-
-  Panel<panel_axis, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
-  static_assert(coord1D == decltype(panel)::coord, "coord types mismatch");
-
-  // if locally there are just incomplete tiles, skip the test (not worth it)
-  if (doesThisRankOwnsJustIncomplete<panel_axis>(dist))
-    return;
-
-  // if there is no local tiles...cannot test external tiles
-  if (dist.localNrTiles().isEmpty())
-    return;
-
-  // Note:
-  // - Even indexed tiles in panel, odd indexed linked to the matrix first column
-  // - Even indexed, i.e. the one using panel memory, are set to a different value
-  for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 0)
-      panel.readwrite_sender(idx) | transformDetach(policy, [idx](TileType&& tile) {
-        matrix::test::set(tile, TypeUtil::element(-idx.get(coord1D), 13));
+    if (idx.template get<coord>() % 2 == 0)
+      panel.readwrite_sender(idx) | transformDetach(Policy<Backend::MC>{}, [idx](auto&& tile) {
+        matrix::test::set(tile, TypeUtil::element(-idx.get(coord), 5));
       });
     else
-      panel.setTile(idx, matrix.read(idx));
-  }
-
-  // Check that the values are correct, both for internal and externally linked tiles
-  for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 0)
-      CHECK_TILE_EQ(TypeUtil::element(-idx.get(coord1D), 13), sync_wait(panel.read_sender(idx)).get());
-    else
-      CHECK_TILE_EQ(sync_wait(matrix.read_sender(idx)).get(), sync_wait(panel.read_sender(idx)).get());
-  }
-
-  // Reset external tiles links
-  panel.reset();
-
-  // Invert the "logic" of external tiles: even are linked to matrix, odd are in-panel
-  for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 1)
-      panel.readwrite_sender(idx) | transformDetach(policy, [idx](TileType&& tile) {
-        matrix::test::set(tile, TypeUtil::element(-idx.get(coord1D), 5));
-      });
-    else
-      panel.setTile(idx, matrix.read(idx));
+      panel.setTile(idx, matrix.read(correctIndex(idx)));
   }
 
   for (const auto& idx : panel.iteratorLocal()) {
-    if (idx.row() % 2 == 1)
-      CHECK_TILE_EQ(TypeUtil::element(-idx.get(coord1D), 5), sync_wait(panel.read_sender(idx)).get());
+    if (idx.template get<coord>() % 2 == 0)
+      CHECK_TILE_EQ(TypeUtil::element(-idx.get(coord), 5), tt::sync_wait(panel.read_sender(idx)).get());
     else
-      CHECK_TILE_EQ(sync_wait(matrix.read_sender(idx)).get(), sync_wait(panel.read_sender(idx)).get());
+      CHECK_TILE_EQ(tt::sync_wait(matrix.read_sender(correctIndex(idx))).get(),
+                    tt::sync_wait(panel.read_sender(idx)).get());
   }
 }
 
 TYPED_TEST(PanelTest, ExternalTilesCol) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testExternalTile<TypeParam, Coord::Col>(cfg, comm_grid);
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testExternalTile<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testExternalTile<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
+  }
 }
 
 TYPED_TEST(PanelTest, ExternalTilesRow) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testExternalTile<TypeParam, Coord::Row>(cfg, comm_grid);
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testExternalTile<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testExternalTile<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
+  }
 }
 
-TYPED_TEST(PanelTest, ExternalTilesColWithSenders) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testExternalTileWithSenders<TypeParam, Coord::Col>(cfg, comm_grid);
-}
+template <Coord Axis, class T, StoreTransposed Storage>
+void testShrink(const GlobalElementSize size, const TileElementSize blocksize,
+                const GlobalTileIndex offset, const comm::CommunicatorGrid& comm_grid) {
+  constexpr Coord coord = orthogonal(Axis);
 
-TYPED_TEST(PanelTest, ExternalTilesRowWithSenders) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testExternalTileWithSenders<TypeParam, Coord::Row>(cfg, comm_grid);
-}
-
-template <class TypeParam, Coord panel_axis>
-void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
-  constexpr Coord coord = orthogonal(panel_axis);
-
-  Matrix<TypeParam, dlaf::Device::CPU> matrix(cfg.sz, cfg.blocksz, comm_grid);
+  Matrix<T, dlaf::Device::CPU> matrix(size, blocksize, comm_grid);
   const auto& dist = matrix.distribution();
   const SizeType bs = dist.blockSize().get(coord);
 
-  Panel<panel_axis, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
+  Panel<Axis, T, dlaf::Device::CPU, Storage> panel(dist, offset);
   static_assert(coord == decltype(panel)::coord, "coord types mismatch");
-  EXPECT_EQ(cfg.offset.get<coord>() * bs, panel.offsetElement());
+  EXPECT_EQ(offset.get<coord>() * bs, panel.offsetElement());
 
   // if locally there are just incomplete tiles, skip the test (not worth it)
-  if (doesThisRankOwnsJustIncomplete<panel_axis>(dist))
+  if (doesThisRankOwnsJustIncomplete<Axis>(dist))
     return;
 
   // if there is no local tiles...there is nothing to check
   if (dist.localNrTiles().isEmpty())
     return;
 
-  auto setTile = [](const auto& tile, TypeParam value) noexcept {
+  auto setTile = [](const auto& tile, T value) noexcept {
     tile::internal::laset(blas::Uplo::General, value, value, tile);
   };
 
+  // Note:
+  // The only difference between StoreTransposed::Yes and StoreTransposed::No is that in the former
+  // case tiles are expected to have a transposed shape.
   auto setAndCheck = [=, &matrix, &panel](std::string msg, SizeType head_loc, SizeType tail_loc) {
     const auto message = ::testing::Message()
                          << msg << " head_loc:" << head_loc << " tail_loc:" << tail_loc;
@@ -392,8 +420,12 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
       auto matrix_tile_f = matrix.read(idx);
       const auto& matrix_tile = matrix_tile_f.get();
 
+      auto tile_size = matrix_tile.size();
+      if constexpr (StoreTransposed::Yes == Storage)
+        tile_size.transpose();
+
       SCOPED_TRACE(message);
-      EXPECT_EQ(panel_tile.size(), matrix_tile.size());
+      EXPECT_EQ(tile_size, panel_tile.size());
     }
 
     counter = 0;
@@ -405,14 +437,19 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
       auto matrix_tile_f = matrix.read(idx);
       const auto& matrix_tile = matrix_tile_f.get();
 
+      auto tile_size = matrix_tile.size();
+      if constexpr (StoreTransposed::Yes == Storage)
+        tile_size.transpose();
+
       SCOPED_TRACE(message);
+      EXPECT_EQ(tile_size, panel_tile.size());
+
       CHECK_TILE_EQ(fixedValueTile(counter++), panel_tile);
-      EXPECT_EQ(panel_tile.size(), matrix_tile.size());
     }
   };
 
   // Shrink from head
-  for (SizeType head = cfg.offset.get<coord>(); head <= dist.nrTiles().get(coord); ++head) {
+  for (SizeType head = offset.get<coord>(); head <= dist.nrTiles().get(coord); ++head) {
     panel.setRangeStart(GlobalTileIndex(coord, head));
     EXPECT_EQ(head * bs, panel.offsetElement());
 
@@ -425,12 +462,12 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
   }
 
   // Shrink from tail
-  for (SizeType tail = dist.nrTiles().get(coord); cfg.offset.get<coord>() <= tail; --tail) {
-    panel.setRangeStart(cfg.offset);
+  for (SizeType tail = dist.nrTiles().get(coord); offset.get<coord>() <= tail; --tail) {
+    panel.setRangeStart(offset);
     panel.setRangeEnd(GlobalTileIndex(coord, tail));
-    EXPECT_EQ(cfg.offset.get<coord>() * bs, panel.offsetElement());
+    EXPECT_EQ(offset.get<coord>() * bs, panel.offsetElement());
 
-    const auto head_loc = dist.template nextLocalTileFromGlobalTile<coord>(cfg.offset.get<coord>());
+    const auto head_loc = dist.template nextLocalTileFromGlobalTile<coord>(offset.get<coord>());
     const auto tail_loc = dist.template nextLocalTileFromGlobalTile<coord>(tail);
 
     setAndCheck("tail", head_loc, tail_loc);
@@ -439,7 +476,7 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
   }
 
   // Shrink from both ends
-  for (SizeType head = cfg.offset.get<coord>(), tail = dist.nrTiles().get(coord); head <= tail;
+  for (SizeType head = offset.get<coord>(), tail = dist.nrTiles().get(coord); head <= tail;
        ++head, --tail) {
     panel.setRange(GlobalTileIndex(coord, head), GlobalTileIndex(coord, tail));
     EXPECT_EQ(head * bs, panel.offsetElement());
@@ -454,107 +491,127 @@ void testShrink(const config_t& cfg, const comm::CommunicatorGrid& comm_grid) {
 }
 
 TYPED_TEST(PanelTest, ShrinkCol) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testShrink<TypeParam, Coord::Col>(cfg, comm_grid);
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testShrink<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testShrink<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
+  }
 }
 
 TYPED_TEST(PanelTest, ShrinkRow) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& cfg : test_params)
-      testShrink<TypeParam, Coord::Row>(cfg, comm_grid);
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testShrink<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+      testShrink<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
+    }
+  }
 }
 
-// For a col panel dim is the panel width.
-// For a row panel dim is the panel height.
-template <Coord panel_axis, class T, Device D>
-void checkPanelTileSize(SizeType dim, Panel<panel_axis, T, D>& panel) {
-  constexpr auto coord = std::decay_t<decltype(panel)>::coord;
+template <Coord CoordMutable, Coord Axis, class T, Device D, StoreTransposed Storage>
+void checkPanelTileSize(SizeType dim_mutable, Panel<Axis, T, D, Storage>& panel) {
+  constexpr Coord CoordFixed = orthogonal(CoordMutable);
   const Distribution& dist = panel.parentDistribution();
-  for (SizeType i = panel.rangeStartLocal(); i < panel.rangeEndLocal(); ++i) {
-    // Define the correct tile_size
-    auto dim_perp = dist.blockSize().get<coord>();
-    if (dist.globalTileFromLocalTile<coord>(i) == dist.nrTiles().get<coord>() - 1)
-      dim_perp = dist.size().get<coord>() % dist.blockSize().get<coord>();
-    const auto tile_size = [](auto dim, auto dim_perp) {
-      return TileElementSize(panel_axis, dim, dim_perp);
-    }(dim, dim_perp);
 
-    EXPECT_EQ(tile_size, panel(LocalTileIndex{coord, i}).get().size());
-    EXPECT_EQ(tile_size, panel.read(LocalTileIndex{coord, i}).get().size());
+  for (const auto ij : panel.iteratorLocal()) {
+    const TileElementSize full_tile_size = dist.tileSize(dist.globalTileIndex(ij));
+    // Note:
+    // Get the fixed coordinate value, but in case it is StoreTransposed::Yes, the expected full tile
+    // size is tranposed wrt the matrix related one.
+    const SizeType dim_fixed =
+        (StoreTransposed::No == Storage ? full_tile_size : common::transposed(full_tile_size))
+            .template get<CoordFixed>();
+    const TileElementSize tile_size(CoordMutable, dim_mutable, dim_fixed);
+
+    EXPECT_EQ(tile_size, panel(ij).get().size());
+    EXPECT_EQ(tile_size, panel.read(ij).get().size());
   }
+}
+
+template <Coord Axis, class T, StoreTransposed Storage>
+void testSetMutable(const GlobalElementSize size, const TileElementSize blocksize,
+                    const GlobalTileIndex offset, const comm::CommunicatorGrid& comm_grid) {
+  const Distribution dist(size, blocksize, comm_grid.size(), comm_grid.rank(), {0, 0});
+
+  constexpr Coord CoordFixed = StoreTransposed::No == Storage ? orthogonal(Axis) : Axis;
+  constexpr Coord CoordMutable = orthogonal(CoordFixed);
+
+  using PanelType = Panel<Axis, T, dlaf::Device::CPU, Storage>;
+
+  PanelType panel(dist, offset);
+
+  // Note:
+  // These next two helpers hides in the test the difference in accessing information about the
+  // mutable dimension for the two different Panel axis.
+  auto getMutableDim = []() {
+    using Func = SizeType (PanelType::*)(void) const;
+    if constexpr (Coord::Col == Axis)
+      return std::mem_fn(Func(&PanelType::getWidth));
+    else
+      return std::mem_fn(Func(&PanelType::getHeight));
+  }();
+
+  auto setMutableDim = []() {
+    using Func = void (PanelType::*)(SizeType);
+    if constexpr (Coord::Col == Axis)
+      return std::mem_fn(Func(&PanelType::setWidth));
+    else
+      return std::mem_fn(Func(&PanelType::setHeight));
+  }();
+
+  const SizeType default_dim =
+      (StoreTransposed::No == Storage ? blocksize : common::transposed(blocksize))
+          .template get<CoordMutable>();
+
+  EXPECT_EQ(default_dim, getMutableDim(panel));
+  checkPanelTileSize<CoordMutable>(default_dim, panel);
+  // Check twice as size shouldn't change
+  checkPanelTileSize<CoordMutable>(default_dim, panel);
+
+  for (const SizeType dim : {default_dim / 2, default_dim}) {
+    panel.reset();
+    setMutableDim(panel, dim);
+    EXPECT_EQ(dim, getMutableDim(panel));
+    checkPanelTileSize<CoordMutable>(dim, panel);
+    // Check twice as size shouldn't change
+    checkPanelTileSize<CoordMutable>(dim, panel);
+  }
+
+  panel.reset();
+  EXPECT_EQ(default_dim, getMutableDim(panel));
+  checkPanelTileSize<CoordMutable>(default_dim, panel);
+  // Check twice as size shouldn't change
+  checkPanelTileSize<CoordMutable>(default_dim, panel);
 }
 
 TYPED_TEST(PanelTest, SetWidth) {
   for (auto& comm_grid : this->commGrids()) {
-    const config_t cfg = {{26, 13}, {4, 5}, {0, 0}};
-
-    Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
-    Panel<Coord::Col, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
-
-    const auto default_dim = cfg.blocksz.cols();
-
-    EXPECT_EQ(default_dim, panel.getWidth());
-    checkPanelTileSize(default_dim, panel);
-    // Check twice as size shouldn't change
-    checkPanelTileSize(default_dim, panel);
-    for (const auto dim : {default_dim / 2, default_dim}) {
-      panel.reset();
-      panel.setWidth(dim);
-      EXPECT_EQ(dim, panel.getWidth());
-      checkPanelTileSize(dim, panel);
-      // Check twice as size shouldn't change
-      checkPanelTileSize(dim, panel);
-    }
-    panel.reset();
-    EXPECT_EQ(default_dim, panel.getWidth());
-    checkPanelTileSize(default_dim, panel);
-    // Check twice as size shouldn't change
-    checkPanelTileSize(default_dim, panel);
+    const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
+    testSetMutable<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+    testSetMutable<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
   }
 }
 
 TYPED_TEST(PanelTest, SetHeight) {
   for (auto& comm_grid : this->commGrids()) {
-    config_t cfg = {{26, 13}, {4, 5}, {0, 0}};
-
-    Distribution dist(cfg.sz, cfg.blocksz, comm_grid.size(), comm_grid.rank(), {0, 0});
-    Panel<Coord::Row, TypeParam, dlaf::Device::CPU> panel(dist, cfg.offset);
-
-    const auto default_dim = cfg.blocksz.rows();
-
-    EXPECT_EQ(default_dim, panel.getHeight());
-    checkPanelTileSize(default_dim, panel);
-    // Check twice as size shouldn't change
-    checkPanelTileSize(default_dim, panel);
-    for (const auto dim : {default_dim / 2, default_dim}) {
-      panel.reset();
-      panel.setHeight(dim);
-      EXPECT_EQ(dim, panel.getHeight());
-      checkPanelTileSize(dim, panel);
-      // Check twice as size shouldn't change
-      checkPanelTileSize(dim, panel);
-    }
-    panel.reset();
-    EXPECT_EQ(default_dim, panel.getHeight());
-    checkPanelTileSize(default_dim, panel);
-    // Check twice as size shouldn't change
-    checkPanelTileSize(default_dim, panel);
+    const auto [size, blocksize, offset] = config_t{{26, 13}, {4, 5}, {0, 0}};
+    testSetMutable<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, offset, comm_grid);
+    testSetMutable<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, offset, comm_grid);
   }
 }
 
-template <class T, Coord Axis>
+template <Coord Axis, class T, StoreTransposed Storage>
 void testOffsetTileUnaligned(const GlobalElementSize size, const TileElementSize blocksize,
                              const comm::CommunicatorGrid& comm_grid) {
   const Distribution dist(size, blocksize, comm_grid.size(), comm_grid.rank(), {0, 0});
 
-  Panel<Axis, T, dlaf::Device::CPU> panel(dist);
-  constexpr auto coord = Panel<Axis, T, Device::CPU>::coord;
+  Panel<Axis, T, dlaf::Device::CPU, Storage> panel(dist);
+  constexpr Coord coord = decltype(panel)::coord;
 
   const SizeType size_axis = std::min(blocksize.get<Axis>(), size.get<Axis>());
   const GlobalElementSize panel_size(coord, size.get<coord>(), size_axis);
 
-  // use each row of the matrix as offset
+  // use each row/col of the matrix as offset
   for (SizeType offset_index = 0; offset_index < panel_size.get(coord); ++offset_index) {
     const GlobalElementIndex offset_e(coord, offset_index);
     const SizeType offset = dist.globalTileFromGlobalElement<coord>(offset_e.get<coord>());
@@ -563,10 +620,8 @@ void testOffsetTileUnaligned(const GlobalElementSize size, const TileElementSize
     EXPECT_EQ(offset_e.get<coord>(), panel.offsetElement());
 
     for (const LocalTileIndex& i : panel.iteratorLocal()) {
-      const TileElementSize expected_size = [&]() {
-        // Note:  globalTile used with GlobalElementIndex is preferred over the one with LocalTileIndex,
-        //        because the former one does not implicitly target anything local, that would otherwise
-        //        be problematic in case of ranks that do not have any part of the matrix locally.
+      TileElementSize expected_tile_size = [&]() {
+        // Get the index of the first column
         const GlobalTileIndex i_global(coord, dist.globalTileFromLocalTile<coord>(i.get<coord>()));
 
         const TileElementSize full_size = dist.tileSize(i_global);
@@ -578,11 +633,15 @@ void testOffsetTileUnaligned(const GlobalElementSize size, const TileElementSize
         // by computing the offseted size with repsect to the acutal tile size, it also checks the
         // edge case where a panel has a single tile, both offseted and "incomplete"
         const SizeType sub_offset = dist.tileElementFromGlobalElement<coord>(offset_e.get<coord>());
+
         return TileElementSize(coord, full_size.get<coord>() - sub_offset, size_axis);
       }();
 
-      EXPECT_EQ(expected_size, panel.read(i).get().size());
-      EXPECT_EQ(expected_size, panel(i).get().size());
+      if constexpr (StoreTransposed::Yes == Storage)
+        expected_tile_size.transpose();
+
+      EXPECT_EQ(expected_tile_size, panel.read(i).get().size());
+      EXPECT_EQ(expected_tile_size, panel(i).get().size());
     }
 
     panel.reset();
@@ -590,13 +649,19 @@ void testOffsetTileUnaligned(const GlobalElementSize size, const TileElementSize
 }
 
 TYPED_TEST(PanelTest, OffsetTileUnalignedRow) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& [size, blocksize, offset] : test_params)
-      testOffsetTileUnaligned<TypeParam, Coord::Row>(size, blocksize, comm_grid);
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, offset] : test_params) {
+      testOffsetTileUnaligned<Coord::Row, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
+      testOffsetTileUnaligned<Coord::Row, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
+    }
+  }
 }
 
 TYPED_TEST(PanelTest, OffsetTileUnalignedCol) {
-  for (auto& comm_grid : this->commGrids())
-    for (const auto& [size, blocksize, offset] : test_params)
-      testOffsetTileUnaligned<TypeParam, Coord::Col>(size, blocksize, comm_grid);
+  for (auto& comm_grid : this->commGrids()) {
+    for (const auto& [size, blocksize, _] : test_params) {
+      testOffsetTileUnaligned<Coord::Col, TypeParam, StoreTransposed::No>(size, blocksize, comm_grid);
+      testOffsetTileUnaligned<Coord::Col, TypeParam, StoreTransposed::Yes>(size, blocksize, comm_grid);
+    }
+  }
 }


### PR DESCRIPTION
This is an extension of the `Panel` we are already used to, which turns out to be needed for #701.

A typical situation is this one

```c++
Panel<Col> panel;
Panel<Row> panelT

// broadcast transpose
broadcast(..., panel, panelT, ...)
```

where we have `panel` storing a (column) result and the algorithms needs to access its transposed variant `panelT` (row). Currently, we achieve that by mean of broadcast transpose which, given a tile at row `i`, in addition to share it with all ranks of the same row, sends it to all ranks of column (not row) `i` no matter the row they are on.

This is quite handy for various algorithms, like `cholesky`, `gen_to_std`, `reduction_to_band`, but as it is currently implemented presents a constraint.

*The key point is that we want to have a panel we can access with transposed coordinates, distributed according the transposed axis, but that will be stored as the original, i.e. not-tranposed* (computation takes care of data transposition).

Currently `panelT` is allocated as a correctly transposed panel, where also tile should be transposed, but thanks to the fact that we always use it in square matrices with square blocksizes, we can ignore that and skip the data transposition. So we are somehow "misusing" it, but it works because we are in a special case.

But, as soon as we switch to sub-block, the transposition of the tile shape result in the impossibility to "misuse" it, i.e. we cannot store anymore the original tile because of the tranposed shape.

Let's see an example. We have a square matrix `(m, m)` with blocksize `(mb, mb)`.

In this case `panel` will be `(m, mb)` and `panelT` will be `(mb, m)`. Each tile is always `(mb, mb)` in each panel, so it is a special case that works, since shape is not varying on transposition, we can "opt" for storing tiles as they were originally or tranposed (and we go for the former one).

Now we want to shrink the column panel by reducing the columns to `b`, leading to
- `panel` being `(m, b)` with tiles `(mb, b)`
- `panelT` being `(b, m)` with tile `(b, mb)`

as it can be seen, shape got tranposed, so we cannot store anymore the original tile.

What this extension do is to create a row panel distributed as the classic one, but where each tile is stored "tranposed" with respect to how it should be. So, if we have `panelT` that classically used to have `(b, mb)`, with the new extension it is possible to deal with tiles whose shape gets tranposed, resulting in tiles of `(mb, b)`, i.e. as they were in the original `panel`.

It's like having a `panelT` where each tile gets transposed individually a second time (in addition that goes from `panel` col to `panelT` row) to be stored as they were originally.

It starts as a draft PR so that we can opt for best naming of things. I will try to highlight main points in the comments.

TODO:
- [x] Adapt/extend test
- [x] Feedbacks on naming of `StoreTransposed`
- [x] Feedbacks on naming of `setWidth`/`setHeight`
- [x] Co-existance of both panel types (gen2std uses a panel in 2 ways, one of them requires the classic panel) or alternative implementation
- [x] Evaluate constraining `Panel<StoreTransposed>` to specific distributions or improve implementation (in case, this might be partially addressed here, and partially later tracking this with an issue)