### PR TITLE
Fix `waitLocalTiles` to guarantee that the next access won't yield

### DIFF
--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -49,7 +49,9 @@ void Matrix<const T, D>::waitLocalTiles() noexcept {
   };
 
   const auto range_local = common::iterate_range2d(distribution().localNrTiles());
-  pika::wait_all(internal::selectGeneric(readwrite_f, range_local));
+  for (auto& f : internal::selectGeneric(readwrite_f, range_local)) {
+    f.get();
+  }
 }
 
 template <class T, Device D>


### PR DESCRIPTION
Fixes failures like this: https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/jobs/4093987502. The segmentation fault was relatively easy to reproduce on hohgant with `test_multiplication_hermitian` with the local-only tests (`test/unit/multiplication/test_multiplication_hermitian --gtest_filter=*Local*`) with at least 10 worker threads.

This changes `waitLocalTiles` to use `future::get` instead of `wait` to ensure that the tile contained in the future is released on the calling thread. When calling `wait` we ensure that the result of the future is ready but we do not ensure that the tile has been released. When only calling `wait` it's possible for `wait` to return but the contained tile not to have been released yet. This means that subsequent reads may end up yielding if the tile has not yet been released. In most cases the tile is released *very soon* after signaling `wait` but there is a delay which opens up the door to race conditions.

Reminder: fundamentally there's nothing wrong with just calling `wait`. Things work correctly from the perspective of pika. This is again just a case of `SCOPED_TRACE` not being allowed to be destroyed on a different thread than where it was created.