### PR TITLE
algo: enable sub-band in ReductionToBand Distributed (both MC and GPU)

### DIFF
--- a/include/dlaf/communication/broadcast_panel.h
+++ b/include/dlaf/communication/broadcast_panel.h
@@ -172,14 +172,7 @@ void broadcast(comm::IndexT_MPI rank_root, matrix::Panel<axis, T, D, storage>& p
 
   auto& chain_step2 = get_taskchain(comm_dir_step2);
 
-  const SizeType last_tile = std::max(panelT.rangeStart(), panelT.rangeEnd() - 1);
-  const auto owner = dist.template rankGlobalTile<coordT>(last_tile);
-  const auto range = dist.rankIndex().get(coordT) == owner
-                         ? common::iterate_range2d(*panelT.iteratorLocal().begin(),
-                                                   LocalTileIndex(coordT, panelT.rangeEndLocal() - 1, 1))
-                         : panelT.iteratorLocal();
-
-  for (const auto& indexT : range) {
+  for (const auto& indexT : panelT.iteratorLocal()) {
     auto [index_diag, owner_diag] = internal::transposedOwner<coordT>(dist, indexT);
 
     namespace ex = pika::execution::experimental;

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -84,7 +84,7 @@ EigensolverResult<T, D> Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, 
   if (uplo != blas::Uplo::Lower)
     DLAF_UNIMPLEMENTED(uplo);
 
-  auto taus = reductionToBand<B>(grid, mat_a);
+  auto taus = reductionToBand<B>(grid, mat_a, band_size);
   auto ret = bandToTridiag<Backend::MC>(grid, uplo, band_size, mat_a);
 
   // Note:

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -125,11 +125,15 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> reduc
 /// @pre mat_a is distributed according to @p grid
 template <Backend B, Device D, class T>
 common::internal::vector<pika::shared_future<common::internal::vector<T>>> reductionToBand(
-    comm::CommunicatorGrid grid, Matrix<T, D>& mat_a) {
+    comm::CommunicatorGrid grid, Matrix<T, D>& mat_a, const SizeType band_size) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::equal_process_grid(mat_a, grid), mat_a, grid);
 
-  return internal::ReductionToBand<B, D, T>::call(grid, mat_a);
+  DLAF_ASSERT(mat_a.blockSize().rows() % band_size == 0, mat_a.blockSize().rows(), band_size);
+
+  return internal::groupTausFromBandsToTiles(internal::ReductionToBand<B, D, T>::call(grid, mat_a,
+                                                                                      band_size),
+                                             band_size, mat_a.blockSize().rows());
 }
 }

--- a/include/dlaf/eigensolver/reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/reduction_to_band/api.h
@@ -19,7 +19,7 @@ struct ReductionToBand {
   static common::internal::vector<pika::shared_future<common::internal::vector<T>>> call(
       Matrix<T, D>& mat_a, const SizeType band_size);
   static common::internal::vector<pika::shared_future<common::internal::vector<T>>> call(
-      comm::CommunicatorGrid grid, Matrix<T, D>& mat_a);
+      comm::CommunicatorGrid grid, Matrix<T, D>& mat_a, const SizeType band_size);
 };
 
 /// ---- ETI

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -561,6 +561,7 @@ template <class MatrixLike, class TriggerSender, class CommSender>
 auto computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
                             CommSender&& mpi_col_chain_panel, MatrixLike& mat_a,
                             const matrix::SubPanelView& panel_view, const SizeType nrefls) {
+  static Device constexpr D = MatrixLike::device;
   using T = typename MatrixLike::ElementType;
   namespace ex = pika::execution::experimental;
 
@@ -578,7 +579,15 @@ auto computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
     return taus;
   };
 
