### PR TITLE
Wait for pika runtime between distributed tests in `test_multiplication_general`

### DIFF
--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -200,6 +200,7 @@ TYPED_TEST(GeneralSubMultiplicationDistTestMC, CorrectnessDistributed) {
       const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
       testGeneralSubMultiplication<TypeParam, Backend::MC, Device::CPU>(comm_grid, a, b, alpha, beta, m,
                                                                         mb);
+      pika::threads::get_thread_manager().wait();
     }
   }
 }
@@ -212,6 +213,7 @@ TYPED_TEST(GeneralSubMultiplicationDistTestGPU, CorrectnessDistributed) {
       const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
       testGeneralSubMultiplication<TypeParam, Backend::GPU, Device::GPU>(comm_grid, a, b, alpha, beta, m,
                                                                          mb);
+      pika::threads::get_thread_manager().wait();
     }
   }
 }


### PR DESCRIPTION
As we do in other tests, to avoid potential deadlocks when running with only two pika worker threads.