### PR TITLE
Add `Matrix::subPipeline{,Const}`

### DIFF
--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -129,6 +129,15 @@ public:
     return readwrite(this->distribution().localTileIndex(index));
   }
 
+private:
+  using typename Matrix<const T, D>::SubPipelineTag;
+  Matrix(Matrix& mat, const SubPipelineTag);
+
+public:
+  Matrix subPipeline() {
+    return Matrix(*this, SubPipelineTag{});
+  }
+
 protected:
   using Matrix<const T, D>::tileLinearIndex;
 
@@ -186,10 +195,18 @@ public:
   /// involving any of the locally available tiles are completed.
   void waitLocalTiles() noexcept;
 
+  Matrix subPipelineConst() {
+    return Matrix(*this, SubPipelineTag{});
+  }
+
 protected:
   Matrix(Distribution distribution) : internal::MatrixBase{std::move(distribution)} {}
 
+  struct SubPipelineTag {};
+  Matrix(Matrix& mat, const SubPipelineTag);
+
   void setUpTiles(const memory::MemoryView<ElementType, D>& mem, const LayoutInfo& layout) noexcept;
+  void setUpSubPipelines(Matrix<const T, D>&) noexcept;
 
   std::vector<internal::TilePipeline<T, D>> tile_managers_;
 };

--- a/include/dlaf/matrix/matrix.tpp
+++ b/include/dlaf/matrix/matrix.tpp
@@ -56,5 +56,8 @@ Matrix<T, D>::Matrix(Distribution distribution, const LayoutInfo& layout, Elemen
 template <class T, Device D>
 Matrix<T, D>::Matrix(const LayoutInfo& layout, ElementType* ptr) : Matrix<const T, D>(layout, ptr) {}
 
+template <class T, Device D>
+Matrix<T, D>::Matrix(Matrix<T, D>& mat, const SubPipelineTag tag) : Matrix<const T, D>(mat, tag) {}
+
 }
 }

--- a/include/dlaf/matrix/matrix_const.tpp
+++ b/include/dlaf/matrix/matrix_const.tpp
@@ -72,5 +72,29 @@ void Matrix<const T, D>::setUpTiles(const memory::MemoryView<ElementType, D>& me
   }
 }
 
+template <class T, Device D>
+Matrix<const T, D>::Matrix(Matrix<const T, D>& mat, const SubPipelineTag)
+    : MatrixBase(mat.distribution()) {
+  setUpSubPipelines(mat);
+}
+
+template <class T, Device D>
+void Matrix<const T, D>::setUpSubPipelines(Matrix<const T, D>& mat) noexcept {
+  namespace ex = pika::execution::experimental;
+
+  // TODO: Optimize read-after-read. This is currently forced to access the base
+  // matrix in readwrite mode so that we can move the tile into the
+  // sub-pipeline. This is semantically not required and should eventually be
+  // optimized.
+  tile_managers_.reserve(mat.tile_managers_.size());
+  for (auto& tm : mat.tile_managers_) {
+    tile_managers_.emplace_back(Tile<T, D>());
+    auto s = ex::when_all(tile_managers_.back().readwrite_with_wrapper(), tm.readwrite()) |
+             ex::then([](internal::TileAsyncRwMutexReadWriteWrapper<T, D> empty_tile_wrapper,
+                         Tile<T, D> tile) { empty_tile_wrapper.get() = std::move(tile); });
+    ex::start_detached(std::move(s));
+  }
+}
+
 }
 }

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -1005,10 +1005,13 @@ TYPED_TEST(MatrixTest, DependenciesReferenceMixSubPipeline) {
   for (const auto& comm_grid : this->commGrids()) {
     for (const auto& test : sizes_tests) {
       // Dependencies graph:
-      // rw0 - rw1 - ro2a - rw3 - ro4a - rw5
-      //           \ ro2b /    \ ro4b /
-      //             +--+        +--+
-      //              sub pipelines
+      // rw0 - rw1 - ro2a ------- rw3 - ro4a ------- rw5
+      //           \ ------ ro2b /    \ ------ ro4b /
+      //                    +--+        +--+
+      //                     sub pipelines
+      //
+      // NOTE: The above is the ideal case. The current implementation does not
+      // merge read-only accesses between a pipeline and a sub-pipeline.
 
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -960,22 +960,22 @@ TYPED_TEST(MatrixTest, DependenciesReferenceMix) {
       auto rosenders2a = getReadSendersUsingGlobalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, rosenders2a));
 
-      decltype(rosenders2a) rosenders2b;
-      {
+      auto rosenders2b = [&]() {
         Matrix<const Type, Device::CPU>& const_mat = mat;
-        rosenders2b = getReadSendersUsingLocalIndex(const_mat);
+        auto rosenders2b = getReadSendersUsingLocalIndex(const_mat);
         EXPECT_TRUE(checkSendersStep(0, rosenders2b));
-      }
+        return rosenders2b;
+      }();
 
       auto senders3 = getReadWriteSendersUsingGlobalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, senders3));
 
-      decltype(rosenders2a) rosenders4a;
-      {
+      auto rosenders4a = [&]() {
         Matrix<const Type, Device::CPU>& const_mat = mat;
-        rosenders4a = getReadSendersUsingLocalIndex(const_mat);
+        auto rosenders4a = getReadSendersUsingLocalIndex(const_mat);
         EXPECT_TRUE(checkSendersStep(0, rosenders4a));
-      }
+        return rosenders4a;
+      }();
 
       CHECK_MATRIX_SENDERS(true, senders1, senders0);
       EXPECT_TRUE(checkSendersStep(0, rosenders2b));
@@ -1025,22 +1025,22 @@ TYPED_TEST(MatrixTest, DependenciesReferenceMixSubPipeline) {
       auto rosenders2a = getReadSendersUsingGlobalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, rosenders2a));
 
-      decltype(rosenders2a) rosenders2b;
-      {
+      auto rosenders2b = [&]() {
         auto mat_sub = mat.subPipelineConst();
-        rosenders2b = getReadSendersUsingLocalIndex(mat_sub);
+        auto rosenders2b = getReadSendersUsingLocalIndex(mat_sub);
         EXPECT_TRUE(checkSendersStep(0, rosenders2b));
-      }
+        return rosenders2b;
+      }();
 
       auto senders3 = getReadWriteSendersUsingGlobalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, senders3));
 
