### PR TITLE
Use busy waiting barrier in reduction to band

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -17,7 +17,7 @@ stages:
   timeout: 6 hours
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
-    SPACK_SHA: b027f64a7f175b0e7a18388d0aa2484599efd12d
+    SPACK_SHA: b313b28e64c15761be0d45a16c922c25b2786f76
     SPACK_DLAF_REPO: ./spack
   before_script:
     - podman login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY

--- a/include/dlaf/eigensolver/internal/get_red2band_barrier_busy_wait.h
+++ b/include/dlaf/eigensolver/internal/get_red2band_barrier_busy_wait.h
@@ -1,0 +1,22 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2023, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <chrono>
+
+#include "dlaf/tune.h"
+
+namespace dlaf::eigensolver::internal {
+
+inline std::chrono::duration<double> getReductionToBandBarrierBusyWait() noexcept {
+  return std::chrono::microseconds(getTuneParameters().red2band_barrier_busy_wait_us);
+}
+
+}

--- a/include/dlaf/eigensolver/internal/get_tridiag_rank1_barrier_busy_wait.h
+++ b/include/dlaf/eigensolver/internal/get_tridiag_rank1_barrier_busy_wait.h
@@ -1,0 +1,22 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2023, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <chrono>
+
+#include "dlaf/tune.h"
+
+namespace dlaf::eigensolver::internal {
+
+inline std::chrono::duration<double> getTridiagRank1BarrierBusyWait() noexcept {
+  return std::chrono::microseconds(getTuneParameters().red2band_barrier_busy_wait_us);
+}
+
+}

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -24,6 +24,9 @@ namespace dlaf {
 /// - red2band_panel_nworkers:
 ///     The maximum number of threads to use for computing the panel in the reduction to band algorithm.
 ///     Set with --dlaf:red2band-panel-nworkers or env variable DLAF_RED2BAND_PANEL_NWORKERS.
+/// - red2band_barrier_busy_wait_us:
+///     The duration in microseconds to busy-wait in barriers in the reduction to band algorithm.
+///     Set with --dlaf:red2band-barrier-busy-wait-us or env variable DLAF_RED2BAND_BARRIER_BUSY_WAIT_US.
 /// - tridiag_rank1_nworkers:
 ///     The maximum number of threads to use for computing rank1 problem solution in tridiagonal solver
 ///     algorithm. Set with --dlaf:tridiag-rank1-nworkers or env variable DLAF_TRIDIAG_RANK1_NWORKERS.
@@ -44,6 +47,7 @@ namespace dlaf {
 struct TuneParameters {
   std::size_t red2band_panel_nworkers =
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
+  std::size_t red2band_barrier_busy_wait_us = 1000;
   std::size_t tridiag_rank1_nworkers =
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
 

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -30,6 +30,10 @@ namespace dlaf {
 /// - tridiag_rank1_nworkers:
 ///     The maximum number of threads to use for computing rank1 problem solution in tridiagonal solver
 ///     algorithm. Set with --dlaf:tridiag-rank1-nworkers or env variable DLAF_TRIDIAG_RANK1_NWORKERS.
+/// - tridiag_rank1_barrier_busy_wait_us:
+///     The duration in microseconds to busy-wait in barriers when computing rank1 problem solution in
+///     the tridiagonal solver algorithm. Set with --dlaf:tridiag-rank1-barrier-busy-wait-us or env
+///     variable DLAF_TRIDIAG_RANK1_BARRIER_BUSY_WAIT_US.
 /// - eigensolver_min_band:
 ///     The minimum value to start looking for a divisor of the block size.
 ///     Set with --dlaf:eigensolver-min-band or env variable DLAF_EIGENSOLVER_MIN_BAND.
@@ -50,6 +54,7 @@ struct TuneParameters {
   std::size_t red2band_barrier_busy_wait_us = 1000;
   std::size_t tridiag_rank1_nworkers =
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
+  std::size_t tridiag_rank1_barrier_busy_wait_us = 0;
 
   SizeType eigensolver_min_band = 100;
   SizeType band_to_tridiag_1d_block_size_base = 8192;

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -47,7 +47,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("umpire+rocm~shared", when="+rocm")
     depends_on("umpire@4.1.0:")
 
-    depends_on("pika@0.15.1:")
+    depends_on("pika@0.16:")
     depends_on("pika-algorithms@0.1:")
     depends_on("pika +mpi")
     depends_on("pika +cuda", when="+cuda")

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -174,6 +174,9 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
   updateConfigurationValue(vm, param.tridiag_rank1_nworkers, "TRIDIAG_RANK1_NWORKERS",
                            "tridiag-rank1-nworkers");
 
+  updateConfigurationValue(vm, param.red2band_barrier_busy_wait_us, "TRIDIAG_RANK1_BARRIER_BUSY_WAIT_US",
+                           "tridiag-rank1-barrier-busy-wait-us");
+
   updateConfigurationValue(vm, param.bt_band_to_tridiag_hh_apply_group_size,
                            "DLAF_BT_BAND_TO_TRIDIAG_HH_APPLY_GROUP_SIZE",
                            "bt-band-to-tridiag-hh-apply-group-size");
@@ -218,6 +221,9 @@ pika::program_options::options_description getOptionsDescription() {
   desc.add_options()(
       "dlaf:tridiag-rank1-nworkers", pika::program_options::value<std::size_t>(),
       "The maximum number of threads to use for computing rank1 problem solution in tridiagonal solver algorithm.");
+  desc.add_options()(
+      "dlaf:tridiag-rank1-barrier-busy-wait-us", pika::program_options::value<std::size_t>(),
+      "The duration in microseconds to busy-wait in barriers when computing rank1 problem solution in the tridiagonal solver algorithm.");
   desc.add_options()(
       "dlaf:bt-band-to-tridiag-hh-apply-group-size", pika::program_options::value<SizeType>(),
       "The application of the HH reflector is splitted in smaller applications of group size reflectors.");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -162,6 +162,9 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
   updateConfigurationValue(vm, param.red2band_panel_nworkers, "RED2BAND_PANEL_NWORKERS",
                            "red2band-panel-nworkers");
 
+  updateConfigurationValue(vm, param.red2band_barrier_busy_wait_us, "RED2BAND_BARRIER_BUSY_WAIT_US",
+                           "red2band-barrier-busy-wait-us");
+
   updateConfigurationValue(vm, param.eigensolver_min_band, "EIGENSOLVER_MIN_BAND",
                            "eigensolver-min-band");
 
@@ -202,7 +205,10 @@ pika::program_options::options_description getOptionsDescription() {
   // Tune parameters command line options
   desc.add_options()(
       "dlaf:red2band-panel-nworkers", pika::program_options::value<std::size_t>(),
-      "Maximum number of threads to use for computing the panel in the reduction to band algorithm.");
+      "The maximum number of threads to use for computing the panel in the reduction to band algorithm.");
+  desc.add_options()(
+      "dlaf:red2band-barrier-busy-wait-us", pika::program_options::value<std::size_t>(),
+      "The duration in microseconds to busy-wait in barriers in the reduction to band algorithm.");
   desc.add_options()(
       "dlaf:eigensolver-min-band", pika::program_options::value<SizeType>(),
       "The minimum value to start looking for a divisor of the block size. When larger than the block size, the block size will be used instead.");


### PR DESCRIPTION
Fixes #833, using the busy wait parameter to `barrier::wait` in https://github.com/pika-org/pika/pull/685. I've added configuration option for the busy wait time (in microseconds) specifically for reduction to band. https://github.com/eth-cscs/DLA-Future/pull/860 will probably also need to use the busy waiting barrier. We can see if we want to merge the options into a single `BARRIER_BUSY_WAIT_US` option, or if we need separate `TRIDIAG_SOLVER_BARRIER_BUSY_WAIT_US`, `RED2BAND_BARRIER_BUSY_WAIT_US` etc. The default value for the busy wait is 1 ms which seemed to show the best performance across daint and eiger, while still being relatively low (about the min task size that we anyway recommend).