### PR TITLE
Only ignore `build*` in root of repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 *~
 *.swp
-build*
+/build*
 .ptp-sync-folder
 .vscode/
 !build.sh


### PR DESCRIPTION
For the longest time I was wondering why files like `build.Dockerfile` didn't show up in file searches for me. It turns out it was because it's using `fd` which uses `.gitignore` by default and it ignores `build*` in _any_ directory. I've updated the `.gitignore` pattern to be `/build*` which will ignore `build*` only in the root of the repository. I'm guessing this was the original intent of this pattern. Is it? Do you have use cases for ignoring `build*` also in subdirectories?