-      decltype(rosenders2a) rosenders4a;
-      {
+      auto rosenders4a = [&]() {
         auto mat_sub = mat.subPipelineConst();
-        rosenders4a = getReadSendersUsingLocalIndex(mat_sub);
+        auto rosenders4a = getReadSendersUsingLocalIndex(mat_sub);
         EXPECT_TRUE(checkSendersStep(0, rosenders4a));
-      }
+        return rosenders4a;
+      }();
 
       CHECK_MATRIX_SENDERS(true, senders1, senders0);
 
@@ -1088,22 +1088,22 @@ TYPED_TEST(MatrixTest, DependenciesPointerMix) {
       auto rosenders2a = getReadSendersUsingLocalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, rosenders2a));
 
-      decltype(rosenders2a) rosenders2b;
-      {
+      auto rosenders2b = [&]() {
         Matrix<const Type, Device::CPU>* const_mat = &mat;
-        rosenders2b = getReadSendersUsingGlobalIndex(*const_mat);
+        auto rosenders2b = getReadSendersUsingGlobalIndex(*const_mat);
         EXPECT_TRUE(checkSendersStep(0, rosenders2b));
-      }
+        return rosenders2b;
+      }();
 
       auto senders3 = getReadWriteSendersUsingLocalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, senders3));
 
-      decltype(rosenders2a) rosenders4a;
-      {
+      auto rosenders4a = [&]() {
         Matrix<const Type, Device::CPU>* const_mat = &mat;
-        rosenders4a = getReadSendersUsingGlobalIndex(*const_mat);
+        auto rosenders4a = getReadSendersUsingGlobalIndex(*const_mat);
         EXPECT_TRUE(checkSendersStep(0, rosenders4a));
-      }
+        return rosenders4a;
+      }();
 
       CHECK_MATRIX_SENDERS(true, senders1, senders0);
       EXPECT_TRUE(checkSendersStep(0, rosenders2b));

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -93,18 +93,41 @@ TYPED_TEST(MatrixLocalTest, StaticAPIConst) {
 
 TYPED_TEST(MatrixLocalTest, Constructor) {
   using Type = TypeParam;
-  auto el = [](const GlobalElementIndex& index) {
+  BaseType<Type> c = 0.0;
+  auto el = [&](const GlobalElementIndex& index) {
     SizeType i = index.row();
     SizeType j = index.col();
-    return TypeUtilities<Type>::element(i + j / 1024., j - i / 128.);
+    return TypeUtilities<Type>::element(i + j / 1024. + c, j - i / 128.);
   };
 
   for (const auto& test : sizes_tests) {
     Matrix<Type, Device::CPU> mat(test.size, test.block_size);
 
-    EXPECT_EQ(Distribution(test.size, test.block_size), mat.distribution());
+    {
+      EXPECT_EQ(Distribution(test.size, test.block_size), mat.distribution());
 
-    set(mat, el);
+      set(mat, el);
+
+      CHECK_MATRIX_EQ(el, mat);
+    }
+
+    {
+      auto mat_sub = mat.subPipelineConst();
+      EXPECT_EQ(mat_sub.distribution(), mat.distribution());
+
+      CHECK_MATRIX_EQ(el, mat_sub);
+    }
+
+    c = 1.0;
+
+    {
+      auto mat_sub = mat.subPipeline();
+      EXPECT_EQ(mat_sub.distribution(), mat.distribution());
+
+      set(mat_sub, el);
+
+      CHECK_MATRIX_EQ(el, mat_sub);
+    }
 
     CHECK_MATRIX_EQ(el, mat);
   }
@@ -112,10 +135,11 @@ TYPED_TEST(MatrixLocalTest, Constructor) {
 
 TYPED_TEST(MatrixTest, Constructor) {
   using Type = TypeParam;
-  auto el = [](const GlobalElementIndex& index) {
+  BaseType<Type> c = 0.0;
+  auto el = [&](const GlobalElementIndex& index) {
     SizeType i = index.row();
     SizeType j = index.col();
-    return TypeUtilities<Type>::element(i + j / 1024., j - i / 128.);
+    return TypeUtilities<Type>::element(i + j / 1024. + c, j - i / 128.);
   };
 
   for (const auto& comm_grid : this->commGrids()) {
@@ -123,10 +147,32 @@ TYPED_TEST(MatrixTest, Constructor) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);
 
-      EXPECT_EQ(Distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0}),
-                mat.distribution());
+      {
+        EXPECT_EQ(Distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0}),
+                  mat.distribution());
 
-      set(mat, el);
+        set(mat, el);
+
+        CHECK_MATRIX_EQ(el, mat);
+      }
+
+      {
+        auto mat_sub = mat.subPipelineConst();
+        EXPECT_EQ(mat_sub.distribution(), mat.distribution());
+
+        CHECK_MATRIX_EQ(el, mat_sub);
+      }
+
+      c = 1.0;
+
+      {
+        auto mat_sub = mat.subPipeline();
+        EXPECT_EQ(mat_sub.distribution(), mat.distribution());
+
+        set(mat_sub, el);
+
+        CHECK_MATRIX_EQ(el, mat_sub);
+      }
 
       CHECK_MATRIX_EQ(el, mat);
     }
@@ -135,10 +181,11 @@ TYPED_TEST(MatrixTest, Constructor) {
 
 TYPED_TEST(MatrixTest, ConstructorFromDistribution) {
   using Type = TypeParam;
-  auto el = [](const GlobalElementIndex& index) {
+  BaseType<Type> c = 0.0;
+  auto el = [&](const GlobalElementIndex& index) {
     SizeType i = index.row();
     SizeType j = index.col();
-    return TypeUtilities<Type>::element(i + j / 1024., j - i / 128.);
+    return TypeUtilities<Type>::element(i + j / 1024. + c, j - i / 128.);
   };
 
   for (const auto& comm_grid : this->commGrids()) {
@@ -154,9 +201,31 @@ TYPED_TEST(MatrixTest, ConstructorFromDistribution) {
 
       Matrix<Type, Device::CPU> mat(std::move(distribution));
 
-      EXPECT_EQ(distribution_copy, mat.distribution());
+      {
+        EXPECT_EQ(distribution_copy, mat.distribution());
 
-      set(mat, el);
+        set(mat, el);
+
+        CHECK_MATRIX_EQ(el, mat);
+      }
+
+      {
+        auto mat_sub = mat.subPipelineConst();
+        EXPECT_EQ(mat_sub.distribution(), mat.distribution());
+
+        CHECK_MATRIX_EQ(el, mat_sub);
+      }
+
+      c = 1.0;
+
+      {
+        auto mat_sub = mat.subPipeline();
+        EXPECT_EQ(mat_sub.distribution(), mat.distribution());
+
+        set(mat_sub, el);
+
+        CHECK_MATRIX_EQ(el, mat_sub);
+      }
 
       CHECK_MATRIX_EQ(el, mat);
     }
@@ -304,12 +373,35 @@ TYPED_TEST(MatrixTest, ConstructorFromDistributionLayout) {
       Distribution distribution_copy(distribution);
 
       Matrix<Type, Device::CPU> mat(std::move(distribution), layout);
+
       Type* ptr = nullptr;
       if (!mat.distribution().localSize().isEmpty()) {
         ptr = tt::sync_wait(mat.readwrite(LocalTileIndex(0, 0))).ptr();
       }
 
       CHECK_DISTRIBUTION_LAYOUT(ptr, distribution_copy, layout, mat);
+
+      {
+        auto mat_sub = mat.subPipelineConst();
+
+        const Type* ptr_sub = nullptr;
+        if (!mat_sub.distribution().localSize().isEmpty()) {
+          ptr_sub = tt::sync_wait(mat_sub.read(LocalTileIndex(0, 0))).get().ptr();
+        }
+
+        ASSERT_EQ(ptr, ptr_sub);
+      }
+
+      {
+        auto mat_sub = mat.subPipeline();
+
+        Type* ptr_sub = nullptr;
+        if (!mat_sub.distribution().localSize().isEmpty()) {
+          ptr_sub = tt::sync_wait(mat_sub.readwrite(LocalTileIndex(0, 0))).ptr();
+        }
+
+        ASSERT_EQ(ptr, ptr_sub);
+      }
     }
   }
 }
@@ -343,6 +435,18 @@ TYPED_TEST(MatrixTest, LocalGlobalAccessOperatorCall) {
 
             EXPECT_NE(ptr_global, nullptr);
             EXPECT_EQ(ptr_global, ptr_local);
+
+            const TypeParam* ptr_sub_global = [&]() {
+              auto mat_sub = mat.subPipeline();
+              return tt::sync_wait(mat_sub.readwrite(global_index)).ptr(TileElementIndex{0, 0});
+            }();
+            const TypeParam* ptr_sub_local = [&]() {
+              auto mat_sub = mat.subPipeline();
+              return tt::sync_wait(mat_sub.readwrite(local_index)).ptr(TileElementIndex{0, 0});
+            }();
+
+            EXPECT_EQ(ptr_sub_global, ptr_global);
+            EXPECT_EQ(ptr_sub_local, ptr_global);
           }
         }
       }
@@ -373,12 +477,36 @@ TYPED_TEST(MatrixTest, LocalGlobalAccessRead) {
             LocalTileIndex local_index = dist.localTileIndex(global_index);
 
             const TypeParam* ptr_global =
-                tt::sync_wait(mat.readwrite(global_index)).ptr(TileElementIndex{0, 0});
+                tt::sync_wait(mat.read(global_index)).get().ptr(TileElementIndex{0, 0});
             const TypeParam* ptr_local =
-                tt::sync_wait(mat.readwrite(local_index)).ptr(TileElementIndex{0, 0});
+                tt::sync_wait(mat.read(local_index)).get().ptr(TileElementIndex{0, 0});
 
             EXPECT_NE(ptr_global, nullptr);
             EXPECT_EQ(ptr_global, ptr_local);
+
+            const TypeParam* ptr_sub_global = [&]() {
+              auto mat_sub = mat.subPipeline();
+              return tt::sync_wait(mat_sub.read(global_index)).get().ptr(TileElementIndex{0, 0});
+            }();
+            const TypeParam* ptr_sub_local = [&]() {
+              auto mat_sub = mat.subPipeline();
+              return tt::sync_wait(mat_sub.read(local_index)).get().ptr(TileElementIndex{0, 0});
+            }();
+
+            EXPECT_EQ(ptr_sub_global, ptr_global);
+            EXPECT_EQ(ptr_sub_local, ptr_global);
+
+            const TypeParam* ptr_sub_const_global = [&]() {
+              auto mat_sub = mat.subPipelineConst();
+              return tt::sync_wait(mat_sub.read(global_index)).get().ptr(TileElementIndex{0, 0});
+            }();
+            const TypeParam* ptr_sub_const_local = [&]() {
+              auto mat_sub = mat.subPipelineConst();
+              return tt::sync_wait(mat_sub.read(local_index)).get().ptr(TileElementIndex{0, 0});
+            }();
+
+            EXPECT_EQ(ptr_sub_const_global, ptr_global);
+            EXPECT_EQ(ptr_sub_const_local, ptr_global);
           }
         }
       }
