### PR TITLE
Test that headers are self-contained

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ cmake_dependent_option(DLAF_WITH_CUDA_MPI_RDMA "Enable MPI CUDA RDMA" OFF "DLAF_
 option(DLAF_WITH_COVERAGE "Enable coverage" OFF)
 option(DLAF_BUILD_MINIAPPS "Build miniapps" ON)
 option(DLAF_BUILD_TESTING "Build tests" ON)
+option(DLAF_BUILD_TESTING_HEADER "Build header tests" OFF)
 option(DLAF_BUILD_DOC "Build documentation" OFF)
 option(DLAF_WITH_PRECOMPILED_HEADERS "Use precompiled headers." OFF)
 

--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -14,6 +14,7 @@
 
 #include <exception>
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include "dlaf/common/source_location.h"

--- a/include/dlaf/eigensolver/reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/reduction_to_band/api.h
@@ -10,7 +10,11 @@
 
 #pragma once
 
-#include "dlaf/types.h"
+#include <pika/future.hpp>
+
+#include <dlaf/common/vector.h>
+#include <dlaf/matrix/matrix.h>
+#include <dlaf/types.h>
 
 namespace dlaf::eigensolver::internal {
 

--- a/include/dlaf/gpu/assert.cu.h
+++ b/include/dlaf/gpu/assert.cu.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#ifdef DLAF_WITH_GPU
+
 #include <stdio.h>
 
 #include <whip.hpp>
@@ -40,3 +42,5 @@ __device__ void gpuAssert(bool expr, PrintFunc&& print_func) {
 }
 
 }
+
+#endif

--- a/include/dlaf/gpu/cub/api.cu.h
+++ b/include/dlaf/gpu/cub/api.cu.h
@@ -141,7 +141,7 @@ struct DeviceSegmentedReduce {
 
 }
 
-#else
+#elif defined(DLAF_WITH_CUDA)
 
 #include <cub/cub.cuh>
 

--- a/include/dlaf/gpu/cublas/error.h
+++ b/include/dlaf/gpu/cublas/error.h
@@ -12,7 +12,9 @@
 
 /// @file
 
-#include "dlaf/gpu/blas/api.h"
+#include <string>
+
+#include <dlaf/gpu/blas/api.h>
 
 #ifdef DLAF_WITH_CUDA
 

--- a/include/dlaf/gpu/cusolver/hegst.h
+++ b/include/dlaf/gpu/cusolver/hegst.h
@@ -51,6 +51,8 @@
 
 #pragma once
 
+#ifdef DLAF_WITH_CUDA
+
 #include <cusolverDn.h>
 
 // clang-format off
@@ -148,3 +150,5 @@ cusolverStatus_t CUSOLVERAPI cusolverDnZhegst(
     int *devInfo);
 }
 // clang-format on
+
+#endif

--- a/include/dlaf/gpu/lapack/assert_info.h
+++ b/include/dlaf/gpu/lapack/assert_info.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#ifdef DLAF_WITH_GPU
+
 #include <whip.hpp>
 
 /// @file
@@ -22,3 +24,5 @@ DLAF_DECLARE_CUSOLVER_ASSERT_INFO(Potrf);
 DLAF_DECLARE_CUSOLVER_ASSERT_INFO(Hegst);
 
 }
+
+#endif

--- a/include/dlaf/gpu/rocblas/error.h
+++ b/include/dlaf/gpu/rocblas/error.h
@@ -11,7 +11,10 @@
 #pragma once
 
 /// @file
-#include "dlaf/gpu/blas/api.h"
+
+#include <string>
+
+#include <dlaf/gpu/blas/api.h>
 
 #ifdef DLAF_WITH_HIP
 

--- a/include/dlaf/multiplication/triangular/api.h
+++ b/include/dlaf/multiplication/triangular/api.h
@@ -9,6 +9,8 @@
 //
 #pragma once
 
+#include <blas.hh>
+
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 

--- a/include/dlaf/sender/traits.h
+++ b/include/dlaf/sender/traits.h
@@ -13,6 +13,8 @@
 #include <pika/execution.hpp>
 #include <pika/future.hpp>
 
