### PR TITLE
Print binary sizes in CI

### DIFF
--- a/ci/docker/codecov.Dockerfile
+++ b/ci/docker/codecov.Dockerfile
@@ -35,6 +35,9 @@ RUN spack repo rm --scope site dlaf && \
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \
     export TEST_BINARIES=`ctest --show-only=json-v1 | jq '.tests | map(.command[0]) | .[]' | tr -d \"` && \
+    echo "Binary sizes:" && \
+    ls -lh ${TEST_BINARIES} && \
+    ls -lh src/lib* && \
     libtree -d ${DEPLOY} ${TEST_BINARIES} && \
     rm -rf ${DEPLOY}/usr/bin && \
     libtree -d ${DEPLOY} $(which ctest gcov addr2line) && \

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -39,6 +39,9 @@ RUN pushd ${SOURCE}/miniapp && \
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \
     export TEST_BINARIES=`ctest --show-only=json-v1 | jq '.tests | map(.command[0]) | .[]' | tr -d \"` && \
+    echo "Binary sizes:" && \
+    ls -lh ${TEST_BINARIES} && \
+    ls -lh src/lib* && \
     libtree -d ${DEPLOY} ${TEST_BINARIES} && \
     rm -rf ${DEPLOY}/usr/bin && \
     libtree -d ${DEPLOY} $(which ctest addr2line) && \


### PR DESCRIPTION
Poor man's solution to keep track of binary sizes. This won't warn us about it, but at least we'd have the numbers in CI to compare without having to manually build different configurations.