### PR TITLE
Buffer text in `std::ostringstream` before printing in `do_assert`

### DIFF
--- a/include/dlaf/common/assert.h
+++ b/include/dlaf/common/assert.h
@@ -42,7 +42,9 @@ template <class... Ts>
 inline void do_assert(bool expr, const common::internal::source_location& loc, const char* expression,
                       const Ts&... ts) noexcept {
   if (!expr) {
-    std::cerr << "[ERROR] " << loc << '\n' << expression << '\n' << concat(ts...) << std::endl;
+    std::ostringstream ss;
+    ss << "[ERROR] " << loc << '\n' << expression << '\n' << concat(ts...) << "\n";
+    std::cerr << ss.str();
     std::terminate();
   }
 }


### PR DESCRIPTION
Slightly improves multithreaded/process output.