### PR TITLE
Permute: review and refine preconditions

### DIFF
--- a/include/dlaf/permutations/general.h
+++ b/include/dlaf/permutations/general.h
@@ -49,16 +49,13 @@ void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
   DLAF_ASSERT(matrix::square_blocksize(mat_in), mat_in);
   DLAF_ASSERT(matrix::equal_size(mat_in, mat_out), mat_in);
   DLAF_ASSERT(matrix::equal_blocksize(mat_in, mat_out), mat_in);
+
   DLAF_ASSERT(perms.size().rows() == mat_in.size().rows(), perms, mat_in);
-
-  DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
-
-  DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
-  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows(), i_end, mat_in);
-  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows(), i_end, mat_out);
-
   DLAF_ASSERT(perms.size().cols() == 1, perms);
   DLAF_ASSERT(perms.blockSize().rows() == mat_in.blockSize().rows(), mat_in, perms);
+
+  DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
+  DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
 
   internal::Permutations<B, D, T, coord>::call(i_begin, i_end, perms, mat_in, mat_out);
 }
@@ -100,15 +97,13 @@ void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& 
   DLAF_ASSERT(matrix::square_blocksize(mat_in), mat_in);
   DLAF_ASSERT(matrix::equal_size(mat_in, mat_out), mat_in);
   DLAF_ASSERT(matrix::equal_blocksize(mat_in, mat_out), mat_in);
+
   DLAF_ASSERT(perms.size().rows() == mat_in.size().rows(), perms, mat_in);
+  DLAF_ASSERT(perms.size().cols() == 1, perms);
+  DLAF_ASSERT(perms.blockSize().rows() == mat_in.blockSize().rows(), mat_in, perms);
 
   DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
   DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
-  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows(), i_end, mat_in);
-  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows(), i_end, mat_out);
-
-  DLAF_ASSERT(perms.size().cols() == 1, perms);
-  DLAF_ASSERT(perms.blockSize().rows() == mat_in.blockSize().rows(), mat_in, perms);
 
   internal::Permutations<B, D, T, coord>::call(sub_task_chain, i_begin, i_end, perms, mat_in, mat_out);
 }

--- a/include/dlaf/permutations/general.h
+++ b/include/dlaf/permutations/general.h
@@ -47,8 +47,8 @@ void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
   // Note:
   // These are not implementation constraints, but more logic constraints. Indeed, these ensure that
   // the range [i_begin, i_end] is square in terms of elements (it would not make sense to have it square
-  // in terms of number of tiles). Moreover, by requiring mat_in and mat_out matrices to have the same shape,
-  // it is ensured that range [i_begin, i_end] is actually the same on both sides.
+  // in terms of number of tiles). Moreover, by requiring mat_in and mat_out matrices to have the same
+  // shape, it is ensured that range [i_begin, i_end] is actually the same on both sides.
   DLAF_ASSERT(square_size(mat_in), mat_in);
   DLAF_ASSERT(matrix::square_blocksize(mat_in), mat_in);
   DLAF_ASSERT(matrix::equal_size(mat_in, mat_out), mat_in);
@@ -102,8 +102,8 @@ void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& 
   // Note:
   // These are not implementation constraints, but more logic constraints. Indeed, these ensure that
   // the range [i_begin, i_end] is square in terms of elements (it would not make sense to have it square
-  // in terms of number of tiles). Moreover, by requiring mat_in and mat_out matrices to have the same shape,
-  // it is ensured that range [i_begin, i_end] is actually the same on both sides.
+  // in terms of number of tiles). Moreover, by requiring mat_in and mat_out matrices to have the same
+  // shape, it is ensured that range [i_begin, i_end] is actually the same on both sides.
   DLAF_ASSERT(square_size(mat_in), mat_in);
   DLAF_ASSERT(matrix::square_blocksize(mat_in), mat_in);
   DLAF_ASSERT(matrix::equal_size(mat_in, mat_out), mat_in);

--- a/include/dlaf/permutations/general.h
+++ b/include/dlaf/permutations/general.h
@@ -49,15 +49,16 @@ void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
   DLAF_ASSERT(matrix::square_blocksize(mat_in), mat_in);
   DLAF_ASSERT(matrix::equal_size(mat_in, mat_out), mat_in);
   DLAF_ASSERT(matrix::equal_blocksize(mat_in, mat_out), mat_in);
+  DLAF_ASSERT(perms.size().rows() == mat_in.size().rows(), perms, mat_in);
 
   DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
 
   DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
-  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows() && i_end <= mat_in.nrTiles().cols(), i_end, mat_in);
-  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows() && i_end <= mat_out.nrTiles().cols(), i_end, mat_out);
+  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows(), i_end, mat_in);
+  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows(), i_end, mat_out);
 
   DLAF_ASSERT(perms.size().cols() == 1, perms);