@@ -417,6 +545,16 @@ TYPED_TEST(MatrixLocalTest, ConstructorExisting) {
     Matrix<Type, Device::CPU> mat(layout, mem());
 
     CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+    {
+      auto mat_sub = mat.subPipeline();
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub);
+    }
+
+    {
+      auto mat_sub_const = mat.subPipelineConst();
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+    }
   }
 }
 
@@ -431,6 +569,11 @@ TYPED_TEST(MatrixLocalTest, ConstructorExistingConst) {
     Matrix<const Type, Device::CPU> mat(layout, p);
 
     CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+    {
+      auto mat_sub_const = mat.subPipelineConst();
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+    }
   }
 }
 
@@ -450,6 +593,16 @@ TYPED_TEST(MatrixTest, ConstructorExisting) {
       Matrix<Type, Device::CPU> mat(std::move(distribution), layout, mem());
 
       CHECK_DISTRIBUTION_LAYOUT(mem(), distribution_copy, layout, mat);
+
+      {
+        auto mat_sub = mat.subPipeline();
+        CHECK_DISTRIBUTION_LAYOUT(mem(), distribution_copy, layout, mat_sub);
+      }
+
+      {
+        auto mat_sub_const = mat.subPipelineConst();
+        CHECK_DISTRIBUTION_LAYOUT(mem(), distribution_copy, layout, mat_sub_const);
+      }
     }
   }
 }
@@ -472,6 +625,11 @@ TYPED_TEST(MatrixTest, ConstructorExistingConst) {
       Matrix<const Type, Device::CPU> mat(std::move(distribution), layout, p);
 
       CHECK_DISTRIBUTION_LAYOUT(mem(), distribution_copy, layout, mat);
+
+      {
+        auto mat_sub_const = mat.subPipelineConst();
+        CHECK_DISTRIBUTION_LAYOUT(mem(), distribution_copy, layout, mat_sub_const);
+      }
     }
   }
 }
@@ -528,6 +686,196 @@ TYPED_TEST(MatrixTest, Dependencies) {
   }
 }
 
