### PR TITLE
CSV output

### DIFF
--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -16,7 +16,9 @@ list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(DLAF REQUIRED)
 find_package(pika 0.11.0 REQUIRED)
 
-cmake_dependent_option(DLAF_MINIAPP_CSV_OUTPUT "Output CSV data in supported miniapps" OFF "DLAF_BUILD_MINIAPPS" OFF)
+cmake_dependent_option(
+  DLAF_MINIAPP_CSV_OUTPUT "Output CSV data in supported miniapps" OFF "DLAF_BUILD_MINIAPPS" OFF
+)
 include(DLAF_AddMiniapp)
 include(DLAF_AddTargetWarnings)
 

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -16,9 +16,6 @@ list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(DLAF REQUIRED)
 find_package(pika 0.11.0 REQUIRED)
 
-cmake_dependent_option(
-  DLAF_MINIAPP_CSV_OUTPUT "Output CSV data in supported miniapps" OFF "DLAF_BUILD_MINIAPPS" OFF
-)
 include(DLAF_AddMiniapp)
 include(DLAF_AddTargetWarnings)
 

--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -16,6 +16,7 @@ list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(DLAF REQUIRED)
 find_package(pika 0.11.0 REQUIRED)
 
+cmake_dependent_option(DLAF_MINIAPP_CSV_OUTPUT "Output CSV data in supported miniapps" OFF "DLAF_BUILD_MINIAPPS" OFF)
 include(DLAF_AddMiniapp)
 include(DLAF_AddTargetWarnings)
 

--- a/miniapp/cmake/DLAF_AddMiniapp.cmake
+++ b/miniapp/cmake/DLAF_AddMiniapp.cmake
@@ -53,7 +53,9 @@ function(DLAF_addMiniapp miniapp_target_name)
   target_compile_definitions(${miniapp_target_name} PRIVATE ${DLAF_AM_COMPILE_DEFINITIONS})
   target_include_directories(${miniapp_target_name} PRIVATE ${DLAF_AM_INCLUDE_DIRS})
   target_add_warnings(${miniapp_target_name})
-
+  if (DLAF_MINIAPP_CSV_OUTPUT)
+    target_compile_definitions(${miniapp_target_name} PRIVATE DLAF_MINIAPP_CSV_OUTPUT)
+  endif()
   ### DEPLOY
   include(GNUInstallDirs)
 

--- a/miniapp/cmake/DLAF_AddMiniapp.cmake
+++ b/miniapp/cmake/DLAF_AddMiniapp.cmake
@@ -53,9 +53,6 @@ function(DLAF_addMiniapp miniapp_target_name)
   target_compile_definitions(${miniapp_target_name} PRIVATE ${DLAF_AM_COMPILE_DEFINITIONS})
   target_include_directories(${miniapp_target_name} PRIVATE ${DLAF_AM_INCLUDE_DIRS})
   target_add_warnings(${miniapp_target_name})
-  if (DLAF_MINIAPP_CSV_OUTPUT)
-    target_compile_definitions(${miniapp_target_name} PRIVATE DLAF_MINIAPP_CSV_OUTPUT)
-  endif()
   ### DEPLOY
   include(GNUInstallDirs)
 