-  DLAF_ASSERT(mat_in.blockSize().template get<coord>() == perms.blockSize().rows(), mat_in, perms);
+  DLAF_ASSERT(perms.blockSize().rows() == mat_in.blockSize().rows(), mat_in, perms);
 
   internal::Permutations<B, D, T, coord>::call(i_begin, i_end, perms, mat_in, mat_out);
 }
@@ -99,14 +100,15 @@ void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& 
   DLAF_ASSERT(matrix::square_blocksize(mat_in), mat_in);
   DLAF_ASSERT(matrix::equal_size(mat_in, mat_out), mat_in);
   DLAF_ASSERT(matrix::equal_blocksize(mat_in, mat_out), mat_in);
+  DLAF_ASSERT(perms.size().rows() == mat_in.size().rows(), perms, mat_in);
 
   DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
   DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
-  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows() && i_end <= mat_in.nrTiles().cols(), i_end, mat_in);
-  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows() && i_end <= mat_out.nrTiles().cols(), i_end, mat_out);
+  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows(), i_end, mat_in);
+  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows(), i_end, mat_out);
 
   DLAF_ASSERT(perms.size().cols() == 1, perms);
-  DLAF_ASSERT(mat_in.blockSize().template get<coord>() == perms.blockSize().rows(), mat_in, perms);
+  DLAF_ASSERT(perms.blockSize().rows() == mat_in.blockSize().rows(), mat_in, perms);
 
   internal::Permutations<B, D, T, coord>::call(sub_task_chain, i_begin, i_end, perms, mat_in, mat_out);
 }

--- a/include/dlaf/permutations/general.h
+++ b/include/dlaf/permutations/general.h
@@ -36,10 +36,6 @@ namespace dlaf::permutations {
 template <Backend B, Device D, class T, Coord coord>
 void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
              Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
-  const matrix::Distribution& distr_perms = perms.distribution();
-  const matrix::Distribution& distr_in = mat_in.distribution();
-  const matrix::Distribution& distr_out = mat_out.distribution();
-
   DLAF_ASSERT(matrix::local_matrix(perms), perms);
   DLAF_ASSERT(matrix::local_matrix(mat_in), mat_in);
   DLAF_ASSERT(matrix::local_matrix(mat_out), mat_out);
@@ -56,13 +52,12 @@ void permute(SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
 
   DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
 
-  DLAF_ASSERT(i_end <= distr_perms.nrTiles().rows(), i_end, perms);
-  DLAF_ASSERT(i_end <= distr_in.nrTiles().rows() && i_end <= distr_in.nrTiles().cols(), i_end, mat_in);
-  DLAF_ASSERT(i_end <= distr_out.nrTiles().rows() && i_end <= distr_out.nrTiles().cols(), i_end,
-              mat_out);
+  DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
+  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows() && i_end <= mat_in.nrTiles().cols(), i_end, mat_in);
+  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows() && i_end <= mat_out.nrTiles().cols(), i_end, mat_out);
 
   DLAF_ASSERT(perms.size().cols() == 1, perms);
-  DLAF_ASSERT(distr_in.blockSize().get<coord>() == distr_perms.blockSize().rows(), mat_in, perms);
+  DLAF_ASSERT(mat_in.blockSize().template get<coord>() == perms.blockSize().rows(), mat_in, perms);
 
   internal::Permutations<B, D, T, coord>::call(i_begin, i_end, perms, mat_in, mat_out);
 }
@@ -91,10 +86,6 @@ template <Backend B, Device D, class T, Coord coord>
 void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& sub_task_chain,
              SizeType i_begin, SizeType i_end, Matrix<const SizeType, D>& perms,
              Matrix<const T, D>& mat_in, Matrix<T, D>& mat_out) {
-  const matrix::Distribution& distr_perms = perms.distribution();
-  const matrix::Distribution& distr_in = mat_in.distribution();
-  const matrix::Distribution& distr_out = mat_out.distribution();
-
   DLAF_ASSERT(matrix::local_matrix(perms), perms);
   DLAF_ASSERT(matrix::equal_process_grid(mat_in, grid), mat_in, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_out, grid), mat_out, grid);