+TYPED_TEST(MatrixTest, DependenciesSubPipeline) {
+  using Type = TypeParam;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      // Dependencies graph:
+      // rw0 - rw1 - ro2a - rw3 - ro4a - rw5
+      //           \ ro2b /     \ ro4b /
+      //
+      //             +--------+
+      //            sub pipeline
+
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+      Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);
+
+      auto senders0 = getReadWriteSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(senders0.size(), senders0));
+
+      auto senders1 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders1));
+
+      auto [rosenders2a, rosenders2b, senders3] = [&]() {
+        auto mat_sub = mat.subPipeline();
+
+        auto rosenders2a = getReadSendersUsingLocalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders2a));
+
+        auto rosenders2b = getReadSendersUsingGlobalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+
+        auto senders3 = getReadWriteSendersUsingLocalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, senders3));
+
+        return std::tuple(std::move(rosenders2a), std::move(rosenders2b), std::move(senders3));
+      }();
+
+      auto rosenders4a = getReadSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, rosenders4a));
+
+      CHECK_MATRIX_SENDERS(true, senders1, senders0);
+      EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+      CHECK_MATRIX_SENDERS(true, rosenders2b, senders1);
+      EXPECT_TRUE(checkSendersStep(rosenders2a.size(), rosenders2a));
+
+      CHECK_MATRIX_SENDERS(false, senders3, rosenders2b);
+      CHECK_MATRIX_SENDERS(true, senders3, rosenders2a);
+
+      CHECK_MATRIX_SENDERS(true, rosenders4a, senders3);
+
+      auto rosenders4b = getReadSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(rosenders4b.size(), rosenders4b));
+
+      auto senders5 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders5));
+
+      CHECK_MATRIX_SENDERS(false, senders5, rosenders4a);
+      CHECK_MATRIX_SENDERS(true, senders5, rosenders4b);
+    }
+  }
+}
+
+TYPED_TEST(MatrixTest, DependenciesSubSubPipeline) {
+  using Type = TypeParam;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      // Dependencies graph:
+      // rw0 - rw1 - ro2a ------- rw3 - ro4a ------- rw5
+      //           \ ------ ro2b /     \ ----- ro4b /
+      //
+      //             +---------------------+
+      //                  sub pipeline
+      //
+      //                    +-------+
+      //                sub-sub pipeline
+
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+      Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);
+
+      auto senders0 = getReadWriteSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(senders0.size(), senders0));
+
+      auto senders1 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders1));
+
+      auto [rosenders2a, rosenders2b, senders3, rosenders4a] = [&]() {
+        auto mat_sub = mat.subPipeline();
+
+        auto rosenders2a = getReadSendersUsingLocalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders2a));
+
+        auto [rosenders2b, senders3] = [&]() {
+          auto rosenders2b = getReadSendersUsingGlobalIndex(mat_sub);
+          EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+
+          auto senders3 = getReadWriteSendersUsingLocalIndex(mat_sub);
+          EXPECT_TRUE(checkSendersStep(0, senders3));
+          return std::tuple(std::move(rosenders2b), std::move(senders3));
+        }();
+
+        auto rosenders4a = getReadSendersUsingGlobalIndex(mat);
+        EXPECT_TRUE(checkSendersStep(0, rosenders4a));
+
+        return std::tuple(std::move(rosenders2a), std::move(rosenders2b), std::move(senders3),
+                          std::move(rosenders4a));
+      }();
+
+      CHECK_MATRIX_SENDERS(true, senders1, senders0);
+      EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+      CHECK_MATRIX_SENDERS(true, rosenders2b, senders1);
+      EXPECT_TRUE(checkSendersStep(rosenders2a.size(), rosenders2a));
+
+      CHECK_MATRIX_SENDERS(false, senders3, rosenders2b);
+      CHECK_MATRIX_SENDERS(true, senders3, rosenders2a);
+
+      CHECK_MATRIX_SENDERS(true, rosenders4a, senders3);
+
+      auto rosenders4b = getReadSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(rosenders4b.size(), rosenders4b));
+
+      auto senders5 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders5));
+
+      CHECK_MATRIX_SENDERS(false, senders5, rosenders4a);
+      CHECK_MATRIX_SENDERS(true, senders5, rosenders4b);
+    }
+  }
+}
+
+TYPED_TEST(MatrixTest, DependenciesSubPipelineConst) {
+  using Type = TypeParam;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      // Dependencies graph:
+      // rw0 - rw1 - ro2a - rw3 - ro4a - rw5
+      //           \ ro2b /     \ ro4b /
+      //
+      //             +--+
+      //         sub pipeline
+
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+      Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);
+
+      auto senders0 = getReadWriteSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(senders0.size(), senders0));
+
+      auto senders1 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders1));
+
+      auto [rosenders2a, rosenders2b] = [&]() {
+        auto mat_sub = mat.subPipelineConst();
+
+        auto rosenders2a = getReadSendersUsingLocalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders2a));
+
+        auto rosenders2b = getReadSendersUsingGlobalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+
+        return std::tuple(std::move(rosenders2a), std::move(rosenders2b));
+      }();
+
+      auto senders3 = getReadWriteSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders3));
+
+      auto rosenders4a = getReadSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, rosenders4a));
+
+      CHECK_MATRIX_SENDERS(true, senders1, senders0);
+      EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+      CHECK_MATRIX_SENDERS(true, rosenders2b, senders1);
+      EXPECT_TRUE(checkSendersStep(rosenders2a.size(), rosenders2a));
+
+      CHECK_MATRIX_SENDERS(false, senders3, rosenders2b);
+      CHECK_MATRIX_SENDERS(true, senders3, rosenders2a);
+
+      CHECK_MATRIX_SENDERS(true, rosenders4a, senders3);
+
+      auto rosenders4b = getReadSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(rosenders4b.size(), rosenders4b));
+
+      auto senders5 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders5));
+
+      CHECK_MATRIX_SENDERS(false, senders5, rosenders4a);
+      CHECK_MATRIX_SENDERS(true, senders5, rosenders4b);
+    }
+  }
+}
+
 TYPED_TEST(MatrixTest, DependenciesConst) {
   using Type = TypeParam;
 
@@ -545,6 +893,38 @@ TYPED_TEST(MatrixTest, DependenciesConst) {
 
       auto rosenders2 = getReadSendersUsingLocalIndex(mat);
       EXPECT_TRUE(checkSendersStep(rosenders2.size(), rosenders2));
+    }
+  }
+}
+
+TYPED_TEST(MatrixTest, DependenciesConstSubPipelineConst) {
+  using Type = TypeParam;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+
+      Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
+      LayoutInfo layout = tileLayout(distribution.localSize(), test.block_size);
+      memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
+      const Type* p = mem();
+      Matrix<const Type, Device::CPU> mat(std::move(distribution), layout, p);
+      auto rosenders1 = getReadSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(rosenders1.size(), rosenders1));
+
+      auto rosenders2 = [&]() {
+        auto mat_sub = mat.subPipelineConst();
+        return getReadSendersUsingLocalIndex(mat_sub);
+      }();
+      // NOTE: This is a limitation of the current implementation. Semantically
+      // read-only access in sub-pipelines should be fused with read-only access
+      // from the parent pipeline.
+      EXPECT_TRUE(checkSendersStep(0, rosenders2));
+      CHECK_MATRIX_SENDERS(true, rosenders2, rosenders1);
+
+      auto rosenders3 = getReadSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, rosenders3));
+      CHECK_MATRIX_SENDERS(true, rosenders3, rosenders2);
     }
   }
 }
