### PR TITLE
Enable warnings as error for all languages

### DIFF
--- a/include/dlaf/gpu/cub/api.h
+++ b/include/dlaf/gpu/cub/api.h
@@ -104,19 +104,18 @@ struct Sum {
 
 class DeviceReduce {
 public:
-  template <typename InputIteratorT, typename OutputIteratorT, typename ReduceOpT, typename T,
-            typename NumItemsType>
+  template <typename InputIteratorT, typename OutputIteratorT, typename ReduceOpT, typename T>
   __host__ static whip::error_t Reduce(void* d_temp_storage, std::size_t& temp_storage_bytes,
-                                       InputIteratorT d_in, OutputIteratorT d_out,
-                                       NumItemsType num_items, ReduceOpT reduction_op, T init,
-                                       whip::stream_t stream = 0, bool debug_synchronous = false) {
-    return ::rocprim::reduce(d_temp_storage, temp_storage_bytes, d_in, d_out, init, num_items,
+                                       InputIteratorT d_in, OutputIteratorT d_out, int num_items,
+                                       ReduceOpT reduction_op, T init, whip::stream_t stream = 0,
+                                       bool debug_synchronous = false) {
+    return ::rocprim::reduce(d_temp_storage, temp_storage_bytes, d_in, d_out, init, to_uint(num_items),
                              detail::convert_result_type<InputIteratorT, OutputIteratorT>(reduction_op),
                              stream, debug_synchronous);
   }
-  template <typename InputIteratorT, typename OutputIteratorT, typename NumItemsType>
+  template <typename InputIteratorT, typename OutputIteratorT>
   __host__ static whip::error_t Sum(void* d_temp_storage, std::size_t& temp_storage_bytes,
-                                    InputIteratorT d_in, OutputIteratorT d_out, NumItemsType num_items,
+                                    InputIteratorT d_in, OutputIteratorT d_out, int num_items,
                                     whip::stream_t stream = 0, bool debug_synchronous = false) {
     using T = typename std::iterator_traits<InputIteratorT>::value_type;
     return Reduce(d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, ::dlaf::gpucub::Sum(),
@@ -126,15 +125,14 @@ public:
 
 struct DeviceSegmentedReduce {
   template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT,
-            typename ReductionOp, typename T, typename NumSegmentType>
+            typename ReductionOp, typename T>
   __host__ static hipError_t Reduce(void* d_temp_storage, std::size_t& temp_storage_bytes,
-                                    InputIteratorT d_in, OutputIteratorT d_out,
-                                    NumSegmentType num_segments, OffsetIteratorT d_begin_offsets,
-                                    OffsetIteratorT d_end_offsets, ReductionOp reduction_op,
-                                    T initial_value, whip::stream_t stream = 0,
+                                    InputIteratorT d_in, OutputIteratorT d_out, int num_segments,
+                                    OffsetIteratorT d_begin_offsets, OffsetIteratorT d_end_offsets,
+                                    ReductionOp reduction_op, T initial_value, whip::stream_t stream = 0,
                                     bool debug_synchronous = false) {
-    return ::rocprim::segmented_reduce(d_temp_storage, temp_storage_bytes, d_in, d_out, num_segments,
-                                       d_begin_offsets, d_end_offsets,
+    return ::rocprim::segmented_reduce(d_temp_storage, temp_storage_bytes, d_in, d_out,
+                                       to_uint(num_segments), d_begin_offsets, d_end_offsets,
                                        detail::convert_result_type<InputIteratorT, OutputIteratorT>(
                                            reduction_op),
                                        initial_value, stream, debug_synchronous);

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -126,7 +126,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         if '+ci-test' in self.spec:
             # Enable TESTS and setup CI specific parameters
             args.append(self.define("CMAKE_CXX_FLAGS", "-Werror"))
-            args.append(self.define("CMAKE_CUDA_FLAGS", "-Werror"))
+            args.append(self.define("CMAKE_CUDA_FLAGS", "-Werror=all-warnings"))
             args.append(self.define("CMAKE_HIP_FLAGS", "-Werror"))
             args.append(self.define("BUILD_TESTING", True))
             args.append(self.define("DLAF_BUILD_TESTING", True))

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -126,6 +126,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         if '+ci-test' in self.spec:
             # Enable TESTS and setup CI specific parameters
             args.append(self.define("CMAKE_CXX_FLAGS", "-Werror"))
+            args.append(self.define("CMAKE_CUDA_FLAGS", "-Werror"))
+            args.append(self.define("CMAKE_HIP_FLAGS", "-Werror"))
             args.append(self.define("BUILD_TESTING", True))
             args.append(self.define("DLAF_BUILD_TESTING", True))
             args.append(self.define("DLAF_CI_RUNNER_USES_MPIRUN", True))

--- a/src/cusolver/stedc.cu
+++ b/src/cusolver/stedc.cu
@@ -118,14 +118,14 @@ void stedc(cusolverDnHandle_t handle, const Tile<T, Device::GPU>& tridiag,
   // rocsolver_*stedc takes a const as 5th argument
   auto stedc_fn = [=](rocblas_int* info) {
     if constexpr (std::is_same<T, float>::value) {
-      DLAF_GPULAPACK_CHECK_ERROR(rocsolver_sstedc(rochandle, evect, n, evals_ptr,
-                                                  const_cast<T*>(offdiag_ptr), evecs_ptr, ld_evecs,
-                                                  info));
+      DLAF_GPULAPACK_CHECK_ERROR(rocsolver_sstedc(rochandle, evect, to_int(n), evals_ptr,
+                                                  const_cast<T*>(offdiag_ptr), evecs_ptr,
+                                                  to_int(ld_evecs), info));
     }
     else {
-      DLAF_GPULAPACK_CHECK_ERROR(rocsolver_dstedc(rochandle, evect, n, evals_ptr,
-                                                  const_cast<T*>(offdiag_ptr), evecs_ptr, ld_evecs,
-                                                  info));
+      DLAF_GPULAPACK_CHECK_ERROR(rocsolver_dstedc(rochandle, evect, to_int(n), evals_ptr,
+                                                  const_cast<T*>(offdiag_ptr), evecs_ptr,
+                                                  to_int(ld_evecs), info));
     }
   };
 


### PR DESCRIPTION
Fix #740

With `+ci-test` variant, we were passing `-Werror` to CMake, but just for the C++ language, and not for GPU specific ones.