### PR TITLE
bump gtest version to remove bogus cmake warning

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD 17)
 include(FetchContent)
 
 FetchContent_Declare(
-  googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG release-1.11.0
+  googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.13.0
 )
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,7 +14,11 @@ set(CMAKE_CXX_STANDARD 17)
 include(FetchContent)
 
 FetchContent_Declare(
-  googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.13.0
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.13.0
+  # Patch for int to float conversion warning.
+  PATCH_COMMAND git cherry-pick -n 5cd81a7848203d3df6959c148eb91f1a4ff32c1d -m 1
 )
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")


### PR DESCRIPTION
Remove the warning
```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   gtest
   gtest_main

This warning is for project developers.  Use -Wno-dev to suppress it.
```