@@ -599,6 +979,71 @@ TYPED_TEST(MatrixTest, DependenciesReferenceMix) {
 
       auto rosenders4b = getReadSendersUsingGlobalIndex(mat);
       EXPECT_TRUE(checkSendersStep(rosenders4b.size(), rosenders4b));
+
+      auto senders5 = getReadWriteSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders5));
+
+      CHECK_MATRIX_SENDERS(false, senders5, rosenders4a);
+      CHECK_MATRIX_SENDERS(true, senders5, rosenders4b);
+    }
+  }
+}
+
+TYPED_TEST(MatrixTest, DependenciesReferenceMixSubPipeline) {
+  using Type = TypeParam;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      // Dependencies graph:
+      // rw0 - rw1 - ro2a - rw3 - ro4a - rw5
+      //           \ ro2b /    \ ro4b /
+      //             +--+        +--+
+      //              sub pipelines
+
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+      Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);
+
+      auto senders0 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(senders0.size(), senders0));
+
+      auto senders1 = getReadWriteSendersUsingLocalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders1));
+
+      auto rosenders2a = getReadSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, rosenders2a));
+
+      decltype(rosenders2a) rosenders2b;
+      {
+        auto mat_sub = mat.subPipelineConst();
+        rosenders2b = getReadSendersUsingLocalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+      }
+
+      auto senders3 = getReadWriteSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, senders3));
+
+      decltype(rosenders2a) rosenders4a;
+      {
+        auto mat_sub = mat.subPipelineConst();
+        rosenders4a = getReadSendersUsingLocalIndex(mat_sub);
+        EXPECT_TRUE(checkSendersStep(0, rosenders4a));
+      }
+
+      CHECK_MATRIX_SENDERS(true, senders1, senders0);
+
+      EXPECT_TRUE(checkSendersStep(0, rosenders2a));
+      EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+      CHECK_MATRIX_SENDERS(true, rosenders2a, senders1);
+
+      EXPECT_TRUE(checkSendersStep(0, rosenders2b));
+      CHECK_MATRIX_SENDERS(true, rosenders2b, rosenders2a);
+
+      CHECK_MATRIX_SENDERS(true, senders3, rosenders2b);
+
+      CHECK_MATRIX_SENDERS(true, rosenders4a, senders3);
+
+      auto rosenders4b = getReadSendersUsingGlobalIndex(mat);
+      EXPECT_TRUE(checkSendersStep(0, rosenders4b));
 
       auto senders5 = getReadWriteSendersUsingLocalIndex(mat);
       EXPECT_TRUE(checkSendersStep(0, senders5));
@@ -676,6 +1121,8 @@ TYPED_TEST(MatrixTest, TileSize) {
     for (const auto& test : sizes_tests) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Matrix<Type, Device::CPU> mat(size, test.block_size, comm_grid);
+      auto mat_sub = mat.subPipeline();
+      auto mat_sub_const = mat.subPipelineConst();
 
       for (SizeType i = 0; i < mat.nrTiles().rows(); ++i) {
         SizeType mb = mat.blockSize().rows();
@@ -684,6 +1131,8 @@ TYPED_TEST(MatrixTest, TileSize) {
           SizeType nb = mat.blockSize().cols();
           SizeType jb = std::min(nb, mat.size().cols() - j * nb);
           EXPECT_EQ(TileElementSize(ib, jb), mat.tileSize({i, j}));
+          EXPECT_EQ(TileElementSize(ib, jb), mat_sub.tileSize({i, j}));
+          EXPECT_EQ(TileElementSize(ib, jb), mat_sub_const.tileSize({i, j}));
         }
       }
     }
@@ -719,10 +1168,22 @@ TYPED_TEST(MatrixLocalTest, FromColMajor) {
   for (const auto& test : col_major_sizes_tests) {
     LayoutInfo layout = colMajorLayout(test.size, test.block_size, test.ld);
     memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
+
     auto mat = createMatrixFromColMajor<Device::CPU>(test.size, test.block_size, test.ld, mem());
     ASSERT_FALSE(haveConstElements(mat));
-
     CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+    {
+      auto mat_sub = mat.subPipeline();
+      ASSERT_FALSE(haveConstElements(mat_sub));
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub);
+    }
+
+    {
+      auto mat_sub_const = mat.subPipelineConst();
+      ASSERT_TRUE(haveConstElements(mat_sub_const));
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+    }
   }
 }
 
@@ -733,10 +1194,16 @@ TYPED_TEST(MatrixLocalTest, FromColMajorConst) {
     LayoutInfo layout = colMajorLayout(test.size, test.block_size, test.ld);
     memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
     const Type* p = mem();
+
     auto mat = createMatrixFromColMajor<Device::CPU>(test.size, test.block_size, test.ld, p);
     ASSERT_TRUE(haveConstElements(mat));
-
     CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+    {
+      auto mat_sub_const = mat.subPipelineConst();
+      ASSERT_TRUE(haveConstElements(mat_sub_const));
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+    }
   }
 }
 
@@ -757,8 +1224,19 @@ TYPED_TEST(MatrixTest, FromColMajor) {
 
         auto mat = createMatrixFromColMajor<Device::CPU>(size, test.block_size, ld, comm_grid, mem());
         ASSERT_FALSE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub = mat.subPipeline();
+          ASSERT_FALSE(haveConstElements(mat_sub));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub);
+        }
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
       {
         // specify src_rank
@@ -773,8 +1251,19 @@ TYPED_TEST(MatrixTest, FromColMajor) {
         auto mat =
             createMatrixFromColMajor<Device::CPU>(size, test.block_size, ld, comm_grid, src_rank, mem());
         ASSERT_FALSE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub = mat.subPipeline();
+          ASSERT_FALSE(haveConstElements(mat_sub));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub);
+        }
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
     }
   }
