### PR TITLE
Remove `shared_ptr<Distribution>` from MatrixBase

### DIFF
--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -21,22 +21,21 @@ namespace internal {
 
 class MatrixBase {
 public:
-  MatrixBase(Distribution distribution)
-      : distribution_(std::make_shared<Distribution>(std::move(distribution))) {
+  MatrixBase(Distribution distribution) : distribution_(std::move(distribution)) {
     DLAF_ASSERT(distribution.blockSize() == distribution.baseTileSize(),
                 "Multi Tile distribution block is not supperted by Matrix yet.");
   }
 
   MatrixBase(const Distribution& distribution, const LocalTileSize& tiles_per_block)
-      : distribution_(std::make_shared<Distribution>(  //
-            distribution.size(), distribution.blockSize(),
-            TileElementSize{distribution.blockSize().rows() / tiles_per_block.rows(),
-                            distribution.blockSize().cols() / tiles_per_block.cols()},
-            distribution.commGridSize(), distribution.rankIndex(), distribution.sourceRankIndex())) {
+      : distribution_(distribution.size(), distribution.blockSize(),
+                      TileElementSize{distribution.blockSize().rows() / tiles_per_block.rows(),
+                                      distribution.blockSize().cols() / tiles_per_block.cols()},
+                      distribution.commGridSize(), distribution.rankIndex(),
+                      distribution.sourceRankIndex()) {
     DLAF_ASSERT(distribution.blockSize() == distribution.baseTileSize(),
                 "distribution should be the distribution of the original Matrix.");
-    DLAF_ASSERT(distribution.blockSize() == distribution_->blockSize(), distribution.blockSize(),
-                distribution_->blockSize());
+    DLAF_ASSERT(distribution.blockSize() == distribution_.blockSize(), distribution.blockSize(),
+                distribution_.blockSize());
   }
 
   MatrixBase(const MatrixBase& rhs) = default;
@@ -44,49 +43,49 @@ public:
 
   /// Returns the global size in elements of the matrix.
   const GlobalElementSize& size() const noexcept {
-    return distribution_->size();
+    return distribution_.size();
   }
 
   /// Returns the block size of the matrix.
   const TileElementSize& blockSize() const noexcept {
-    return distribution_->blockSize();
+    return distribution_.blockSize();
   }
 
   /// Returns the complete tile size of the matrix.
   const TileElementSize& baseTileSize() const noexcept {
-    return distribution_->baseTileSize();
+    return distribution_.baseTileSize();
   }
 
   /// Returns the number of tiles of the global matrix (2D size).
   const GlobalTileSize& nrTiles() const noexcept {
-    return distribution_->nrTiles();
+    return distribution_.nrTiles();
   }
 
   /// Returns the id associated to the matrix of this rank.
   const comm::Index2D& rankIndex() const noexcept {
-    return distribution_->rankIndex();
+    return distribution_.rankIndex();
   }
 
   /// Returns the size of the communicator grid associated to the matrix.
   const comm::Size2D& commGridSize() const noexcept {
-    return distribution_->commGridSize();
+    return distribution_.commGridSize();
   }
 
   /// Returns the 2D rank index of the process that stores the tile with global index @p global_tile.
   ///
   /// @pre global_tile.isIn(nrTiles()).
   comm::Index2D rankGlobalTile(const GlobalTileIndex& global_tile) const noexcept {
-    return distribution_->rankGlobalTile(global_tile);
+    return distribution_.rankGlobalTile(global_tile);
   }
 
   /// Returns the distribution of the matrix.
   const matrix::Distribution& distribution() const noexcept {
-    return *distribution_;
+    return distribution_;
   }
 
   /// Returns the size of the Tile with global index @p index.
   TileElementSize tileSize(const GlobalTileIndex& index) const noexcept {
-    return distribution_->tileSize(index);
+    return distribution_.tileSize(index);
   }
 
 protected:
@@ -102,9 +101,8 @@ protected:
   ///
   /// @pre index.isIn(localNrTiles()).
   std::size_t tileLinearIndex(const LocalTileIndex& index) const noexcept {
-    DLAF_ASSERT_MODERATE(index.isIn(distribution_->localNrTiles()), index,
-                         distribution_->localNrTiles());
-    return to_sizet(index.row() + distribution_->localNrTiles().rows() * index.col());
+    DLAF_ASSERT_MODERATE(index.isIn(distribution_.localNrTiles()), index, distribution_.localNrTiles());
+    return to_sizet(index.row() + distribution_.localNrTiles().rows() * index.col());
   }
 
   /// Prints information about the matrix.
@@ -119,7 +117,7 @@ protected:
   }
 
 private:
-  std::shared_ptr<const Distribution> distribution_;
+  Distribution distribution_;
 };
 
 }


### PR DESCRIPTION
Cleanup in preparation to update `Distribution` to handle incomplete tiles in top-left corner.