### PR TITLE
Fix bt_reduction_to_band

### DIFF
--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -63,6 +63,7 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType, SizeType, SizeType>> 
         {3, 3, 2, 2, 2}, {3, 27, 2, 4, 2}, {3, 3, 2, 2, 2},   {3, 3, 2, 2, 2},    // m = b + 1
         {3, 3, 1, 1, 1}, {4, 4, 2, 2, 4},  {12, 2, 4, 4, 2},  {24, 36, 6, 6, 4},  // mb = nb
         {5, 8, 3, 2, 3}, {8, 27, 5, 4, 3}, {15, 34, 4, 6, 6},                     // mb != nb
+        {3, 3, 3, 3, 2}, {8, 6, 8, 6, 3},  {9, 5, 4, 3, 1},   {5, 8, 2, 3, 1},    // PR #824
 };
 
 template <class T>
@@ -161,6 +162,9 @@ void testBackTransformationReductionToBand(SizeType m, SizeType n, SizeType mb, 
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };
 
+  mat_c_h.waitLocalTiles();
+  SCOPED_TRACE(::testing::Message() << "m = " << m << ", n = " << n << ", mb = " << mb << ", nb = " << nb
+                                    << ", b = " << b);
   const auto error = (mat_c_h.size().rows() + 1) * dlaf::test::TypeUtilities<T>::error;
   CHECK_MATRIX_NEAR(result, mat_c_h, error, error);
 }
@@ -212,6 +216,9 @@ void testBackTransformationReductionToBand(comm::CommunicatorGrid grid, SizeType
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };
 
+  mat_c_h.waitLocalTiles();
+  SCOPED_TRACE(::testing::Message() << grid << ", m = " << m << ", n = " << n << ", mb = " << mb
+                                    << ", nb = " << nb << ", b = " << b);
   const auto error = (mat_c_h.size().rows() + 1) * dlaf::test::TypeUtilities<T>::error;
   CHECK_MATRIX_NEAR(result, mat_c_h, error, error);
 }


### PR DESCRIPTION
Fixed 2 bugs, and added relative test cases.
- removed quick return when the HH matrix has a single tile (it is correct only if `b == mb`)
- fixed an out of tile index problem when the last tile of the matrix has a single row