@@ -794,12 +1283,17 @@ TYPED_TEST(MatrixTest, FromColMajorConst) {
         SizeType ld = distribution.localSize().rows() + 3;
         LayoutInfo layout = colMajorLayout(distribution, ld);
         memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
-
         const Type* p = mem();
+
         auto mat = createMatrixFromColMajor<Device::CPU>(size, test.block_size, ld, comm_grid, p);
         ASSERT_TRUE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
       {
         // specify src_rank
@@ -810,13 +1304,18 @@ TYPED_TEST(MatrixTest, FromColMajorConst) {
         SizeType ld = distribution.localSize().rows() + 3;
         LayoutInfo layout = colMajorLayout(distribution, ld);
         memory::MemoryView<Type, Device::CPU> mem(layout.minMemSize());
-
         const Type* p = mem();
+
         auto mat =
             createMatrixFromColMajor<Device::CPU>(size, test.block_size, ld, comm_grid, src_rank, p);
         ASSERT_TRUE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
     }
   }
@@ -846,15 +1345,37 @@ TYPED_TEST(MatrixLocalTest, FromTile) {
     if (test.is_basic) {
       auto mat = createMatrixFromTile<Device::CPU>(test.size, test.block_size, mem());
       ASSERT_FALSE(haveConstElements(mat));
-
       CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+      {
+        auto mat_sub = mat.subPipeline();
+        ASSERT_FALSE(haveConstElements(mat_sub));
+        CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub);
+      }
+
+      {
+        auto mat_sub_const = mat.subPipelineConst();
+        ASSERT_TRUE(haveConstElements(mat_sub_const));
+        CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+      }
     }
 
     auto mat = createMatrixFromTile<Device::CPU>(test.size, test.block_size, test.ld, test.tiles_per_col,
                                                  mem());
     ASSERT_FALSE(haveConstElements(mat));
-
     CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+    {
+      auto mat_sub = mat.subPipeline();
+      ASSERT_FALSE(haveConstElements(mat_sub));
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub);
+    }
+
+    {
+      auto mat_sub_const = mat.subPipelineConst();
+      ASSERT_TRUE(haveConstElements(mat_sub_const));
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+    }
   }
 }
 
@@ -868,15 +1389,25 @@ TYPED_TEST(MatrixLocalTest, FromTileConst) {
     if (test.is_basic) {
       auto mat = createMatrixFromTile<Device::CPU>(test.size, test.block_size, p);
       ASSERT_TRUE(haveConstElements(mat));
-
       CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+      {
+        auto mat_sub_const = mat.subPipelineConst();
+        ASSERT_TRUE(haveConstElements(mat_sub_const));
+        CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+      }
     }
 
     auto mat =
         createMatrixFromTile<Device::CPU>(test.size, test.block_size, test.ld, test.tiles_per_col, p);
     ASSERT_TRUE(haveConstElements(mat));
-
     CHECK_LAYOUT_LOCAL(mem(), layout, mat);
+
+    {
+      auto mat_sub_const = mat.subPipelineConst();
+      ASSERT_TRUE(haveConstElements(mat_sub_const));
+      CHECK_LAYOUT_LOCAL(mem(), layout, mat_sub_const);
+    }
   }
 }
 
@@ -898,8 +1429,19 @@ TYPED_TEST(MatrixTest, FromTile) {
 
         auto mat = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid, mem());
         ASSERT_FALSE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub = mat.subPipeline();
+          ASSERT_FALSE(haveConstElements(mat_sub));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub);
+        }
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
       {
         // specify src_rank
@@ -911,8 +1453,19 @@ TYPED_TEST(MatrixTest, FromTile) {
 
         auto mat = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid, src_rank, mem());
         ASSERT_FALSE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub = mat.subPipeline();
+          ASSERT_FALSE(haveConstElements(mat_sub));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub);
+        }
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
 
       // Advanced tile layout
@@ -929,8 +1482,19 @@ TYPED_TEST(MatrixTest, FromTile) {
         auto mat = createMatrixFromTile<Device::CPU>(size, test.block_size, ld_tiles, tiles_per_col,
                                                      comm_grid, mem());
         ASSERT_FALSE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub = mat.subPipeline();
+          ASSERT_FALSE(haveConstElements(mat_sub));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub);
+        }
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
       {
         // specify src_rank
@@ -947,8 +1511,19 @@ TYPED_TEST(MatrixTest, FromTile) {
         auto mat = createMatrixFromTile<Device::CPU>(size, test.block_size, ld_tiles, tiles_per_col,
                                                      comm_grid, src_rank, mem());
         ASSERT_FALSE(haveConstElements(mat));
-
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub = mat.subPipeline();
+          ASSERT_FALSE(haveConstElements(mat_sub));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub);
+        }
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
     }
   }
@@ -975,6 +1550,12 @@ TYPED_TEST(MatrixTest, FromTileConst) {
         ASSERT_TRUE(haveConstElements(mat));
 
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
       {
         // specify src_rank
@@ -989,6 +1570,12 @@ TYPED_TEST(MatrixTest, FromTileConst) {
         ASSERT_TRUE(haveConstElements(mat));
 
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
 
       // Advanced tile layout
@@ -1008,6 +1595,12 @@ TYPED_TEST(MatrixTest, FromTileConst) {
         ASSERT_TRUE(haveConstElements(mat));
 
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
       {
         // specify src_rank
@@ -1027,6 +1620,12 @@ TYPED_TEST(MatrixTest, FromTileConst) {
         ASSERT_TRUE(haveConstElements(mat));
 
         CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat);
+
+        {
+          auto mat_sub_const = mat.subPipelineConst();
+          ASSERT_TRUE(haveConstElements(mat_sub_const));
+          CHECK_DISTRIBUTION_LAYOUT(mem(), distribution, layout, mat_sub_const);
+        }
       }
     }
   }
@@ -1064,6 +1663,47 @@ TYPED_TEST(MatrixTest, CopyFrom) {
                               [](const auto&) { return TypeUtilities<TypeParam>::element(13, 26); });
 
       copy(mat_src_const, mat_dst);
+
+      CHECK_MATRIX_NEAR(input_matrix, mat_dst, 0, TypeUtilities<TypeParam>::error);
+    }
+  }
+}
+
+TYPED_TEST(MatrixTest, CopyFromSubPipeline) {
+  using MemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::CPU>;
+  using MatrixT = dlaf::Matrix<TypeParam, Device::CPU>;
+  using MatrixConstT = dlaf::Matrix<const TypeParam, Device::CPU>;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+
+      Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
+      LayoutInfo layout = tileLayout(distribution.localSize(), test.block_size);
+
+      auto input_matrix = [](const GlobalElementIndex& index) {
+        SizeType i = index.row();
+        SizeType j = index.col();
+        return TypeUtilities<TypeParam>::element(i + j / 1024., j - i / 128.);
+      };
+
+      MemoryViewT mem_src(layout.minMemSize());
+      MatrixT mat_src = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                          static_cast<TypeParam*>(mem_src()));
+      dlaf::matrix::util::set(mat_src, input_matrix);
+
+      MemoryViewT mem_dst(layout.minMemSize());
+      MatrixT mat_dst = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                          static_cast<TypeParam*>(mem_dst()));
+      dlaf::matrix::util::set(mat_dst,
+                              [](const auto&) { return TypeUtilities<TypeParam>::element(13, 26); });
+
+      {
+        MatrixConstT mat_sub_src_const = mat_src.subPipelineConst();
+        MatrixT mat_sub_dst = mat_dst.subPipeline();
+
+        copy(mat_sub_src_const, mat_sub_dst);
+      }
 
       CHECK_MATRIX_NEAR(input_matrix, mat_dst, 0, TypeUtilities<TypeParam>::error);
     }
