### PR TITLE
tridiagonal eigensolver -> improve perf on AMD gpus

### DIFF
--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -46,26 +46,11 @@ EigensolverResult<T, D> Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>
   auto taus = reductionToBand<B>(mat_a, band_size);
   auto ret = bandToTridiag<Backend::MC>(uplo, band_size, mat_a);
 
-  // Note:
-  // Since reduction from band to tridiagonal happens on MC for all backends, but eigensolver
-  // requires tridiagonal matrix to be on CPU or GPU depending on the backend used, next snippet
-  // ensures that tridiagonal matrix gets copied if needed (i.e. just for GPU backend).
-  matrix::Matrix<BaseType<T>, D> tridiagonal = [&ret]() {
-    if constexpr (B == Backend::MC) {
-      return std::move(ret.tridiagonal);
-    }
-    else {
-      matrix::Matrix<BaseType<T>, D> tridiagonal(ret.tridiagonal.distribution());
-      copy(ret.tridiagonal, tridiagonal);
-      return tridiagonal;
-    }
-  }();
-
   matrix::Matrix<BaseType<T>, D> evals(LocalElementSize(size, 1),
                                        TileElementSize(mat_a.blockSize().rows(), 1));
   matrix::Matrix<T, D> mat_e(LocalElementSize(size, size), mat_a.blockSize());
 
-  eigensolver::tridiagSolver<B>(tridiagonal, evals, mat_e);
+  eigensolver::tridiagSolver<B>(ret.tridiagonal, evals, mat_e);
 
   backTransformationBandToTridiag<B>(band_size, mat_e, ret.hh_reflectors);
   backTransformationReductionToBand<B>(band_size, mat_e, mat_a, taus);
@@ -88,26 +73,11 @@ EigensolverResult<T, D> Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, 
   auto taus = reductionToBand<B>(grid, mat_a, band_size);
   auto ret = bandToTridiag<Backend::MC>(grid, uplo, band_size, mat_a);
 
-  // Note:
-  // Since reduction from band to tridiagonal happens on MC for all backends, but eigensolver
-  // requires tridiagonal matrix to be on CPU or GPU depending on the backend used, next snippet
-  // ensures that tridiagonal matrix gets copied if needed (i.e. just for GPU backend).
-  matrix::Matrix<BaseType<T>, D> tridiagonal = [&ret]() {
-    if constexpr (B == Backend::MC) {
-      return std::move(ret.tridiagonal);
-    }
-    else {
-      matrix::Matrix<BaseType<T>, D> tridiagonal(ret.tridiagonal.distribution());
-      copy(ret.tridiagonal, tridiagonal);
-      return tridiagonal;
-    }
-  }();
-
   matrix::Matrix<BaseType<T>, D> evals(LocalElementSize(size, 1),
                                        TileElementSize(mat_a.blockSize().rows(), 1));
   matrix::Matrix<T, D> mat_e(GlobalElementSize(size, size), mat_a.blockSize(), grid);
 
-  eigensolver::tridiagSolver<B>(grid, tridiagonal, evals, mat_e);
+  eigensolver::tridiagSolver<B>(grid, ret.tridiagonal, evals, mat_e);
 
   backTransformationBandToTridiag<B>(grid, band_size, mat_e, ret.hh_reflectors);
   backTransformationReductionToBand<B>(grid, band_size, mat_e, mat_a, taus);

