### PR TITLE
Add library deployment check in CI

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -17,7 +17,9 @@ stages:
   timeout: 6 hours
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: 7efcb5ae73bdaa85886079ccfd5ff0f44b838508
+    # TODO waiting for ROCm 5.3.3 in spack
+    # https://github.com/spack/spack/pull/34862
+    SPACK_SHA: d74223ba20b00cb85d911e5ada92a5a3ac4fd754
     SPACK_DLAF_REPO: ./spack
   before_script:
     - podman login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
@@ -193,22 +195,23 @@ cuda codecov build gcc11:
     THREADS_PER_NODE: 24
     USE_CODECOV: "true"
 
-rocm release build clang10+rocm-5.2.3:
+rocm release build clang10+rocm-5.3.3:
   extends: .build_spack_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile
     DEPLOY_DOCKER_FILE: ci/docker/deploy.Dockerfile
-    BASE_IMAGE: docker.io/rocm/dev-ubuntu-20.04:5.2.3
-    DEPLOY_BASE_IMAGE: docker.io/rocm/dev-ubuntu-20.04:5.2.3
-    EXTRA_APTGET: "clang rocblas rocblas-dev rocsolver rocsolver-dev rocprim-dev rocthrust-dev llvm-amdgpu rocm-device-libs"
-    EXTRA_APTGET_DEPLOY: ""
-    COMPILER: clang@10.0.0
+    BASE_IMAGE: $CSCS_REGISTRY_PATH/rocm-patched:5.3.3
+    DEPLOY_BASE_IMAGE: $CSCS_REGISTRY_PATH/rocm-patched:5.3.3
+    EXTRA_APTGET: "clang-14 rocblas rocblas-dev rocsolver rocsolver-dev rocprim-dev rocthrust-dev llvm-amdgpu rocm-device-libs"
+    EXTRA_APTGET_DEPLOY: "glibc-tools"
+    # glibc-tools is needed for libSegFault on ubuntu:22.04
+    COMPILER: clang@14.0.0
     CXXSTD: 17
     USE_MKL: "OFF"
     USE_ROCBLAS: "ON"
-    SPACK_ENVIRONMENT: ci/docker/release-rocm523.yaml
-    BUILD_IMAGE: $CSCS_REGISTRY_PATH/release-rocm-clang10/build
-    DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/release-rocm-clang10/deploy:$CI_COMMIT_SHA
+    SPACK_ENVIRONMENT: ci/docker/release-rocm533.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_PATH/release-rocm-clang14/build
+    DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/release-rocm-clang14/deploy:$CI_COMMIT_SHA
     SLURM_CONSTRAINT: mc
     THREADS_PER_NODE: 64
     USE_CODECOV: "false"

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
     GIT_SUBMODULE_STRATEGY: recursive
     # TODO waiting for ROCm 5.3.3 in spack
     # https://github.com/spack/spack/pull/34862
-    SPACK_SHA: d74223ba20b00cb85d911e5ada92a5a3ac4fd754
+    SPACK_SHA: 84f65f5bda6270e1f0a4b6c942274768dae0bf83
     SPACK_DLAF_REPO: ./spack
   before_script:
     - podman login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -193,7 +193,7 @@ cuda codecov build gcc11:
     THREADS_PER_NODE: 24
     USE_CODECOV: "true"
 
-rocm release build clang10+rocm-5.3.3:
+rocm release build clang14+rocm-5.3.3:
   extends: .build_spack_common
   variables:
     BUILD_DOCKER_FILE: ci/docker/build.Dockerfile

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -17,9 +17,7 @@ stages:
   timeout: 6 hours
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    # TODO waiting for ROCm 5.3.3 in spack
-    # https://github.com/spack/spack/pull/34862
-    SPACK_SHA: 84f65f5bda6270e1f0a4b6c942274768dae0bf83
+    SPACK_SHA: 4b6715361340a2dc1fe7a0ab92fd84a958983433
     SPACK_DLAF_REPO: ./spack
   before_script:
     - podman login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -29,6 +29,13 @@ RUN spack repo rm --scope site dlaf && \
     ln -s ${BUILD} `spack -e ci location -b dla-future` && \
     spack -e ci install --jobs ${NUM_PROCS} --keep-stage --verbose
 
+# Test deployment with miniapps as independent project
+RUN pushd ${SOURCE}/miniapp && \
+    mkdir build-miniapps && cd build-miniapps && \
+    spack -e ci build-env dla-future@develop -- \
+    bash -c "cmake -DCMAKE_PREFIX_PATH=`spack -e ci location -i dla-future` .. && make -j ${NUM_PROCS}" && \
+    popd
+
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \
     export TEST_BINARIES=`ctest --show-only=json-v1 | jq '.tests | map(.command[0]) | .[]' | tr -d \"` && \

