### PR TITLE
Don't include algorithm implementations in public headers

### DIFF
--- a/include/dlaf/eigensolver/bt_reduction_to_band.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band.h
@@ -12,7 +12,7 @@
 #include <blas.hh>
 
 #include "dlaf/communication/communicator_grid.h"
-#include "dlaf/eigensolver/bt_reduction_to_band/impl.h"
+#include "dlaf/eigensolver/bt_reduction_to_band/api.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
@@ -89,35 +89,5 @@ void backTransformationReductionToBand(
 
   internal::BackTransformationReductionToBand<backend, device, T>::call(b, grid, mat_c, mat_v, taus);
 }
-
-/// ---- ETI
-#define DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(KWORD, BACKEND, DEVICE, T)                    \
-  KWORD template void backTransformationReductionToBand<                                              \
-      BACKEND, DEVICE, T>(const SizeType b, Matrix<T, DEVICE>& mat_c, Matrix<const T, DEVICE>& mat_v, \
-                          common::internal::vector<pika::shared_future<common::internal::vector<T>>>  \
-                              taus);
-
-#define DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_DISTR_ETI(KWORD, BACKEND, DEVICE, T)                   \
-  KWORD template void backTransformationReductionToBand<                                             \
-      BACKEND, DEVICE, T>(const SizeType b, comm::CommunicatorGrid grid, Matrix<T, DEVICE>& mat_c,   \
-                          Matrix<const T, DEVICE>& mat_v,                                            \
-                          common::internal::vector<pika::shared_future<common::internal::vector<T>>> \
-                              taus);
-
-#define DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_DISTR_ETI(KWORD, BACKEND, DEVICE, DATATYPE)
-
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, float)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, double)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
-
-#ifdef DLAF_WITH_GPU
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, float)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, double)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
-#endif
 }
 }

--- a/include/dlaf/eigensolver/bt_reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/api.h
@@ -25,4 +25,19 @@ struct BackTransformationReductionToBand {
                    common::internal::vector<pika::shared_future<common::internal::vector<T>>> taus);
 };
 
+/// ---- ETI
+#define DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct BackTransformationReductionToBand<BACKEND, DEVICE, DATATYPE>;
+
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, float)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, double)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
+
+#ifdef DLAF_WITH_GPU
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, float)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, double)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
+#endif
 }

--- a/include/dlaf/eigensolver/gen_to_std.h
+++ b/include/dlaf/eigensolver/gen_to_std.h
@@ -11,7 +11,7 @@
 
 #include <blas.hh>
 #include "dlaf/communication/communicator_grid.h"
-#include "dlaf/eigensolver/gen_to_std/impl.h"
+#include "dlaf/eigensolver/gen_to_std/api.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"

--- a/include/dlaf/eigensolver/gen_to_std/api.h
+++ b/include/dlaf/eigensolver/gen_to_std/api.h
@@ -9,6 +9,7 @@
 //
 #pragma once
 
+#include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 
 namespace dlaf {

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -16,7 +16,7 @@
 #include "dlaf/sender/when_all_lift.h"
 #include "dlaf/util_matrix.h"
 
-#include "dlaf/eigensolver/reduction_to_band/impl.h"
+#include "dlaf/eigensolver/reduction_to_band/api.h"
 
 namespace dlaf::eigensolver {
 
@@ -132,25 +132,4 @@ common::internal::vector<pika::shared_future<common::internal::vector<T>>> reduc
 
   return internal::ReductionToBand<B, D, T>::call(grid, mat_a);
 }
-
-/// ---- ETI
-#define DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(KWORD, BACKEND, DEVICE, DATATYPE)                   \
-  KWORD template common::internal::vector<pika::shared_future<common::internal::vector<DATATYPE>>> \
-  reductionToBand<BACKEND, DEVICE, DATATYPE>(Matrix<DATATYPE, DEVICE> & mat_a,                     \
-                                             const SizeType band_size);                            \
-  KWORD template common::internal::vector<pika::shared_future<common::internal::vector<DATATYPE>>> \
-  reductionToBand<BACKEND, DEVICE, DATATYPE>(comm::CommunicatorGrid grid,                          \
-                                             Matrix<DATATYPE, DEVICE> & mat_a);
-
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, float)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, double)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
-
-#ifdef DLAF_WITH_GPU
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, float)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, double)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
-#endif
 }

