### PR TITLE
Make `miniapp` an independent project

### DIFF
--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -24,7 +24,7 @@ jobs:
         if: always()          # needed so that it runs even if previous one fails
         run: |
           # highlight if in these folders there are files with other extensions
-          find src include test miniapp -type f                                   \
+          find src include test -type f                                           \
                ! '('                                                              \
                        -name '*.cpp'                                              \
                    -o  -name '*.h'                                                \
@@ -70,7 +70,7 @@ jobs:
           # Generate header license CMake/Python compliant (with hashes)
           sed 's|^//|#|g' misc/HEADER > HEADER_HASH
 
-          # Check license in files that should the license at the very beginning
+          # Check license in files that should have the license at the very beginning
           find  '(' -type f ! -path './misc*' ')'                                 \
                 '('                                                               \
                         -name 'CMakeLists.txt'                                    \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,16 @@ add_subdirectory(src)
 # mini Apps
 # ---------------------------------------------------------------------------
 if(DLAF_BUILD_MINIAPPS)
+  # Create a "do-nothing" DLAFConfig.cmake, and make it usable by find_package
+  # by adding it in CMAKE_PREFIX_PATH.
+  # In this way any call to `find_package(DLAF)` is a no-op. Indeed, nothing
+  # is necessary to be done, since we are in-project and targets are still
+  # available thanks to manually created aliases for exported targets.
+  set(FAKE_INSTALL_DIR ${PROJECT_BINARY_DIR}/fake)
+  file(MAKE_DIRECTORY ${FAKE_INSTALL_DIR})
+  file(TOUCH ${FAKE_INSTALL_DIR}/DLAFConfig.cmake)
+  list(PREPEND CMAKE_PREFIX_PATH ${FAKE_INSTALL_DIR})
+
   add_subdirectory(miniapp)
 endif()
 

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -14,12 +14,13 @@ project(DLAF-miniapps)
 list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(DLAF REQUIRED)
+find_package(pika 0.11.0 REQUIRED)
 
 include(DLAF_AddMiniapp)
 include(DLAF_AddTargetWarnings)
 
 add_library(DLAF_miniapp INTERFACE)