--- a/ci/docker/patch-rocm-image/build-rocm-patched.sh
+++ b/ci/docker/patch-rocm-image/build-rocm-patched.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# dlaf-no-license-check
 
 CSCS_REGISTRY="jfrog.svc.cscs.ch/contbuild/testing/anfink/4700071344751697"
 docker build -t $CSCS_REGISTRY/rocm-patched:5.3.3 -f build.Dockerfile .

--- a/ci/docker/patch-rocm-image/build-rocm-patched.sh
+++ b/ci/docker/patch-rocm-image/build-rocm-patched.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+CSCS_REGISTRY="jfrog.svc.cscs.ch/contbuild/testing/anfink/4700071344751697"
+docker build -t $CSCS_REGISTRY/rocm-patched:5.3.3 -f build.Dockerfile .
+docker push $CSCS_REGISTRY/rocm-patched:5.3.3

--- a/ci/docker/patch-rocm-image/build.Dockerfile
+++ b/ci/docker/patch-rocm-image/build.Dockerfile
@@ -1,0 +1,5 @@
+FROM rocm/dev-ubuntu-22.04:5.3.3
+
+COPY ./rocm-hip-cmake-clang_rt-builtins.patch /
+
+RUN patch -p1 < rocm-hip-cmake-clang_rt-builtins.patch

