### PR TITLE
Minor updates to `Pipeline`, `TilePipeline`, and `Tile`

### DIFF
--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -12,6 +12,7 @@
 
 #include <pika/async_rw_mutex.hpp>
 #include <pika/execution.hpp>
+#include <dlaf/common/assert.h>
 
 namespace dlaf::common {
 
@@ -42,10 +43,25 @@ public:
   ///
   /// @return a sender that will become ready as soon as the previous user releases the resource.
   Sender operator()() {
-    return pipeline.readwrite();
+    DLAF_ASSERT(pipeline.has_value(), "");
+    return pipeline->readwrite();
+  }
+
+  /// Check if the pipeline is valid.
+  ///
+  /// @return true if the pipeline hasn't been reset, otherwise false.
+  bool valid() const noexcept {
+    return pipeline.has_value();
+  }
+
+  /// Reset the pipeline.
+  ///
+  /// @post !valid()
+  void reset() noexcept {
+    pipeline.reset();
   }
 
 private:
-  AsyncRwMutex pipeline;
+  std::optional<AsyncRwMutex> pipeline = std::nullopt;
 };
 }

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -42,8 +42,9 @@ public:
   /// Enqueue for the resource.
   ///
   /// @return a sender that will become ready as soon as the previous user releases the resource.
+  /// @pre valid()
   Sender operator()() {
-    DLAF_ASSERT(pipeline.has_value(), "");
+    DLAF_ASSERT(valid(), "");
     return pipeline->readwrite();
   }
 

--- a/include/dlaf/matrix/internal/tile_pipeline.h
+++ b/include/dlaf/matrix/internal/tile_pipeline.h
@@ -46,6 +46,12 @@ public:
     return pipeline->readwrite() | pika::execution::experimental::then(&createTileAsyncRwMutex<T, D>);
   }
 
