### PR TITLE
Fix `tridiag_rank1_barrier_busy_wait` configuration option

### DIFF
--- a/include/dlaf/eigensolver/internal/get_tridiag_rank1_barrier_busy_wait.h
+++ b/include/dlaf/eigensolver/internal/get_tridiag_rank1_barrier_busy_wait.h
@@ -16,7 +16,7 @@
 namespace dlaf::eigensolver::internal {
 
 inline std::chrono::duration<double> getTridiagRank1BarrierBusyWait() noexcept {
-  return std::chrono::microseconds(getTuneParameters().red2band_barrier_busy_wait_us);
+  return std::chrono::microseconds(getTuneParameters().tridiag_rank1_barrier_busy_wait_us);
 }
 
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -174,8 +174,8 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
   updateConfigurationValue(vm, param.tridiag_rank1_nworkers, "TRIDIAG_RANK1_NWORKERS",
                            "tridiag-rank1-nworkers");
 
-  updateConfigurationValue(vm, param.red2band_barrier_busy_wait_us, "TRIDIAG_RANK1_BARRIER_BUSY_WAIT_US",
-                           "tridiag-rank1-barrier-busy-wait-us");
+  updateConfigurationValue(vm, param.tridiag_rank1_barrier_busy_wait_us,
+                           "TRIDIAG_RANK1_BARRIER_BUSY_WAIT_US", "tridiag-rank1-barrier-busy-wait-us");
 
   updateConfigurationValue(vm, param.bt_band_to_tridiag_hh_apply_group_size,
                            "DLAF_BT_BAND_TO_TRIDIAG_HH_APPLY_GROUP_SIZE",


### PR DESCRIPTION
It was initialized with the wrong value. Sorry about this.

I will separately rerun the benchmarks that I did for the tridiagonal solver, but now I can include the distributed results as well (with #904).