### PR TITLE
Add tile sum kernel

### DIFF
--- a/include/dlaf/blas/tile_extensions.h
+++ b/include/dlaf/blas/tile_extensions.h
@@ -67,11 +67,9 @@ void add(T alpha, const matrix::Tile<const T, Device::CPU>& tile_b,
 
 #ifdef DLAF_WITH_GPU
 template <class T>
-void add(cublasHandle_t handle, T alpha, const matrix::Tile<const T, Device::GPU>& tile_b,
-         const matrix::Tile<T, Device::GPU>& tile_a) {
+void add(T alpha, const matrix::Tile<const T, Device::GPU>& tile_b,
+         const matrix::Tile<T, Device::GPU>& tile_a, whip::stream_t stream) {
   DLAF_ASSERT(equal_size(tile_a, tile_b), tile_a, tile_b);
-  whip::stream_t stream;
-  cublasGetStream(handle, &stream);
 
   gpulapack::add(blas::Uplo::General, tile_a.size().rows(), tile_a.size().cols(), alpha, tile_b.ptr(),
                  tile_b.ld(), tile_a.ptr(), tile_a.ld(), stream);
@@ -81,7 +79,7 @@ void add(cublasHandle_t handle, T alpha, const matrix::Tile<const T, Device::GPU
 DLAF_MAKE_CALLABLE_OBJECT(add);
 }
 
-DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(dlaf::internal::TransformDispatchType::Blas, add, internal::add_o)
+DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(dlaf::internal::TransformDispatchType::Plain, add, internal::add_o)
 
 #endif
 }

--- a/include/dlaf/lapack/gpu/add.h
+++ b/include/dlaf/lapack/gpu/add.h
@@ -1,0 +1,38 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2023, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#ifdef DLAF_WITH_GPU
+
+#include "dlaf/gpu/blas/api.h"
+#include "dlaf/types.h"
+
+#include <blas.hh>
+#include <whip.hpp>
+
+namespace dlaf::gpulapack {
+
+template <class T>
+void add(const blas::Uplo uplo, const SizeType m, const SizeType n, const T& alpha, const T* a,
+         const SizeType lda, T* b, const SizeType ldb, const whip::stream_t stream);
+
+#define DLAF_CUBLAS_ADD_ETI(kword, Type)                                                                \
+  kword template void add(const blas::Uplo uplo, const SizeType m, const SizeType n, const Type& alpha, \
+                          const Type* a, const SizeType lda, Type* b, const SizeType ldb,               \
+                          const whip::stream_t stream)
+
+DLAF_CUBLAS_ADD_ETI(extern, float);
+DLAF_CUBLAS_ADD_ETI(extern, double);
+DLAF_CUBLAS_ADD_ETI(extern, std::complex<float>);
+DLAF_CUBLAS_ADD_ETI(extern, std::complex<double>);
+}
+
+#endif

--- a/include/dlaf/util_cuda.h
+++ b/include/dlaf/util_cuda.h
@@ -12,10 +12,11 @@
 
 #ifdef DLAF_WITH_GPU
 
-#if defined DLAF_WITH_HIP
+#ifdef DLAF_WITH_HIP
 
 // Float
 #define make_cuComplex make_hipComplex
+#define cuConjf        hipConjf
 #define cuCaddf        hipCaddf
 #define cuCsubf        hipCsubf
 #define cuCmulf        hipCmulf
@@ -24,6 +25,7 @@
 
 // Double
 #define make_cuDoubleComplex make_hipDoubleComplex
+#define cuConj               hipConj
 #define cuCadd               hipCadd
 #define cuCsub               hipCsub
 #define cuCmul               hipCmul
@@ -112,16 +114,8 @@ __host__ __device__ inline float fma(const float& a, const float& b, const float
 }
 
 // Complex
-__host__ __device__ inline cuComplex operator-(const cuComplex& a) noexcept {
-  return make_cuComplex(-a.x, -a.y);
-}
-
 __host__ __device__ inline cuComplex conj(const cuComplex& a) noexcept {
-#ifdef DLAF_WITH_CUDA
   return cuConjf(a);
-#elif defined DLAF_WITH_HIP
-  return make_cuComplex(a.x, -a.y);
-#endif
 }
 
 __host__ __device__ inline float real(const cuComplex& a) noexcept {
@@ -132,7 +126,11 @@ __host__ __device__ inline float imag(const cuComplex& a) noexcept {
   return a.y;
 }
 
-#if defined DLAF_WITH_CUDA
+#ifdef DLAF_WITH_CUDA
+__host__ __device__ inline cuComplex operator-(const cuComplex& a) noexcept {
+  return make_cuComplex(-a.x, -a.y);
+}
+
 __host__ __device__ inline bool operator==(const cuComplex& a, const cuComplex& b) noexcept {
   return a.x == b.x && a.y == b.y;
 }
@@ -140,7 +138,6 @@ __host__ __device__ inline bool operator==(const cuComplex& a, const cuComplex& 
 __host__ __device__ inline bool operator!=(const cuComplex& a, const cuComplex& b) noexcept {
   return !operator==(a, b);
 }
-#endif
 
 __host__ __device__ inline cuComplex operator+(const cuComplex& a, const cuComplex& b) noexcept {
   return cuCaddf(a, b);
@@ -157,6 +154,7 @@ __host__ __device__ inline cuComplex operator*(const cuComplex& a, const cuCompl
 __host__ __device__ inline cuComplex operator/(const cuComplex& a, const cuComplex& b) noexcept {
   return cuCdivf(a, b);
 }
+#endif
 
 __host__ __device__ inline cuComplex fma(const cuComplex& a, const cuComplex& b,
                                          const cuComplex& c) noexcept {
@@ -193,16 +191,8 @@ __host__ __device__ inline double fma(const double& a, const double& b, const do
 }
 
 // Double complex
-__host__ __device__ inline cuDoubleComplex operator-(const cuDoubleComplex& a) noexcept {
-  return make_cuDoubleComplex(-a.x, -a.y);
-}
-
 __host__ __device__ inline cuDoubleComplex conj(const cuDoubleComplex& a) noexcept {
-#if defined DLAF_WITH_CUDA
   return cuConj(a);
-#elif defined DLAF_WITH_HIP
-  return make_cuDoubleComplex(a.x, -a.y);
-#endif
 }
 
 __host__ __device__ inline double real(const cuDoubleComplex& a) noexcept {
@@ -213,7 +203,11 @@ __host__ __device__ inline double imag(const cuDoubleComplex& a) noexcept {
   return a.y;
 }
 
-#if defined DLAF_WITH_CUDA
+#ifdef DLAF_WITH_CUDA
+__host__ __device__ inline cuDoubleComplex operator-(const cuDoubleComplex& a) noexcept {
+  return make_cuDoubleComplex(-a.x, -a.y);
+}
+
 __host__ __device__ inline bool operator==(const cuDoubleComplex& a, const cuDoubleComplex& b) noexcept {
   return a.x == b.x && a.y == b.y;
 }
@@ -221,7 +215,6 @@ __host__ __device__ inline bool operator==(const cuDoubleComplex& a, const cuDou
 __host__ __device__ inline bool operator!=(const cuDoubleComplex& a, const cuDoubleComplex& b) noexcept {
   return !operator==(a, b);
 }
-#endif
 
 __host__ __device__ inline cuDoubleComplex operator+(const cuDoubleComplex& a,
                                                      const cuDoubleComplex& b) noexcept {
@@ -242,6 +235,7 @@ __host__ __device__ inline cuDoubleComplex operator/(const cuDoubleComplex& a,
                                                      const cuDoubleComplex& b) noexcept {
   return cuCdiv(a, b);
 }
+#endif
 
 __host__ __device__ inline cuDoubleComplex fma(const cuDoubleComplex& a, const cuDoubleComplex& b,
                                                const cuDoubleComplex& c) noexcept {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,7 +193,8 @@ DLAF_addSublibrary(
           memory/memory_view.cpp
           memory/memory_chunk.cpp
           tune.cpp
-  GPU_SOURCES cusolver/assert_info.cu cusolver/stedc.cu lapack/gpu/add.cu lapack/gpu/lacpy.cu lapack/gpu/laset.cu
+  GPU_SOURCES cusolver/assert_info.cu cusolver/stedc.cu lapack/gpu/add.cu lapack/gpu/lacpy.cu
+              lapack/gpu/laset.cu
   COMPILE_OPTIONS $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,7 +193,7 @@ DLAF_addSublibrary(
           memory/memory_view.cpp
           memory/memory_chunk.cpp
           tune.cpp
-  GPU_SOURCES cusolver/assert_info.cu cusolver/stedc.cu lapack/gpu/lacpy.cu lapack/gpu/laset.cu
+  GPU_SOURCES cusolver/assert_info.cu cusolver/stedc.cu lapack/gpu/add.cu lapack/gpu/lacpy.cu lapack/gpu/laset.cu
   COMPILE_OPTIONS $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>
 )
 

--- a/src/lapack/gpu/add.cu
+++ b/src/lapack/gpu/add.cu
@@ -1,0 +1,170 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2023, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include <whip.hpp>
+
+#include "dlaf/gpu/assert.cu.h"
+#include "dlaf/gpu/blas/api.h"
+#include "dlaf/lapack/gpu/add.h"
+#include "dlaf/types.h"
+#include "dlaf/util_cublas.h"
+#include "dlaf/util_math.h"
+
+namespace dlaf::gpulapack {
+namespace kernels {
+
+using namespace dlaf::util::cuda_operators;
+
+struct AddParams {
+  static constexpr unsigned kernel_tile_size_rows = 64;
+  static constexpr unsigned kernel_tile_size_cols = 16;
+};
+
+template <class T>
+__device__ inline void addAlpha(const T& alpha, const T& a, T& b) {
+  b = b + alpha * a;
+}
+
+template <class T>
+__device__ inline void sum(const T& /*alpha*/, const T& a, T& b) {
+  b = b + a;
+}
+
+template <class T>
+__device__ inline void sub(const T& /*alpha*/, const T& a, T& b) {
+  b = b - a;
+}
+
+template <class T, void (*add)(const T&, const T&, T&)>
+__device__ void addAllInternal(const unsigned m, const unsigned n, const T& alpha, const T* a,
+                               const unsigned lda, T* b, const unsigned ldb) {
+  constexpr unsigned kernel_tile_size_rows = AddParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = AddParams::kernel_tile_size_cols;
+
+  const unsigned i = blockIdx.x * kernel_tile_size_rows + threadIdx.x;
+  const unsigned j = blockIdx.y * kernel_tile_size_cols;
+
+  if (i >= m)
+    return;
+
+  const unsigned k_max = min(j + kernel_tile_size_cols, n);
+
+  for (unsigned k = j; k < k_max; ++k)
+    add(alpha, a[i + k * lda], b[i + k * ldb]);
+}
+
+template <class T>
+__device__ inline void addAll(const unsigned m, const unsigned n, const T& alpha, const T* a,
+                              const unsigned lda, T* b, const unsigned ldb) {
+  if (real(alpha) == 1 && imag(alpha) == 0)
+    addAllInternal<T, sum>(m, n, alpha, a, lda, b, ldb);
+  else if (real(alpha) == -1 && imag(alpha) == 0)
+    addAllInternal<T, sub>(m, n, alpha, a, lda, b, ldb);
+  else
+    addAllInternal<T, addAlpha>(m, n, alpha, a, lda, b, ldb);
+}
+
+template <bool (*comp)(unsigned, unsigned), class T, void (*add)(const T&, const T&, T&)>
+__device__ void addDiagInternal(const unsigned m, const unsigned n, const T& alpha, const T* a,
+                                const unsigned lda, T* b, const unsigned ldb) {
+  constexpr unsigned kernel_tile_size_rows = AddParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = AddParams::kernel_tile_size_cols;
+
+  const unsigned i = blockIdx.x * kernel_tile_size_rows + threadIdx.x;
+  const unsigned j = blockIdx.y * kernel_tile_size_cols;
+
+  if (i >= m)
+    return;
+
+  const unsigned k_max = min(j + kernel_tile_size_cols, n);
+
+  for (unsigned k = j; k < k_max; ++k)
+    if (comp(i, k))
+      add(alpha, a[i + k * lda], b[i + k * ldb]);
+}
+
+template <bool (*comp)(unsigned, unsigned), class T>
+__device__ inline void addDiag(const unsigned m, const unsigned n, const T& alpha, const T* a,
+                               const unsigned lda, T* b, const unsigned ldb) {
+  if (real(alpha) == 1 && imag(alpha) == 0)
+    addDiagInternal<comp, T, sum>(m, n, alpha, a, lda, b, ldb);
+  else if (real(alpha) == -1 && imag(alpha) == 0)
+    addDiagInternal<comp, T, sub>(m, n, alpha, a, lda, b, ldb);
+  else
+    addDiagInternal<comp, T, addAlpha>(m, n, alpha, a, lda, b, ldb);
+}
+
+template <class T>
+__global__ void add(cublasFillMode_t uplo, const unsigned m, const unsigned n, const T alpha, const T* a,
+                    const unsigned lda, T* b, const unsigned ldb) {
+  constexpr unsigned kernel_tile_size_rows = AddParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = AddParams::kernel_tile_size_cols;
+
+  DLAF_GPU_ASSERT_HEAVY(kernel_tile_size_rows % kernel_tile_size_cols == 0);
+  DLAF_GPU_ASSERT_HEAVY(kernel_tile_size_rows == blockDim.x);
+  DLAF_GPU_ASSERT_HEAVY(1 == blockDim.y);
+  DLAF_GPU_ASSERT_HEAVY(1 == blockDim.z);
+  DLAF_GPU_ASSERT_HEAVY(gridDim.x == ceilDiv(m, kernel_tile_size_rows));
+  DLAF_GPU_ASSERT_HEAVY(gridDim.y == ceilDiv(n, kernel_tile_size_cols));
+  DLAF_GPU_ASSERT_HEAVY(1 == gridDim.z);
+
+  const unsigned i = blockIdx.x;
+  const unsigned j = blockIdx.y * kernel_tile_size_cols / kernel_tile_size_rows;
+
+  // Note: if (i == j) the kernel tile contains parts of the diagonal
+
+  switch (uplo) {
+    case CUBLAS_FILL_MODE_LOWER:
+      if (i == j)
+        addDiag<dlaf::util::isLower>(m, n, alpha, a, lda, b, ldb);
+      else if (i > j)
+        addAll(m, n, alpha, a, lda, b, ldb);
+      break;
+    case CUBLAS_FILL_MODE_UPPER:
+      if (i == j)
+        addDiag<dlaf::util::isUpper>(m, n, alpha, a, lda, b, ldb);
+      else if (i < j)
+        addAll(m, n, alpha, a, lda, b, ldb);
+      break;
+    case CUBLAS_FILL_MODE_FULL:
+      addAll(m, n, alpha, a, lda, b, ldb);
+      break;
+  }
+}
+}
+
+template <class T>
+void add(const blas::Uplo uplo, const SizeType m, const SizeType n, const T& alpha, const T* a,
+         const SizeType lda, T* b, const SizeType ldb, const whip::stream_t stream) {
+  if (m == 0 || n == 0)
+    return;
+
+  DLAF_ASSERT_HEAVY(m <= lda, m, lda);
+  DLAF_ASSERT_HEAVY(m <= ldb, m, ldb);
+
+  constexpr unsigned kernel_tile_size_rows = kernels::AddParams::kernel_tile_size_rows;
+  constexpr unsigned kernel_tile_size_cols = kernels::AddParams::kernel_tile_size_cols;
+
+  const unsigned um = to_uint(m);
+  const unsigned un = to_uint(n);
+
+  const dim3 nr_threads(kernel_tile_size_rows, 1);
+  const dim3 nr_blocks(util::ceilDiv(um, kernel_tile_size_rows),
+                       util::ceilDiv(un, kernel_tile_size_cols));
+  kernels::add<<<nr_blocks, nr_threads, 0, stream>>>(util::blasToCublas(uplo), um, un,
+                                                     util::cppToCudaCast(alpha), util::cppToCudaCast(a),
+                                                     to_uint(lda), util::cppToCudaCast(b), to_uint(ldb));
+}
+
+DLAF_CUBLAS_ADD_ETI(, float);
+DLAF_CUBLAS_ADD_ETI(, double);
+DLAF_CUBLAS_ADD_ETI(, std::complex<float>);
+DLAF_CUBLAS_ADD_ETI(, std::complex<double>);
+}


### PR DESCRIPTION
This change alone improves the GPU distributed case of bt_band_to_tridiagonal by more than 10x:
```
> srun -n 2 -c 24 miniapp/miniapp_bt_band_to_tridiag --m 20480 --n 20480 --mb 1024 --nb 1024 --b 128 --grid-rows 2 --grid-cols 1 --nruns 2 --nwarmups=0
[0]
[0] 11.4487s 1500.6GFlop/s d (20480, 20480) (1024, 1024) 128 (2, 1) 12 GPU
[1]
[1] 11.0745s 1551.29GFlop/s d (20480, 20480) (1024, 1024) 128 (2, 1) 12 GPU

> srun -n 2 -c 24 miniapp/miniapp_bt_band_to_tridiag --m 40960 --n 40960 --mb 1024 --nb 1024 --b 128 --grid-rows 2 --grid-cols 1 --nruns 2 --nwarmups=0
[0]
[0] 84.9127s 1618.59GFlop/s d (40960, 40960) (1024, 1024) 128 (2, 1) 12 GPU
[1]
[1] 83.6638s 1642.75GFlop/s d (40960, 40960) (1024, 1024) 128 (2, 1) 12 GPU
```

Old results:
```
[0]
[0] 200.33s 85.7579GFlop/s d (20480, 20480) (1024, 1024) 128 (2, 1) 12 GPU
[1]
[1] 199.625s 86.0606GFlop/s d (20480, 20480) (1024, 1024) 128 (2, 1) 12 GPU

[0]
[0] 995.409s 138.073GFlop/s d (40960, 40960) (1024, 1024) 128 (2, 1) 12 GPU
[1]
[1] 993.733s 138.306GFlop/s d (40960, 40960) (1024, 1024) 128 (2, 1) 12 GPU
```