### PR TITLE
TridiagSolver (local): "bulkerify" rank1 problem solution

### DIFF
--- a/include/dlaf/common/vector.h
+++ b/include/dlaf/common/vector.h
@@ -35,6 +35,10 @@ struct vector : public std::vector<T> {
     std::vector<T>::resize(to_sizet(size));
   }
 
+  void resize(SizeType size, const T& value) {
+    std::vector<T>::resize(to_sizet(size), value);
+  }
+
   T& operator[](SizeType index) {
     return std::vector<T>::operator[](to_sizet(index));
   }

--- a/include/dlaf/eigensolver/get_red2band_panel_nworkers.h
+++ b/include/dlaf/eigensolver/get_red2band_panel_nworkers.h
@@ -10,23 +10,22 @@
 #pragma once
 
 #include <algorithm>
-#include <cmath>
+#include <cstdint>
 
 #include <pika/runtime.hpp>
 
-#include "dlaf/common/assert.h"
 #include "dlaf/tune.h"
 
 namespace dlaf::eigensolver::internal {
 
 inline size_t getReductionToBandPanelNWorkers() noexcept {
-  const size_t nworkers = getTuneParameters().red2band_panel_nworkers;
+  // Note: precautionarily we leave at least 1 thread "free" to do other stuff (if possible)
+  const std::size_t available_workers = pika::resource::get_thread_pool("default").get_os_thread_count();
+  const std::size_t min_workers = 1;
+  const auto max_workers = std::max(min_workers, available_workers - 1);
 
-  // Note: precautionarily we leave at least 1 thread "free" to do other stuff
-  const size_t max_workers = pika::resource::get_thread_pool("default").get_os_thread_count() - 1;
-
-  // 1 <= number of workers < max_workers
-  return std::max<std::size_t>(1, std::min<std::size_t>(max_workers, nworkers));
+  const std::size_t nworkers = getTuneParameters().red2band_panel_nworkers;
+  return std::clamp(nworkers, min_workers, max_workers);
 }
 
 }

--- a/include/dlaf/eigensolver/get_tridiag_rank1_nworkers.h
+++ b/include/dlaf/eigensolver/get_tridiag_rank1_nworkers.h
@@ -19,13 +19,13 @@
 namespace dlaf::eigensolver::internal {
 
 inline std::size_t getTridiagRank1NWorkers() noexcept {
+  // Note: precautionarily we leave at least 1 thread "free" to do other stuff (if possible)
+  const std::size_t available_workers = pika::resource::get_thread_pool("default").get_os_thread_count();
+  const std::size_t min_workers = 1;
+  const auto max_workers = std::max(min_workers, available_workers - 1);
+
   const std::size_t nworkers = getTuneParameters().tridiag_rank1_nworkers;
-
-  // Note: precautionarily we leave at least 1 thread "free" to do other stuff
-  const std::size_t max_workers = pika::resource::get_thread_pool("default").get_os_thread_count() - 1;
-
-  // 1 <= number of workers < max_workers
-  return std::max<std::size_t>(1, std::min<std::size_t>(max_workers, nworkers));
+  return std::clamp(nworkers, min_workers, max_workers);
 }
 
 }

--- a/include/dlaf/eigensolver/get_tridiag_rank1_nworkers.h
+++ b/include/dlaf/eigensolver/get_tridiag_rank1_nworkers.h
@@ -1,0 +1,30 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2023, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <cstdint>
+
+#include <pika/runtime.hpp>
+
+#include "dlaf/tune.h"
+
+namespace dlaf::eigensolver::internal {
+
+inline std::size_t getTridiagRank1NWorkers() noexcept {
+  const std::size_t nworkers = getTuneParameters().tridiag_rank1_nworkers;
+
+  // Note: precautionarily we leave at least 1 thread "free" to do other stuff
+  const std::size_t max_workers = pika::resource::get_thread_pool("default").get_os_thread_count() - 1;
+
+  // 1 <= number of workers < max_workers
+  return std::max<std::size_t>(1, std::min<std::size_t>(max_workers, nworkers));
+}
+
+}

