### PR TITLE
Add `__host__` annotation to lambda whose return type needs to be queried on the host

### DIFF
--- a/src/eigensolver/tridiag_solver/kernels.cu
+++ b/src/eigensolver/tridiag_solver/kernels.cu
@@ -293,7 +293,7 @@ void divideEvecsByDiagonal(const SizeType& k, const SizeType& i_subm_el, const S
   // Multiply along rows
   //
   // Note: the output of the reduction is saved in the first column.
-  auto mult_op = [] __device__(const T& a, const T& b) { return a * b; };
+  auto mult_op = [] __host__ __device__(const T& a, const T& b) { return a * b; };
   size_t temp_storage_bytes;
 
   using OffsetIterator =


### PR DESCRIPTION
With CUDA 12 the changed line before the change triggers a static assertion:
```
/apps/hohgant/simbergm/spack/opt/spack/linux-sles15-zen2/gcc-11.3.0/cuda-12.0.0-3lzpzgbk6binlwcpr773ohx2acry3dbe/include/cuda/std/detail/libcxx/include/type_traits:44
05:16: error: static assertion failed: Attempt to use an extended __device__ lambda in a context that requires querying its return type in host code. Use a named func
tion object, a __host__ __device__ lambda, or cuda::proclaim_return_type instead.
 4405 |   static_assert(!__nv_is_extended_device_lambda_closure_type(_Fp),
      |               ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I figured adding `__host__` is the simplest fix. Using `cuda::proclaim_return_type` requires including `cuda/functional` and using a named function object requires bigger changes.