### PR TITLE
Enable tridiagonal solver distributed on GPU for SEP and GEP (remove temporary local constraint)

### DIFF
--- a/include/dlaf/eigensolver/eigensolver.h
+++ b/include/dlaf/eigensolver/eigensolver.h
@@ -40,6 +40,19 @@ EigensolverResult<T, D> eigensolver(blas::Uplo uplo, Matrix<T, D>& mat) {
   return internal::Eigensolver<B, D, T>::call(uplo, mat);
 }
 
+/// Standard Eigensolver.
+///
+/// It solves the standard eigenvalue problem A * x = lambda * x.
+///
+/// On exit, the lower triangle or the upper triangle (depending on @p uplo) of @p mat_a,
+/// including the diagonal, is destroyed.
+///
+/// Implementation on distributed memory.
+///
+/// @return struct ReturnEigensolverType with eigenvalues, as a vector<T>, and eigenvectors as a Matrix
+/// @param grid is the communicator grid on which the matrix @p mat has been distributed,
+/// @param uplo specifies if upper or lower triangular part of @p mat will be referenced
+/// @param mat contains the Hermitian matrix A
 template <Backend B, Device D, class T>
 EigensolverResult<T, D> eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat) {
   DLAF_ASSERT(matrix::equal_process_grid(mat, grid), mat);

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -106,13 +106,7 @@ EigensolverResult<T, D> Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, 
                                        TileElementSize(mat_a.blockSize().rows(), 1));
   matrix::Matrix<T, D> mat_e(GlobalElementSize(size, size), mat_a.blockSize(), grid);
 
-  if constexpr (B == Backend::GPU) {
-    DLAF_ASSERT(grid.size() == comm::Size2D(1, 1), grid.size());
-    eigensolver::tridiagSolver<B>(tridiagonal, evals, mat_e);
-  }
-  else {
-    eigensolver::tridiagSolver<B>(grid, tridiagonal, evals, mat_e);
-  }
+  eigensolver::tridiagSolver<B>(grid, tridiagonal, evals, mat_e);
 
   backTransformationBandToTridiag<B>(grid, band_size, mat_e, ret.hh_reflectors);
   backTransformationReductionToBand<B>(grid, mat_e, mat_a, taus);

--- a/include/dlaf/eigensolver/gen_eigensolver.h
+++ b/include/dlaf/eigensolver/gen_eigensolver.h
@@ -46,6 +46,22 @@ EigensolverResult<T, D> genEigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Mat
   return internal::GenEigensolver<B, D, T>::call(uplo, mat_a, mat_b);
 }
 
+/// Generalized Eigensolver.
+///
+/// It solves the generalized eigenvalue problem A * x = lambda * B * x.
+///
+/// On exit:
+/// - the lower triangle or the upper triangle (depending on @p uplo) of @p mat_a,
+/// including the diagonal, is destroyed.
+/// - @p mat_b contains the Cholesky decomposition of B
+///
+/// Implementation on distributed memory.
+///
+/// @return struct ReturnEigensolverType with eigenvalues, as a vector<T>, and eigenvectors as a Matrix
+/// @param grid is the communicator grid on which the matrices @p mat_a and @p mat_b have been distributed,
+/// @param uplo specifies if upper or lower triangular part of @p mat_a and @p mat_b will be referenced
+/// @param mat_a contains the Hermitian matrix A
+/// @param mat_b contains the Hermitian positive definite matrix B
 template <Backend B, Device D, class T>
 EigensolverResult<T, D> genEigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat_a,
                                        Matrix<T, D>& mat_b) {

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -194,10 +194,6 @@ TYPED_TEST(EigensolverTestGPU, CorrectnessLocal) {
 
 TYPED_TEST(EigensolverTestGPU, CorrectnessDistributed) {
   for (const comm::CommunicatorGrid& grid : this->commGrids()) {
-    // Note: solver not yet ready for GPU distributed, fallback to local GPU
-    if (grid.size() != comm::Size2D(1, 1))
-      continue;
-
     for (auto uplo : blas_uplos) {
       for (auto sz : sizes) {
         const auto& [m, mb] = sz;

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -217,10 +217,6 @@ TYPED_TEST(GenEigensolverTestGPU, CorrectnessLocal) {
 
 TYPED_TEST(GenEigensolverTestGPU, CorrectnessDistributed) {
   for (const comm::CommunicatorGrid& grid : this->commGrids()) {
-    // TODO not all algorithms ready for a real distributed
-    if (grid.size() != comm::Size2D(1, 1))
-      continue;
-
     for (auto uplo : blas_uplos) {
       for (auto sz : sizes) {
         const auto& [m, mb] = sz;


### PR DESCRIPTION
AFAIK the only constraints were in the SEP implementation and in the tests for both GEP and SEP (IIRC related miniapps were not constrained).

I took the chance also to add a bit of documentation to the SEP/GEP distributed calls.