### PR TITLE
Fix codecov: remove old gitlab mirror repo and keep only github, change badge to point to github badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pipeline status](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/commits/master) [![codecov](https://codecov.io/gl/cscs-ci:eth-cscs/DLA-Future/branch/master/graph/badge.svg)](https://codecov.io/gl/cscs-ci:eth-cscs/DLA-Future)
+[![pipeline status](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/commits/master) [![codecov](https://codecov.io/gh/eth-cscs/DLA-Future/branch/master/graph/badge.svg)](https://codecov.io/gh/eth-cscs/DLA-Future)
 
 # Distributed Linear Algebra with Futures.
 

--- a/ci/upload_codecov
+++ b/ci/upload_codecov
@@ -7,5 +7,4 @@ fastcov -C ${TRACE_FILES} --lcov -o "$SHARED_REPORTS/combined.info"
 
 pushd /DLA-Future > /dev/null
 codecov.sh -f "$SHARED_REPORTS/combined.info" -t $CODECOV_TOKEN_GITHUB
-codecov.sh -f "$SHARED_REPORTS/combined.info" -t $CODECOV_TOKEN_GITLAB
 popd > /dev/null


### PR DESCRIPTION
Added `$CODECOV_TOKEN_GITHUB` variable in the new gitlab mirror as well.