@@ -110,12 +101,12 @@ void permute(comm::CommunicatorGrid grid, common::Pipeline<comm::Communicator>& 
   DLAF_ASSERT(matrix::equal_blocksize(mat_in, mat_out), mat_in);
 
   DLAF_ASSERT(i_begin >= 0 && i_begin <= i_end, i_begin, i_end);
-  DLAF_ASSERT(i_end <= distr_perms.nrTiles().rows(), i_end, perms);
-  DLAF_ASSERT(i_end <= distr_in.nrTiles().rows() && i_end <= distr_in.nrTiles().cols(), i_end, mat_in);
-  DLAF_ASSERT(i_end <= distr_out.nrTiles().rows() && i_end <= distr_out.nrTiles().cols(), i_end, mat_out);
+  DLAF_ASSERT(i_end <= perms.nrTiles().rows(), i_end, perms);
+  DLAF_ASSERT(i_end <= mat_in.nrTiles().rows() && i_end <= mat_in.nrTiles().cols(), i_end, mat_in);
+  DLAF_ASSERT(i_end <= mat_out.nrTiles().rows() && i_end <= mat_out.nrTiles().cols(), i_end, mat_out);
 
-  DLAF_ASSERT(distr_perms.size().cols() == 1, perms);
-  DLAF_ASSERT(distr_in.blockSize().get<coord>() == distr_perms.blockSize().rows(), mat_in, perms);
+  DLAF_ASSERT(perms.size().cols() == 1, perms);
+  DLAF_ASSERT(mat_in.blockSize().template get<coord>() == perms.blockSize().rows(), mat_in, perms);
 
   internal::Permutations<B, D, T, coord>::call(sub_task_chain, i_begin, i_end, perms, mat_in, mat_out);
 }

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -96,7 +96,11 @@ void applyPermutations(
                                distr.distanceToAdjacentTile<orth_coord>(out_begin.get<orth_coord>()));
 
     // Parallelized over the number of permuted columns or rows
-    pika::for_loop(pika::execution::par, to_sizet(0), to_sizet(sz.get<coord>()), [&](SizeType i_perm) {
+    const SizeType nperms = sz.get<coord>();
+    pika::for_loop(pika::execution::par, to_sizet(0), to_sizet(nperms), [&](SizeType i_perm) {
+      DLAF_ASSERT_HEAVY(i_perm >= 0 && i_perm < nperms, i_perm, nperms);
+      DLAF_ASSERT_HEAVY(perm_arr[i_perm] >= 0 && perm_arr[i_perm] < nperms, i_perm, nperms);
+
       for (std::size_t i_split = 0; i_split < splits.size() - 1; ++i_split) {
         const SizeType split = splits[i_split];
 

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -341,7 +341,8 @@ auto initPackingIndex(comm::IndexT_MPI nranks, SizeType offset_sub, const matrix
       for (SizeType perm_index_local = 0; perm_index_local < nperms; ++perm_index_local) {
         const SizeType perm_index_global = offset_sub + loc2sub[perm_index_local];
         DLAF_ASSERT_HEAVY(perm_index_local >= 0 && perm_index_local < nperms, perm_index_local, nperms);
-        DLAF_ASSERT_HEAVY(perm_index_global >= 0 && perm_index_global < dist.size().get<C>(), perm_index_global, dist.size());
+        DLAF_ASSERT_HEAVY(perm_index_global >= 0 && perm_index_global < dist.size().get<C>(),
+                          perm_index_global, dist.size());
         if (dist.rankGlobalElement<C>(perm_index_global) == rank) {
           const SizeType perm_index_packed = rank_displacement + nperms_local;
 

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "dlaf/common/assert.h"
 #include "dlaf/matrix/index.h"
 #include "dlaf/permutations/general/api.h"
 #include "dlaf/permutations/general/perms.h"
@@ -339,6 +340,8 @@ auto initPackingIndex(comm::IndexT_MPI nranks, SizeType offset_sub, const matrix
 
       for (SizeType perm_index_local = 0; perm_index_local < nperms; ++perm_index_local) {
         const SizeType perm_index_global = offset_sub + loc2sub[perm_index_local];
+        DLAF_ASSERT_HEAVY(perm_index_local >= 0 && perm_index_local < nperms, perm_index_local, nperms);
+        DLAF_ASSERT_HEAVY(perm_index_global >= 0 && perm_index_global < dist.size().get<C>(), perm_index_global, dist.size());
         if (dist.rankGlobalElement<C>(perm_index_global) == rank) {
           const SizeType perm_index_packed = rank_displacement + nperms_local;
 

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -449,7 +449,7 @@ void permuteOnCPU(common::Pipeline<comm::Communicator>& sub_task_chain, SizeType
   // Local single tile column matrices representing index maps used for packing and unpacking of
   // communication data
   const SizeType nvecs = sz_loc.get<C>();
-  const Distribution index_dist(LocalElementSize(nvecs, 1), TileElementSize(blk.rows(), 1));
+  const Distribution index_dist(LocalElementSize(nvecs, 1), TileElementSize(blk.get<C>(), 1));
   Matrix<SizeType, D> local2global_index(index_dist);
   Matrix<SizeType, D> packing_index(index_dist);
   Matrix<SizeType, D> unpacking_index(index_dist);


### PR DESCRIPTION
@rasolca asked to check if preconditions could be relaxed or why they were there, to be aware of the real constraints.

Actually, the algorithm might easily support even "non-square" matrices and/or block sizes, but after a discussion we preferred to go with the `square` constraint because those additional use-cases do not make sense.

Changelog:
- Explain constraints and normalise between local and distributed implementation
- Remove unused functions for transposition (leftover from previous communication constraints)
- Add check about permutation value consistency
- Minor changes