@@ -1115,6 +1755,63 @@ TYPED_TEST(MatrixTest, GPUCopy) {
       copy(mat_src_const, mat_gpu1);
       copy(mat_gpu1, mat_gpu2);
       copy(mat_gpu2, mat_dst);
+
+      CHECK_MATRIX_NEAR(input_matrix, mat_dst, 0, TypeUtilities<TypeParam>::error);
+    }
+  }
+}
+
+TYPED_TEST(MatrixTest, GPUCopySubPipeline) {
+  using MemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::CPU>;
+  using MatrixT = dlaf::Matrix<TypeParam, Device::CPU>;
+  using MatrixConstT = dlaf::Matrix<const TypeParam, Device::CPU>;
+  using GPUMemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::GPU>;
+  using GPUMatrixT = dlaf::Matrix<TypeParam, Device::GPU>;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+
+      Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
+      LayoutInfo layout = tileLayout(distribution.localSize(), test.block_size);
+
+      auto input_matrix = [](const GlobalElementIndex& index) {
+        SizeType i = index.row();
+        SizeType j = index.col();
+        return TypeUtilities<TypeParam>::element(i + j / 1024., j - i / 128.);
+      };
+
+      MemoryViewT mem_src(layout.minMemSize());
+      MatrixT mat_src = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                          static_cast<TypeParam*>(mem_src()));
+      dlaf::matrix::util::set(mat_src, input_matrix);
+
+      MatrixConstT mat_src_const = std::move(mat_src);
+
+      GPUMemoryViewT mem_gpu1(layout.minMemSize());
+      GPUMatrixT mat_gpu1 = createMatrixFromTile<Device::GPU>(size, test.block_size, comm_grid,
+                                                              static_cast<TypeParam*>(mem_gpu1()));
+
+      GPUMemoryViewT mem_gpu2(layout.minMemSize());
+      GPUMatrixT mat_gpu2 = createMatrixFromTile<Device::GPU>(size, test.block_size, comm_grid,
+                                                              static_cast<TypeParam*>(mem_gpu2()));
+
+      MemoryViewT mem_dst(layout.minMemSize());
+      MatrixT mat_dst = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                          static_cast<TypeParam*>(mem_dst()));
+      dlaf::matrix::util::set(mat_dst,
+                              [](const auto&) { return TypeUtilities<TypeParam>::element(13, 26); });
+
+      {
+        MatrixConstT mat_sub_src_const = mat_src_const.subPipelineConst();
+        GPUMatrixT mat_sub_gpu1 = mat_gpu1.subPipeline();
+        GPUMatrixT mat_sub_gpu2 = mat_gpu2.subPipeline();
+        MatrixT mat_sub_dst = mat_dst.subPipeline();
+
+        copy(mat_sub_src_const, mat_sub_gpu1);
+        copy(mat_sub_gpu1, mat_sub_gpu2);
+        copy(mat_sub_gpu2, mat_sub_dst);
+      }
 
       CHECK_MATRIX_NEAR(input_matrix, mat_dst, 0, TypeUtilities<TypeParam>::error);
     }
@@ -1173,6 +1870,56 @@ TEST_F(MatrixGenericTest, SelectTilesReadonly) {
   }
 }
 
