### PR TITLE
minor: introduce parseFromString for bools 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -121,6 +124,24 @@ struct parseFromString<SizeType> {
   static std::optional<SizeType> call(const std::string& var) {
     return std::stoll(var);
   };
+};
+
+template <>
+struct parseFromString<bool> {
+  static std::optional<std::size_t> call(const std::string& var) {
+    if (is_one_of_ignore_case(var, {"ON", "TRUE", "YES", "1"}))
+      return true;
+    if (is_one_of_ignore_case(var, {"OFF", "FALSE", "NO", "0"}))
+      return false;
+    return std::nullopt;
+  };
+
+private:
+  static bool is_one_of_ignore_case(std::string value, const std::array<std::string, 4>& values) {
+    std::transform(value.cbegin(), value.cend(), value.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+    return (values.cend()) != std::find(values.cbegin(), values.cend(), value);
+  }
 };
 
 template <class T>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -128,7 +128,7 @@ struct parseFromString<SizeType> {
 
 template <>
 struct parseFromString<bool> {
-  static std::optional<std::size_t> call(const std::string& var) {
+  static std::optional<bool> call(const std::string& var) {
     if (is_one_of_ignore_case(var, {"ON", "TRUE", "YES", "1"}))
       return true;
     if (is_one_of_ignore_case(var, {"OFF", "FALSE", "NO", "0"}))

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <cctype>
 #include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -157,11 +158,14 @@ void updateConfigurationValue(const pika::program_options::variables_map& vm, T&
   const std::string dlaf_env_var = "DLAF_" + env_var;
   char* env_var_value = std::getenv(dlaf_env_var.c_str());
   if (env_var_value) {
-    if (auto parsed_value = parseFromString<T>::call(env_var_value))
+    if (auto parsed_value = parseFromString<T>::call(env_var_value)) {
       var = parsed_value.value();
-    else
+    }
+    else {
       std::cerr << "Environment variable " << dlaf_env_var << " has an invalid value (='"
                 << env_var_value << "').\n";
+      std::terminate();
+    }
   }
 
   const std::string dlaf_cmdline_option = "dlaf:" + cmdline_option;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <optional>
 
 #include <pika/runtime.hpp>
 
@@ -103,21 +104,21 @@ struct Init<Backend::GPU> {
 
 template <class T>
 struct parseFromString {
-  static T call(const std::string& val) {
+  static std::optional<T> call(const std::string& val) {
     return val;
   };
 };
 
 template <>
 struct parseFromString<std::size_t> {
-  static std::size_t call(const std::string& var) {
+  static std::optional<std::size_t> call(const std::string& var) {
     return std::stoull(var);
   };
 };
 
 template <>
 struct parseFromString<SizeType> {
-  static SizeType call(const std::string& var) {
+  static std::optional<SizeType> call(const std::string& var) {
     return std::stoll(var);
   };
 };
@@ -135,7 +136,8 @@ void updateConfigurationValue(const pika::program_options::variables_map& vm, T&
   const std::string dlaf_env_var = "DLAF_" + env_var;
   char* env_var_value = std::getenv(dlaf_env_var.c_str());
   if (env_var_value) {
-    var = parseFromString<T>::call(env_var_value);
+    if (auto parsed_value = parseFromString<T>::call(env_var_value))
+      var = parsed_value.value();
   }
 
   const std::string dlaf_cmdline_option = "dlaf:" + cmdline_option;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -159,6 +159,9 @@ void updateConfigurationValue(const pika::program_options::variables_map& vm, T&
   if (env_var_value) {
     if (auto parsed_value = parseFromString<T>::call(env_var_value))
       var = parsed_value.value();
+    else
+      std::cerr << "Environment variable " << dlaf_env_var << " has an invalid value (='"
+                << env_var_value << "').\n";
   }
 
   const std::string dlaf_cmdline_option = "dlaf:" + cmdline_option;


### PR DESCRIPTION
Following discussion in https://github.com/eth-cscs/DLA-Future/pull/880#discussion_r1221368140, this PR introduces `parseFromString` for `bool` types.

| option |  b | d | e |
| -- |  -- | -- | --  |
| unset DEBUG |  default  | default | default |
| export DEBUG |  false | true | default |
| export DEBUG=TRUE |  true | true | true |
| export DEBUG=FALSE  | false | false | false |
| export DEBUG=*  | ? | ? | default | 

Currently I went for the last option suggested E, but now the change between different solution B, D, E should be quite easy.