### PR TITLE
Add `noexcept` to `MemoryChunk` and `MemoryView` move constructors

### DIFF
--- a/include/dlaf/memory/memory_chunk.h
+++ b/include/dlaf/memory/memory_chunk.h
@@ -88,7 +88,8 @@ public:
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
   /// Move constructor.
-  MemoryChunk(MemoryChunk&& rhs) : size_(rhs.size_), ptr_(rhs.ptr_), allocated_(rhs.allocated_) {
+  MemoryChunk(MemoryChunk&& rhs) noexcept
+      : size_(rhs.size_), ptr_(rhs.ptr_), allocated_(rhs.allocated_) {
     rhs.ptr_ = nullptr;
     rhs.size_ = 0;
     rhs.allocated_ = false;

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -12,6 +12,7 @@
 
 #include <cstdlib>
 #include <memory>
+#include <utility>
 
 #include "memory_chunk.h"
 #include "dlaf/common/assert.h"
@@ -62,14 +63,14 @@ public:
   MemoryView(const MemoryView<ElementType, D>& rhs)
       : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {}
 
-  MemoryView(MemoryView&& rhs)
+  MemoryView(MemoryView&& rhs) noexcept
       : memory_(std::move(rhs.memory_)), offset_(rhs.offset_), size_(rhs.size_) {
     rhs.size_ = 0;
     rhs.offset_ = 0;
   }
 
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
-  MemoryView(MemoryView<ElementType, D>&& rhs)
+  MemoryView(MemoryView<ElementType, D>&& rhs) noexcept
       : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {
     rhs.memory_ = std::make_shared<MemoryChunk<ElementType, D>>();
     rhs.size_ = 0;


### PR DESCRIPTION
Solves one of the compilation error I had with stdexec.
Note: the assignment operator is not marked noexcept as `umpire::Allocator::deallocate` can throw.