### PR TITLE
Fix plot title generation in `postprocess.py`

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -418,7 +418,7 @@ def add_basic_legend(fig, ax):
 
 def _gen_plot(
     scaling,
-    title,
+    name,
     routine,
     filename,
     size_type,
@@ -437,7 +437,7 @@ def _gen_plot(
     """
     Args:
         scaling         strong | weak
-        title:          name of the routine to be included in the title
+        name:           name of the routine to be included in the title
         routine:        chol | hegst | red2band | band2trid | trid_evp | bt_band2trid | trsm | evp | gevp
         combine_mb:     bool indicates if different mb has to be included in the same plot
         size_type:      m | mn It indicates which sizes are relevant.
@@ -512,7 +512,7 @@ def _gen_plot(
                     b = int(x[i])
                     i += 1
 
-        title = f"{title}: {scaling} scaling"
+        title = f"{name}: {scaling} scaling"
         filename_ppn = f"{filename}_{scaling}_ppn"
         filename_time = f"{filename}_{scaling}_time"
         if size_type == "m":
@@ -584,7 +584,7 @@ def gen_chol_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="Cholesky",
+        name="Cholesky",
         routine="chol",
         filename="chol",
         size_type="m",
@@ -618,7 +618,7 @@ def gen_chol_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="Cholesky",
+        name="Cholesky",
         routine="chol",
         filename="chol",
         size_type="m",
@@ -652,7 +652,7 @@ def gen_trsm_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="TRSM",
+        name="TRSM",
         routine="trsm",
         filename="trsm",
         size_type="mn",
@@ -686,7 +686,7 @@ def gen_trsm_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="TRSM",
+        name="TRSM",
         routine="trsm",
         filename="trsm",
         size_type="mn",
@@ -720,7 +720,7 @@ def gen_gen2std_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="HEGST",
+        name="HEGST",
         routine="hegst",
         filename="gen2std",
         size_type="m",
@@ -754,7 +754,7 @@ def gen_gen2std_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="HEGST",
+        name="HEGST",
         routine="hegst",
         filename="gen2std",
         size_type="m",
@@ -788,7 +788,7 @@ def gen_red2band_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="RED2B",
+        name="RED2B",
         routine="red2band",
         filename="red2band",
         size_type="m",
@@ -823,7 +823,7 @@ def gen_red2band_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="RED2B",
+        name="RED2B",
         routine="red2band",
         filename="red2band",
         size_type="m",
@@ -858,7 +858,7 @@ def gen_band2trid_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="B2T",
+        name="B2T",
         routine="band2trid",
         filename="band2trid",
         size_type="m",
@@ -893,7 +893,7 @@ def gen_band2trid_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="B2T",
+        name="B2T",
         routine="band2trid",
         filename="band2trid",
         size_type="m",
@@ -928,7 +928,7 @@ def gen_trid_evp_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="TridiagSolver",
+        name="TridiagSolver",
         routine="trid_evp",
         filename="trid_evp",
         size_type="m",
@@ -961,7 +961,7 @@ def gen_trid_evp_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="TridiagSolver",
+        name="TridiagSolver",
         routine="trid_evp",
         filename="trid_evp",
         size_type="m",
@@ -994,7 +994,7 @@ def gen_bt_band2trid_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="BT_B2T",
+        name="BT_B2T",
         routine="bt_band2trid",
         filename="bt_band2trid",
         size_type="mn",
@@ -1029,7 +1029,7 @@ def gen_bt_band2trid_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="BT_B2T",
+        name="BT_B2T",
         routine="bt_band2trid",
         filename="bt_band2trid",
         size_type="mn",
@@ -1064,7 +1064,7 @@ def gen_bt_red2band_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="BT_RED2B",
+        name="BT_RED2B",
         routine="bt_red2band",
         filename="bt_red2band",
         size_type="mn",
@@ -1099,7 +1099,7 @@ def gen_bt_red2band_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="BT_RED2B",
+        name="BT_RED2B",
         routine="bt_red2band",
         filename="bt_red2band",
         size_type="mn",
@@ -1134,7 +1134,7 @@ def gen_evp_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="EVP",
+        name="EVP",
         routine="evp",
         filename="evp",
         size_type="m",
@@ -1168,7 +1168,7 @@ def gen_evp_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="EVP",
+        name="EVP",
         routine="evp",
         filename="evp",
         size_type="m",
@@ -1202,7 +1202,7 @@ def gen_gevp_plots_strong(
     """
     _gen_plot(
         scaling="strong",
-        title="GEVP",
+        name="GEVP",
         routine="gevp",
         filename="gevp",
         size_type="m",
@@ -1236,7 +1236,7 @@ def gen_gevp_plots_weak(
     """
     _gen_plot(
         scaling="weak",
-        title="GEVP",
+        name="GEVP",
         routine="gevp",
         filename="gevp",
         size_type="m",


### PR DESCRIPTION
The `title` was included in itself for the second and subsequent runs of the for loop here: https://github.com/msimberg/DLA-Future/blob/c118ef9b1e93e09869921f5d50b4b30516f0ad36/scripts/postprocess.py#L496. This lead to plot titles like `TridiagSolver: strong scaling (20480 x 20480), block_size = 256 x 256: strong scaling (20480 x 20480), block_size = 256 x 256`.