### PR TITLE
fetch tokens from middleware

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -20,6 +20,7 @@ stages:
     SPACK_SHA: b313b28e64c15761be0d45a16c922c25b2786f76
     SPACK_DLAF_REPO: ./spack
   before_script:
+    - !reference [.fetch-registry-tokens, script]
     - podman login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   script:
     # Note: a tag can contain 0-9 A-Z a-z -_.


### PR DESCRIPTION
Soon static tokens will be removed, and tokens must be fetched explicitly when needed from the middleware. These tokens will be valid only for the duration of the job.