### PR TITLE
Keep `-Werror` flags in CI

### DIFF
--- a/ci/docker/codecov.Dockerfile
+++ b/ci/docker/codecov.Dockerfile
@@ -30,7 +30,7 @@ RUN spack repo rm --scope site dlaf && \
     spack -e ci concretize -f && \
     mkdir ${BUILD} && \
     ln -s ${BUILD} `spack -e ci location -b dla-future` && \
-    spack -e ci install --jobs ${NUM_PROCS} --keep-stage --verbose
+    spack -e ci --config "config:flags:keep_werror:all" install --jobs ${NUM_PROCS} --keep-stage --verbose
 
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -27,7 +27,7 @@ RUN spack repo rm --scope site dlaf && \
     spack -e ci concretize -f && \
     mkdir ${BUILD} && \
     ln -s ${BUILD} `spack -e ci location -b dla-future` && \
-    spack -e ci install --jobs ${NUM_PROCS} --keep-stage --verbose
+    spack -e ci --config "config:flags:keep_werror:all" install --jobs ${NUM_PROCS} --keep-stage --verbose
 
 # Test deployment with miniapps as independent project
 RUN pushd ${SOURCE}/miniapp && \

--- a/include/dlaf/lapack/tile.h
+++ b/include/dlaf/lapack/tile.h
@@ -353,7 +353,8 @@ void hegst(const int itype, const blas::Uplo uplo, const Tile<T, Device::CPU>& a
   DLAF_ASSERT(itype >= 1 && itype <= 3, itype);
 
   common::internal::SingleThreadedBlasScope single;
-  auto info = lapack::hegst(itype, uplo, a.size().cols(), a.ptr(), a.ld(), b.ptr(), b.ld());
+  [[maybe_unused]] auto info =
+      lapack::hegst(itype, uplo, a.size().cols(), a.ptr(), a.ld(), b.ptr(), b.ld());
 
   DLAF_ASSERT(info == 0, info);
 }
