### PR TITLE
bug fix: warnings as errors for cuda/rocm were not enabled

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -142,9 +142,9 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         if "+ci-test" in self.spec:
             # Enable TESTS and setup CI specific parameters
             args.append(self.define("CMAKE_CXX_FLAGS", "-Werror"))
-            if "+cuda":
+            if "+cuda" in self.spec:
                 args.append(self.define("CMAKE_CUDA_FLAGS", "-Werror=all-warnings"))
-            if "+rocm":
+            if "+rocm" in self.spec:
                 args.append(self.define("CMAKE_HIP_FLAGS", "-Werror"))
             args.append(self.define("BUILD_TESTING", True))
             args.append(self.define("DLAF_BUILD_TESTING", True))


### PR DESCRIPTION
Warning as errors were not enabled due to an error in the spack package.

Since this is used by the CI, it might be that this will trigger new errors that I will try to fix in this PR.