+#include <dlaf/types.h>
+
 namespace dlaf::internal {
 template <typename...>
 struct TypeList {};

--- a/include/dlaf/solver/triangular/api.h
+++ b/include/dlaf/solver/triangular/api.h
@@ -9,6 +9,8 @@
 //
 #pragma once
 
+#include <blas.hh>
+
 #include "dlaf/matrix/matrix.h"
 #include "dlaf/types.h"
 

--- a/include/dlaf/util_rocblas.h
+++ b/include/dlaf/util_rocblas.h
@@ -10,10 +10,11 @@
 
 #pragma once
 
-#ifdef DLAF_WITH_GPU
+#ifdef DLAF_WITH_HIP
 
 #include <blas.hh>
 #include "dlaf/gpu/blas/api.h"
+#include "dlaf/gpu/lapack/api.h"
 
 namespace dlaf::util {
 namespace internal {

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -148,6 +148,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
                 args.append(self.define("CMAKE_HIP_FLAGS", "-Werror"))
             args.append(self.define("BUILD_TESTING", True))
             args.append(self.define("DLAF_BUILD_TESTING", True))
+            args.append(self.define("DLAF_BUILD_TESTING_HEADER", True))
             args.append(self.define("DLAF_CI_RUNNER_USES_MPIRUN", True))
         else:
             # TEST

--- a/src/eigensolver/tridiag_solver/kernels.cu
+++ b/src/eigensolver/tridiag_solver/kernels.cu
@@ -26,7 +26,7 @@
 #include <pika/cuda.hpp>
 #include <whip.hpp>
 #include "dlaf/gpu/blas/api.h"
-#include "dlaf/gpu/cub/api.h"
+#include "dlaf/gpu/cub/api.cu.h"
 #include "dlaf/gpu/lapack/api.h"
 #include "dlaf/gpu/lapack/error.h"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,5 +122,6 @@ target_include_directories(DLAF_test INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT
 
 target_link_libraries(DLAF_test INTERFACE gtest)
 
+add_subdirectory(header)
 add_subdirectory(src)
 add_subdirectory(unit)

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2023, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+if(NOT DLAF_BUILD_TESTING_HEADER)
+  return()
+endif()
+
+add_custom_target(test_header)
+
+function(DLAF_addHeaderTest header)
+  # Create a filename with a cpp extension based on the header file. This
+  # assumes a relative header path.
+  string(REGEX REPLACE "\.h$" ".cpp" test_source "${header}")
+  set(test_source "${CMAKE_CURRENT_BINARY_DIR}/${test_source}")
+
+  # Create a test name
+  string(REGEX REPLACE "[^A-Za-z]" "_" test_name "${header}")
+  set(test_name "test_header_${test_name}")
+
+  # Write a source file which will only include a single header for testing that
+  # the header is self-contained
+  file(WRITE "${test_source}" "#include <${header}>")
+
+  add_library(${test_name} OBJECT "${test_source}")
+  target_link_libraries(${test_name} PRIVATE dlaf.prop dlaf.prop_private)
+  target_add_warnings(${test_name})
+  add_dependencies(test_header ${test_name})
+endfunction()
+
+file(GLOB_RECURSE headers RELATIVE "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/include/*.h")
+foreach(header ${headers})
+  dlaf_addheadertest(${header})
+endforeach()

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -15,9 +15,17 @@ endif()
 add_custom_target(test_header)
 
 function(DLAF_addHeaderTest header)
-  # Create a filename with a cpp extension based on the header file. This
+  # Create a filename with a cpp/cu extension based on the header file. This
   # assumes a relative header path.
-  string(REGEX REPLACE "\.h$" ".cpp" test_source "${header}")
+  get_filename_component(header_ext "${header}" EXT)
+  if(DLAF_WITH_GPU AND ("${header_ext}" STREQUAL ".cu.h"))
+    string(REGEX REPLACE "\.h$" "" test_source "${header}")
+    if(DLAF_WITH_HIP)
+      set_source_files_properties("${test_source}" LANGUAGE HIP)
+    endif()
+  else()
+    string(REGEX REPLACE "\.h$" ".cpp" test_source "${header}")
+  endif()
   set(test_source "${CMAKE_CURRENT_BINARY_DIR}/${test_source}")
 
   # Create a test name


### PR DESCRIPTION
Fixes #883.

Adds a `DLAF_BUILD_TESTING_HEADER` CMake option (off by default) which adds object library targets which build a cpp file for each header file in `include`. This option is enabled under the `ci-test` spack variant. This also adds a top-level pseudotarget `test_header` (should this be `header_test` or something else?) which depends on all the individual header tests.

Note, this uses `file(GLOB)` which means that headers that are added to the `include` directory will not be picked up without an explicit CMake reconfiguration. For CI this is not a problem, but may be annoying for local development. The alternative is to explicitly list all header files though, which I find more error prone, especially since all headers will still be checked in CI.