@@ -371,7 +372,7 @@ long long potrfInfo(const blas::Uplo uplo, const Tile<T, Device::CPU>& a) {
 
 template <class T>
 void potrf(const blas::Uplo uplo, const Tile<T, Device::CPU>& a) noexcept {
-  auto info = potrfInfo(uplo, a);
+  [[maybe_unused]] auto info = potrfInfo(uplo, a);
 
   DLAF_ASSERT(info == 0, info);
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -63,7 +63,7 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
   DLAF_ASSERT(equal_size(mat_a, mat_b), mat_a, mat_b);
   DLAF_ASSERT(equal_size(mat_a, mat_c), mat_a, mat_c);
 
-  const SizeType m = mat_a.nrTiles().rows();
+  [[maybe_unused]] const SizeType m = mat_a.nrTiles().rows();
   DLAF_ASSERT(a <= b, a, b);
   DLAF_ASSERT(a >= 0 && a < m, a, m);
 
@@ -91,7 +91,8 @@ void generalSubMatrix(const SizeType a, const SizeType b, const blas::Op opA, co
 /// @pre mat_a, mat_b and mat_c have the same size,
 /// @pre a <= b < mat_a.nrTiles().rows()
 template <Backend B, Device D, class T>
-void generalSubMatrix(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& row_task_chain,
+void generalSubMatrix([[maybe_unused]] comm::CommunicatorGrid grid,
+                      common::Pipeline<comm::Communicator>& row_task_chain,
                       common::Pipeline<comm::Communicator>& col_task_chain, const SizeType a,
                       const SizeType b, const T alpha, Matrix<const T, D>& mat_a,
                       Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
@@ -113,7 +114,7 @@ void generalSubMatrix(comm::CommunicatorGrid grid, common::Pipeline<comm::Commun
   DLAF_ASSERT(equal_size(mat_a, mat_b), mat_a, mat_b);
   DLAF_ASSERT(equal_size(mat_a, mat_c), mat_a, mat_c);
 
-  const SizeType m = mat_a.nrTiles().rows();
+  [[maybe_unused]] const SizeType m = mat_a.nrTiles().rows();
   DLAF_ASSERT(a <= b, a, b);
   DLAF_ASSERT(a >= 0 && a < m, a, m);
 

--- a/include/dlaf/permutations/general.h
+++ b/include/dlaf/permutations/general.h
@@ -36,9 +36,9 @@ namespace dlaf::permutations {
 template <Backend B, Device D, class T, Coord coord>
 void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
              Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
-  const matrix::Distribution& distr_perms = perms.distribution();
-  const matrix::Distribution& distr_in = mat_in.distribution();
-  const matrix::Distribution& distr_out = mat_out.distribution();
+  [[maybe_unused]] const matrix::Distribution& distr_perms = perms.distribution();
+  [[maybe_unused]] const matrix::Distribution& distr_in = mat_in.distribution();
+  [[maybe_unused]] const matrix::Distribution& distr_out = mat_out.distribution();
 
   DLAF_ASSERT(matrix::local_matrix(perms), perms);
   DLAF_ASSERT(matrix::local_matrix(mat_in), mat_in);
@@ -84,8 +84,8 @@ template <Backend B, Device D, class T, Coord coord>
 void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& sub_task_chain,
              SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
              Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
-  const matrix::Distribution& distr_perms = perms.distribution();
-  const matrix::Distribution& distr_in = mat_in.distribution();
+  [[maybe_unused]] const matrix::Distribution& distr_perms = perms.distribution();
+  [[maybe_unused]] const matrix::Distribution& distr_in = mat_in.distribution();
 
   DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
 

--- a/include/dlaf/util_blas.h
+++ b/include/dlaf/util_blas.h
@@ -29,7 +29,8 @@ struct gemmSizes {
 
 template <typename T, Device D>
 gemmSizes getGemmSizes(const blas::Op op_a, const blas::Op op_b, const dlaf::matrix::Tile<const T, D>& a,
-                       const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
+                       const dlaf::matrix::Tile<const T, D>& b,
+                       [[maybe_unused]] const dlaf::matrix::Tile<T, D>& c) {
   SizeType m;
   SizeType n;
   SizeType k;
@@ -43,7 +44,7 @@ gemmSizes getGemmSizes(const blas::Op op_a, const blas::Op op_b, const dlaf::mat
     k = a.size().rows();
   }
 
-  SizeType k2;
+  [[maybe_unused]] SizeType k2;
   if (op_b == blas::Op::NoTrans) {
     k2 = b.size().rows();
     n = b.size().cols();
@@ -66,8 +67,9 @@ struct hemmSizes {
 };
 
 template <typename T, Device D>
-hemmSizes getHemmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
-                       const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
+hemmSizes getHemmSizes(const blas::Side side, [[maybe_unused]] const dlaf::matrix::Tile<const T, D>& a,
+                       [[maybe_unused]] const dlaf::matrix::Tile<const T, D>& b,
+                       const dlaf::matrix::Tile<T, D>& c) {
   const hemmSizes s{c.size().rows(), c.size().cols()};
 
   if (side == blas::Side::Left) {
@@ -91,7 +93,8 @@ struct her2kSizes {
 
 template <typename T, Device D>
 her2kSizes getHer2kSizes(blas::Op op, const dlaf::matrix::Tile<const T, D>& a,
-                         const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
+                         [[maybe_unused]] const dlaf::matrix::Tile<const T, D>& b,
+                         [[maybe_unused]] const dlaf::matrix::Tile<T, D>& c) {
   const SizeType rows = a.size().rows();
   const SizeType cols = a.size().cols();
   const auto s = (op == blas::Op::NoTrans) ? her2kSizes{rows, cols} : her2kSizes{cols, rows};
@@ -112,7 +115,7 @@ struct herkSizes {
 
 template <typename T, Device D>
 herkSizes getHerkSizes(const blas::Op op, const dlaf::matrix::Tile<const T, D>& a,
-                       const dlaf::matrix::Tile<T, D>& c) {
+                       [[maybe_unused]] const dlaf::matrix::Tile<T, D>& c) {
   const SizeType rows = a.size().rows();
   const SizeType cols = a.size().cols();
   const auto s = (op == blas::Op::NoTrans) ? herkSizes{rows, cols} : herkSizes{cols, rows};
@@ -130,10 +133,10 @@ struct trmmSizes {
 };
 
 template <typename T, Device D>
-trmmSizes getTrmmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
+trmmSizes getTrmmSizes(const blas::Side side, [[maybe_unused]] const dlaf::matrix::Tile<const T, D>& a,
                        const dlaf::matrix::Tile<T, D>& b) {
   trmmSizes s{b.size().rows(), b.size().cols()};
-  const auto b_side = (side == blas::Side::Left ? s.m : s.n);
+  [[maybe_unused]] const auto b_side = (side == blas::Side::Left ? s.m : s.n);
 
   DLAF_ASSERT(square_size(a), a);
   DLAF_ASSERT(a.size().rows() == b_side, a, side, b);
@@ -143,7 +146,8 @@ trmmSizes getTrmmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, 
 
 template <typename T, Device D>
 trmmSizes getTrmm3Sizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
-                        const dlaf::matrix::Tile<const T, D>& b, const dlaf::matrix::Tile<T, D>& c) {
+                        [[maybe_unused]] const dlaf::matrix::Tile<const T, D>& b,
+                        const dlaf::matrix::Tile<T, D>& c) {
   DLAF_ASSERT(b.size() == c.size(), b, c);
   return getTrmmSizes(side, a, c);
 }
@@ -154,13 +158,13 @@ struct trsmSizes {
 };
 
 template <typename T, Device D>
-trsmSizes getTrsmSizes(const blas::Side side, const dlaf::matrix::Tile<const T, D>& a,
+trsmSizes getTrsmSizes(const blas::Side side, [[maybe_unused]] const dlaf::matrix::Tile<const T, D>& a,
                        const dlaf::matrix::Tile<T, D>& b) {
   trsmSizes s{b.size().rows(), b.size().cols()};
 
   DLAF_ASSERT(square_size(a), a);
 
-  const auto left_side = (side == blas::Side::Left ? s.m : s.n);
+  [[maybe_unused]] const auto left_side = (side == blas::Side::Left ? s.m : s.n);
   DLAF_ASSERT(a.size().rows() == left_side, a, side, b);
 
   return s;

--- a/src/cusolver/assert_info.cu
+++ b/src/cusolver/assert_info.cu
@@ -25,7 +25,7 @@
 #else
 
 #define DLAF_DEFINE_CUSOLVER_ASSERT_INFO(func) \
-  void assertInfo##func(whip::stream_t stream, int* info) {}
+  void assertInfo##func(whip::stream_t, int*) {}
 
 #endif
 

--- a/src/matrix/layout_info.cpp
+++ b/src/matrix/layout_info.cpp
@@ -31,9 +31,9 @@ LayoutInfo::LayoutInfo(const LocalElementSize& size, const TileElementSize& bloc
     DLAF_ASSERT(tile_offset_col_ >= 1, tile_offset_col);
   }
   else {
-    SizeType last_rows = size_.rows() - block_size_.rows() * (nr_tiles_.rows() - 1);
+    [[maybe_unused]] SizeType last_rows = size_.rows() - block_size_.rows() * (nr_tiles_.rows() - 1);
 
-    SizeType max_rows_tiles = std::min(size_.rows(), block_size_.rows());
+    [[maybe_unused]] SizeType max_rows_tiles = std::min(size_.rows(), block_size_.rows());
 
     DLAF_ASSERT(ld_tile_ >= max_rows_tiles, ld_tile_, max_rows_tiles);
     DLAF_ASSERT(tile_offset_row_ >= max_rows_tiles, tile_offset_row, max_rows_tiles);

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -25,9 +25,10 @@
 namespace dlaf::matrix::test {
 
 template <class T>
-auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b, const SizeType m,
-                                      const SizeType n, const SizeType k, const T alpha, const T beta,
-                                      const blas::Op opA, const blas::Op opB) {
+auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b,
+                                      [[maybe_unused]] const SizeType m,
+                                      [[maybe_unused]] const SizeType n, const SizeType k, const T alpha,
+                                      const T beta, const blas::Op opA, const blas::Op opB) {
   using dlaf::test::TypeUtilities;
 
   if (opA != blas::Op::NoTrans)

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -160,8 +160,16 @@ void MPIListener::OnTestEndAllRanks(const ::testing::TestInfo& test_info) const 
 
 namespace internal {
 void mpi_send_string(const std::string& message, int to_rank) {
-  MPI_Send(const_cast<char*>(message.c_str()), static_cast<int>(message.size()) + 1, MPI_CHAR, to_rank,
-           0, MPI_COMM_WORLD);
+// -Wtype-safety disabled because of false positive warning in clang:
+// https://github.com/llvm/llvm-project/issues/62512
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtype-safety"
+#endif
+  MPI_Send(message.c_str(), static_cast<int>(message.size()) + 1, MPI_CHAR, to_rank, 0, MPI_COMM_WORLD);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 std::string mpi_receive_string(int from_rank) {

--- a/test/unit/communication/test_communicator_grid.cpp
+++ b/test/unit/communication/test_communicator_grid.cpp
@@ -29,7 +29,7 @@ void test_grid_communication(CommunicatorGrid& grid) {
   if (MPI_COMM_NULL == grid.rowCommunicator() || MPI_COMM_NULL == grid.colCommunicator())
     return;
 
-  const int buffer_send = 1;
+  int buffer_send = 1;
   int buffer, buffer_recv;
 
   // All Communication

--- a/test/unit/communication/test_transform_mpi.cpp
+++ b/test/unit/communication/test_transform_mpi.cpp
@@ -98,7 +98,7 @@ TEST_F(TransformMPITest, PromiseGuardManagement) {
     // Note:
     // At this point we checked if everything went as expected in the posting phase. Let's signal
     // Rank 1 that it can send back the message that will unlock IRecv.
-    const int signal = 13;
+    int signal = 13;
     MPI_Send(&signal, 1, MPI_INT, 1, 0, world);
 
     // Note:


### PR DESCRIPTION
~I'm speculating, but I think warnings stopped being errors on CI some time ago. I suspect it's this PR that introduced it: https://github.com/spack/spack/pull/30882. This PR attempts to enable warnings as errors again in CI.~

~I have not tried to fix warnings yet in this PR, I first want to see that this works.~

This does seem to reenable warnings as errors in CI again. I'll work on fixing the warnings.