+TEST_F(MatrixGenericTest, SelectTilesReadonlySubPipeline) {
+  using TypeParam = double;
+  using MemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::CPU>;
+  using MatrixT = dlaf::Matrix<TypeParam, Device::CPU>;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+
+      Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
+      LayoutInfo layout = tileLayout(distribution.localSize(), test.block_size);
+
+      MemoryViewT mem(layout.minMemSize());
+      MatrixT mat = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                      static_cast<TypeParam*>(mem()));
+      auto mat_sub = mat.subPipeline();
+
+      // if this rank has no tiles locally, there's nothing interesting to do...
+      if (distribution.localNrTiles().isEmpty())
+        continue;
+
+      const auto ncols = to_sizet(distribution.localNrTiles().cols());
+      const LocalTileSize local_row_size{1, to_SizeType(ncols)};
+      auto row0_range = common::iterate_range2d(local_row_size);
+
+      // top left tile is selected in rw (i.e. exclusive access)
+      auto sender_tl = mat_sub.readwrite(LocalTileIndex{0, 0});
+
+      // the entire first row is selected in ro
+      auto senders_row = selectRead(mat_sub, row0_range);
+      EXPECT_EQ(ncols, senders_row.size());
+
+      // eagerly start the tile senders, but don't release them
+      std::vector<EagerVoidSender> void_senders_row;
+      void_senders_row.reserve(senders_row.size());
+      for (auto& s : senders_row) {
+        void_senders_row.emplace_back(std::move(s));
+      }
+
+      // Since the top left tile has been selected two times, the group selection
+      // would have all but the first tile ready...
+      EXPECT_TRUE(checkSendersStep(1, void_senders_row, true));
+
+      // ... until the first one will be released.
+      tt::sync_wait(std::move(sender_tl));
+      EXPECT_TRUE(checkSendersStep(ncols, void_senders_row));
+    }
+  }
+}
+
 TEST_F(MatrixGenericTest, SelectTilesReadwrite) {
   using TypeParam = double;
   using MemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::CPU>;
@@ -1202,6 +1949,56 @@ TEST_F(MatrixGenericTest, SelectTilesReadwrite) {
 
       // the entire first row is selected in rw
       auto senders_row = select(mat, row0_range);
+      EXPECT_EQ(ncols, senders_row.size());
+
+      // eagerly start the tile senders, but don't release them
+      std::vector<EagerVoidSender> void_senders_row;
+      void_senders_row.reserve(senders_row.size());
+      for (auto& s : senders_row) {
+        void_senders_row.emplace_back(std::move(s));
+      }
+
+      // Since the top left tile has been selected two times, the group selection
+      // would have all but the first tile ready...
+      EXPECT_TRUE(checkSendersStep(1, void_senders_row, true));
+
+      // ... until the first one will be released.
+      tt::sync_wait(std::move(sender_tl));
+      EXPECT_TRUE(checkSendersStep(ncols, void_senders_row));
+    }
+  }
+}
+
+TEST_F(MatrixGenericTest, SelectTilesReadwriteSubPipeline) {
+  using TypeParam = double;
+  using MemoryViewT = dlaf::memory::MemoryView<TypeParam, Device::CPU>;
+  using MatrixT = dlaf::Matrix<TypeParam, Device::CPU>;
+
+  for (const auto& comm_grid : this->commGrids()) {
+    for (const auto& test : sizes_tests) {
+      GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
+
+      Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
+      LayoutInfo layout = tileLayout(distribution.localSize(), test.block_size);
+
+      MemoryViewT mem(layout.minMemSize());
+      MatrixT mat = createMatrixFromTile<Device::CPU>(size, test.block_size, comm_grid,
+                                                      static_cast<TypeParam*>(mem()));
+      auto mat_sub = mat.subPipeline();
+
+      // if this rank has no tiles locally, there's nothing interesting to do...
+      if (distribution.localNrTiles().isEmpty())
+        continue;
+
+      const auto ncols = to_sizet(distribution.localNrTiles().cols());
+      const LocalTileSize local_row_size{1, to_SizeType(ncols)};
+      auto row0_range = common::iterate_range2d(local_row_size);
+
+      // top left tile is selected in rw (i.e. exclusive access)
+      auto sender_tl = mat_sub.readwrite(LocalTileIndex{0, 0});
+
+      // the entire first row is selected in rw
+      auto senders_row = select(mat_sub, row0_range);
       EXPECT_EQ(ncols, senders_row.size());
 
       // eagerly start the tile senders, but don't release them
@@ -1368,6 +2165,145 @@ TEST(MatrixDestructor, ConstAfterRead_UserMemory) {
   {
     T data;
     auto matrix = createConstMatrix<T>(data);
+
+    auto tile_sender = matrix.read(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, NonConstAfterReadSubPipeline) {
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    auto matrix = createMatrix<T>();
+    auto matrix_sub = matrix.subPipeline();
+
+    auto tile_sender = matrix_sub.read(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, NonConstAfterReadSubPipelineConst) {
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    auto matrix = createMatrix<T>();
+    auto matrix_sub = matrix.subPipelineConst();
+
+    auto tile_sender = matrix_sub.read(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, NonConstAfterReadWriteSubPipeline) {
+  namespace ex = pika::execution::experimental;
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    auto matrix = createMatrix<T>();
+    auto matrix_sub = matrix.subPipeline();
+
+    auto tile_sender = matrix_sub.readwrite(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, NonConstAfterReadSubPipeline_UserMemory) {
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    T data;
+    auto matrix = createMatrix<T>(data);
+    auto matrix_sub = matrix.subPipeline();
+
+    auto tile_sender = matrix.read(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, NonConstAfterReadSubPipelineConst_UserMemory) {
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    T data;
+    auto matrix = createMatrix<T>(data);
+    auto matrix_sub = matrix.subPipelineConst();
+
+    auto tile_sender = matrix.read(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, NonConstAfterReadWriteSubPipeline_UserMemory) {
+  namespace ex = pika::execution::experimental;
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    T data;
+    auto matrix = createMatrix<T>(data);
+    auto matrix_sub = matrix.subPipeline();
+
+    auto tile_sender = matrix_sub.readwrite(LocalTileIndex(0, 0));
+    last_task = std::move(tile_sender) |
+                dlaf::internal::transform(dlaf::internal::Policy<dlaf::Backend::MC>(),
+                                          WaitGuardHelper{is_exited_from_scope}) |
+                ex::ensure_started();
+  }
+  is_exited_from_scope = true;
+
+  tt::sync_wait(std::move(last_task));
+}
+
+TEST(MatrixDestructor, ConstAfterReadSubPipeline_UserMemory) {
+  ex::unique_any_sender<> last_task;
+
+  std::atomic<bool> is_exited_from_scope{false};
+  {
+    T data;
+    auto matrix = createConstMatrix<T>(data);
+    auto matrix_sub = matrix.subPipelineConst();
 
     auto tile_sender = matrix.read(LocalTileIndex(0, 0));
     last_task = std::move(tile_sender) |


### PR DESCRIPTION
Fixes part of #868.

This adds the naive, non-optimized, version of getting a `Matrix` from another `Matrix` with tiles in a sub-pipeline, i.e. tile accesses from the sub-pipelined `Matrix` are sequenced after all previous tile accesses to the original `Matrix` and before all later tile accesses to the original `Matrix`.

The missing optimization is merging of read-only accesses between the parent `Matrix` and the sub-pipelined `Matrix`. Creating a sub-pipelined `Matrix` currently implies one "hidden" read-write access to the parent `Matrix`. Releasing the sub-pipelined `Matrix` releases all subsequent accesses from the parent `Matrix`.

In the end this naive version required very few changes to `Matrix`, and did not require a separate type. I think this is a good thing. One of the open questions from this is if `Matrix` should have a `done` method? As far as I can tell `RetiledMatrix` should be possible to refactor into `Matrix` in exactly the same way and that would also introduce `done` into `Matrix`.

This can already now be used in conjunction with `View`s to access a sub-matrix with sub-pipelines. To have sub-matrices with sub-pipelines we first need to update `Distribution`.

Are the names `subPipeline` and `subPipelineConst` understandable? I'd like to avoid `subMatrixPipeline` since this doesn't yet handle sub-matrices. "nest" is a word that I'm thinking could fit well to the "sub-pipeline" aspect of the access but not sure yet. `nest`/`nestRead`/`nestConst`/`nested*`. In order to allow optimizing access to only a sub-matrix in the future I'd imagine the function signature would be expanded in the future to look like: `subPipeline/nested/whatever(SubTileMatrixSpec/SubElementMatrixSpec const& = full_matrix)` and then it'd be nice if the name would cleanly cover the future use cases as well but this future version could of course simply get a new name. Suggestions welcome.