### PR TITLE
TridiagSolver (local): embed row permutation in rank1 solver

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/kernels.h
+++ b/include/dlaf/eigensolver/tridiag_solver/kernels.h
@@ -273,43 +273,6 @@ void initIndexTileAsync(SizeType tile_row, TileSender&& tile) {
   di::transformDetach(di::Policy<DefaultBackend_v<D>>(), initIndexTile_o, std::move(sender));
 }
 
-template <class T>
-void setUnitDiagonal(const SizeType& k, const SizeType& tile_begin,
-                     const matrix::Tile<T, Device::CPU>& tile);
-
-#define DLAF_CPU_SET_UNIT_DIAGONAL_ETI(kword, Type)                                  \
-  kword template void setUnitDiagonal(const SizeType& k, const SizeType& tile_begin, \
-                                      const matrix::Tile<Type, Device::CPU>& tile)
-
-DLAF_CPU_SET_UNIT_DIAGONAL_ETI(extern, float);
-DLAF_CPU_SET_UNIT_DIAGONAL_ETI(extern, double);
-
-#ifdef DLAF_WITH_GPU
-template <class T>
-void setUnitDiagonal(const SizeType& k, const SizeType& tile_begin,
-                     const matrix::Tile<T, Device::GPU>& tile, whip::stream_t stream);
-
-#define DLAF_GPU_SET_UNIT_DIAGONAL_ETI(kword, Type)                                  \
-  kword template void setUnitDiagonal(const SizeType& k, const SizeType& tile_begin, \
-                                      const matrix::Tile<Type, Device::GPU>& tile,   \
-                                      whip::stream_t stream)
-
-DLAF_GPU_SET_UNIT_DIAGONAL_ETI(extern, float);
-DLAF_GPU_SET_UNIT_DIAGONAL_ETI(extern, double);
-
-#endif
-
-DLAF_MAKE_CALLABLE_OBJECT(setUnitDiagonal);
-
-template <Device D, class KSender, class TileSender>
-void setUnitDiagonalAsync(KSender&& k, SizeType tile_begin, TileSender&& tile) {
-  namespace di = dlaf::internal;
-  auto sender = di::whenAllLift(std::forward<KSender>(k), tile_begin, std::forward<TileSender>(tile));
-  di::transformDetach(di::Policy<DefaultBackend_v<D>>(), setUnitDiagonal_o, std::move(sender));
-}
-
-// ---------------------------
-
 #ifdef DLAF_WITH_GPU
 
 // Returns the number of non-deflated entries

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -618,17 +618,6 @@ void solveRank1Problem(const SizeType i_begin, const SizeType i_end, KSender&& k
       }));
 }
 
-template <class T, Device D, class KSender>
-void setUnitDiag(const SizeType i_begin, const SizeType i_end, KSender&& k, Matrix<T, D>& mat) {
-  // Iterate over diagonal tiles
-  const matrix::Distribution& distr = mat.distribution();
-  for (SizeType i_tile = i_begin; i_tile < i_end; ++i_tile) {
-    const SizeType tile_begin = distr.globalTileElementDistance<Coord::Row>(i_begin, i_tile);
-
-    setUnitDiagonalAsync<D>(k, tile_begin, mat.readwrite(GlobalTileIndex(i_tile, i_tile)));
-  }
-}
-
 template <Backend B, Device D, class T, class RhoSender>
 void mergeSubproblems(const SizeType i_begin, const SizeType i_split, const SizeType i_end,
                       RhoSender&& rho, WorkSpace<T, D>& ws, WorkSpaceHost<T>& ws_h,

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -487,7 +487,21 @@ void solveRank1Problem(const SizeType i_begin, const SizeType i_end, KSender&& k
         const std::size_t begin = thread_idx * batch_size;
         const std::size_t end = std::min(thread_idx * batch_size + batch_size, to_sizet(k));
 
-        // STEP 0: Initialize workspaces (single-thread)
+        // STEP 0a: Fill ones for deflated Eigenvectors. (single-thread)
+        // Note: this step is completely independent from the rest, but it is small and it is going
+        // to be dropped soon.
+        // Note: use last thread that in principle should have less work to do
+        if (thread_idx == nthreads - 1) {
+          for (auto j = k; j < n; ++j) {
+            const GlobalElementIndex kk(j, j);
+            const auto diag_tile = distr.globalTileLinearIndex(kk);
+            const auto diag_element = distr.tileElementIndex(kk);
+
+            evec_tiles[to_sizet(diag_tile)](diag_element) = 1;
+          }
+        }
+
+        // STEP 0b: Initialize workspaces (single-thread)
         if (thread_idx == 0) {
           ws_vecs.reserve(nthreads);
           for (std::size_t i = 0; i < nthreads; ++i)
@@ -698,10 +712,7 @@ void mergeSubproblems(const SizeType i_begin, const SizeType i_split, const Size
   matrix::util::set0<Backend::MC>(pika::execution::thread_priority::normal, idx_loc_begin, sz_loc_tiles,
                                   ws_hm.e2);
   solveRank1Problem(i_begin, i_end, k, scaled_rho, ws_hm.d1, ws_hm.z1, ws_h.d0, ws_hm.e2);
-
   copy(idx_loc_begin, sz_loc_tiles, ws_hm.e2, ws.e2);
-
-  setUnitDiag(i_begin, i_end, k, ws.e2);
 
   // Step #3: Eigenvectors of the tridiagonal system: Q * U
   //

--- a/src/eigensolver/tridiag_solver/kernels.cpp
+++ b/src/eigensolver/tridiag_solver/kernels.cpp
@@ -93,20 +93,4 @@ void initIndexTile(SizeType offset, const matrix::Tile<SizeType, Device::CPU>& t
   }
 }
 
-template <class T>
-void setUnitDiagonal(const SizeType& k, const SizeType& tile_begin,
-                     const matrix::Tile<T, Device::CPU>& tile) {
-  // If all elements of the tile are after the `k` index reset the offset
-  SizeType tile_offset = k - tile_begin;
-  if (tile_offset < 0)
-    tile_offset = 0;
-
-  // Set all diagonal elements of the tile to 1.
-  for (SizeType i = tile_offset; i < tile.size().rows(); ++i) {
-    tile(TileElementIndex(i, i)) = 1;
-  }
-}
-
-DLAF_CPU_SET_UNIT_DIAGONAL_ETI(, float);
-DLAF_CPU_SET_UNIT_DIAGONAL_ETI(, double);
 }


### PR DESCRIPTION
Distributed and local implementations have slightly diverged in the last months.

This PR addresses the main (and probably the only ones) differences. With #831 distributed implementation got row permutations and `setUnitDiag` embedded in rank1 solution, removing the need of explicitly doing so just before doing the gemm. Local implementation was still doing the permutation separately.

With this PR both `setUnitDiag` and row permutation happen during rank1 solver also for the local implementation.