### PR TITLE
Panel StoreTranposed adaptations to algorithms

### DIFF
--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -284,7 +284,8 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
   common::RoundRobin<matrix::Panel<Coord::Col, T, device>> a_panels(n_workspaces, distr);
   common::RoundRobin<matrix::Panel<Coord::Row, T, device>> a_panelsT(n_workspaces, distr);
   common::RoundRobin<matrix::Panel<Coord::Col, T, device>> l_panels(n_workspaces, distr);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, device>> l_panelsT(n_workspaces, distr);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, device, matrix::StoreTransposed::Yes>>
+      l_panelsT(n_workspaces, distr);
 
   for (SizeType k = 0; k < nrtile; ++k) {
     const GlobalTileIndex kk{k, k};
@@ -553,7 +554,8 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
   common::RoundRobin<matrix::Panel<Coord::Row, T, device>> a_panels(n_workspaces, distr);
   common::RoundRobin<matrix::Panel<Coord::Col, T, device>> a_panelsT(n_workspaces, distr);
   common::RoundRobin<matrix::Panel<Coord::Row, T, device>> u_panels(n_workspaces, distr);
-  common::RoundRobin<matrix::Panel<Coord::Col, T, device>> u_panelsT(n_workspaces, distr);
+  common::RoundRobin<matrix::Panel<Coord::Col, T, device, matrix::StoreTransposed::Yes>>
+      u_panelsT(n_workspaces, distr);
 
   for (SizeType k = 0; k < nrtile; ++k) {
     const GlobalTileIndex kk{k, k};

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -589,9 +589,10 @@ auto computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
 
 template <Backend B, Device D, class T>
 void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>& x,
-                  matrix::Panel<Coord::Row, T, D>& xt, const LocalTileSize at_offset,
-                  matrix::Matrix<const T, D>& a, matrix::Panel<Coord::Col, const T, D>& w,
-                  matrix::Panel<Coord::Row, const T, D>& wt,
+                  matrix::Panel<Coord::Row, T, D, matrix::StoreTransposed::Yes>& xt,
+                  const LocalTileSize at_offset, matrix::Matrix<const T, D>& a,
+                  matrix::Panel<Coord::Col, const T, D>& w,
+                  matrix::Panel<Coord::Row, const T, D, matrix::StoreTransposed::Yes>& wt,
                   common::Pipeline<comm::Communicator>& mpi_row_chain,
                   common::Pipeline<comm::Communicator>& mpi_col_chain) {
   namespace ex = pika::execution::experimental;
@@ -702,9 +703,9 @@ void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>&
 template <Backend B, Device D, class T>
 void her2kUpdateTrailingMatrix(const LocalTileSize& at_start, Matrix<T, D>& a,
                                matrix::Panel<Coord::Col, const T, D>& x,
-                               matrix::Panel<Coord::Row, const T, D>& vt,
+                               matrix::Panel<Coord::Row, const T, D, matrix::StoreTransposed::Yes>& vt,
                                matrix::Panel<Coord::Col, const T, D>& v,
-                               matrix::Panel<Coord::Row, const T, D>& xt) {
+                               matrix::Panel<Coord::Row, const T, D, matrix::StoreTransposed::Yes>& xt) {
   static_assert(std::is_signed_v<BaseType<T>>, "alpha in computations requires to be -1");
 
   using pika::execution::thread_priority;
@@ -1025,13 +1026,16 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<matrix::Panel<Coord::Col, T, D>> panels_v(n_workspaces, dist);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> panels_vt(n_workspaces, dist);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D, matrix::StoreTransposed::Yes>>
+      panels_vt(n_workspaces, dist);
 
   common::RoundRobin<matrix::Panel<Coord::Col, T, D>> panels_w(n_workspaces, dist);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> panels_wt(n_workspaces, dist);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D, matrix::StoreTransposed::Yes>>
+      panels_wt(n_workspaces, dist);
 
   common::RoundRobin<matrix::Panel<Coord::Col, T, D>> panels_x(n_workspaces, dist);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> panels_xt(n_workspaces, dist);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D, matrix::StoreTransposed::Yes>>
+      panels_xt(n_workspaces, dist);
 
   red2band::ComputePanelHelper<B, D, T> compute_panel_helper(n_workspaces, dist);
 

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -185,7 +185,8 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid grid, Matrix<T,
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<matrix::Panel<Coord::Col, T, device>> panels(n_workspaces, distr);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, device>> panelsT(n_workspaces, distr);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, device, matrix::StoreTransposed::Yes>>
+      panelsT(n_workspaces, distr);
 
   for (SizeType k = 0; k < nrtile; ++k) {
     const GlobalTileIndex kk_idx(k, k);
@@ -325,7 +326,8 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
 
   constexpr std::size_t n_workspaces = 2;
   common::RoundRobin<matrix::Panel<Coord::Row, T, device>> panels(n_workspaces, distr);
-  common::RoundRobin<matrix::Panel<Coord::Col, T, device>> panelsT(n_workspaces, distr);
+  common::RoundRobin<matrix::Panel<Coord::Col, T, device, matrix::StoreTransposed::Yes>>
+      panelsT(n_workspaces, distr);
 
   for (SizeType k = 0; k < nrtile; ++k) {
     const GlobalTileIndex kk_idx(k, k);


### PR DESCRIPTION
This is a fork of #724 to isolate changes in the algorithms.

In the intentions, just the type of panels used transposed are changed, and it should not really affect anything, nor from the API point of view, nor from the allocation one (for current use-cases it should be allocated exactly as it was before).

Depending one the decisions in #724 this can change, but IMHO I hope not much because keeping the same API represents a big pro.