-  return ex::when_all(ex::when_all_vector(matrix::select(mat_a, panel_view.iteratorLocal())),
+  std::vector<pika::future<matrix::Tile<T, D>>> panel_tiles;
+  panel_tiles.reserve(
+      to_sizet(std::distance(panel_view.iteratorLocal().begin(), panel_view.iteratorLocal().end())));
+  for (const auto& i : panel_view.iteratorLocal()) {
+    const matrix::SubTileSpec& spec = panel_view(i);
+    panel_tiles.emplace_back(matrix::splitTile(mat_a(i), spec));
+  }
+
+  return ex::when_all(ex::when_all_vector(std::move(panel_tiles)),
                       std::forward<CommSender>(mpi_col_chain_panel),
                       std::forward<TriggerSender>(trigger)) |
          dlaf::internal::transform(dlaf::internal::Policy<Backend::MC>(
@@ -590,7 +599,7 @@ auto computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
 template <Backend B, Device D, class T>
 void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>& x,
                   matrix::Panel<Coord::Row, T, D, matrix::StoreTransposed::Yes>& xt,
-                  const LocalTileSize at_offset, matrix::Matrix<const T, D>& a,
+                  const matrix::SubMatrixView& view, matrix::Matrix<const T, D>& a,
                   matrix::Panel<Coord::Col, const T, D>& w,
                   matrix::Panel<Coord::Row, const T, D, matrix::StoreTransposed::Yes>& wt,
                   common::Pipeline<comm::Communicator>& mpi_row_chain,
@@ -608,17 +617,21 @@ void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>&
   matrix::util::set0<B>(thread_priority::high, x);
   matrix::util::set0<B>(thread_priority::high, xt);
 
-  for (SizeType i = at_offset.rows(); i < dist.localNrTiles().rows(); ++i) {
+  const LocalTileIndex at_offset = view.begin();
+
+  for (SizeType i = at_offset.row(); i < dist.localNrTiles().rows(); ++i) {
     const auto limit = dist.template nextLocalTileFromGlobalTile<Coord::Col>(
         dist.template globalTileFromLocalTile<Coord::Row>(i) + 1);
-    for (SizeType j = limit - 1; j >= at_offset.cols(); --j) {
+    for (SizeType j = limit - 1; j >= at_offset.col(); --j) {
       const LocalTileIndex ij_local{i, j};
       const GlobalTileIndex ij = dist.globalTileIndex(ij_local);
 
       const bool is_diagonal_tile = (ij.row() == ij.col());
 
+      const auto& tile_a = splitTile(a.read(ij), view(ij_local));
+
       if (is_diagonal_tile) {
-        hemmDiag<B>(thread_priority::high, a.read_sender(ij_local), w.read_sender(ij_local),
+        hemmDiag<B>(thread_priority::high, ex::keep_future(tile_a), w.read_sender(ij_local),
                     x.readwrite_sender(ij_local));
       }
       else {
@@ -628,7 +641,7 @@ void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>&
         // support panel Wt.
         // However, since we are still computing the "straight" part, the result can be stored
         // in the "local" panel X.
-        hemmOffDiag<B>(thread_priority::high, blas::Op::NoTrans, a.read_sender(ij_local),
+        hemmOffDiag<B>(thread_priority::high, blas::Op::NoTrans, ex::keep_future(tile_a),
                        wt.read_sender(ij_local), x.readwrite_sender(ij_local));
 
         // Note:
@@ -647,7 +660,7 @@ void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>&
         auto tile_x = (dist.rankIndex().row() == owner) ? x.readwrite_sender(index_x)
                                                         : xt.readwrite_sender(index_xt);
 
-        hemmOffDiag<B>(thread_priority::high, blas::Op::ConjTrans, a.read_sender(ij_local),
+        hemmOffDiag<B>(thread_priority::high, blas::Op::ConjTrans, ex::keep_future(tile_a),
                        w.read_sender(ij_local), std::move(tile_x));
       }
     }
@@ -701,7 +714,7 @@ void hemmComputeX(comm::IndexT_MPI reducer_col, matrix::Panel<Coord::Col, T, D>&
 }
 
 template <Backend B, Device D, class T>
-void her2kUpdateTrailingMatrix(const LocalTileSize& at_start, Matrix<T, D>& a,
+void her2kUpdateTrailingMatrix(const matrix::SubMatrixView& view, Matrix<T, D>& a,
                                matrix::Panel<Coord::Col, const T, D>& x,
                                matrix::Panel<Coord::Row, const T, D, matrix::StoreTransposed::Yes>& vt,
                                matrix::Panel<Coord::Col, const T, D>& v,
@@ -712,31 +725,33 @@ void her2kUpdateTrailingMatrix(const LocalTileSize& at_start, Matrix<T, D>& a,
 
   const auto dist = a.distribution();
 
-  for (SizeType i = at_start.rows(); i < dist.localNrTiles().rows(); ++i) {
+  const LocalTileIndex at_start = view.begin();
+
+  for (SizeType i = at_start.row(); i < dist.localNrTiles().rows(); ++i) {
     const auto limit = dist.template nextLocalTileFromGlobalTile<Coord::Col>(
         dist.template globalTileFromLocalTile<Coord::Row>(i) + 1);
-    for (SizeType j = at_start.cols(); j < limit; ++j) {
+    for (SizeType j = at_start.col(); j < limit; ++j) {
       const LocalTileIndex ij_local{i, j};
       const GlobalTileIndex ij = dist.globalTileIndex(ij_local);
 
       const bool is_diagonal_tile = (ij.row() == ij.col());
 
+      auto tile_a = a(ij_local);
+      auto getSubA = [&view, ij_local](auto& tile_a) { return splitTile(tile_a, view(ij_local)); };
+
       // The first column of the trailing matrix (except for the very first global tile) has to be
       // updated first, in order to unlock the next iteration as soon as possible.
-      const auto priority = (j == at_start.cols()) ? thread_priority::high : thread_priority::normal;
+      const auto priority = (j == at_start.col()) ? thread_priority::high : thread_priority::normal;
 
       if (is_diagonal_tile) {
-        her2kDiag<B>(priority, v.read_sender(ij_local), x.read_sender(ij_local),
-                     a.readwrite_sender(ij_local));
+        her2kDiag<B>(priority, v.read_sender(ij_local), x.read_sender(ij_local), getSubA(tile_a));
       }
       else {
         // A -= X . V*
-        her2kOffDiag<B>(priority, x.read_sender(ij_local), vt.read_sender(ij_local),
-                        a.readwrite_sender(ij_local));
+        her2kOffDiag<B>(priority, x.read_sender(ij_local), vt.read_sender(ij_local), getSubA(tile_a));
 
         // A -= V . X*
-        her2kOffDiag<B>(priority, v.read_sender(ij_local), xt.read_sender(ij_local),
-                        a.readwrite_sender(ij_local));
+        her2kOffDiag<B>(priority, v.read_sender(ij_local), xt.read_sender(ij_local), getSubA(tile_a));
       }
     }
   }
@@ -937,7 +952,7 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     // TODO probably the first one in any panel is ok?
     Matrix<T, D> t({nrefls_block, nrefls_block}, dist.blockSize());
 
-    computeTFactor<B>(v, taus.back(), t(t_idx));
+    computeTFactor<B>(v, taus.back(), t.readwrite_sender(t_idx));
 
     // PREPARATION FOR TRAILING MATRIX UPDATE
     const GlobalElementIndex at_offset(ij_offset + GlobalElementSize(0, band_size));
@@ -996,7 +1011,7 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
 /// @return a vector of shared futures of vectors, where each inner vector contains a block of taus
 template <Backend B, Device D, class T>
 common::internal::vector<pika::shared_future<common::internal::vector<T>>> ReductionToBand<B, D, T>::call(
-    comm::CommunicatorGrid grid, Matrix<T, D>& mat_a) {
+    comm::CommunicatorGrid grid, Matrix<T, D>& mat_a, const SizeType band_size) {
   using namespace red2band::distributed;
 
   using common::iterate_range2d;
@@ -1016,12 +1031,16 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
   const auto& dist = mat_a.distribution();
   const comm::Index2D rank = dist.rankIndex();
 
-  common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus;
-  const SizeType nblocks = std::max<SizeType>(0, dist.nrTiles().cols() - 1);
+  // Note:
+  // Reflector of size = 1 is not considered whatever T is (i.e. neither real nor complex)
+  const SizeType nrefls = std::max<SizeType>(0, dist.size().rows() - band_size - 1);
 
-  if (nblocks == 0)
+  common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus;
+
+  if (nrefls == 0)
     return taus;
 
+  const SizeType nblocks = (nrefls - 1) / band_size + 1;
   taus.reserve(nblocks);
 
   constexpr std::size_t n_workspaces = 2;
@@ -1040,76 +1059,77 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
   red2band::ComputePanelHelper<B, D, T> compute_panel_helper(n_workspaces, dist);
 
   ex::unique_any_sender<> trigger_panel{ex::just()};
-  for (SizeType j_block = 0; j_block < nblocks; ++j_block) {
-    const GlobalTileIndex ai_start{GlobalTileIndex{j_block, j_block} + GlobalTileSize{1, 0}};
-    const GlobalTileIndex at_start{ai_start + GlobalTileSize{0, 1}};
+  for (SizeType j_sub = 0; j_sub < nblocks; ++j_sub) {
+    const SizeType i_sub = j_sub + 1;
 
-    const GlobalElementIndex ij_offset(ai_start.row() * dist.blockSize().rows(),
-                                       ai_start.col() * dist.blockSize().cols());
+    const GlobalElementIndex ij_offset(i_sub * band_size, j_sub * band_size);
+    const GlobalElementIndex at_offset(i_sub * band_size, (j_sub + 1) * band_size);
 
-    const comm::Index2D rank_v0 = dist.rankGlobalTile(ai_start);
-
-    const LocalTileSize ai_offset{
-        dist.template nextLocalTileFromGlobalTile<Coord::Row>(ai_start.row()),
-        dist.template nextLocalTileFromGlobalTile<Coord::Col>(ai_start.col()),
-    };
-    const LocalTileSize at_offset{
-        ai_offset.rows(),
-        dist.template nextLocalTileFromGlobalTile<Coord::Col>(at_start.col()),
+    const comm::Index2D rank_v0{
+        dist.template rankGlobalElement<Coord::Row>(ij_offset.row()),
+        dist.template rankGlobalElement<Coord::Col>(ij_offset.col()),
     };
 
     const bool is_panel_rank_col = rank_v0.col() == rank.col();
 
-    const auto v0_size = mat_a.tileSize(ai_start);
-    const SizeType nrefls = [ai_start, nrTiles = mat_a.nrTiles(), v0_size]() {
-      if (ai_start.row() != nrTiles.rows() - 1)
-        return v0_size.cols();
-      else
-        return std::min(v0_size.rows(), v0_size.cols()) - 1;
+    const SizeType nrefls_block = [=]() {
+      const bool is_last = j_sub == nblocks - 1;
+      if (!is_last)
+        return band_size;
+
+      const SizeType nrefls_last = nrefls % band_size;
+      return nrefls_last == 0 ? band_size : nrefls_last;
     }();
 
-    if (nrefls == 0)
+    if (nrefls_block == 0)
       break;
 
     auto& v = panels_v.nextResource();
     auto& vt = panels_vt.nextResource();
 
-    v.setRangeStart(ai_start);
-    vt.setRangeStart(at_start);
+    v.setRangeStart(at_offset);
+    vt.setRangeStart(at_offset);
 
-    v.setWidth(nrefls);
-    vt.setHeight(nrefls);
+    v.setWidth(nrefls_block);
+    vt.setHeight(nrefls_block);
 
     const LocalTileIndex t_idx(0, 0);
     // TODO used just by the column, maybe we can re-use a panel tile?
     // TODO or we can keep just the sh_future and allocate just inside if (is_panel_rank_col)
-    matrix::Matrix<T, D> t({nrefls, nrefls}, dist.blockSize());
+    matrix::Matrix<T, D> t({nrefls_block, nrefls_block}, dist.blockSize());
 
     // PANEL
-    const SizeType band_size = dist.blockSize().cols();
     const matrix::SubPanelView panel_view(dist, ij_offset, band_size);
 
     if (is_panel_rank_col) {
       taus.emplace_back(compute_panel_helper.call(std::move(trigger_panel), rank_v0.row(),
-                                                  mpi_col_chain_panel(), mat_a, panel_view, nrefls));
+                                                  mpi_col_chain_panel(), mat_a, panel_view,
+                                                  nrefls_block));
 
-      red2band::local::setupReflectorPanelV<B, D>(rank.row() == rank_v0.row(), panel_view, nrefls, v,
-                                                  mat_a);
-      computeTFactor<B>(v, taus.back(), t(t_idx), mpi_col_chain);
+      red2band::local::setupReflectorPanelV<B, D, T, true>(rank.row() == rank_v0.row(), panel_view,
+                                                           nrefls_block, v, mat_a);
+      computeTFactor<B>(v, taus.back(), t.readwrite_sender(t_idx), mpi_col_chain);
     }
 
     // PREPARATION FOR TRAILING MATRIX UPDATE
+
+    // Note: if there is no trailing matrix, algorithm has finised
+    if (!at_offset.isIn(mat_a.size()))
+      break;
+
+    const matrix::SubMatrixView trailing_matrix_view(dist, at_offset);
+
     comm::broadcast(rank_v0.col(), v, vt, mpi_row_chain, mpi_col_chain);
 
     // W = V . T
     auto& w = panels_w.nextResource();
     auto& wt = panels_wt.nextResource();
 
-    w.setRangeStart(at_start);
-    wt.setRangeStart(at_start);
+    w.setRangeStart(at_offset);
+    wt.setRangeStart(at_offset);
 
-    w.setWidth(nrefls);
-    wt.setHeight(nrefls);
+    w.setWidth(nrefls_block);
+    wt.setHeight(nrefls_block);
 
     if (is_panel_rank_col)
       red2band::local::trmmComputeW<B, D>(w, v, t.read(t_idx));
@@ -1120,11 +1140,11 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     auto& x = panels_x.nextResource();
     auto& xt = panels_xt.nextResource();
 
-    x.setRangeStart(at_start);
-    xt.setRangeStart(at_start);
+    x.setRangeStart(at_offset);
+    xt.setRangeStart(at_offset);
 
-    x.setWidth(nrefls);
-    xt.setHeight(nrefls);
+    x.setWidth(nrefls_block);
+    xt.setHeight(nrefls_block);
 
     // Note:
     // Since At is hermitian, just the lower part is referenced.
@@ -1134,7 +1154,8 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     //
     // On exit, x will contain a valid result just on ranks belonging to the column panel.
     // For what concerns xt, it is just used as support and it contains junk data on all ranks.
-    hemmComputeX<B, D>(rank_v0.col(), x, xt, at_offset, mat_a, w, wt, mpi_row_chain, mpi_col_chain);
+    hemmComputeX<B, D>(rank_v0.col(), x, xt, trailing_matrix_view, mat_a, w, wt, mpi_row_chain,
+                       mpi_col_chain);
 
     // In the next section the next two operations are performed
     // A) W2 = W* . X
@@ -1160,8 +1181,8 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     // xt has been used previously as workspace for hemmComputeX, so it has to be reset, because now it
     // will be used for accessing the broadcasted version of x
     xt.reset();
-    xt.setRangeStart(at_start);
-    xt.setHeight(nrefls);
+    xt.setRangeStart(at_offset);
+    xt.setHeight(nrefls_block);
 
     comm::broadcast(rank_v0.col(), x, xt, mpi_row_chain, mpi_col_chain);
 
@@ -1207,9 +1228,17 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     //
     // And in order to not be blocked, it must be ensured that the actual communication task has
     // been scheduled.
-    const comm::IndexT_MPI rank_next_col = (rank_v0.col() + 1) % dist.commGridSize().cols();
+    const SizeType j_tile_current = ij_offset.col() / dist.blockSize().cols();
+    const SizeType j_tile_next = at_offset.col() / dist.blockSize().cols();
+    const bool isNextColumnOnSameRank = (j_tile_current == j_tile_next);
+    const comm::IndexT_MPI rank_next_col =
+        isNextColumnOnSameRank ? rank_v0.col() : (rank_v0.col() + 1) % dist.commGridSize().cols();
+
     if (rank.col() == rank_next_col) {
-      const LocalTileIndex at(indexFromOrigin(at_offset));
+      const LocalTileIndex at{
+          dist.template nextLocalTileFromGlobalElement<Coord::Row>(at_offset.row()),
+          dist.template nextLocalTileFromGlobalElement<Coord::Col>(at_offset.col()),
+      };
 
       if constexpr (dlaf::comm::CommunicationDevice_v<D> == D) {
         // Note:
@@ -1227,7 +1256,6 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
         }
       }
       else {
-        const LocalTileIndex at(indexFromOrigin(at_offset));
         if (rank.row() == rank_v0.row()) {
           // Note:
           // on the pivot rank, i.e. the one that would quickly go to the next panel and block, from
@@ -1250,7 +1278,7 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> Reduc
     }
 
     // At -= X . V* + V . X*
-    her2kUpdateTrailingMatrix<B>(at_offset, mat_a, x, vt, v, xt);
+    her2kUpdateTrailingMatrix<B>(trailing_matrix_view, mat_a, x, vt, v, xt);
 
     xt.reset();
     x.reset();

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -533,7 +533,7 @@ public:
 
   auto read_sender(LocalTileIndex index) {
     index.transpose();
-    return pika::execution::experimental::keep_future(BaseT::read(index));
+    return BaseT::read_sender(index);
   }
 
   using BaseT::reset;

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -132,7 +132,7 @@ struct reductionToBandMiniapp {
           if constexpr (Backend::GPU == backend)
             return dlaf::eigensolver::reductionToBand<backend>(matrix, opts.b);
           else
-            return dlaf::eigensolver::reductionToBand<backend>(comm_grid, matrix);
+            return dlaf::eigensolver::reductionToBand<backend>(comm_grid, matrix, opts.b);
         }();
 
         // wait and barrier for all ranks

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -45,8 +45,6 @@ struct Options
   Options(const pika::program_options::variables_map& vm)
       : MiniappOptions(vm), m(vm["matrix-size"].as<SizeType>()), mb(vm["block-size"].as<SizeType>()),
         b(vm["band-size"].as<SizeType>()) {
-    const bool isDistributed = (grid_rows * grid_cols) > 1;
-
     DLAF_ASSERT(m > 0, m);
     DLAF_ASSERT(mb > 0, mb);
 
@@ -55,21 +53,10 @@ struct Options
 
     DLAF_ASSERT(b > 0 && (mb % b == 0), b, mb);
 
-    if (isDistributed && mb != b) {
-      std::cerr << "Warning! "
-                   "At the moment distributed variant does not support band-size != block-size."
-                << std::endl;
-      b = mb;
-    }
-
     if (do_check != dlaf::miniapp::CheckIterFreq::None) {
       std::cerr << "Warning! At the moment result checking it is not implemented." << std::endl;
       do_check = dlaf::miniapp::CheckIterFreq::None;
     }
-
-    DLAF_ASSERT(backend == dlaf::Backend::MC || !isDistributed,
-                "Error! At the moment the GPU backend is supported just with local runs. "
-                "Please rerun with --backend=mc or with both --grid-rows and --grid-cols set to 1");
   }
 
   Options(Options&&) = default;
@@ -90,9 +77,6 @@ struct reductionToBandMiniapp {
     using MatrixMirrorType = matrix::MatrixMirror<T, DefaultDevice_v<backend>, Device::CPU>;
     using HostMatrixType = Matrix<T, Device::CPU>;
     using ConstMatrixType = Matrix<const T, Device::CPU>;
-
-    if (backend == dlaf::Backend::GPU && (opts.grid_rows * opts.grid_cols) != 1)
-      DLAF_UNIMPLEMENTED("Distributed reduction to band is not implemented on GPU yet.");
 
     Communicator world(MPI_COMM_WORLD);
     CommunicatorGrid comm_grid(world, opts.grid_rows, opts.grid_cols, common::Ordering::ColumnMajor);


### PR DESCRIPTION
Close #701

- [x] Requires #724
- [x] Requires #725 
- [x] Fix trigger problem (possible workaround: copy also last tile in broadcast transpose)
- [x] Remove `ex::keep_future`
- [x] Evaluate refactoring to avoid tile copies workaround for full-band 
- [x] Use in eigensolver
- [x] Update miniapp (remove constraints)

Changes:
- Adapt implementation to work with sub-band
- Add sub-band test-cases
- Extend doc (both local and distributed)
- Fix and improve test

