### PR TITLE
Avoid unnecessary allocation of `shared_ptr`s in `MemoryView`

### DIFF
--- a/include/dlaf/memory/memory_chunk.h
+++ b/include/dlaf/memory/memory_chunk.h
@@ -78,7 +78,7 @@ public:
   ///
   /// @param ptr  The pointer to the already allocated memory,
   /// @param size The size (in number of elements of type @c T) of the existing allocation,
-  /// @pre @p ptr+i can be deferenced for 0 < @c i < @p size.
+  /// @pre @p ptr+i can be dereferenced for 0 <= @c i < @p size.
   MemoryChunk(T* ptr, SizeType size) : size_(size), ptr_(size > 0 ? ptr : nullptr), allocated_(false) {
     DLAF_ASSERT_HEAVY(size == 0 ? ptr_ == nullptr : ptr_ != nullptr, size);
   }

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -55,7 +55,8 @@ public:
   /// @param size The size (in number of elements of type @c T) of the existing allocation,
   /// @pre @p ptr+i can be deferenced for 0 < @c i < @p size.
   MemoryView(T* ptr, SizeType size)
-      : memory_(std::make_shared<MemoryChunk<ElementType, D>>(const_cast<ElementType*>(ptr), size)),
+      : memory_(ptr ? std::make_shared<MemoryChunk<ElementType, D>>(const_cast<ElementType*>(ptr), size)
+                    : nullptr),
         offset_(0), size_(size) {
     DLAF_ASSERT(size >= 0, size);
   }
@@ -73,8 +74,7 @@ public:
 
   template <class U = T, class = typename std::enable_if_t<std::is_const_v<U> && std::is_same_v<T, U>>>
   MemoryView(MemoryView<ElementType, D>&& rhs) noexcept
-      : memory_(rhs.memory_), offset_(rhs.offset_), size_(rhs.size_) {
-    rhs.memory_ = std::make_shared<MemoryChunk<ElementType, D>>();
+      : memory_(std::move(rhs.memory_)), offset_(rhs.offset_), size_(rhs.size_) {
     rhs.size_ = 0;
     rhs.offset_ = 0;
   }

--- a/include/dlaf/memory/memory_view.h
+++ b/include/dlaf/memory/memory_view.h
@@ -53,7 +53,7 @@ public:
   ///
   /// @param ptr  The pointer to the already allocated memory,
   /// @param size The size (in number of elements of type @c T) of the existing allocation,
-  /// @pre @p ptr+i can be deferenced for 0 < @c i < @p size.
+  /// @pre @p ptr+i can be dereferenced for 0 <= @c i < @p size.
   MemoryView(T* ptr, SizeType size)
       : memory_(ptr ? std::make_shared<MemoryChunk<ElementType, D>>(const_cast<ElementType*>(ptr), size)
                     : nullptr),


### PR DESCRIPTION
I didn't run any benchmarks with this as it seems we're only using these in the `MemoryView` tests. It's likely that the `MemoryView(T* ptr, SizeType size)` constructor is used by the C API but I haven't checked if it makes a difference there. Similar motivation as #579. 