### PR TITLE
Update pika to 0.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,8 @@ else()
 endif()
 
 # ----- pika
-find_package(pika 0.9.0 REQUIRED)
+find_package(pika 0.11.0 REQUIRED)
+find_package(pika-algorithms 0.1.0 REQUIRED)
 
 # ----- BLASPP/LAPACKPP
 find_package(blaspp REQUIRED)

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -17,9 +17,7 @@ stages:
   timeout: 6 hours
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    # Custom spack sha used to make an umpire fix available
-    # (https://github.com/msimberg/spack/commit/770d71dff6428876f2cc996f8a0551df36a59e4f)
-    SPACK_SHA: 770d71dff6428876f2cc996f8a0551df36a59e4f
+    SPACK_SHA: 7efcb5ae73bdaa85886079ccfd5ff0f44b838508
     SPACK_DLAF_REPO: ./spack
   before_script:
     - podman login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -47,19 +47,27 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/eth-cscs/DLA-Future/issues/420
     conflicts("umpire@6:")
 
+    depends_on("pika@0.11:")
+    depends_on("pika-algorithms@0.1:")
     depends_on("pika +mpi")
-    depends_on("pika@0.9:")
     depends_on("pika +cuda", when="+cuda")
     depends_on("pika +rocm", when="+rocm")
     for cxxstd in cxxstds:
+        depends_on("pika cxxstd={0}".format(cxxstd), when="cxxstd={0}".format(cxxstd))
         depends_on(
-            "pika cxxstd={0}".format(cxxstd),
-            when="cxxstd={0}".format(cxxstd)
+            "pika-algorithms cxxstd={0}".format(cxxstd),
+            when="cxxstd={0}".format(cxxstd),
         )
 
-    depends_on("pika build_type=Debug", when="build_type=Debug")
-    depends_on("pika build_type=Release", when="build_type=Release")
-    depends_on("pika build_type=RelWithDebInfo", when="build_type=RelWithDebInfo")
+    for build_type in ("Debug", "RelWithDebInfo", "Release"):
+        depends_on(
+            "pika build_type={0}".format(build_type),
+            when="build_type={0}".format(build_type),
+        )
+        depends_on(
+            "pika-algorithms build_type={0}".format(build_type),
+            when="build_type={0}".format(build_type),
+        )
 
     depends_on("whip +cuda", when="+cuda")
     depends_on("whip +rocm", when="+rocm")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(
     MPI::MPI_CXX
     DLAF::LAPACK
     pika::pika
+    pika-algorithms::pika_algorithms
     lapackpp
     blaspp
     umpire


### PR DESCRIPTION
This also adds pika-algorithms as a dependency. From pika 0.11.0 onwards the algorithms live in a separate repository. There are no other changes for this release.

~Note, I've rebased this on #678 since 1. I'm hoping that'll be merged soon and 2. I don't want to disturb the regular bors tests, but I _do_ want to run CI on this before the next pika/pika-algorithms releases.~