### PR TITLE
Add `amdgpu_target` constraints for `rocprim`, `rocthrust`, and `whip` to spack package

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -87,6 +87,12 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
                 when="amdgpu_target={0}".format(val))
             depends_on("rocblas amdgpu_target={0}".format(val),
                 when="amdgpu_target={0}".format(val))
+            depends_on("rocprim amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
+            depends_on("rocthrust amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
+            depends_on("whip amdgpu_target={0}".format(val),
+                when="amdgpu_target={0}".format(val))
             depends_on("umpire amdgpu_target={0}".format(val),
                 when="amdgpu_target={0}".format(val))
 


### PR DESCRIPTION
For `rocprim` and `rocthrust` it's just to avoid using `auto`, for `whip` spack will actually complain that it's none unless explicitly set. Requiring them to be the same as DLA-Future seems the most consistent considering we already do this for `rocblas`, `rocsolver`, and `umpire`.