--- a/ci/docker/patch-rocm-image/rocm-hip-cmake-clang_rt-builtins.patch
+++ b/ci/docker/patch-rocm-image/rocm-hip-cmake-clang_rt-builtins.patch
@@ -1,0 +1,26 @@
+--- /opt/rocm-5.3.3/lib/cmake/hip/hip-config.cmake	2023-01-11 14:11:41.461621974 +0000
++++ /opt/rocm-5.3.3/lib/cmake/hip/hip-config.cmake	2023-01-11 14:11:47.489566322 +0000
+@@ -186,14 +186,16 @@
+       set(HIP_CLANG_PATCH_LEVEL ${CMAKE_MATCH_3})
+     endif()
+   endif()
+-  if(HIP_CXX_COMPILER MATCHES ".*hipcc")
+-    if(HIP_CXX_COMPILER_VERSION_OUTPUT MATCHES "InstalledDir:[ \t]*([^\n]*)")
+-      get_filename_component(HIP_CLANG_ROOT "${CMAKE_MATCH_1}" DIRECTORY)
++  if(NOT HIP_CLANG_ROOT)
++    if(HIP_CXX_COMPILER MATCHES ".*hipcc")
++      if(HIP_CXX_COMPILER_VERSION_OUTPUT MATCHES "InstalledDir:[ \t]*([^\n]*)")
++        get_filename_component(HIP_CLANG_ROOT "${CMAKE_MATCH_1}" DIRECTORY)
++      endif()
++    elseif (HIP_CXX_COMPILER MATCHES ".*clang\\+\\+")
++      get_filename_component(_HIP_CLANG_REAL_PATH "${HIP_CXX_COMPILER}" REALPATH)
++      get_filename_component(_HIP_CLANG_BIN_PATH "${_HIP_CLANG_REAL_PATH}" DIRECTORY)
++      get_filename_component(HIP_CLANG_ROOT "${_HIP_CLANG_BIN_PATH}" DIRECTORY)
+     endif()
+-  elseif (HIP_CXX_COMPILER MATCHES ".*clang\\+\\+")
+-    get_filename_component(_HIP_CLANG_REAL_PATH "${HIP_CXX_COMPILER}" REALPATH)
+-    get_filename_component(_HIP_CLANG_BIN_PATH "${_HIP_CLANG_REAL_PATH}" DIRECTORY)
+-    get_filename_component(HIP_CLANG_ROOT "${_HIP_CLANG_BIN_PATH}" DIRECTORY)
+   endif()
+   file(GLOB HIP_CLANG_INCLUDE_SEARCH_PATHS ${HIP_CLANG_ROOT}/lib/clang/*/include)
+   find_path(HIP_CLANG_INCLUDE_PATH stddef.h

--- a/ci/docker/release-rocm533.yaml
+++ b/ci/docker/release-rocm533.yaml
@@ -55,41 +55,41 @@ spack:
       - 0.4.1
     llvm-amdgpu:
       externals:
-      - spec: llvm-amdgpu@5.2.3 ~rocm-device-libs
-        prefix: /opt/rocm-5.2.3/llvm
+      - spec: llvm-amdgpu@5.3.3 ~rocm-device-libs
+        prefix: /opt/rocm-5.3.3/llvm
       buildable: false
     rocm-device-libs:
       externals:
-      - spec: rocm-device-libs@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: rocm-device-libs@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false
     hip:
       externals:
-      - spec: hip@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: hip@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false
     rocblas:
       externals:
-      - spec: rocblas@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: rocblas@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false
     rocsolver:
       externals:
-      - spec: rocsolver@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: rocsolver@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false
     rocprim:
       externals:
-      - spec: rocprim@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: rocprim@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false
     rocthrust:
       externals:
-      - spec: rocthrust@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: rocthrust@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false
     hsa-rocr-dev:
       externals:
-      - spec: hsa-rocr-dev@5.2.3
-        prefix: /opt/rocm-5.2.3
+      - spec: hsa-rocr-dev@5.3.3
+        prefix: /opt/rocm-5.3.3
       buildable: false

--- a/ci/docker/release-rocm533.yaml
+++ b/ci/docker/release-rocm533.yaml
@@ -21,38 +21,26 @@ spack:
       - build_type=Release
       - cxxstd=17
       - amdgpu_target=gfx90a:xnack-
-      providers:
-        mpi: [mpich]
-        blas: [openblas]
-        lapack: [openblas]
+    blas:
+      require: openblas
+    lapack:
+      require: openblas
+    mpi:
+      require: mpich ~fortran ~rocm device=ch3 netmod=tcp ~libxml2
     blaspp:
-      variants:
-      - ~cuda
-      - ~rocm
-      - ~openmp
+      require: ~cuda ~rocm ~openmp
     pika:
-      variants:
-      - malloc=mimalloc
-    mpich:
-      variants:
-      - ~fortran
-      - ~rocm
-      - device=ch3
-      - netmod=tcp
-      - ~libxml2
+      require: malloc=mimalloc
     hwloc:
-      variants:
-      - ~libxml2
+      require: ~libxml2
     git:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040
       buildable: false
     umpire:
-      version:
-      - 4.1.2
+      require: "@4.1.2"
     blt:
-      version:
-      - 0.4.1
+      require: "@0.4.1"
     llvm-amdgpu:
       externals:
       - spec: llvm-amdgpu@5.3.3 ~rocm-device-libs

--- a/ci/docker/release-rocm533.yaml
+++ b/ci/docker/release-rocm533.yaml
@@ -10,7 +10,7 @@
 
 spack:
   specs:
-  - dla-future@develop +rocm +miniapps +ci-test
+  - dla-future@develop +rocm amdgpu_target=gfx90a:xnack- +miniapps +ci-test
   view: false
   concretizer:
     unify: true


### PR DESCRIPTION
Close #755 

Add an additional step in CI for verifying that DLAF library can be correctly used by an independent project using CMake.

- [x] Requires #764
- [x] Wait for https://github.com/spack/spack/pull/34862

Changelog:
- Add deploy verification step, trying to build miniapps as external project
- Bump spack (so that it recognises ROCm 5.3.3)
- Utilities for creating a patched ROCm Docker image (see notes below)
- Update CI to use ROCm 5.3.3 and Clang 14 on Ubuntu 22.04
- Spack environment used by ROCm image updated to use requirements instead of preferences

# WHAT
Currently, ROCm CMake is a bit buggy. Deployment of miniapps as external project (without calling `enable_language(HIP)`) shown a problem related to `CLANGRT_BUILTINS`.

`enable_language(HIP)` calls `hip-lang-config.cmake` that correctly sets various variables, among which `HIP_CLANG_INCLUDE_PATH`. When you do `find_package(HIP)` it will do its mess and realize that `HIP_CLANG_INCLUDE_PATH` has been already set, so despite the mess, it does not touch them, and everything works. But...

If you don’t do `enable_language(HIP)`, `hip-lang-config.cmake` does not get called, so the mess from `hip-config.cmake` finds its realization by setting wrongly all relevant variables, ending in not being able to find `CLANGRT_BUILTINS`. So, the problem arise just when “deploying” something that uses HIP but does not compile device code (so no `enable_language(HIP)`).

In addition to this, there was a bug in `CLANGRT_BUILTINS` cmake variable check. Starting from 5.3.0 the check has been fixed, so a call to `find_package(HIP)` without `enable_language(HIP)` will result in a CMake configure error, because `CLANGRT_BUILTINS`, due to the mess that `hip-config.cmake` does, cannot be detected correctly.

If you are not using spack, probably all this mess does not trigger because of assumptions done by cmake hip scripts, which do not stand anymore with spack, due to the usage of compiler wrappers.

# SOLUTION
The solution we opted for in CI is to patch the ROCm docker image. In particular, the patch applies to `hip-config.cmake` file, that will not try to infer anymore the `HIP_CLANG_ROOT` from the compiler when it has been already set.

The ROCm patched image can be easily built with helpers available in `ci/docker/patch-rocm-image`, that contains:
- `build.Dockerfile` the docker recipe that starting from an official image applies the patch on it
- `rocm-hip-cmake-clang_rt-builtins.patch` the patch that will be actually applied
- `build-rocm-patched.sh` the script to run in order to build and push the ROCm patched image to CSCS Registry on JFROG, so that it can be used in CI as base image.