### PR TITLE
Disable extension check for hidden files

### DIFF
--- a/.github/workflows/check_license_header.yaml
+++ b/.github/workflows/check_license_header.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           # Highlight if in these folders there are files with other extensions.
           # Hidden files are excluded from the check.
-          find src include test miniapp ! -path './miniapp/cmake/*' -type f       \
+          find src include test miniapp ! -path 'miniapp/cmake/*' -type f         \
                ! '('                                                              \
                        -name '*.cpp'                                              \
                    -o  -name '*.h'                                                \


### PR DESCRIPTION
Needed for #877 to have a different .clang-format for unit tests.

Extra: re-enable extension check in the miniapp directory (disabled by mistake in #764).