### PR TITLE
Fix scripts problem with numpy@1.24.0

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -104,9 +104,9 @@ def _gen_nodes_plot(
 
         if fill_area:
             ax.fill_between(
-                lib_data["nodes"],
-                lib_data[f"{plt_type}_min"],
-                lib_data[f"{plt_type}_max"],
+                lib_data["nodes"].values,
+                lib_data[f"{plt_type}_min"].values,
+                lib_data[f"{plt_type}_max"].values,
                 alpha=0.2,
                 color=line_color,
             )


### PR DESCRIPTION
Starting from `numpy@1.24.0` scripts started complaining about `"ufunc 'isfinite' not supported for the input types"` when a `pd.Series` is passed to `matplotlib.fill_between`.

Tested with `numpy@1.23.5` for backward compatibility.