### PR TITLE
Ignore bogus pika warnings locally in source files

### DIFF
--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -82,9 +82,16 @@ public:
     pika::lcos::local::promise<T> promise_next;
     sender_ = promise_next.get_future();
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     auto make_promise_guard = [promise_next = std::move(promise_next)](T object) mutable {
       return PromiseGuard<T>{std::move(object), std::move(promise_next)};
     };
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     namespace ex = pika::execution::experimental;
     return std::move(before_last) | ex::then(std::move(make_promise_guard));

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -264,22 +264,6 @@ DLAF_addSublibrary(
   LIBRARIES dlaf.core
 )
 
-target_compile_options(
-  dlaf.core_object PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=stringop-overflow
-                           -Wno-error=array-bounds>
-)
-target_compile_options(dlaf.eigensolver_object PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>)
-target_compile_options(
-  dlaf.tridiagonal_eigensolver_object PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>
-)
-target_compile_options(
-  dlaf.factorization_object PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>
-)
-target_compile_options(
-  dlaf.multiplication_object PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>
-)
-target_compile_options(dlaf.solver_object PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>)
-
 # Define DLAF's complete library
 add_library(
   DLAF

--- a/src/communication/kernels/all_reduce.cpp
+++ b/src/communication/kernels/all_reduce.cpp
@@ -132,10 +132,17 @@ template <class T, Device D>
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   auto all_reduce_in_place = [reduce_op, pcomm = std::move(pcomm)](auto const& tile_comm) mutable {
     return whenAllLift(std::move(pcomm), reduce_op, std::cref(tile_comm)) |
            transformMPI(allReduceInPlace_o);
   };
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
   // The tile has to be copied both to and from the temporary tile since the
   // reduction is done in-place. The reduction is explicitly done on CPU memory

--- a/src/communication/kernels/broadcast.cpp
+++ b/src/communication/kernels/broadcast.cpp
@@ -91,9 +91,16 @@ template <class T, Device D, class Comm>
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   auto recv = [root_rank, pcomm = std::move(pcomm)](auto const& tile_comm) mutable {
     return whenAllLift(std::move(pcomm), root_rank, std::cref(tile_comm)) | transformMPI(recvBcast_o);
   };
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
   constexpr Device in_device_type = D;
   constexpr Device comm_device_type = CommunicationDevice_v<in_device_type>;

--- a/src/communication/kernels/reduce.cpp
+++ b/src/communication/kernels/reduce.cpp
@@ -96,10 +96,17 @@ template <class T, Device D>
   using dlaf::internal::whenAllLift;
   using dlaf::internal::withTemporaryTile;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   auto reduce_recv_in_place = [reduce_op, pcomm = std::move(pcomm)](auto const& tile_comm) mutable {
     return whenAllLift(std::move(pcomm), reduce_op, std::cref(tile_comm)) |
            transformMPI(reduceRecvInPlace_o);
   };
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
   // The input tile must be copied to the temporary tile to participate in the
   // reduction. The temporary tile is also copied back so that the reduced

--- a/test/unit/auxiliary/mc/CMakeLists.txt
+++ b/test/unit/auxiliary/mc/CMakeLists.txt
@@ -15,5 +15,3 @@ DLAF_addTest(
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
-
-target_compile_options(test_broadcast_panel PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>)

--- a/test/unit/communication/CMakeLists.txt
+++ b/test/unit/communication/CMakeLists.txt
@@ -80,8 +80,6 @@ DLAF_addTest(
   USE_MAIN MPIPIKA
 )
 
-target_compile_options(test_broadcast_panel PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>)
-
 DLAF_addTest(
   test_comm_sender
   SOURCES test_comm_sender.cpp
@@ -105,8 +103,6 @@ DLAF_addTest(
   MPIRANKS 2
   USE_MAIN MPIPIKA
 )
-
-target_compile_options(test_collective_async PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>)
 
 DLAF_addTest(
   test_transform_mpi

--- a/test/unit/eigensolver/CMakeLists.txt
+++ b/test/unit/eigensolver/CMakeLists.txt
@@ -62,21 +62,12 @@ DLAF_addTest(
   MPIRANKS 6
 )
 
-target_compile_options(
-  test_reduction_to_band PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=stringop-overflow
-                                 -Wno-error=array-bounds>
-)
-
 DLAF_addTest(
   test_bt_reduction_to_band
   SOURCES test_bt_reduction_to_band.cpp
   LIBRARIES dlaf.eigensolver dlaf.core
   USE_MAIN MPIPIKA
   MPIRANKS 6
-)
-
-target_compile_options(
-  test_bt_reduction_to_band PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>
 )
 
 DLAF_addTest(
@@ -101,9 +92,4 @@ DLAF_addTest(
   LIBRARIES dlaf.core dlaf.tridiagonal_eigensolver dlaf.multiplication dlaf.permutations
   USE_MAIN MPIPIKA
   MPIRANKS 6
-)
-
-target_compile_options(
-  test_tridiag_solver_distributed PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=stringop-overflow
-                                          -Wno-error=array-bounds>
 )

--- a/test/unit/factorization/CMakeLists.txt
+++ b/test/unit/factorization/CMakeLists.txt
@@ -23,5 +23,3 @@ DLAF_addTest(
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
-
-target_compile_options(test_compute_t_factor PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>)

--- a/test/unit/permutations/CMakeLists.txt
+++ b/test/unit/permutations/CMakeLists.txt
@@ -22,7 +22,3 @@ DLAF_addTest(
   USE_MAIN MPIPIKA
   MPIRANKS 6
 )
-
-target_compile_options(
-  test_permutations_distributed PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>
-)


### PR DESCRIPTION
"Fixes" https://github.com/eth-cscs/DLA-Future/issues/688 by locally ignoring warnings in the source files instead of through compiler flags. I have not been able to silence these properly from pika so doing the next best thing and silencing them locally instead.

It seems like these bogus warnings may no longer be present in GCC 12, but I'm leaving the `#pragma GCC diagnostic ignored` for all versions because I've only tested with 12.2.0.

~To do: check if the `stringop-overflow` warning still needs to be silenced.~ It seems to not be required anymore.