### PR TITLE
Fix small typos in `test_matrix`

### DIFF
--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -519,7 +519,7 @@ TYPED_TEST(MatrixTest, Dependencies) {
       EXPECT_TRUE(checkFuturesStep(shfut4b.size(), shfut4b));
 
       auto fut5 = getFuturesUsingGlobalIndex(mat);
-      EXPECT_TRUE(checkFuturesStep(0, fut3));
+      EXPECT_TRUE(checkFuturesStep(0, fut5));
 
       CHECK_MATRIX_FUTURES(false, fut5, shfut4a);
       CHECK_MATRIX_FUTURES(true, fut5, shfut4b);
@@ -600,7 +600,7 @@ TYPED_TEST(MatrixTest, DependenciesReferenceMix) {
       EXPECT_TRUE(checkFuturesStep(shfut4b.size(), shfut4b));
 
       auto fut5 = getFuturesUsingLocalIndex(mat);
-      EXPECT_TRUE(checkFuturesStep(0, fut3));
+      EXPECT_TRUE(checkFuturesStep(0, fut5));
 
       CHECK_MATRIX_FUTURES(false, fut5, shfut4a);
       CHECK_MATRIX_FUTURES(true, fut5, shfut4b);
@@ -660,7 +660,7 @@ TYPED_TEST(MatrixTest, DependenciesPointerMix) {
       EXPECT_TRUE(checkFuturesStep(shfut4b.size(), shfut4b));
 
       auto fut5 = getFuturesUsingGlobalIndex(mat);
-      EXPECT_TRUE(checkFuturesStep(0, fut3));
+      EXPECT_TRUE(checkFuturesStep(0, fut5));
 
       CHECK_MATRIX_FUTURES(false, fut5, shfut4a);
       CHECK_MATRIX_FUTURES(true, fut5, shfut4b);


### PR DESCRIPTION
The test was checking the wrong vector of futures.

Internally `checkFuturesStep` was expecting the futures to return `false` from `is_ready`. The futures in `fut3` are in principle ready, but since they have already been checked, the futures are empty, and when a future is empty (no shared state) `is_ready` still returns `false` so the test was passing anyway.