--- a/include/dlaf/eigensolver/reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/reduction_to_band/api.h
@@ -22,4 +22,19 @@ struct ReductionToBand {
       comm::CommunicatorGrid grid, Matrix<T, D>& mat_a);
 };
 
+/// ---- ETI
+#define DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct ReductionToBand<BACKEND, DEVICE, DATATYPE>;
+
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, float)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, double)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
+
+#ifdef DLAF_WITH_GPU
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, float)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, double)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
+#endif
 }

--- a/include/dlaf/eigensolver/tridiag_solver.h
+++ b/include/dlaf/eigensolver/tridiag_solver.h
@@ -11,7 +11,7 @@
 
 #include "dlaf/common/assert.h"
 #include "dlaf/communication/communicator_grid.h"
-#include "dlaf/eigensolver/tridiag_solver/impl.h"
+#include "dlaf/eigensolver/tridiag_solver/api.h"
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"

--- a/include/dlaf/factorization/qr.h
+++ b/include/dlaf/factorization/qr.h
@@ -9,13 +9,10 @@
 //
 #pragma once
 
-#include "dlaf/factorization/qr/mc.h"
-#include "dlaf/factorization/qr/t_factor_impl.h"
+#include "dlaf/factorization/qr/api.h"
 #include "dlaf/matrix/index.h"
 
-namespace dlaf::factorization {
-
-namespace internal {
+namespace dlaf::factorization::internal {
 
 /// Forms the triangular factor T of a block reflector H of order n,
 /// which is defined as a product of k := hh_panel.getWidth() elementary reflectors.
@@ -50,36 +47,6 @@ void computeTFactor(matrix::Panel<Coord::Col, T, device>& hh_panel,
                     pika::future<matrix::Tile<T, device>> t,
                     common::Pipeline<comm::Communicator>& mpi_col_task_chain) {
   QR_Tfactor<backend, device, T>::call(hh_panel, taus, std::move(t), mpi_col_task_chain);
-}
-/// ---- ETI
-#define DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(KWORD, BACKEND, DEVICE, T)                  \
-  KWORD template void                                                                       \
-  computeTFactor<BACKEND, DEVICE, T>(matrix::Panel<Coord::Col, T, DEVICE> & hh_panel,       \
-                                     pika::shared_future<common::internal::vector<T>> taus, \
-                                     pika::future<matrix::Tile<T, DEVICE>> t);
-
-#define DLAF_FACTORIZATION_QR_TFACTOR_DISTR_ETI(KWORD, BACKEND, DEVICE, T)                  \
-  KWORD template void                                                                       \
-  computeTFactor<BACKEND, DEVICE, T>(matrix::Panel<Coord::Col, T, DEVICE> & hh_panel,       \
-                                     pika::shared_future<common::internal::vector<T>> taus, \
-                                     pika::future<matrix::Tile<T, DEVICE>> t,               \
-                                     common::Pipeline<comm::Communicator> & mpi_col_task_chain);
-
-#define DLAF_FACTORIZATION_QR_TFACTOR_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
-  DLAF_FACTORIZATION_QR_TFACTOR_DISTR_ETI(KWORD, BACKEND, DEVICE, DATATYPE)
-
-DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, float)
-DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, double)
-DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
-DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
-
-#ifdef DLAF_WITH_GPU
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(extern, Backend::GPU, Device::GPU, float)
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(extern, Backend::GPU, Device::GPU, double)
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
-#endif
 }
 
 }

--- a/include/dlaf/factorization/qr/api.h
+++ b/include/dlaf/factorization/qr/api.h
@@ -84,4 +84,19 @@ struct QR_Tfactor {
                    common::Pipeline<comm::Communicator>& mpi_col_task_chain);
 };
 
+/// ---- ETI
+#define DLAF_FACTORIZATION_QR_TFACTOR_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct QR_Tfactor<BACKEND, DEVICE, DATATYPE>;
+
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, float)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, double)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, std::complex<float>)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::MC, Device::CPU, std::complex<double>)
+
+#ifdef DLAF_WITH_GPU
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::GPU, Device::GPU, float)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::GPU, Device::GPU, double)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
+#endif
 }

