### PR TITLE
Permute Distributed: migrate from AllToAll to Send/Recv

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -35,8 +35,6 @@
 #include "dlaf/types.h"
 #include "dlaf/util_matrix.h"
 
-#include "dlaf/matrix/print_csv.h"
-
 namespace dlaf::eigensolver::internal {
 
 // Auxiliary matrix and vectors used for the D&C algorithm

--- a/include/dlaf/permutations/general.h
+++ b/include/dlaf/permutations/general.h
@@ -34,8 +34,8 @@ namespace dlaf::permutations {
 ///        the closed range [i_begin,i_end] are accessed in write-only mode.
 ///
 template <Backend B, Device D, class T, Coord coord>
-void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms, Matrix<T, D>& mat_in,
-             Matrix<T, D>& mat_out) {
+void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
+             Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
   const matrix::Distribution& distr_perms = perms.distribution();
   const matrix::Distribution& distr_in = mat_in.distribution();
   const matrix::Distribution& distr_out = mat_out.distribution();
@@ -82,8 +82,8 @@ void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
 ///
 template <Backend B, Device D, class T, Coord coord>
 void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& sub_task_chain,
-             SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms, Matrix<T, D>& mat_in,
-             Matrix<T, D>& mat_out) {
+             SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
+             Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
   const matrix::Distribution& distr_perms = perms.distribution();
   const matrix::Distribution& distr_in = mat_in.distribution();
 
@@ -110,7 +110,7 @@ void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& 
 ///
 template <Backend B, Device D, class T, Coord coord>
 void permute(comm::CommunicatorGrid grid, SizeType i_begin, SizeType i_end,
-             Matrix<const SizeType, D>& perms, Matrix<T, D>& mat_in, Matrix<T, D>& mat_out) {
+             Matrix<const SizeType, D>& perms, Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
   common::Pipeline<comm::Communicator> sub_task_chain(grid.subCommunicator(orthogonal(coord)).clone());
   permute<B, D, T, coord>(grid, sub_task_chain, i_begin, i_end, perms, mat_in, mat_out);
 }

--- a/include/dlaf/permutations/general/api.h
+++ b/include/dlaf/permutations/general/api.h
@@ -21,9 +21,9 @@ namespace dlaf::permutations::internal {
 template <Backend B, Device D, class T, Coord coord>
 struct Permutations {
   static void call(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
-                   Matrix<T, D>& mat_in, Matrix<T, D>& mat_out);
+                   Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out);
   static void call(common::Pipeline<comm::Communicator>& sub_task_chain, SizeType i_begin,
-                   SizeType i_end, Matrix<const SizeType, D>& perms, Matrix<T, D>& mat_in,
+                   SizeType i_end, Matrix<const SizeType, D>& perms, Matrix<const T, D>& mat_in,
                    Matrix<T, D>& mat_out);
 };
 

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -173,7 +173,7 @@ void applyPermutationsFiltered(
 
 template <Backend B, Device D, class T, Coord C>
 void Permutations<B, D, T, C>::call(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
-                                    Matrix<T, D>& mat_in, Matrix<T, D>& mat_out) {
+                                    Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
   namespace ut = matrix::util;
   namespace ex = pika::execution::experimental;
 
@@ -474,7 +474,7 @@ inline void invertIndex(SizeType i_begin, SizeType i_end, Matrix<const SizeType,
 template <class T, Coord C>
 void permuteOnCPU(common::Pipeline<comm::Communicator>& sub_task_chain, SizeType i_begin,
                   SizeType i_last, Matrix<const SizeType, Device::CPU>& perms,
-                  Matrix<T, Device::CPU>& mat_in, Matrix<T, Device::CPU>& mat_out) {
+                  Matrix<const T, Device::CPU>& mat_in, Matrix<T, Device::CPU>& mat_out) {
   constexpr Device D = Device::CPU;
 
   using namespace dlaf::matrix;
@@ -609,7 +609,7 @@ void permuteOnCPU(common::Pipeline<comm::Communicator>& sub_task_chain, SizeType
 template <Backend B, Device D, class T, Coord C>
 void Permutations<B, D, T, C>::call(common::Pipeline<comm::Communicator>& sub_task_chain,
                                     SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
-                                    Matrix<T, D>& mat_in, Matrix<T, D>& mat_out) {
+                                    Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
   if constexpr (D == Device::GPU) {
     // This is a temporary placeholder which avoids diverging GPU API:
     DLAF_UNIMPLEMENTED("GPU implementation not available yet");

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -129,12 +129,13 @@ void applyPermutations(GlobalElementIndex out_begin, GlobalElementSize sz, SizeT
   }
 }
 
-template <class T, Device D, Coord C>
+// FilterFunc is a function with signature bool(*)(SizeType)
+template <class T, Device D, Coord C, class FilterFunc>
 void applyPermutationsFiltered(
     GlobalElementIndex out_begin, GlobalElementSize sz, SizeType in_offset,
     const matrix::Distribution& subm_dist, const SizeType* perm_arr,
     const std::vector<pika::shared_future<matrix::Tile<const T, D>>>& in_tiles_fut,
-    const std::vector<matrix::Tile<T, D>>& out_tiles, std::function<bool(SizeType)> filter) {
+    const std::vector<matrix::Tile<T, D>>& out_tiles, FilterFunc&& filter) {
   constexpr auto OC = orthogonal(C);
   std::vector<SizeType> splits =
       dlaf::util::interleaveSplits(sz.get<OC>(), subm_dist.blockSize().get<OC>(),

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -262,9 +262,9 @@ void all2allDataCol(common::Pipeline<comm::Communicator>& sub_task_chain, int nr
     }
 
     // Note:
-    // Once all communications are scheuled, while they complete, just do the "local" copy that imhitates
-    // the communication. This is superfluous and is going to be removed, since it also add an
-    // additioanl dependency that impose to wait all communications also for data already available
+    // Once all communications are scheduled, while they complete, just do the "local" copy that
+    // imhitates the communication. This is superfluous and is going to be removed, since it also add an
+    // additional dependency that impose to wait all communications also for data already available
     // locally
     const auto rank_index = to_sizet(rank);
     std::memcpy(recv_ptr + recv_displs[rank_index], send_ptr + send_displs[rank_index],

--- a/test/src/gtest_mpi_listener.cpp
+++ b/test/src/gtest_mpi_listener.cpp
@@ -160,7 +160,8 @@ void MPIListener::OnTestEndAllRanks(const ::testing::TestInfo& test_info) const 
 
 namespace internal {
 void mpi_send_string(const std::string& message, int to_rank) {
-  MPI_Send(message.c_str(), static_cast<int>(message.size()) + 1, MPI_CHAR, to_rank, 0, MPI_COMM_WORLD);
+  MPI_Send(const_cast<char*>(message.c_str()), static_cast<int>(message.size()) + 1, MPI_CHAR, to_rank,
+           0, MPI_COMM_WORLD);
 }
 
 std::string mpi_receive_string(int from_rank) {

--- a/test/unit/permutations/test_permutations_distributed.cpp
+++ b/test/unit/permutations/test_permutations_distributed.cpp
@@ -106,9 +106,9 @@ void testDistPermutations(comm::CommunicatorGrid grid, SizeType n, SizeType nb, 
 
   const auto [index_start, index_end] = tileToElementRange(n, nb, i_begin, i_last + 1);
 
-  Matrix<const SizeType, Device::CPU> perms_h = [=]() {
+  Matrix<const SizeType, Device::CPU> perms_h = [=, index_start = index_start, index_end = index_end] {
     Matrix<SizeType, Device::CPU> perms_h(LocalElementSize(n, 1), TileElementSize(nb, 1));
-    dlaf::matrix::util::set(perms_h, [perms, index_start, index_end](GlobalElementIndex i) {
+    dlaf::matrix::util::set(perms_h, [=](GlobalElementIndex i) {
       if (index_start > i.row() || i.row() >= index_end)
         return SizeType(0);
 
@@ -138,8 +138,7 @@ void testDistPermutations(comm::CommunicatorGrid grid, SizeType n, SizeType nb, 
                                                         mat_out.get());
   }
 
-  auto expected_out = [dist, i_begin, i_last, index_start, index_end, perms, value_in,
-                       value_out](const GlobalElementIndex& i) {
+  auto expected_out = [=, index_start = index_start](const GlobalElementIndex& i) {
     const GlobalTileIndex i_tile = dist.globalTileIndex(i);
     if (i_begin <= i_tile.row() && i_tile.row() <= i_last && i_begin <= i_tile.col() &&
         i_tile.col() <= i_last) {


### PR DESCRIPTION
Optimizations:
- Split unpacking of permutations from "all-at-once" to "local + others".
"locals" do not depend anymore on communication and can happen in parallel with the communication of "others".
- Migrate from MPI_AllToAllv to MPI_Send/MPI_Recv
  - Might reduce amount of data to be communicated (local are not communicated anymore)
  - Do not require anymore contiguousness of the MPI datatype
  For permute-row, this means not having anymore to transpose data, which implied a copy on a support memory (alternatively mat_in and mat_out...).
  - Not having to use `mat_in` as support memory, it was possible to fix const-correctness of the API

Additional Changelog:
- Test has been improved: now it also checks out-of-the-range invariability + there is a test-config for checking an edge case of the new implementation (related to local unpacking)
- Fix const-correctness also in `test_permutations_local`
- minor: Fix warning in MPI call inside gtest_listener
- some renamings to make some parts of the code more self-explanatory

_Note: I'm not super-happy about the code duplication introduced by `applyPermutationsFiltered` (more or less a copy of `applyPermutations`). I don't want to spend to much now on it, but in the near future I might have to do some other change on that part and your suggestion might be helpful._