### PR TITLE
Fix tridiagonal eigensolver when the rank 1 problem size is 2

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -506,6 +506,9 @@ void solveRank1Problem(const SizeType i_begin, const SizeType i_end, KSender&& k
 
             lapack::laed4(to_int(k), to_int(i), d_ptr, z_ptr, delta, rho, &eigenval);
           }
+          // Note for in-place row permutation implementation: The rows should be permuted for the k=2 case as well.
+          if (k <= 2)
+            return;
         }
 
         barrier_ptr->arrive_and_wait();

--- a/src/eigensolver/tridiag_solver/kernels.cpp
+++ b/src/eigensolver/tridiag_solver/kernels.cpp
@@ -100,7 +100,7 @@ void divideEvecsByDiagonal(const SizeType& k_row, const SizeType& k_col, const S
                            const matrix::Tile<const T, Device::CPU>& diag_cols,
                            const matrix::Tile<const T, Device::CPU>& evecs_tile,
                            const matrix::Tile<T, Device::CPU>& ws_tile) {
-  if (i_subm_el >= k_row || j_subm_el >= k_col)
+  if (k_col <= 2 || i_subm_el >= k_row || j_subm_el >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - i_subm_el, evecs_tile.size().rows());
@@ -127,7 +127,7 @@ template <class T>
 void multiplyFirstColumns(const SizeType& k_row, const SizeType& k_col, const SizeType& row,
                           const SizeType& col, const matrix::Tile<const T, Device::CPU>& in,
                           const matrix::Tile<T, Device::CPU>& out) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, in.size().rows());
@@ -146,7 +146,7 @@ void calcEvecsFromWeightVec(const SizeType& k_row, const SizeType& k_col, const 
                             const SizeType& col, const matrix::Tile<const T, Device::CPU>& z_tile,
                             const matrix::Tile<const T, Device::CPU>& ws_tile,
                             const matrix::Tile<T, Device::CPU>& evecs_tile) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, evecs_tile.size().rows());
@@ -172,7 +172,7 @@ template <class T>
 void sumsqCols(const SizeType& k_row, const SizeType& k_col, const SizeType& row, const SizeType& col,
                const matrix::Tile<const T, Device::CPU>& evecs_tile,
                const matrix::Tile<T, Device::CPU>& ws_tile) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, evecs_tile.size().rows());
@@ -195,7 +195,7 @@ template <class T>
 void addFirstRows(const SizeType& k_row, const SizeType& k_col, const SizeType& row, const SizeType& col,
                   const matrix::Tile<const T, Device::CPU>& in,
                   const matrix::Tile<T, Device::CPU>& out) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType ncols = std::min(k_col - col, in.size().cols());
@@ -212,7 +212,7 @@ template <class T>
 void divideColsByFirstRow(const SizeType& k_row, const SizeType& k_col, const SizeType& row,
                           const SizeType& col, const matrix::Tile<const T, Device::CPU>& in,
                           const matrix::Tile<T, Device::CPU>& out) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, out.size().rows());
@@ -252,7 +252,7 @@ void copy1D(const SizeType& k_row, const SizeType& k_col, const SizeType& row, c
             const Coord& out_coord, const matrix::Tile<T, Device::CPU>& out_tile) {
   dlaf::common::internal::SingleThreadedBlasScope single;
 
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   const T* in_ptr = in_tile.ptr();

--- a/src/eigensolver/tridiag_solver/kernels.cu
+++ b/src/eigensolver/tridiag_solver/kernels.cu
@@ -233,7 +233,7 @@ void divideEvecsByDiagonal(const SizeType& k_row, const SizeType& k_col, const S
                            const matrix::Tile<const T, Device::GPU>& diag_cols,
                            const matrix::Tile<const T, Device::GPU>& evecs_tile,
                            const matrix::Tile<T, Device::GPU>& ws_tile, whip::stream_t stream) {
-  if (i_subm_el >= k_row || j_subm_el >= k_col)
+  if (k_col <= 2 || i_subm_el >= k_row || j_subm_el >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - i_subm_el, evecs_tile.size().rows());
@@ -304,7 +304,7 @@ template <class T>
 void multiplyFirstColumns(const SizeType& k_row, const SizeType& k_col, const SizeType& row,
                           const SizeType& col, const matrix::Tile<const T, Device::GPU>& in,
                           const matrix::Tile<T, Device::GPU>& out, whip::stream_t stream) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, in.size().rows());
@@ -350,7 +350,7 @@ void calcEvecsFromWeightVec(const SizeType& k_row, const SizeType& k_col, const 
                             const SizeType& col, const matrix::Tile<const T, Device::GPU>& z_tile,
                             const matrix::Tile<const T, Device::GPU>& ws_tile,
                             const matrix::Tile<T, Device::GPU>& evecs_tile, whip::stream_t stream) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, evecs_tile.size().rows());
@@ -391,7 +391,7 @@ template <class T>
 void sumsqCols(const SizeType& k_row, const SizeType& k_col, const SizeType& row, const SizeType& col,
                const matrix::Tile<const T, Device::GPU>& evecs_tile,
                const matrix::Tile<T, Device::GPU>& ws_tile, whip::stream_t stream) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, evecs_tile.size().rows());
@@ -447,7 +447,7 @@ template <class T>
 void addFirstRows(const SizeType& k_row, const SizeType& k_col, const SizeType& row, const SizeType& col,
                   const matrix::Tile<const T, Device::GPU>& in, const matrix::Tile<T, Device::GPU>& out,
                   whip::stream_t stream) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType ncols = std::min(k_col - col, in.size().cols());
@@ -490,7 +490,7 @@ template <class T>
 void divideColsByFirstRow(const SizeType& k_row, const SizeType& k_col, const SizeType& row,
                           const SizeType& col, const matrix::Tile<const T, Device::GPU>& in,
                           const matrix::Tile<T, Device::GPU>& out, whip::stream_t stream) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   SizeType nrows = std::min(k_row - row, out.size().rows());
@@ -550,7 +550,7 @@ void copy1D(cublasHandle_t handle, const SizeType& k_row, const SizeType& k_col,
             const SizeType& col, const Coord& in_coord,
             const matrix::Tile<const T, Device::GPU>& in_tile, const Coord& out_coord,
             const matrix::Tile<T, Device::GPU>& out_tile) {
-  if (row >= k_row || col >= k_col)
+  if (k_col <= 2 || row >= k_row || col >= k_col)
     return;
 
   const T* in_ptr = in_tile.ptr();

--- a/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
@@ -46,6 +46,7 @@ TYPED_TEST_SUITE(TridiagSolverDistTestGPU, MatrixElementTypes);
 const std::vector<std::tuple<SizeType, SizeType>> tested_problems = {
     // n, nb
     {0, 8},
+    {4, 2},
     {16, 16},
     {16, 8},
     {16, 4},

--- a/test/unit/eigensolver/test_tridiag_solver_local.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_local.cpp
@@ -197,6 +197,7 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
 const std::vector<std::tuple<SizeType, SizeType>> tested_problems = {
     // n, nb
     {0, 8},
+    {4, 2},
     {16, 16},
     {16, 8},
     {16, 4},


### PR DESCRIPTION
When merging subproblems the `k=2` case was not handled correctly.
Closes #892.