--- a/src/eigensolver/bt_reduction_to_band/gpu.cpp
+++ b/src/eigensolver/bt_reduction_to_band/gpu.cpp
@@ -8,13 +8,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/eigensolver/bt_reduction_to_band.h"
+#include "dlaf/eigensolver/bt_reduction_to_band/impl.h"
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, float)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, double)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_LOCAL_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, float)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, double)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
 
 }

--- a/src/eigensolver/bt_reduction_to_band/mc.cpp
+++ b/src/eigensolver/bt_reduction_to_band/mc.cpp
@@ -8,9 +8,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/eigensolver/bt_reduction_to_band.h"
+#include "dlaf/eigensolver/bt_reduction_to_band/impl.h"
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
 DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(, Backend::MC, Device::CPU, float)
 DLAF_EIGENSOLVER_BT_REDUCTION_TO_BAND_ETI(, Backend::MC, Device::CPU, double)

--- a/src/eigensolver/reduction_to_band/gpu.cpp
+++ b/src/eigensolver/reduction_to_band/gpu.cpp
@@ -8,9 +8,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/eigensolver/reduction_to_band.h"
+#include "dlaf/eigensolver/reduction_to_band/impl.h"
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, float)
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::GPU, Device::GPU, double)

--- a/src/eigensolver/reduction_to_band/mc.cpp
+++ b/src/eigensolver/reduction_to_band/mc.cpp
@@ -8,9 +8,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/eigensolver/reduction_to_band.h"
+#include "dlaf/eigensolver/reduction_to_band/impl.h"
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::MC, Device::CPU, float)
 DLAF_EIGENSOLVER_REDUCTION_TO_BAND_ETI(, Backend::MC, Device::CPU, double)

--- a/src/factorization/qr/gpu.cpp
+++ b/src/factorization/qr/gpu.cpp
@@ -8,12 +8,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/factorization/qr.h"
+#include "dlaf/factorization/qr/t_factor_impl.h"
 
 namespace dlaf::factorization::internal {
 
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(, Backend::GPU, Device::GPU, float)
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(, Backend::GPU, Device::GPU, double)
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
-DLAF_FACTORIZATION_QR_TFACTOR_LOCAL_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(, Backend::GPU, Device::GPU, float)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(, Backend::GPU, Device::GPU, double)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(, Backend::GPU, Device::GPU, std::complex<float>)
+DLAF_FACTORIZATION_QR_TFACTOR_ETI(, Backend::GPU, Device::GPU, std::complex<double>)
 }

--- a/src/factorization/qr/mc.cpp
+++ b/src/factorization/qr/mc.cpp
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "dlaf/factorization/qr.h"
+#include "dlaf/factorization/qr/t_factor_impl.h"
 
 namespace dlaf::factorization::internal {
 

--- a/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
@@ -10,8 +10,10 @@
 #include <gtest/gtest.h>
 #include <pika/runtime.hpp>
 
+#include "dlaf/communication/kernels.h"
 #include "dlaf/eigensolver/tridiag_solver.h"
 #include "dlaf/matrix/matrix_mirror.h"
+#include "dlaf/multiplication/general.h"
 
 #include "dlaf_test/comm_grids/grids_6_ranks.h"
 #include "dlaf_test/matrix/util_generic_lapack.h"

--- a/test/unit/eigensolver/test_tridiag_solver_local.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_local.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "dlaf/eigensolver/tridiag_solver.h"
+#include "dlaf/eigensolver/tridiag_solver/impl.h"
 #include "dlaf/matrix/matrix_mirror.h"
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
This updates a few more algorithms to only include the `api.h` header, instead of the full `impl.h` header. The difference is not dramatic, but I measured e.g. a recompilation time of `test_tridiag_solver_distributed` of 44 seconds with these changes vs 47 seconds before (after first fully compiling the test, then `touch`ing `include/dlaf/eigensolver/tridiag_solver.h`).

If I instead `touch` the `impl.h` file after fully building the build time is roughly the same if built in parallel, but the test file itself doesn't have to be rebuilt so the total amount of work is less.

I ask you to have a closer look especially at the ones that used to have ETI done separately with a `LOCAL` macro for GPUs. It's not 100% clear that I'm not adding instantiations that are actually not used.