--- a/include/dlaf/eigensolver/tridiag_solver.h
+++ b/include/dlaf/eigensolver/tridiag_solver.h
@@ -34,7 +34,7 @@ namespace eigensolver {
 /// @pre evecs is a square matrix with number of rows equal to the number of rows of @p tridiag and @p evals
 /// @pre evecs has a square block size with number of block rows eqaul to the block rows of @p tridiag and @p evals
 template <Backend backend, Device device, class T>
-void tridiagSolver(Matrix<BaseType<T>, device>& tridiag, Matrix<BaseType<T>, device>& evals,
+void tridiagSolver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T>, device>& evals,
                    Matrix<T, device>& evecs) {
   DLAF_ASSERT(matrix::local_matrix(tridiag), tridiag);
   DLAF_ASSERT(tridiag.distribution().size().cols() == 2, tridiag);
@@ -76,7 +76,7 @@ void tridiagSolver(Matrix<BaseType<T>, device>& tridiag, Matrix<BaseType<T>, dev
 /// @pre evecs is a square matrix with global number of rows equal to the number of rows of @p tridiag and @p evals
 /// @pre evecs has a square block size with number of block rows eqaul to the block rows of @p tridiag and @p evals
 template <Backend B, Device D, class T>
-void tridiagSolver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, D>& tridiag,
+void tridiagSolver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, Device::CPU>& tridiag,
                    Matrix<BaseType<T>, D>& evals, Matrix<T, D>& evecs) {
   DLAF_ASSERT(matrix::local_matrix(tridiag), tridiag);
   DLAF_ASSERT(tridiag.distribution().size().cols() == 2, tridiag);

--- a/include/dlaf/eigensolver/tridiag_solver/api.h
+++ b/include/dlaf/eigensolver/tridiag_solver/api.h
@@ -16,13 +16,13 @@ namespace dlaf::eigensolver::internal {
 
 template <Backend backend, Device device, class T>
 struct TridiagSolver {
-  static void call(Matrix<T, device>& tridiag, Matrix<T, device>& evals, Matrix<T, device>& evecs);
-  static void call(Matrix<T, device>& tridiag, Matrix<T, device>& evals,
+  static void call(Matrix<T, Device::CPU>& tridiag, Matrix<T, device>& evals, Matrix<T, device>& evecs);
+  static void call(Matrix<T, Device::CPU>& tridiag, Matrix<T, device>& evals,
                    Matrix<std::complex<T>, device>& evecs);
-  static void call(comm::CommunicatorGrid grid, Matrix<T, device>& tridiag, Matrix<T, device>& evals,
-                   Matrix<T, device>& evecs);
-  static void call(comm::CommunicatorGrid grid, Matrix<T, device>& tridiag, Matrix<T, device>& evals,
-                   Matrix<std::complex<T>, device>& evecs);
+  static void call(comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& tridiag,
+                   Matrix<T, device>& evals, Matrix<T, device>& evecs);
+  static void call(comm::CommunicatorGrid grid, Matrix<T, Device::CPU>& tridiag,
+                   Matrix<T, device>& evals, Matrix<std::complex<T>, device>& evecs);
 };
 
 /// ---- ETI

--- a/include/dlaf/eigensolver/tridiag_solver/kernels.h
+++ b/include/dlaf/eigensolver/tridiag_solver/kernels.h
@@ -87,47 +87,17 @@ T cuppensDecomp(const matrix::Tile<T, Device::CPU>& top, const matrix::Tile<T, D
 DLAF_CPU_CUPPENS_DECOMP_ETI(extern, float);
 DLAF_CPU_CUPPENS_DECOMP_ETI(extern, double);
 
-#ifdef DLAF_WITH_GPU
-
-template <class T>
-void cuppensDecomp(const matrix::Tile<T, Device::GPU>& top, const matrix::Tile<T, Device::GPU>& bottom,
-                   T* host_offdiag_val_ptr, whip::stream_t stream);
-
-#define DLAF_GPU_CUPPENS_DECOMP_ETI(kword, Type)                                   \
-  kword template void cuppensDecomp(const matrix::Tile<Type, Device::GPU>& top,    \
-                                    const matrix::Tile<Type, Device::GPU>& bottom, \
-                                    Type* host_offdiag_val_ptr, whip::stream_t stream)
-
-DLAF_GPU_CUPPENS_DECOMP_ETI(extern, float);
-DLAF_GPU_CUPPENS_DECOMP_ETI(extern, double);
-
-#endif
-
 DLAF_MAKE_CALLABLE_OBJECT(cuppensDecomp);
 
-template <class T, Device D, class TopTileSender, class BottomTileSender>
+template <class T, class TopTileSender, class BottomTileSender>
 auto cuppensDecompAsync(TopTileSender&& top, BottomTileSender&& bottom) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
-  constexpr auto backend = dlaf::DefaultBackend_v<D>;
+  constexpr auto backend = Backend::MC;
 
-  if constexpr (D == Device::CPU) {
-    return ex::when_all(std::forward<TopTileSender>(top), std::forward<BottomTileSender>(bottom)) |
-           di::transform(di::Policy<backend>(), cuppensDecomp_o);
-  }
-  else {
-#ifdef DLAF_WITH_GPU
-    using ElementType = dlaf::internal::SenderElementType<TopTileSender>;
-    return ex::when_all(std::forward<TopTileSender>(top), std::forward<BottomTileSender>(bottom),
-                        ex::just(memory::MemoryChunk<ElementType, Device::CPU>{1})) |
-           ex::let_value([](auto& top, auto& bottom, auto& host_offdiag_val) {
-             return ex::just(std::ref(top), std::ref(bottom), host_offdiag_val()) |
-                    di::transform(di::Policy<backend>(), cuppensDecomp_o) |
-                    ex::then([&host_offdiag_val]() { return *host_offdiag_val(); });
-           });
-#endif
-  }
+  return ex::when_all(std::forward<TopTileSender>(top), std::forward<BottomTileSender>(bottom)) |
+         di::transform(di::Policy<backend>(), cuppensDecomp_o);
 }
 
 template <class T>
@@ -145,13 +115,13 @@ DLAF_CPU_COPY_DIAGONAL_FROM_COMPACT_TRIDIAGONAL_ETI(extern, double);
 #ifdef DLAF_WITH_GPU
 
 template <class T>
-void copyDiagonalFromCompactTridiagonal(const matrix::Tile<const T, Device::GPU>& tridiag_tile,
+void copyDiagonalFromCompactTridiagonal(const matrix::Tile<const T, Device::CPU>& tridiag_tile,
                                         const matrix::Tile<T, Device::GPU>& diag_tile,
                                         whip::stream_t stream);
 
 #define DLAF_GPU_COPY_DIAGONAL_FROM_COMPACT_TRIDIAGONAL_ETI(kword, Type)                        \
   kword template void                                                                           \
-  copyDiagonalFromCompactTridiagonal(const matrix::Tile<const Type, Device::GPU>& tridiag_tile, \
+  copyDiagonalFromCompactTridiagonal(const matrix::Tile<const Type, Device::CPU>& tridiag_tile, \
                                      const matrix::Tile<Type, Device::GPU>& diag_tile,          \
                                      whip::stream_t stream)
 

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -107,6 +107,9 @@ struct WorkSpaceHostMirror {
   // only needed for the distributed tridiagonal solver
   matrix::Matrix<T, Device::CPU> evecs;
   matrix::Matrix<T, Device::CPU> mat2;
+
+  // Test
+  matrix::Matrix<T, Device::CPU> tridiag;
 };
 
 template <class T>
@@ -122,6 +125,9 @@ struct WorkSpaceHostMirror<T, Device::CPU> {
   // only needed for the distributed tridiagonal solver
   matrix::Matrix<T, Device::CPU>& evecs;
   matrix::Matrix<T, Device::CPU>& mat2;
+
+  // Test
+  matrix::Matrix<T, Device::CPU>& tridiag;
 };
 
 template <class T>

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -107,9 +107,6 @@ struct WorkSpaceHostMirror {
   // only needed for the distributed tridiagonal solver
   matrix::Matrix<T, Device::CPU> evecs;
   matrix::Matrix<T, Device::CPU> mat2;
-
-  // Test
-  matrix::Matrix<T, Device::CPU> tridiag;
 };
 
 template <class T>
@@ -125,9 +122,6 @@ struct WorkSpaceHostMirror<T, Device::CPU> {
   // only needed for the distributed tridiagonal solver
   matrix::Matrix<T, Device::CPU>& evecs;
   matrix::Matrix<T, Device::CPU>& mat2;
-
-  // Test
-  matrix::Matrix<T, Device::CPU>& tridiag;
 };
 
 template <class T>

--- a/miniapp/miniapp_tridiag_solver.cpp
+++ b/miniapp/miniapp_tridiag_solver.cpp
@@ -100,12 +100,11 @@ struct TridiagSolverMiniapp {
 
       double elapsed_time;
       {
-        MatrixMirror<T, DefaultDevice_v<backend>, Device::CPU> tridiag_mirror(tridiag);
         MatrixMirror<T, DefaultDevice_v<backend>, Device::CPU> evals_mirror(evals);
         MatrixMirror<T, DefaultDevice_v<backend>, Device::CPU> evecs_mirror(evecs);
 
         // Wait for matrix to be copied to GPU (if necessary)
-        tridiag_mirror.get().waitLocalTiles();
+        tridiag.waitLocalTiles();
         evals_mirror.get().waitLocalTiles();
         evecs_mirror.get().waitLocalTiles();
         DLAF_MPI_CHECK_ERROR(MPI_Barrier(world));
@@ -113,13 +112,12 @@ struct TridiagSolverMiniapp {
         dlaf::common::Timer<> timeit;
         using dlaf::eigensolver::tridiagSolver;
         if (opts.local)
-          tridiagSolver<backend>(tridiag_mirror.get(), evals_mirror.get(), evecs_mirror.get());
+          tridiagSolver<backend>(tridiag, evals_mirror.get(), evecs_mirror.get());
         else
-          tridiagSolver<backend>(comm_grid, tridiag_mirror.get(), evals_mirror.get(),
-                                 evecs_mirror.get());
+          tridiagSolver<backend>(comm_grid, tridiag, evals_mirror.get(), evecs_mirror.get());
 
         // wait and barrier for all ranks
-        tridiag_mirror.get().waitLocalTiles();
+        tridiag.waitLocalTiles();
         evals_mirror.get().waitLocalTiles();
         evecs_mirror.get().waitLocalTiles();
         DLAF_MPI_CHECK_ERROR(MPI_Barrier(world));

--- a/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
@@ -93,11 +93,10 @@ void solveDistributedLaplace1D(comm::CommunicatorGrid grid, SizeType n, SizeType
   matrix::util::set(tridiag, std::move(tridiag_fn));
 
   {
-    matrix::MatrixMirror<RealParam, D, Device::CPU> tridiag_mirror(tridiag);
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
-    eigensolver::tridiagSolver<B>(grid, tridiag_mirror.get(), evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiagSolver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
   }
   if (n == 0)
     return;
@@ -215,14 +214,13 @@ void solveRandomTridiagMatrix(comm::CommunicatorGrid grid, SizeType n, SizeType 
   tridiag.waitLocalTiles();  // makes sure that diag_arr and offdiag_arr don't go out of scope
 
   {
-    matrix::MatrixMirror<RealParam, D, Device::CPU> tridiag_mirror(tridiag);
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
     // Find eigenvalues and eigenvectors of the tridiagonal matrix.
     //
     // Note: this modifies `tridiag`
-    eigensolver::tridiagSolver<B>(grid, tridiag_mirror.get(), evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiagSolver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
   }
 
   if (n == 0)

--- a/test/unit/eigensolver/test_tridiag_solver_local.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_local.cpp
@@ -74,11 +74,10 @@ void solveLaplace1D(SizeType n, SizeType nb) {
   matrix::util::set(tridiag, std::move(tridiag_fn));
 
   {
-    matrix::MatrixMirror<RealParam, D, Device::CPU> tridiag_mirror(tridiag);
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
-    eigensolver::tridiagSolver<B>(tridiag_mirror.get(), evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiagSolver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
   }
   if (n == 0)
     return;
@@ -159,14 +158,13 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
   tridiag.waitLocalTiles();  // makes sure that diag_arr and offdiag_arr don't go out of scope
 
   {
-    matrix::MatrixMirror<RealParam, D, Device::CPU> tridiag_mirror(tridiag);
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
     // Find eigenvalues and eigenvectors of the tridiagonal matrix.
     //
     // Note: this modifies `tridiag`
-    eigensolver::tridiagSolver<B>(tridiag_mirror.get(), evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiagSolver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
   }
 
   if (n == 0)


### PR DESCRIPTION
- the leaf solver is moved on CPU
- the Cuppen decomposition is done on CPU as well
-> the tridiagonal matrix can now be kept on CPU and unnecessary copies can be avoided

This solves the huge performance bottleneck on AMD GPUs. For P100 there is a marginal improvement, while for A100 the change is almost irrelevant.

See https://confluence.cscs.ch/display/SCISWDEV/2023-03-14+Optimisation+Round+2