+  /// Get a read-write sender to a wrapped tile.
+  ///
+  /// The returned sender will send its value when the previous access to the
+  /// til has completed.
+  ///
+  /// @return A sender to a read-write tile wrapper.
   auto readwrite_with_wrapper() {
     DLAF_ASSERT(valid(), "");
     return pipeline->readwrite();

--- a/include/dlaf/matrix/internal/tile_pipeline.h
+++ b/include/dlaf/matrix/internal/tile_pipeline.h
@@ -30,6 +30,7 @@ public:
   /// to the tile will be provided.
   ///
   /// @return A sender to a read-only tile wrapper.
+  /// @pre valid()
   ReadOnlyTileSender<T, D> read() {
     DLAF_ASSERT(valid(), "");
     return pipeline->read();
@@ -41,6 +42,7 @@ public:
   /// tile has completed.
   ///
   /// @return A sender to a read-write tile.
+  /// @pre valid()
   ReadWriteTileSender<T, D> readwrite() {
     DLAF_ASSERT(valid(), "");
     return pipeline->readwrite() | pika::execution::experimental::then(&createTileAsyncRwMutex<T, D>);
@@ -52,6 +54,7 @@ public:
   /// til has completed.
   ///
   /// @return A sender to a read-write tile wrapper.
+  /// @pre valid()
   auto readwrite_with_wrapper() {
     DLAF_ASSERT(valid(), "");
     return pipeline->readwrite();

--- a/include/dlaf/matrix/internal/tile_pipeline.h
+++ b/include/dlaf/matrix/internal/tile_pipeline.h
@@ -51,7 +51,7 @@ public:
   /// Get a read-write sender to a wrapped tile.
   ///
   /// The returned sender will send its value when the previous access to the
-  /// til has completed.
+  /// tile has completed.
   ///
   /// @return A sender to a read-write tile wrapper.
   /// @pre valid()

--- a/include/dlaf/matrix/internal/tile_pipeline.h
+++ b/include/dlaf/matrix/internal/tile_pipeline.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "dlaf/common/assert.h"
 #include "dlaf/matrix/tile.h"
 
 namespace dlaf::matrix::internal {
@@ -22,19 +23,49 @@ public:
   TilePipeline(const TilePipeline&) = delete;
   TilePipeline& operator=(const TilePipeline&) = delete;
 
+  /// Get a read-only sender to a wrapped tile.
+  ///
+  /// The returned sender will send its value when the previous access to the
+  /// tile has completed. If the previous access is read-only concurrent access
+  /// to the tile will be provided.
+  ///
+  /// @return A sender to a read-only tile wrapper.
   ReadOnlyTileSender<T, D> read() {
-    return pipeline.read();
+    DLAF_ASSERT(valid(), "");
+    return pipeline->read();
   }
 
+  /// Get a read-write sender to a tile.
+  ///
+  /// The returned sender will send its value when the previous access to the
+  /// tile has completed.
+  ///
+  /// @return A sender to a read-write tile.
   ReadWriteTileSender<T, D> readwrite() {
-    return pipeline.readwrite() | pika::execution::experimental::then(&createTileAsyncRwMutex<T, D>);
+    DLAF_ASSERT(valid(), "");
+    return pipeline->readwrite() | pika::execution::experimental::then(&createTileAsyncRwMutex<T, D>);
   }
 
   auto readwrite_with_wrapper() {
-    return pipeline.readwrite();
+    DLAF_ASSERT(valid(), "");
+    return pipeline->readwrite();
+  }
+
+  /// Check if the pipeline is valid.
+  ///
+  /// @return true if the pipeline hasn't been reset, otherwise false.
+  bool valid() const noexcept {
+    return pipeline.has_value();
+  }
+
+  /// Reset the pipeline.
+  ///
+  /// @post !valid()
+  void reset() noexcept {
+    pipeline.reset();
   }
 
 private:
-  TileAsyncRwMutex<T, D> pipeline;
+  std::optional<TileAsyncRwMutex<T, D>> pipeline;
 };
 }

--- a/include/dlaf/matrix/retiled_matrix.h
+++ b/include/dlaf/matrix/retiled_matrix.h
@@ -146,8 +146,7 @@ public:
 
   void done(const LocalTileIndex& index) noexcept {
     const auto i = tileLinearIndex(index);
-    tile_managers_[i] =
-        internal::TilePipeline<T, D>(Tile<T, D>(TileElementSize{0, 0}, memory::MemoryView<T, D>(), 1));
+    tile_managers_[i].reset();
   }
 
   void done(const GlobalTileIndex& index) noexcept {

--- a/include/dlaf/matrix/retiled_matrix.h
+++ b/include/dlaf/matrix/retiled_matrix.h
@@ -50,7 +50,7 @@ public:
     const auto n = to_sizet(distribution().localNrTiles().linear_size());
     tile_managers_.reserve(n);
     for (std::size_t i = 0; i < n; ++i) {
-      tile_managers_.emplace_back(Tile<T, D>(TileElementSize{0, 0}, memory::MemoryView<T, D>(), 1));
+      tile_managers_.emplace_back(Tile<T, D>());
     }
 
     const auto tile_size = distribution().baseTileSize();

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -32,6 +32,8 @@ namespace internal {
 template <class T, Device D>
 class TileData {
 public:
+  TileData() = default;
+
   TileData(const TileElementSize& size, memory::MemoryView<T, D> memory_view, SizeType ld) noexcept
       : size_(size), memory_view_(std::move(memory_view)), ld_(ld) {
     DLAF_ASSERT(size_.isValid(), size_);
@@ -95,9 +97,9 @@ private:
     ld_ = 1;
   }
 
-  TileElementSize size_;
-  memory::MemoryView<T, D> memory_view_;
-  SizeType ld_;
+  TileElementSize size_{0, 0};
+  memory::MemoryView<T, D> memory_view_{};
+  SizeType ld_{1};
 };
 }
 
@@ -204,6 +206,9 @@ public:
   using ElementType = T;
   static constexpr Device device = D;
 
+  /// Constructs an empty Tile.
+  Tile() = default;
+
   /// Constructs a (@p size.rows() x @p size.cols()) Tile.
   ///
   /// @pre size.isValid(),
@@ -305,7 +310,7 @@ private:
   Tile(const Tile& tile, const SubTileSpec& spec) noexcept
       : Tile(spec.size, Tile::createMemoryViewForSubtile(tile, spec), tile.ld()) {}
 
-  TileDataType data_;
+  TileDataType data_{};
   std::variant<
       // No dependency
       std::monostate,
@@ -315,7 +320,7 @@ private:
       internal::TileAsyncRwMutexReadWriteWrapper<T, D>,
       // Disjoint read-write access
       std::shared_ptr<internal::TileAsyncRwMutexReadWriteWrapper<T, D>>>
-      dep_tracker_;
+      dep_tracker_{};
 };
 
 template <class T, Device D>
@@ -337,6 +342,9 @@ public:
   friend Tile<T, D> internal::createDisjointSubTile<>(const Tile<T, D>& tile, const SubTileSpec& spec);
 
   using ElementType = T;
+
+  /// Constructs an empty Tile.
+  Tile() = default;
 
   /// Constructs a (@p size.rows() x @p size.cols()) Tile.
   ///

--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -27,6 +27,20 @@ using dlaf::common::Pipeline;
 namespace ex = pika::execution::experimental;
 namespace tt = pika::this_thread::experimental;
 
+TEST(Pipeline, ResetValid) {
+  // The pipeline is valid after construction
+  dlaf::common::Pipeline<int> pipeline(42);
+  ASSERT_TRUE(pipeline.valid());
+
+  // The pipeline can be reset and is invalid afterwards
+  pipeline.reset();
+  ASSERT_FALSE(pipeline.valid());
+
+  // The pipeline can be reset multiple times and remains invalid
+  pipeline.reset();
+  ASSERT_FALSE(pipeline.valid());
+}
+
 TEST(Pipeline, Basic) {
   {
     Pipeline<int> serial(26);

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -47,6 +47,22 @@ TileSizes getSizes(const Tile<T, D>& tile) {
   return TileSizes(tile.size(), tile.ld());
 }
 
+TEST(TilePipeline, ResetValid) {
+  Tile<float, Device::CPU> tile(TileElementSize{0, 0}, memory::MemoryView<float, Device::CPU>(), 1);
+
+  // The pipeline is valid after construction
+  dlaf::matrix::internal::TilePipeline<float, Device::CPU> pipeline(std::move(tile));
+  ASSERT_TRUE(pipeline.valid());
+
+  // The pipeline can be reset and is invalid afterwards
+  pipeline.reset();
+  ASSERT_FALSE(pipeline.valid());
+
+  // The pipeline can be reset multiple times and remains invalid
+  pipeline.reset();
+  ASSERT_FALSE(pipeline.valid());
+}
+
 template <typename Type>
 class TileTest : public ::testing::Test {};
 

--- a/test/unit/matrix/test_tile.cpp
+++ b/test/unit/matrix/test_tile.cpp
@@ -48,10 +48,8 @@ TileSizes getSizes(const Tile<T, D>& tile) {
 }
 
 TEST(TilePipeline, ResetValid) {
-  Tile<float, Device::CPU> tile(TileElementSize{0, 0}, memory::MemoryView<float, Device::CPU>(), 1);
-
   // The pipeline is valid after construction
-  dlaf::matrix::internal::TilePipeline<float, Device::CPU> pipeline(std::move(tile));
+  dlaf::matrix::internal::TilePipeline<float, Device::CPU> pipeline({});
   ASSERT_TRUE(pipeline.valid());
 
   // The pipeline can be reset and is invalid afterwards


### PR DESCRIPTION
- Add `reset` and `valid` member functions to `TilePipeline`
- Add `reset` and `valid` member functions to `Pipeline`
- Add default constructors to `Tile` and `TileData`
- Implement `RetiledMatrix::done` in terms of `TilePipeline::reset`

Note, I named it `{Tile,}Pipeline::reset` to mirror `optional::reset`. I'm indifferent about `RetiledMatrix::done` and happy to leave it as `done` since it's a higher level abstraction. I also did not add separate assertions in `RetiledMatrix::read{,write}` but rely on the assertions in `TilePipeline`, though it might make sense to add the assertions also to `RetiledMatrix`.

Fixes #872.