### PR TITLE
Remove unnecessary `barrier::arrive_and_wait` from `reduction_to_band`

### DIFF
--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -338,7 +338,9 @@ auto computePanelReflectors(MatrixLike& mat_a, const matrix::SubPanelView& panel
 
                       // STEP3: update trailing panel (multi-threaded)
                       updateTrailingPanel(has_head, tiles, j, w[0], taus.back(), begin, end);
-                      barrier_ptr->arrive_and_wait();
+                      if (j + 1 < nrefls) {
+                        barrier_ptr->arrive_and_wait();
+                      }
                     }
                   }) |
          ex::then([](auto barrier_ptr, auto w, auto taus, auto tiles) {
@@ -682,7 +684,9 @@ auto computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
 
                       // STEP3: update trailing panel (multi-threaded)
                       updateTrailingPanel(has_head, tiles, j, w[0], taus.back(), begin, end);
-                      barrier_ptr->arrive_and_wait();
+                      if (j + 1 < nrefls) {
+                        barrier_ptr->arrive_and_wait();
+                      }
                     }
                   }) |
          ex::then([](auto barrier_ptr, auto w, auto taus, auto tiles, auto pcomm) {


### PR DESCRIPTION
~The end of the `bulk` region is anyway synchronized before the `then` continuation is called, so there's no need for the extra `arrive_and_wait`.~ The synchronization is probably still needed between iterations of the for-loop, but not for the last iteration.

This improves performance by 0 to a few percent. A couple of plots comparing this PR (`dlaf_4b965...`) to [master](https://github.com/eth-cscs/DLA-Future/commit/c1b515f911d4670fed46b57944c49ba166824497) (`dlaf_c1b51...`):
![red2band_strong_time_10240_512_128](https://user-images.githubusercontent.com/42977/233418893-5475237d-767a-43c6-bb9e-5c68fb17d60f.png)
![red2band_strong_time_20480_512_128](https://user-images.githubusercontent.com/42977/233418912-653803cf-da83-44f5-9cd2-b967d2138b8f.png)
The difference seems to be smaller with smaller blocksizes. There's still quite a bit of noise, but I think it looks like there's some signal there as well to say that it makes a small difference.