### PR TITLE
Add placeholder for v0.1.0 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ target_link_libraries(<your_target> PRIVATE DLAF::DLAF)
 
 ### Documentation
 
-[Documentation of `v0.1.0`](https://eth-cscs.github.io/DLA-Future/v0.1.0/)
-[Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
+- [Documentation of `v0.1.0`](https://eth-cscs.github.io/DLA-Future/v0.1.0/)
+- [Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
 
 #### How to generate the documentation
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ target_link_libraries(<your_target> PRIVATE DLAF::DLAF)
 
 ### Documentation
 
-[Documentation of `v0.1.0` branch](https://eth-cscs.github.io/DLA-Future/v0.1.0/)
+[Documentation of `v0.1.0`](https://eth-cscs.github.io/DLA-Future/v0.1.0/)
 [Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
 
 #### How to generate the documentation

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ target_link_libraries(<your_target> PRIVATE DLAF::DLAF)
 
 ### Documentation
 
+[Documentation of `v0.1.0` branch](https://eth-cscs.github.io/DLA-Future/v0.1.0/)
 [Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
 
 #### How to generate the documentation


### PR DESCRIPTION
Adding placeholder for v0.1.0 doc.
The documentation will be generated after the release is tagged.