### PR TITLE
Automatically upload master doxygen documentation to github pages.

### DIFF
--- a/.github/workflows/doc-push.yml
+++ b/.github/workflows/doc-push.yml
@@ -1,9 +1,6 @@
 name: Docs
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/.github/workflows/doc-push.yml
+++ b/.github/workflows/doc-push.yml
@@ -1,0 +1,30 @@
+name: Docs
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  doc:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Install tools
+        run: sudo apt-get install --no-install-recommends doxygen
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fetch docs
+        run: git fetch --no-tags --depth=1 origin +refs/heads/docs:refs/heads/docs
+      - name: Make Docs
+        run: |
+          cd doc && make doc && cd .. && mv doc/html master
+      - name: Push Docs
+        run: |
+          COMMIT_MSG=`git log -n 1 --pretty=format:%s`
+          git config user.name "Doc CI Action" && git config user.email "rasolca@users.noreply.github.com"
+          git symbolic-ref HEAD refs/heads/docs && git reset
+          git add master && git commit -m "Doc $COMMIT_MSG" && git push --set-upstream origin docs

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,16 +1,13 @@
 name: Docs
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
 
 jobs:
   doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Install tools

--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ find_package(DLAF)
 target_link_libraries(<your_target> PRIVATE DLAF::DLAF)
 ```
 
-### How to generate the documentation
+### Documentation
+
+[Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
+
+#### How to generate the documentation
 
 The documentation can be built together with the project by enabling its generation with the flag `DLAF_BUILD_DOC=on` and then use the `doc` target to eventually generate it.
 


### PR DESCRIPTION
The previous `docs` action now runs only on pull request.
For pushes in the `master` branch a new action that also pushes the documentation in the `docs`  branch (which is used by github pages).

See https://eth-cscs.github.io/DLA-Future/master/.

Part of #865.