### PR TITLE
TridiagSolver: number of bulk workers for rank1 solver

### DIFF
--- a/include/dlaf/eigensolver/internal/get_tridiag_rank1_nworkers.h
+++ b/include/dlaf/eigensolver/internal/get_tridiag_rank1_nworkers.h
@@ -22,7 +22,7 @@ inline std::size_t getTridiagRank1NWorkers() noexcept {
   // Note: precautionarily we leave at least 1 thread "free" to do other stuff (if possible)
   const std::size_t available_workers = pika::resource::get_thread_pool("default").get_os_thread_count();
   const std::size_t min_workers = 1;
-  const auto max_workers = std::max(min_workers, available_workers - 1);
+  const auto max_workers = std::max(min_workers, available_workers);
 
   const std::size_t nworkers = getTuneParameters().tridiag_rank1_nworkers;
   return std::clamp(nworkers, min_workers, max_workers);

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -60,8 +60,7 @@ struct TuneParameters {
   std::size_t red2band_panel_nworkers =
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
   std::size_t red2band_barrier_busy_wait_us = 1000;
-  std::size_t tridiag_rank1_nworkers =
-      std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count());
+  std::size_t tridiag_rank1_nworkers = pika::resource::get_thread_pool("default").get_os_thread_count();
   std::size_t tridiag_rank1_barrier_busy_wait_us = 0;
 
   SizeType eigensolver_min_band = 100;

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -61,7 +61,7 @@ struct TuneParameters {
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
   std::size_t red2band_barrier_busy_wait_us = 1000;
   std::size_t tridiag_rank1_nworkers =
-      std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);
+      std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count());
   std::size_t tridiag_rank1_barrier_busy_wait_us = 0;
 
   SizeType eigensolver_min_band = 100;


### PR DESCRIPTION
TridiagSolver computes the solution by working on sub-problems that varies a lot in terms of sizes. For this reason, rank1 problem solution now adopts, for both local and distributed implementation, an "auto-limiting" policy in terms of workers used per problem.

Smaller problems will have less workers, allowing to solve more of them concurrently, and bigger problems will be assigned more workers, so that the computation will be carried out faster.

In addition, this PR also changes the default number of workers used: all threads in default pool are now considered for being used in the rank1 bulk. In particular, no thread is left out as previously done for others, when for "staying on the safe side" we opted for leaving out a thread.

- [x] #904