--- a/include/dlaf/eigensolver/get_tridiag_rank1_nworkers.h
+++ b/include/dlaf/eigensolver/get_tridiag_rank1_nworkers.h
@@ -9,6 +9,7 @@
 //
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 #include <pika/runtime.hpp>

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -776,6 +776,9 @@ void mergeSubproblems(const SizeType i_begin, const SizeType i_split, const Size
   //
   invertIndex(i_begin, i_end, ws_h.i3, ws_hm.i2);
 
+  // Note:
+  // This is neeeded to set to zero elements of e2 outside of the k by k top-left part.
+  // The input is not required to be zero for solveRank1Problem.
   matrix::util::set0<Backend::MC>(pika::execution::thread_priority::normal, idx_loc_begin, sz_loc_tiles,
                                   ws_hm.e2);
   solveRank1Problem(i_begin, i_end, k, scaled_rho, ws_hm.d1, ws_hm.z1, ws_h.d0, ws_hm.e2);

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 
-#include <pika/algorithm.hpp>
 #include <pika/barrier.hpp>
 #include <pika/execution.hpp>
 

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -9,8 +9,11 @@
 //
 #pragma once
 
+#include <cstdint>
+
 #include <pika/runtime.hpp>
-#include <dlaf/types.h>
+
+#include "dlaf/types.h"
 
 namespace dlaf {
 /// DLA-Future tuning parameters.
@@ -32,8 +35,10 @@ namespace dlaf {
 ///     DLAF_BT_BAND_TO_TRIDIAG_HH_APPLY_GROUP_SIZE.
 /// Note to developers: Users can change these values, therefore consistency has to be ensured by algorithms.
 struct TuneParameters {
-  size_t red2band_panel_nworkers =
-      std::max<size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
+  std::size_t red2band_panel_nworkers =
+      std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
+  std::size_t tridiag_rank1_nworkers =
+      std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
 
   SizeType eigensolver_min_band = 100;
   SizeType band_to_tridiag_1d_block_size_base = 8192;

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -22,18 +22,23 @@ namespace dlaf {
 /// - red2band_panel_nworkers:
 ///     The maximum number of threads to use for computing the panel in the reduction to band algorithm.
 ///     Set with --dlaf:red2band-panel-nworkers or env variable DLAF_RED2BAND_PANEL_NWORKERS.
+/// - tridiag_rank1_nworkers:
+///     The maximum number of threads to use for computing rank1 problem solution in tridiagonal solver
+///     algorithm. Set with --dlaf:tridiag-rank1-nworkers or env variable DLAF_TRIDIAG_RANK1_NWORKERS.
 /// - eigensolver_min_band:
 ///     The minimum value to start looking for a divisor of the block size.
 ///     Set with --dlaf:eigensolver-min-band or env variable DLAF_EIGENSOLVER_MIN_BAND.
 /// - band_to_tridiag_1d_block_size_base:
-///     The 1D block size for band_to_tridiagonal is computed as 1d_block_size_base / nb * nb. The input matrix
-///     is distributed with a {nb x nb} block size.
-///     Set with --dlaf:band-to-tridiag-1d-block-size-base or env variable DLAF_BAND_TO_TRIDIAG_1D_BLOCK_SIZE_BASE.
+///     The 1D block size for band_to_tridiagonal is computed as 1d_block_size_base / nb * nb. The input
+///     matrix is distributed with a {nb x nb} block size. Set with
+///     --dlaf:band-to-tridiag-1d-block-size-base or env variable
+///     DLAF_BAND_TO_TRIDIAG_1D_BLOCK_SIZE_BASE.
 /// - bt_band_to_tridiag_hh_apply_group_size:
-///     The application of the HH reflector is splitted in smaller applications of the group size reflectors.
-///     Set with --dlaf:bt-band-to-tridiag-hh-apply-group-size or env variable
+///     The application of the HH reflector is splitted in smaller applications of the group size
+///     reflectors. Set with --dlaf:bt-band-to-tridiag-hh-apply-group-size or env variable
 ///     DLAF_BT_BAND_TO_TRIDIAG_HH_APPLY_GROUP_SIZE.
-/// Note to developers: Users can change these values, therefore consistency has to be ensured by algorithms.
+/// Note to developers: Users can change these values, therefore consistency has to be ensured by
+/// algorithms.
 struct TuneParameters {
   std::size_t red2band_panel_nworkers =
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -211,7 +211,7 @@ pika::program_options::options_description getOptionsDescription() {
       "The 1D block size for band_to_tridiagonal is computed as 1d_block_size_base / nb * nb. (The input matrix is distributed with a {nb x nb} block size.)");
   desc.add_options()(
       "dlaf:tridiag-rank1-nworkers", pika::program_options::value<std::size_t>(),
-      "Maximum number of threads to use for computing rank1 problem solution in tridiagonal solver algorithm.");
+      "The maximum number of threads to use for computing rank1 problem solution in tridiagonal solver algorithm.");
   desc.add_options()(
       "dlaf:bt-band-to-tridiag-hh-apply-group-size", pika::program_options::value<SizeType>(),
       "The application of the HH reflector is splitted in smaller applications of group size reflectors.");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -168,6 +168,9 @@ void updateConfiguration(pika::program_options::variables_map const& vm, configu
   updateConfigurationValue(vm, param.band_to_tridiag_1d_block_size_base,
                            "BAND_TO_TRIDIAG_1D_BLOCK_SIZE_BASE", "band-to-tridiag-1d-block-size-base");
 
+  updateConfigurationValue(vm, param.tridiag_rank1_nworkers, "TRIDIAG_RANK1_NWORKERS",
+                           "tridiag-rank1-nworkers");
+
   updateConfigurationValue(vm, param.bt_band_to_tridiag_hh_apply_group_size,
                            "DLAF_BT_BAND_TO_TRIDIAG_HH_APPLY_GROUP_SIZE",
                            "bt-band-to-tridiag-hh-apply-group-size");
@@ -206,6 +209,9 @@ pika::program_options::options_description getOptionsDescription() {
   desc.add_options()(
       "dlaf:band-to-tridiag-1d-block-size-base", pika::program_options::value<SizeType>(),
       "The 1D block size for band_to_tridiagonal is computed as 1d_block_size_base / nb * nb. (The input matrix is distributed with a {nb x nb} block size.)");
+  desc.add_options()(
+      "dlaf:tridiag-rank1-nworkers", pika::program_options::value<std::size_t>(),
+      "Maximum number of threads to use for computing rank1 problem solution in tridiagonal solver algorithm.");
   desc.add_options()(
       "dlaf:bt-band-to-tridiag-hh-apply-group-size", pika::program_options::value<SizeType>(),
       "The application of the HH reflector is splitted in smaller applications of group size reflectors.");


### PR DESCRIPTION
This PR aims at reducing micro-tasking for rank1 problem solution (local).

TODO:
- [x] #843 
- [x] Is re-use of `z` vector workspace a good thing? (it allows to allocate just one vector<vector> workspace for partial results, see next point)
- [x] Workspaces for multi-threading in bulk are allocated as vector<vector> instead of re-using a Matrix in a workspace. Is it ok?
- [x] ~Apply also row-permutations in bulk? (@rasolca)~
- [x] Evaluate if something can be done for set0
- [x] ~Do we want to embed `setUnitDiag`?~
- [x] How many `nthreads` for bulk?