### PR TITLE
Fix tiny typo in and add clarification to `--dlaf:eigensolver-min-band` command line option description

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -188,7 +188,7 @@ pika::program_options::options_description getOptionsDescription() {
 
   // Tune parameters command line options
   desc.add_options()("dlaf:eigensolver-min-band", pika::program_options::value<SizeType>(),
-                     "The minimun value to start looking for a divisor of the block size.");
+                     "The minimum value to start looking for a divisor of the block size.");
 
   return desc;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -187,8 +187,9 @@ pika::program_options::options_description getOptionsDescription() {
   desc.add_options()("dlaf:no-mpi-pool", pika::program_options::bool_switch(), "Disable the MPI pool.");
 
   // Tune parameters command line options
-  desc.add_options()("dlaf:eigensolver-min-band", pika::program_options::value<SizeType>(),
-                     "The minimum value to start looking for a divisor of the block size.");
+  desc.add_options()(
+      "dlaf:eigensolver-min-band", pika::program_options::value<SizeType>(),
+      "The minimum value to start looking for a divisor of the block size. When larger than the block size, the block size will be used instead.");
 
   return desc;
 }


### PR DESCRIPTION
I'm also wondering if the description should say something like `When larger than the block size, the block size will be used instead.`?