--- a/miniapp/include/dlaf/miniapp/options.h
+++ b/miniapp/include/dlaf/miniapp/options.h
@@ -207,6 +207,7 @@ struct MiniappOptions {
   int64_t nruns;
   int64_t nwarmups;
   CheckIterFreq do_check;
+  bool csv_output;
   std::string info;
 
   MiniappOptions(const pika::program_options::variables_map& vm)
@@ -216,8 +217,7 @@ struct MiniappOptions {
         local(vm["local"].as<bool>()), nruns(vm["nruns"].as<int64_t>()),
         nwarmups(vm["nwarmups"].as<int64_t>()),
         do_check(parseCheckIterFreq(vm["check-result"].as<std::string>())),
-        info(vm["pp-info"].as<std::string>())
-  {
+        csv_output(vm["csv"].as<bool>()), info(vm["pp-info"].as<std::string>()) {
     DLAF_ASSERT(grid_rows > 0, grid_rows);
     DLAF_ASSERT(grid_cols > 0, grid_cols);
     DLAF_ASSERT(!local || grid_cols * grid_rows == 1, local, grid_rows, grid_cols);
@@ -252,8 +252,10 @@ inline pika::program_options::options_description getMiniappOptionsDescription()
                      "Number of warmup runs");
   desc.add_options()("check-result", pika::program_options::value<std::string>()->default_value("none"),
                      "Enable result checking ('none', 'all', 'last')");
+  desc.add_options()("csv", pika::program_options::bool_switch()->default_value(false),
+                     "Enable CSV output of values");
   desc.add_options()("pp-info", pika::program_options::value<std::string>()->default_value(""),
-                     "info for postprocessing scripts");
+                     "Info for postprocessing scripts appended to csv output (if enabled)");
   return desc;
 }
 

--- a/miniapp/include/dlaf/miniapp/options.h
+++ b/miniapp/include/dlaf/miniapp/options.h
@@ -207,6 +207,7 @@ struct MiniappOptions {
   int64_t nruns;
   int64_t nwarmups;
   CheckIterFreq do_check;
+  std::string info;
 
   MiniappOptions(const pika::program_options::variables_map& vm)
       : backend(parseBackend(vm["backend"].as<std::string>())),
@@ -214,7 +215,9 @@ struct MiniappOptions {
         grid_rows(vm["grid-rows"].as<int>()), grid_cols(vm["grid-cols"].as<int>()),
         local(vm["local"].as<bool>()), nruns(vm["nruns"].as<int64_t>()),
         nwarmups(vm["nwarmups"].as<int64_t>()),
-        do_check(parseCheckIterFreq(vm["check-result"].as<std::string>())) {
+        do_check(parseCheckIterFreq(vm["check-result"].as<std::string>())),
+        info(vm["pp-info"].as<std::string>())
+  {
     DLAF_ASSERT(grid_rows > 0, grid_rows);
     DLAF_ASSERT(grid_cols > 0, grid_cols);
     DLAF_ASSERT(!local || grid_cols * grid_rows == 1, local, grid_rows, grid_cols);
@@ -249,7 +252,8 @@ inline pika::program_options::options_description getMiniappOptionsDescription()
                      "Number of warmup runs");
   desc.add_options()("check-result", pika::program_options::value<std::string>()->default_value("none"),
                      "Enable result checking ('none', 'all', 'last')");
-
+  desc.add_options()("pp-info", pika::program_options::value<std::string>()->default_value(""),
+                     "info for postprocessing scripts");
   return desc;
 }
 

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -165,25 +165,22 @@ struct choleskyMiniapp {
                   << dlaf::internal::FormatShort{opts.uplo} << " " << matrix_host.size() << " "
                   << matrix_host.blockSize() << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
-#ifdef DLAF_MINIAPP_CSV_OUTPUT
-        // clang-format off
-        // CSV formatted output with column names that can be read by pandas to simplify post-processing
-        // CSVData{-version}, value_0, title_0, value_1, title_1
-        std::cout << "CSVData-2, "
-                  << "run, "        << run_index << ", "
-                  << "time, "       << elapsed_time << ", "
-                  << "GFlops, "     << gigaflops << ", "
-                  << "type, "       << dlaf::internal::FormatShort{opts.type}.value << ", "
-                  << "UpLo, "       << dlaf::internal::FormatShort{opts.uplo}.value << ", "
-                  << "matrixsize, " << matrix_host.size().rows() << ", "
-                  << "blocksize, "  << block_size.rows() << ", "
-                  << "comm_rows, "  << comm_grid.size().rows() << ", "
-                  << "comm_cols, "  << comm_grid.size().cols() << ", "
-                  << "threads, "    << pika::get_os_thread_count() << ", "
-                  << "backend, "    << backend << ", "
-                  << opts.info << std::endl;
-        // clang-format on
-#endif
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "UpLo, " << dlaf::internal::FormatShort{opts.uplo}.value << ", "
+                    << "matrixsize, " << matrix_host.size().rows() << ", "
+                    << "blocksize, " << block_size.rows() << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
       }
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -176,7 +176,7 @@ struct choleskyMiniapp {
                   << "type, "       << dlaf::internal::FormatShort{opts.type}.value << ", "
                   << "UpLo, "       << dlaf::internal::FormatShort{opts.uplo}.value << ", "
                   << "matrixsize, " << matrix_host.size().rows() << ", "
-                  << "blocksize, "  << matrix_host.size().rows() << ", "
+                  << "blocksize, "  << block_size.rows() << ", "
                   << "comm_rows, "  << comm_grid.size().rows() << ", "
                   << "comm_cols, "  << comm_grid.size().cols() << ", "
                   << "threads, "    << pika::get_os_thread_count() << ", "

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -152,7 +152,7 @@ struct reductionToBandMiniapp {
                   << "GFlops, " << gigaflops << ", "
                   << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
                   << "matrixsize, " << matrix_host.size().rows() << ", "
-                  << "blocksize, " << matrix_host.size().rows() << ", "
+                  << "blocksize, " << block_size.rows() << ", "
                   << "band_size, " << opts.b << ", "
                   << "comm_rows, " << comm_grid.size().rows() << ", "
                   << "comm_cols, " << comm_grid.size().cols() << ", "

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -143,22 +143,22 @@ struct reductionToBandMiniapp {
                   << " " << dlaf::internal::FormatShort{opts.type} << " " << matrix_host.size() << " "
                   << matrix_host.blockSize() << " " << opts.b << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
-#ifdef DLAF_MINIAPP_CSV_OUTPUT
-        // CSV formatted output with column names that can be read by pandas to simplify post-processing
-        // CSVData{-version}, value_0, title_0, value_1, title_1
-        std::cout << "CSVData-2, "
-                  << "run, " << run_index << ", "
-                  << "time, " << elapsed_time << ", "
-                  << "GFlops, " << gigaflops << ", "
-                  << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
-                  << "matrixsize, " << matrix_host.size().rows() << ", "
-                  << "blocksize, " << block_size.rows() << ", "
-                  << "band_size, " << opts.b << ", "
-                  << "comm_rows, " << comm_grid.size().rows() << ", "
-                  << "comm_cols, " << comm_grid.size().cols() << ", "
-                  << "threads, " << pika::get_os_thread_count() << ", "
-                  << "backend, " << backend << ", " << opts.info << std::endl;
-#endif
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "matrixsize, " << matrix_host.size().rows() << ", "
+                    << "blocksize, " << block_size.rows() << ", "
+                    << "band_size, " << opts.b << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
       }
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||


### PR DESCRIPTION
1) Add csv output (and launch info) to supported miniapps

    When enabled, extra csv values are displayed using a format that
    includes column titles as well as values.
    
    This makes it easier to use a general purpose post-processing script
    to import data into a pandas table and filter/plot different parameters
    against each other. Different miniapps will have different columns
    but a single script can read any of them and treat them accordingly.
    
    Add a "--info=" command line param so that settings can be passed
    from a launch script into the benchmark output

    An example might look as follows:
    CSVData-2, run, 19, time, 0.145857964, GFlops, 157.04656514561887, type,
      Double, UpLo, Lower, matrixsize, 4096, blocksize, 256, comm_rows, 1,
      comm_cols, 1, threads, 8, backend, GPU,
      machine, daint, branchname, new_polling, ranks_per_node, 4

2) Add a max-seconds param to supported miniapps

    This enables benchmarks to set number of runs to a large number
    but stop after 1 minute, or longer.
    
    This is useful when running many benchmarks with different params that
    might take varying (unpredictable) amounts of time.
