### PR TITLE
Test about-to-be whip 0.1.0

### DIFF
--- a/ci/docker/debug-cuda.yaml
+++ b/ci/docker/debug-cuda.yaml
@@ -42,3 +42,6 @@ spack:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040
       buildable: false
+    whip:
+      version:
+        - git.6cbe9b8cb636348c3e2ad28f3d376a5004e14827

--- a/ci/docker/release-cuda.yaml
+++ b/ci/docker/release-cuda.yaml
@@ -41,3 +41,6 @@ spack:
       # Force git as non-buildable to allow deprecated versions in environments
       # https://github.com/spack/spack/pull/30040
       buildable: false
+    whip:
+      version:
+        - git.6cbe9b8cb636348c3e2ad28f3d376a5004e14827

--- a/ci/docker/release-rocm533.yaml
+++ b/ci/docker/release-rocm533.yaml
@@ -81,3 +81,6 @@ spack:
       - spec: hsa-rocr-dev@5.3.3
         prefix: /opt/rocm-5.3.3
       buildable: false
+    whip:
+      version:
+        - git.6cbe9b8cb636348c3e2ad28f3d376a5004e14827


### PR DESCRIPTION
This is just to check that the commit that will become whip 0.1.0 works fine in DLA-Future. There were only very minor changes, so I don't expect anything special here, but want to run it in any case.