### PR TITLE
Allow empty commit when pushing doc

### DIFF
--- a/.github/workflows/doc-push.yml
+++ b/.github/workflows/doc-push.yml
@@ -1,6 +1,9 @@
 name: Docs
 
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
@@ -24,4 +27,4 @@ jobs:
           COMMIT_MSG=`git log -n 1 --pretty=format:%s`
           git config user.name "Doc CI Action" && git config user.email "rasolca@users.noreply.github.com"
           git symbolic-ref HEAD refs/heads/docs && git reset
-          git add master && git commit -m "Doc $COMMIT_MSG" && git push --set-upstream origin docs
+          git add master && git commit --allow-empty -m "Doc $COMMIT_MSG" && git push --set-upstream origin docs

--- a/.github/workflows/doc-push.yml
+++ b/.github/workflows/doc-push.yml
@@ -1,9 +1,6 @@
 name: Docs
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master


### PR DESCRIPTION
The github action is currently failing if no changes are made to the documentation.