-target_link_libraries(DLAF_miniapp INTERFACE DLAF::DLAF)
+target_link_libraries(DLAF_miniapp INTERFACE DLAF::DLAF pika::pika)
 target_include_directories(DLAF_miniapp INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 DLAF_addMiniapp(miniapp_cholesky SOURCES miniapp_cholesky.cpp)

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 
 cmake_minimum_required(VERSION 3.22)
-project(dlaf-miniapps)
+project(DLAF-miniapps)
 
 list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -24,10 +24,8 @@ target_include_directories(DLAF_miniapp INTERFACE $<BUILD_INTERFACE:${CMAKE_CURR
 
 DLAF_addMiniapp(miniapp_cholesky SOURCES miniapp_cholesky.cpp)
 
-if(DLAF_BUILD_TESTING)
-  # TODO it depends on DLAF_TEST exclusively for the check part (uses CHECK_MATRIX_NEAR)
-  DLAF_addMiniapp(miniapp_triangular_solver SOURCES miniapp_triangular_solver.cpp LIBRARIES DLAF_test)
-endif()
+# TODO it depends on DLAF_TEST exclusively for the check part (uses CHECK_MATRIX_NEAR)
+DLAF_addMiniapp(miniapp_triangular_solver SOURCES miniapp_triangular_solver.cpp LIBRARIES DLAF_test)
 
 DLAF_addMiniapp(miniapp_gen_to_std SOURCES miniapp_gen_to_std.cpp)
 
@@ -42,6 +40,7 @@ DLAF_addMiniapp(miniapp_bt_band_to_tridiag SOURCES miniapp_bt_band_to_tridiag.cp
 DLAF_addMiniapp(miniapp_bt_reduction_to_band SOURCES miniapp_bt_reduction_to_band.cpp)
 
 DLAF_addMiniapp(miniapp_eigensolver SOURCES miniapp_eigensolver.cpp)
+
 DLAF_addMiniapp(miniapp_gen_eigensolver SOURCES miniapp_gen_eigensolver.cpp)
 
 add_subdirectory(kernel)

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -8,8 +8,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+cmake_minimum_required(VERSION 3.22)
+project(dlaf-miniapps)
+
+list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+include(DLAF_AddMiniapp)
+
+find_package(DLAF REQUIRED)
+
 add_library(DLAF_miniapp INTERFACE)
-target_link_libraries(DLAF_miniapp INTERFACE DLAF)
+target_link_libraries(DLAF_miniapp INTERFACE DLAF::DLAF)
 target_include_directories(DLAF_miniapp INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 DLAF_addMiniapp(miniapp_cholesky SOURCES miniapp_cholesky.cpp)

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -12,10 +12,11 @@ cmake_minimum_required(VERSION 3.22)
 project(dlaf-miniapps)
 
 list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-include(DLAF_AddMiniapp)
-include(DLAF_AddTargetWarnings)
 
 find_package(DLAF REQUIRED)
+
+include(DLAF_AddMiniapp)
+include(DLAF_AddTargetWarnings)
 
 add_library(DLAF_miniapp INTERFACE)
 target_link_libraries(DLAF_miniapp INTERFACE DLAF::DLAF)

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -13,6 +13,7 @@ project(dlaf-miniapps)
 
 list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(DLAF_AddMiniapp)
+include(DLAF_AddTargetWarnings)
 
 find_package(DLAF REQUIRED)
 

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 
 add_library(DLAF_miniapp INTERFACE)
-target_link_libraries(DLAF_miniapp INTERFACE DLAF pika::pika)
+target_link_libraries(DLAF_miniapp INTERFACE DLAF)
 target_include_directories(DLAF_miniapp INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 DLAF_addMiniapp(miniapp_cholesky SOURCES miniapp_cholesky.cpp)

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -24,9 +24,6 @@ target_include_directories(DLAF_miniapp INTERFACE $<BUILD_INTERFACE:${CMAKE_CURR
 
 DLAF_addMiniapp(miniapp_cholesky SOURCES miniapp_cholesky.cpp)
 
-# TODO it depends on DLAF_TEST exclusively for the check part (uses CHECK_MATRIX_NEAR)
-DLAF_addMiniapp(miniapp_triangular_solver SOURCES miniapp_triangular_solver.cpp LIBRARIES DLAF_test)
-
 DLAF_addMiniapp(miniapp_gen_to_std SOURCES miniapp_gen_to_std.cpp)
 
 DLAF_addMiniapp(miniapp_reduction_to_band SOURCES miniapp_reduction_to_band.cpp)
@@ -38,6 +35,8 @@ DLAF_addMiniapp(miniapp_tridiag_solver SOURCES miniapp_tridiag_solver.cpp)
 DLAF_addMiniapp(miniapp_bt_band_to_tridiag SOURCES miniapp_bt_band_to_tridiag.cpp)
 
 DLAF_addMiniapp(miniapp_bt_reduction_to_band SOURCES miniapp_bt_reduction_to_band.cpp)
+
+DLAF_addMiniapp(miniapp_triangular_solver SOURCES miniapp_triangular_solver.cpp)
 
 DLAF_addMiniapp(miniapp_eigensolver SOURCES miniapp_eigensolver.cpp)
 

--- a/miniapp/cmake/DLAF_AddMiniapp.cmake
+++ b/miniapp/cmake/DLAF_AddMiniapp.cmake
@@ -53,7 +53,6 @@ function(DLAF_addMiniapp miniapp_target_name)
   target_compile_definitions(${miniapp_target_name} PRIVATE ${DLAF_AM_COMPILE_DEFINITIONS})
   target_include_directories(${miniapp_target_name} PRIVATE ${DLAF_AM_INCLUDE_DIRS})
   target_add_warnings(${miniapp_target_name})
-  DLAF_addPrecompiledHeaders(${miniapp_target_name})
 
   ### DEPLOY
   include(GNUInstallDirs)

--- a/miniapp/cmake/DLAF_AddMiniapp.cmake
+++ b/miniapp/cmake/DLAF_AddMiniapp.cmake
@@ -48,7 +48,7 @@ function(DLAF_addMiniapp miniapp_target_name)
   ### Miniapp executable target
   add_executable(${miniapp_target_name} ${DLAF_AM_SOURCES})
   target_link_libraries(
-    ${miniapp_target_name} PRIVATE DLAF_miniapp ${DLAF_AM_LIBRARIES} dlaf.prop_private
+    ${miniapp_target_name} PRIVATE DLAF_miniapp ${DLAF_AM_LIBRARIES} DLAF::dlaf.prop_private
   )
   target_compile_definitions(${miniapp_target_name} PRIVATE ${DLAF_AM_COMPILE_DEFINITIONS})
   target_include_directories(${miniapp_target_name} PRIVATE ${DLAF_AM_INCLUDE_DIRS})

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -33,9 +33,6 @@
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
 
-#include "dlaf_test/matrix/util_matrix.h"
-#include "dlaf_test/util_types.h"
-
 #include "dlaf/miniapp/dispatch.h"
 #include "dlaf/miniapp/options.h"
 
@@ -72,6 +69,11 @@ struct Options
         diag(dlaf::miniapp::parseDiag(vm["diag"].as<std::string>())) {
     DLAF_ASSERT(m > 0 && n > 0, m, n);
     DLAF_ASSERT(mb > 0 && nb > 0, mb, nb);
+
+    if (do_check != dlaf::miniapp::CheckIterFreq::None) {
+      std::cerr << "Warning! At the moment result checking it is not implemented." << std::endl;
+      do_check = dlaf::miniapp::CheckIterFreq::None;
+    }
   }
 
   Options(Options&&) = default;
@@ -165,12 +167,7 @@ struct triangularSolverMiniapp {
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||
           opts.do_check == dlaf::miniapp::CheckIterFreq::All) {
-        // TODO do not check element by element, but evaluate the entire matrix
-        static_assert(std::is_arithmetic_v<T>, "mul/add error is valid just for arithmetic types");
-        constexpr T muladd_error = 2 * std::numeric_limits<T>::epsilon();
-
-        const T max_error = 20 * (bh.size().rows() + 1) * muladd_error;
-        CHECK_MATRIX_NEAR(ref_x, bh, max_error, 0);
+        DLAF_UNIMPLEMENTED("Check");
       }
     }
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,9 +306,8 @@ endforeach()
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # install custom DLAF scripts
-install(
-  FILES ${PROJECT_SOURCE_DIR}/cmake/DLAF_AddTargetWarnings.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/DLAF_AddTargetWarnings.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )
 
 # install custom FindModules
@@ -333,8 +332,7 @@ install(EXPORT DLAF-Targets NAMESPACE DLAF::
 
 # Config-file preparation and install
 configure_package_config_file(
-  ${PROJECT_SOURCE_DIR}/cmake/template/DLAFConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/template/DLAFConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,12 +283,24 @@ target_add_warnings(DLAF)
 # ----- DEPLOY
 include(GNUInstallDirs)
 
+set(DLAF_EXPORTED_TARGETS DLAF dlaf.prop dlaf.prop_private)
+
 install(
-  TARGETS DLAF dlaf.prop dlaf.prop_private
+  TARGETS ${DLAF_EXPORTED_TARGETS}
   EXPORT DLAF-Targets
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+# Create aliases as a `find_package(DLAF)` call would do.
+# This allows external projects embedded in this build and depending on DLAF
+# to use targets at configure time.
+# Indeed, otherwise, targets would be available just calling find_package,
+# that relies on DLAFConfig.cmake and DLAF-Targets, but the latter one would
+# be available just after the cmake generate phase (i.e. too late).
+foreach(_target ${DLAF_EXPORTED_TARGETS})
+  add_library(DLAF::${_target} ALIAS ${_target})
+endforeach()
 
 # install includes
 install(DIRECTORY ../include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,11 +303,17 @@ foreach(_target ${DLAF_EXPORTED_TARGETS})
 endforeach()
 
 # install includes
-install(DIRECTORY ../include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# install custom DLAF scripts
+install(
+  FILES ${PROJECT_SOURCE_DIR}/cmake/DLAF_AddTargetWarnings.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
+)
 
 # install custom FindModules
 install(
-  DIRECTORY ../cmake/
+  DIRECTORY ${PROJECT_SOURCE_DIR}/cmake/
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
   FILES_MATCHING
   PATTERN "Find*.cmake"
@@ -327,7 +333,7 @@ install(EXPORT DLAF-Targets NAMESPACE DLAF::
 
 # Config-file preparation and install
 configure_package_config_file(
-  ${CMAKE_CURRENT_LIST_DIR}/../cmake/template/DLAFConfig.cmake.in
+  ${PROJECT_SOURCE_DIR}/cmake/template/DLAFConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )


### PR DESCRIPTION
This is an attempt to make the `miniapp` folder an independent project. Apart the more clear separation between library and miniapps, this would also allow to test the deployment of the library.

The main requirement was that `miniapp` should be an independent project, so that it can be built separately specifying where DLAF library is located, but also together with the library seeming-lessly so that developer can easily work with them.

TODO
- [x] Requires #758
- [ ] Do we want to add a more specific check for `miniapp`? (see https://github.com/eth-cscs/DLA-Future/pull/764/commits/1eb8c749dac6640ed324b1cb59a407d2552444b0)
- [x] Open issue about https://github.com/eth-cscs/DLA-Future/pull/764/commits/6873c3268070c2872b952df39923a95bf49f34e9 https://github.com/eth-cscs/DLA-Future/issues/779

Changelog:
- For each EXPORTED targets an alias namespaced DLAF:: target is created
- Install also `DLAF_AddTargetWarnings` CMake script
- If `DLAF_BUILD_MINIAPPS=on`, create an empty `DLAFConfig.cmake` to use for embedded projects for which everything is already set correctly
- Make miniapp an independent project and migrate to using `DLAF::` namespaced targets
- Miniapp do not use anymore precompiled headers
- Remove miniapp dependency on `DLAF_test` (see issue #779)
- Exclude miniapp from check about "files with other extensions"