### PR TITLE
Public algorithm interface renaming using snake_case

### DIFF
--- a/include/dlaf/eigensolver/band_to_tridiag/api.h
+++ b/include/dlaf/eigensolver/band_to_tridiag/api.h
@@ -13,15 +13,13 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/types.h>
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
 template <class T, Device D>
 struct TridiagResult {
   Matrix<BaseType<T>, D> tridiagonal;
   Matrix<T, D> hh_reflectors;
 };
-
-namespace internal {
 
 template <class T>
 SizeType nrSweeps(SizeType size) noexcept {
@@ -62,5 +60,4 @@ DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, double)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, std::complex<float>)
 DLAF_EIGENSOLVER_B2T_ETI(extern, Backend::MC, Device::GPU, std::complex<double>)
 #endif
-}
 }

--- a/include/dlaf/eigensolver/bt_band_to_tridiag.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag.h
@@ -54,8 +54,8 @@ namespace dlaf::eigensolver {
 // @pre mat_e has equal tile and block sizes
 // @pre mat_hh has equal tile and block sizes
 template <Backend B, Device D, class T>
-void backTransformationBandToTridiag(const SizeType band_size, matrix::Matrix<T, D>& mat_e,
-                                     matrix::Matrix<const T, Device::CPU>& mat_hh) {
+void bt_band_to_tridiag(const SizeType band_size, matrix::Matrix<T, D>& mat_e,
+                        matrix::Matrix<const T, Device::CPU>& mat_hh) {
   DLAF_ASSERT(matrix::local_matrix(mat_e), mat_e);
   DLAF_ASSERT(matrix::local_matrix(mat_hh), mat_hh);
 
@@ -75,9 +75,8 @@ void backTransformationBandToTridiag(const SizeType band_size, matrix::Matrix<T,
 }
 
 template <Backend B, Device D, class T>
-void backTransformationBandToTridiag(comm::CommunicatorGrid grid, const SizeType band_size,
-                                     matrix::Matrix<T, D>& mat_e,
-                                     matrix::Matrix<const T, Device::CPU>& mat_hh) {
+void bt_band_to_tridiag(comm::CommunicatorGrid grid, const SizeType band_size,
+                        matrix::Matrix<T, D>& mat_e, matrix::Matrix<const T, Device::CPU>& mat_hh) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_e, grid), mat_e, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_hh, grid), mat_hh, grid);
 

--- a/include/dlaf/eigensolver/bt_band_to_tridiag.h
+++ b/include/dlaf/eigensolver/bt_band_to_tridiag.h
@@ -17,7 +17,7 @@
 #include <dlaf/types.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
 // Eigenvalue back-transformation implementation on local memory, which applies the inverse of the
 // transformation used to get a tridiagonal matrix from a band one.
@@ -54,8 +54,8 @@ namespace dlaf::eigensolver {
 // @pre mat_e has equal tile and block sizes
 // @pre mat_hh has equal tile and block sizes
 template <Backend B, Device D, class T>
-void bt_band_to_tridiag(const SizeType band_size, matrix::Matrix<T, D>& mat_e,
-                        matrix::Matrix<const T, Device::CPU>& mat_hh) {
+void bt_band_to_tridiagonal(const SizeType band_size, matrix::Matrix<T, D>& mat_e,
+                            matrix::Matrix<const T, Device::CPU>& mat_hh) {
   DLAF_ASSERT(matrix::local_matrix(mat_e), mat_e);
   DLAF_ASSERT(matrix::local_matrix(mat_hh), mat_hh);
 
@@ -71,12 +71,12 @@ void bt_band_to_tridiag(const SizeType band_size, matrix::Matrix<T, D>& mat_e,
   DLAF_ASSERT(band_size >= 2, band_size);
   DLAF_ASSERT(mat_hh.blockSize().rows() % band_size == 0, mat_hh.blockSize(), band_size);
 
-  internal::BackTransformationT2B<B, D, T>::call(band_size, mat_e, mat_hh);
+  BackTransformationT2B<B, D, T>::call(band_size, mat_e, mat_hh);
 }
 
 template <Backend B, Device D, class T>
-void bt_band_to_tridiag(comm::CommunicatorGrid grid, const SizeType band_size,
-                        matrix::Matrix<T, D>& mat_e, matrix::Matrix<const T, Device::CPU>& mat_hh) {
+void bt_band_to_tridiagonal(comm::CommunicatorGrid grid, const SizeType band_size,
+                            matrix::Matrix<T, D>& mat_e, matrix::Matrix<const T, Device::CPU>& mat_hh) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_e, grid), mat_e, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_hh, grid), mat_hh, grid);
 
@@ -89,6 +89,6 @@ void bt_band_to_tridiag(comm::CommunicatorGrid grid, const SizeType band_size,
   DLAF_ASSERT(band_size >= 2, band_size);
   DLAF_ASSERT(mat_hh.blockSize().rows() % band_size == 0, mat_hh.blockSize(), band_size);
 
-  internal::BackTransformationT2B<B, D, T>::call(grid, band_size, mat_e, mat_hh);
+  BackTransformationT2B<B, D, T>::call(grid, band_size, mat_e, mat_hh);
 }
 }

--- a/include/dlaf/eigensolver/bt_reduction_to_band.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band.h
@@ -19,8 +19,7 @@
 #include <dlaf/types.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace eigensolver {
+namespace dlaf::eigensolver::internal {
 
 /// Eigenvalue back-transformation implementation on local memory.
 ///
@@ -56,7 +55,7 @@ void bt_reduction_to_band(const SizeType b, Matrix<T, device>& mat_c, Matrix<con
   };
   DLAF_ASSERT(mat_taus.nrTiles().rows() == nr_reflectors_blocks(), mat_taus.size().rows(), mat_v, b);
 
-  internal::BackTransformationReductionToBand<backend, device, T>::call(b, mat_c, mat_v, mat_taus);
+  BackTransformationReductionToBand<backend, device, T>::call(b, mat_c, mat_v, mat_taus);
 }
 
 /// Eigenvalue back-transformation implementation on distributed memory.
@@ -95,7 +94,6 @@ void bt_reduction_to_band(comm::CommunicatorGrid grid, const SizeType b, Matrix<
   DLAF_ASSERT(mat_taus.distribution().localNrTiles().rows() == nr_reflectors_blocks(), mat_taus, mat_v,
               b);
 
-  internal::BackTransformationReductionToBand<backend, device, T>::call(grid, b, mat_c, mat_v, mat_taus);
-}
+  BackTransformationReductionToBand<backend, device, T>::call(grid, b, mat_c, mat_v, mat_taus);
 }
 }

--- a/include/dlaf/eigensolver/bt_reduction_to_band.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band.h
@@ -38,9 +38,8 @@ namespace eigensolver {
 /// @pre mat_c has equal tile and block sizes,
 /// @pre mat_v has equal tile and block sizes.
 template <Backend backend, Device device, class T>
-void backTransformationReductionToBand(const SizeType b, Matrix<T, device>& mat_c,
-                                       Matrix<const T, device>& mat_v,
-                                       Matrix<const T, Device::CPU>& mat_taus) {
+void bt_reduction_to_band(const SizeType b, Matrix<T, device>& mat_c, Matrix<const T, device>& mat_v,
+                          Matrix<const T, Device::CPU>& mat_taus) {
   DLAF_ASSERT(matrix::local_matrix(mat_c), mat_c);
   DLAF_ASSERT(matrix::local_matrix(mat_v), mat_v);
   DLAF_ASSERT(square_size(mat_v), mat_v);
@@ -76,9 +75,8 @@ void backTransformationReductionToBand(const SizeType b, Matrix<T, device>& mat_
 /// @pre mat_c has equal tile and block sizes,
 /// @pre mat_v has equal tile and block sizes.
 template <Backend backend, Device device, class T>
-void backTransformationReductionToBand(comm::CommunicatorGrid grid, const SizeType b,
-                                       Matrix<T, device>& mat_c, Matrix<const T, device>& mat_v,
-                                       Matrix<const T, Device::CPU>& mat_taus) {
+void bt_reduction_to_band(comm::CommunicatorGrid grid, const SizeType b, Matrix<T, device>& mat_c,
+                          Matrix<const T, device>& mat_v, Matrix<const T, Device::CPU>& mat_taus) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_c, grid), mat_c, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_v, grid), mat_v, grid);
   DLAF_ASSERT(square_size(mat_v), mat_v);

--- a/include/dlaf/eigensolver/eigensolver.h
+++ b/include/dlaf/eigensolver/eigensolver.h
@@ -19,7 +19,7 @@
 #include <dlaf/types.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf::eigensolver {
+namespace dlaf {
 
 /// Standard Eigensolver.
 ///
@@ -36,8 +36,8 @@ namespace dlaf::eigensolver {
 /// @param eigenvalues is a N x 1 matrix which on output contains the eigenvalues
 /// @param eigenvectors is a N x N matrix which on output contains the eigenvectors
 template <Backend B, Device D, class T>
-void eigensolver(blas::Uplo uplo, Matrix<T, D>& mat, Matrix<BaseType<T>, D>& eigenvalues,
-                 Matrix<T, D>& eigenvectors) {
+void hermitian_eigensolver(blas::Uplo uplo, Matrix<T, D>& mat, Matrix<BaseType<T>, D>& eigenvalues,
+                           Matrix<T, D>& eigenvectors) {
   DLAF_ASSERT(matrix::local_matrix(mat), mat);
   DLAF_ASSERT(square_size(mat), mat);
   DLAF_ASSERT(square_blocksize(mat), mat);
@@ -54,7 +54,7 @@ void eigensolver(blas::Uplo uplo, Matrix<T, D>& mat, Matrix<BaseType<T>, D>& eig
   DLAF_ASSERT(single_tile_per_block(eigenvalues), eigenvalues);
   DLAF_ASSERT(single_tile_per_block(eigenvectors), eigenvectors);
 
-  internal::Eigensolver<B, D, T>::call(uplo, mat, eigenvalues, eigenvectors);
+  eigensolver::internal::Eigensolver<B, D, T>::call(uplo, mat, eigenvalues, eigenvectors);
 }
 
 /// Standard Eigensolver.
@@ -70,13 +70,13 @@ void eigensolver(blas::Uplo uplo, Matrix<T, D>& mat, Matrix<BaseType<T>, D>& eig
 /// @param uplo specifies if upper or lower triangular part of @p mat will be referenced
 /// @param mat contains the Hermitian matrix A
 template <Backend B, Device D, class T>
-EigensolverResult<T, D> eigensolver(blas::Uplo uplo, Matrix<T, D>& mat) {
+EigensolverResult<T, D> hermitian_eigensolver(blas::Uplo uplo, Matrix<T, D>& mat) {
   const SizeType size = mat.size().rows();
   matrix::Matrix<BaseType<T>, D> eigenvalues(LocalElementSize(size, 1),
                                              TileElementSize(mat.blockSize().rows(), 1));
   matrix::Matrix<T, D> eigenvectors(LocalElementSize(size, size), mat.blockSize());
 
-  eigensolver<B, D, T>(uplo, mat, eigenvalues, eigenvectors);
+  hermitian_eigensolver<B, D, T>(uplo, mat, eigenvalues, eigenvectors);
   return {std::move(eigenvalues), std::move(eigenvectors)};
 }
 
@@ -96,8 +96,8 @@ EigensolverResult<T, D> eigensolver(blas::Uplo uplo, Matrix<T, D>& mat) {
 /// @param eigenvalues is a N x 1 matrix which on output contains the eigenvalues
 /// @param eigenvectors is a N x N matrix which on output contains the eigenvectors
 template <Backend B, Device D, class T>
-void eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat,
-                 Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
+void hermitian_eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat,
+                           Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
   DLAF_ASSERT(matrix::equal_process_grid(mat, grid), mat);
   DLAF_ASSERT(square_size(mat), mat);
   DLAF_ASSERT(square_blocksize(mat), mat);
@@ -114,7 +114,7 @@ void eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat
   DLAF_ASSERT(single_tile_per_block(eigenvalues), eigenvalues);
   DLAF_ASSERT(single_tile_per_block(eigenvectors), eigenvectors);
 
-  internal::Eigensolver<B, D, T>::call(grid, uplo, mat, eigenvalues, eigenvectors);
+  eigensolver::internal::Eigensolver<B, D, T>::call(grid, uplo, mat, eigenvalues, eigenvectors);
 }
 
 /// Standard Eigensolver.
@@ -131,13 +131,14 @@ void eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat
 /// @param uplo specifies if upper or lower triangular part of @p mat will be referenced
 /// @param mat contains the Hermitian matrix A
 template <Backend B, Device D, class T>
-EigensolverResult<T, D> eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat) {
+EigensolverResult<T, D> hermitian_eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo,
+                                              Matrix<T, D>& mat) {
   const SizeType size = mat.size().rows();
   matrix::Matrix<BaseType<T>, D> eigenvalues(LocalElementSize(size, 1),
                                              TileElementSize(mat.blockSize().rows(), 1));
   matrix::Matrix<T, D> eigenvectors(GlobalElementSize(size, size), mat.blockSize(), grid);
 
-  eigensolver<B, D, T>(grid, uplo, mat, eigenvalues, eigenvectors);
+  hermitian_eigensolver<B, D, T>(grid, uplo, mat, eigenvalues, eigenvectors);
   return {std::move(eigenvalues), std::move(eigenvectors)};
 }
 }

--- a/include/dlaf/eigensolver/eigensolver/api.h
+++ b/include/dlaf/eigensolver/eigensolver/api.h
@@ -16,7 +16,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/types.h>
 
-namespace dlaf::eigensolver {
+namespace dlaf {
 
 template <class T, Device D>
 struct EigensolverResult {
@@ -24,7 +24,7 @@ struct EigensolverResult {
   Matrix<T, D> eigenvectors;
 };
 
-namespace internal {
+namespace eigensolver::internal {
 
 template <Backend B, Device D, class T>
 struct Eigensolver {

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -42,7 +42,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
   if (uplo != blas::Uplo::Lower)
     DLAF_UNIMPLEMENTED(uplo);
 
-  auto mat_taus = reductionToBand<B>(mat_a, band_size);
+  auto mat_taus = reduction_to_band<B>(mat_a, band_size);
   auto ret = band_to_tridiag<Backend::MC>(uplo, band_size, mat_a);
 
   eigensolver::tridiagSolver<B>(ret.tridiagonal, evals, mat_e);
@@ -60,7 +60,7 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
   if (uplo != blas::Uplo::Lower)
     DLAF_UNIMPLEMENTED(uplo);
 
-  auto mat_taus = reductionToBand<B>(grid, mat_a, band_size);
+  auto mat_taus = reduction_to_band<B>(grid, mat_a, band_size);
   auto ret = band_to_tridiag<Backend::MC>(grid, uplo, band_size, mat_a);
 
 #ifdef DLAF_WITH_HDF5

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -47,7 +47,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
 
   eigensolver::tridiagSolver<B>(ret.tridiagonal, evals, mat_e);
 
-  backTransformationBandToTridiag<B>(band_size, mat_e, ret.hh_reflectors);
+  bt_band_to_tridiag<B>(band_size, mat_e, ret.hh_reflectors);
   backTransformationReductionToBand<B>(band_size, mat_e, mat_a, mat_taus);
 }
 
@@ -81,7 +81,7 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
   }
 #endif
 
-  backTransformationBandToTridiag<B>(grid, band_size, mat_e, ret.hh_reflectors);
+  bt_band_to_tridiag<B>(grid, band_size, mat_e, ret.hh_reflectors);
   backTransformationReductionToBand<B>(grid, band_size, mat_e, mat_a, mat_taus);
 }
 }

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -45,7 +45,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
   auto mat_taus = reduction_to_band<B>(mat_a, band_size);
   auto ret = band_to_tridiagonal<Backend::MC>(uplo, band_size, mat_a);
 
-  eigensolver::tridiag_solver<B>(ret.tridiagonal, evals, mat_e);
+  tridiagonal_eigensolver<B>(ret.tridiagonal, evals, mat_e);
 
   bt_band_to_tridiagonal<B>(band_size, mat_e, ret.hh_reflectors);
   bt_reduction_to_band<B>(band_size, mat_e, mat_a, mat_taus);
@@ -72,7 +72,7 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
   }
 #endif
 
-  eigensolver::tridiag_solver<B>(grid, ret.tridiagonal, evals, mat_e);
+  tridiagonal_eigensolver<B>(grid, ret.tridiagonal, evals, mat_e);
 
 #ifdef DLAF_WITH_HDF5
   if (getTuneParameters().debug_dump_trisolver_data) {

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -47,7 +47,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
 
   eigensolver::tridiag_solver<B>(ret.tridiagonal, evals, mat_e);
 
-  bt_band_to_tridiag<B>(band_size, mat_e, ret.hh_reflectors);
+  bt_band_to_tridiagonal<B>(band_size, mat_e, ret.hh_reflectors);
   bt_reduction_to_band<B>(band_size, mat_e, mat_a, mat_taus);
 }
 
@@ -81,7 +81,7 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
   }
 #endif
 
-  bt_band_to_tridiag<B>(grid, band_size, mat_e, ret.hh_reflectors);
+  bt_band_to_tridiagonal<B>(grid, band_size, mat_e, ret.hh_reflectors);
   bt_reduction_to_band<B>(grid, band_size, mat_e, mat_a, mat_taus);
 }
 }

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -48,7 +48,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
   eigensolver::tridiagSolver<B>(ret.tridiagonal, evals, mat_e);
 
   bt_band_to_tridiag<B>(band_size, mat_e, ret.hh_reflectors);
-  backTransformationReductionToBand<B>(band_size, mat_e, mat_a, mat_taus);
+  bt_reduction_to_band<B>(band_size, mat_e, mat_a, mat_taus);
 }
 
 template <Backend B, Device D, class T>
@@ -82,6 +82,6 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
 #endif
 
   bt_band_to_tridiag<B>(grid, band_size, mat_e, ret.hh_reflectors);
-  backTransformationReductionToBand<B>(grid, band_size, mat_e, mat_a, mat_taus);
+  bt_reduction_to_band<B>(grid, band_size, mat_e, mat_a, mat_taus);
 }
 }

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -45,7 +45,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
   auto mat_taus = reduction_to_band<B>(mat_a, band_size);
   auto ret = band_to_tridiag<Backend::MC>(uplo, band_size, mat_a);
 
-  eigensolver::tridiagSolver<B>(ret.tridiagonal, evals, mat_e);
+  eigensolver::tridiag_solver<B>(ret.tridiagonal, evals, mat_e);
 
   bt_band_to_tridiag<B>(band_size, mat_e, ret.hh_reflectors);
   bt_reduction_to_band<B>(band_size, mat_e, mat_a, mat_taus);
@@ -72,7 +72,7 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
   }
 #endif
 
-  eigensolver::tridiagSolver<B>(grid, ret.tridiagonal, evals, mat_e);
+  eigensolver::tridiag_solver<B>(grid, ret.tridiagonal, evals, mat_e);
 
 #ifdef DLAF_WITH_HDF5
   if (getTuneParameters().debug_dump_trisolver_data) {

--- a/include/dlaf/eigensolver/eigensolver/impl.h
+++ b/include/dlaf/eigensolver/eigensolver/impl.h
@@ -43,7 +43,7 @@ void Eigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<Bas
     DLAF_UNIMPLEMENTED(uplo);
 
   auto mat_taus = reduction_to_band<B>(mat_a, band_size);
-  auto ret = band_to_tridiag<Backend::MC>(uplo, band_size, mat_a);
+  auto ret = band_to_tridiagonal<Backend::MC>(uplo, band_size, mat_a);
 
   eigensolver::tridiag_solver<B>(ret.tridiagonal, evals, mat_e);
 
@@ -61,7 +61,7 @@ void Eigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Ma
     DLAF_UNIMPLEMENTED(uplo);
 
   auto mat_taus = reduction_to_band<B>(grid, mat_a, band_size);
-  auto ret = band_to_tridiag<Backend::MC>(grid, uplo, band_size, mat_a);
+  auto ret = band_to_tridiagonal<Backend::MC>(grid, uplo, band_size, mat_a);
 
 #ifdef DLAF_WITH_HDF5
   std::optional<matrix::internal::FileHDF5> file;

--- a/include/dlaf/eigensolver/gen_eigensolver.h
+++ b/include/dlaf/eigensolver/gen_eigensolver.h
@@ -39,8 +39,8 @@ namespace dlaf::eigensolver {
 /// @param eigenvalues is a N x 1 matrix which on output contains the eigenvalues
 /// @param eigenvectors is a N x N matrix which on output contains the eigenvectors
 template <Backend B, Device D, class T>
-void genEigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b,
-                    Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
+void gen_eigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b,
+                     Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
   DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
   DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
   DLAF_ASSERT(matrix::local_matrix(eigenvalues), eigenvalues);
@@ -82,7 +82,7 @@ void genEigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b,
 /// @param mat_a contains the Hermitian matrix A
 /// @param mat_b contains the Hermitian positive definite matrix B
 template <Backend B, Device D, class T>
-EigensolverResult<T, D> genEigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b) {
+EigensolverResult<T, D> gen_eigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b) {
   DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
   DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
@@ -98,7 +98,7 @@ EigensolverResult<T, D> genEigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Mat
                                              TileElementSize(mat_a.blockSize().rows(), 1));
   matrix::Matrix<T, D> eigenvectors(LocalElementSize(size, size), mat_a.blockSize());
 
-  genEigensolver<B, D, T>(uplo, mat_a, mat_b, eigenvalues, eigenvectors);
+  gen_eigensolver<B, D, T>(uplo, mat_a, mat_b, eigenvalues, eigenvectors);
 
   return {std::move(eigenvalues), std::move(eigenvectors)};
 }
@@ -123,9 +123,9 @@ EigensolverResult<T, D> genEigensolver(blas::Uplo uplo, Matrix<T, D>& mat_a, Mat
 /// @param eigenvalues is a N x 1 matrix which on output contains the eigenvalues
 /// @param eigenvectors is a N x N matrix which on output contains the eigenvectors
 template <Backend B, Device D, class T>
-void genEigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat_a,
-                    Matrix<T, D>& mat_b, Matrix<BaseType<T>, D>& eigenvalues,
-                    Matrix<T, D>& eigenvectors) {
+void gen_eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat_a,
+                     Matrix<T, D>& mat_b, Matrix<BaseType<T>, D>& eigenvalues,
+                     Matrix<T, D>& eigenvectors) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_a, grid), mat_a, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_b, grid), mat_b, grid);
   DLAF_ASSERT(matrix::local_matrix(eigenvalues), eigenvalues);
@@ -168,8 +168,8 @@ void genEigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& 
 /// @param mat_a contains the Hermitian matrix A
 /// @param mat_b contains the Hermitian positive definite matrix B
 template <Backend B, Device D, class T>
-EigensolverResult<T, D> genEigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat_a,
-                                       Matrix<T, D>& mat_b) {
+EigensolverResult<T, D> gen_eigensolver(comm::CommunicatorGrid grid, blas::Uplo uplo,
+                                        Matrix<T, D>& mat_a, Matrix<T, D>& mat_b) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_a, grid), mat_a, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_b, grid), mat_b, grid);
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
@@ -185,7 +185,7 @@ EigensolverResult<T, D> genEigensolver(comm::CommunicatorGrid grid, blas::Uplo u
                                              TileElementSize(mat_a.blockSize().rows(), 1));
   matrix::Matrix<T, D> eigenvectors(GlobalElementSize(size, size), mat_a.blockSize(), grid);
 
-  genEigensolver<B, D, T>(grid, uplo, mat_a, mat_b, eigenvalues, eigenvectors);
+  gen_eigensolver<B, D, T>(grid, uplo, mat_a, mat_b, eigenvalues, eigenvectors);
 
   return {std::move(eigenvalues), std::move(eigenvectors)};
 }

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -25,7 +25,7 @@ void GenEigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<
   factorization::cholesky<B>(uplo, mat_b);
   eigensolver::gen_to_std<B>(uplo, mat_a, mat_b);
 
-  eigensolver::eigensolver<B>(uplo, mat_a, eigenvalues, eigenvectors);
+  hermitian_eigensolver<B>(uplo, mat_a, eigenvalues, eigenvectors);
 
   solver::triangular<B>(blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1), mat_b,
                         eigenvectors);
@@ -38,7 +38,7 @@ void GenEigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo,
   factorization::cholesky<B>(grid, uplo, mat_b);
   eigensolver::gen_to_std<B>(grid, uplo, mat_a, mat_b);
 
-  eigensolver::eigensolver<B>(grid, uplo, mat_a, eigenvalues, eigenvectors);
+  hermitian_eigensolver<B>(grid, uplo, mat_a, eigenvalues, eigenvectors);
 
   solver::triangular<B>(grid, blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1),
                         mat_b, eigenvectors);

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -23,7 +23,7 @@ template <Backend B, Device D, class T>
 void GenEigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b,
                                    Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
   cholesky_factorization<B>(uplo, mat_b);
-  eigensolver::gen_to_std<B>(uplo, mat_a, mat_b);
+  generalized_to_standard<B>(uplo, mat_a, mat_b);
 
   hermitian_eigensolver<B>(uplo, mat_a, eigenvalues, eigenvectors);
 
@@ -36,7 +36,7 @@ void GenEigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo,
                                    Matrix<T, D>& mat_b, Matrix<BaseType<T>, D>& eigenvalues,
                                    Matrix<T, D>& eigenvectors) {
   cholesky_factorization<B>(grid, uplo, mat_b);
-  eigensolver::gen_to_std<B>(grid, uplo, mat_a, mat_b);
+  generalized_to_standard<B>(grid, uplo, mat_a, mat_b);
 
   hermitian_eigensolver<B>(grid, uplo, mat_a, eigenvalues, eigenvectors);
 

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -23,7 +23,7 @@ template <Backend B, Device D, class T>
 void GenEigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b,
                                    Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
   factorization::cholesky<B>(uplo, mat_b);
-  eigensolver::genToStd<B>(uplo, mat_a, mat_b);
+  eigensolver::gen_to_std<B>(uplo, mat_a, mat_b);
 
   eigensolver::eigensolver<B>(uplo, mat_a, eigenvalues, eigenvectors);
 
@@ -36,7 +36,7 @@ void GenEigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo,
                                    Matrix<T, D>& mat_b, Matrix<BaseType<T>, D>& eigenvalues,
                                    Matrix<T, D>& eigenvectors) {
   factorization::cholesky<B>(grid, uplo, mat_b);
-  eigensolver::genToStd<B>(grid, uplo, mat_a, mat_b);
+  eigensolver::gen_to_std<B>(grid, uplo, mat_a, mat_b);
 
   eigensolver::eigensolver<B>(grid, uplo, mat_a, eigenvalues, eigenvectors);
 

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -27,8 +27,8 @@ void GenEigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<
 
   hermitian_eigensolver<B>(uplo, mat_a, eigenvalues, eigenvectors);
 
-  solver::triangular<B>(blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1), mat_b,
-                        eigenvectors);
+  triangular_solver<B>(blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1), mat_b,
+                       eigenvectors);
 }
 
 template <Backend B, Device D, class T>
@@ -40,8 +40,8 @@ void GenEigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo,
 
   hermitian_eigensolver<B>(grid, uplo, mat_a, eigenvalues, eigenvectors);
 
-  solver::triangular<B>(grid, blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1),
-                        mat_b, eigenvectors);
+  triangular_solver<B>(grid, blas::Side::Left, uplo, blas::Op::ConjTrans, blas::Diag::NonUnit, T(1),
+                       mat_b, eigenvectors);
 }
 
 }

--- a/include/dlaf/eigensolver/gen_eigensolver/impl.h
+++ b/include/dlaf/eigensolver/gen_eigensolver/impl.h
@@ -22,7 +22,7 @@ namespace dlaf::eigensolver::internal {
 template <Backend B, Device D, class T>
 void GenEigensolver<B, D, T>::call(blas::Uplo uplo, Matrix<T, D>& mat_a, Matrix<T, D>& mat_b,
                                    Matrix<BaseType<T>, D>& eigenvalues, Matrix<T, D>& eigenvectors) {
-  factorization::cholesky<B>(uplo, mat_b);
+  cholesky_factorization<B>(uplo, mat_b);
   eigensolver::gen_to_std<B>(uplo, mat_a, mat_b);
 
   hermitian_eigensolver<B>(uplo, mat_a, eigenvalues, eigenvectors);
@@ -35,7 +35,7 @@ template <Backend B, Device D, class T>
 void GenEigensolver<B, D, T>::call(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, D>& mat_a,
                                    Matrix<T, D>& mat_b, Matrix<BaseType<T>, D>& eigenvalues,
                                    Matrix<T, D>& eigenvectors) {
-  factorization::cholesky<B>(grid, uplo, mat_b);
+  cholesky_factorization<B>(grid, uplo, mat_b);
   eigensolver::gen_to_std<B>(grid, uplo, mat_a, mat_b);
 
   hermitian_eigensolver<B>(grid, uplo, mat_a, eigenvalues, eigenvectors);

--- a/include/dlaf/eigensolver/gen_to_std.h
+++ b/include/dlaf/eigensolver/gen_to_std.h
@@ -41,7 +41,7 @@ namespace eigensolver {
 /// @pre mat_a and mat_b have the same tile and block sizes,
 /// @pre mat_a and mat_b are not distributed.
 template <Backend backend, Device device, class T>
-void genToStd(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& mat_b) {
+void gen_to_std(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_size(mat_b), mat_b);
@@ -86,8 +86,8 @@ void genToStd(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& mat_
 /// @pre mat_a and mat_b have the same tile and block sizes,
 /// @pre mat_a and mat_b are distributed according to the grid.
 template <Backend backend, Device device, class T>
-void genToStd(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& mat_a,
-              Matrix<T, device>& mat_b) {
+void gen_to_std(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& mat_a,
+                Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_size(mat_b), mat_b);

--- a/include/dlaf/eigensolver/gen_to_std.h
+++ b/include/dlaf/eigensolver/gen_to_std.h
@@ -19,8 +19,7 @@
 #include <dlaf/types.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace eigensolver {
+namespace dlaf::eigensolver::internal {
 
 /// Reduce a Hermitian definite generalized eigenproblem to standard form.
 ///
@@ -41,7 +40,7 @@ namespace eigensolver {
 /// @pre mat_a and mat_b have the same tile and block sizes,
 /// @pre mat_a and mat_b are not distributed.
 template <Backend backend, Device device, class T>
-void gen_to_std(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& mat_b) {
+void generalized_to_standard(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_size(mat_b), mat_b);
@@ -55,10 +54,10 @@ void gen_to_std(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& ma
 
   switch (uplo) {
     case blas::Uplo::Lower:
-      internal::GenToStd<backend, device, T>::call_L(mat_a, mat_b);
+      GenToStd<backend, device, T>::call_L(mat_a, mat_b);
       break;
     case blas::Uplo::Upper:
-      internal::GenToStd<backend, device, T>::call_U(mat_a, mat_b);
+      GenToStd<backend, device, T>::call_U(mat_a, mat_b);
       break;
     case blas::Uplo::General:
       DLAF_UNIMPLEMENTED(uplo);
@@ -86,8 +85,8 @@ void gen_to_std(blas::Uplo uplo, Matrix<T, device>& mat_a, Matrix<T, device>& ma
 /// @pre mat_a and mat_b have the same tile and block sizes,
 /// @pre mat_a and mat_b are distributed according to the grid.
 template <Backend backend, Device device, class T>
-void gen_to_std(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& mat_a,
-                Matrix<T, device>& mat_b) {
+void generalized_to_standard(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& mat_a,
+                             Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_size(mat_b), mat_b);
@@ -101,10 +100,10 @@ void gen_to_std(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>&
 
   switch (uplo) {
     case blas::Uplo::Lower:
-      internal::GenToStd<backend, device, T>::call_L(grid, mat_a, mat_b);
+      GenToStd<backend, device, T>::call_L(grid, mat_a, mat_b);
       break;
     case blas::Uplo::Upper:
-      internal::GenToStd<backend, device, T>::call_U(grid, mat_a, mat_b);
+      GenToStd<backend, device, T>::call_U(grid, mat_a, mat_b);
       break;
     case blas::Uplo::General:
       DLAF_UNIMPLEMENTED(uplo);
@@ -112,5 +111,4 @@ void gen_to_std(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>&
   }
 }
 
-}
 }

--- a/include/dlaf/eigensolver/gen_to_std/api.h
+++ b/include/dlaf/eigensolver/gen_to_std/api.h
@@ -12,9 +12,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/types.h>
 
-namespace dlaf {
-namespace eigensolver {
-namespace internal {
+namespace dlaf::eigensolver::internal {
 
 template <Backend backend, Device device, class T>
 struct GenToStd {
@@ -39,6 +37,4 @@ DLAF_GENTOSTD_ETI(extern, Backend::GPU, Device::GPU, double)
 DLAF_GENTOSTD_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_GENTOSTD_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
-}
-}
 }

--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -28,9 +28,7 @@
 #include <dlaf/sender/traits.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace eigensolver {
-namespace internal {
+namespace dlaf::eigensolver::internal {
 
 namespace gentostd_l {
 template <Backend backend, class AKKSender, class LKKSender>
@@ -722,6 +720,4 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
   }
 }
 
-}
-}
 }

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -18,7 +18,7 @@
 #include <dlaf/sender/when_all_lift.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf::eigensolver {
+namespace dlaf::eigensolver::internal {
 
 /// Reduce a local lower Hermitian matrix to symmetric band-diagonal form, with specified band_size.
 ///
@@ -46,7 +46,7 @@ Matrix<T, Device::CPU> reduction_to_band(Matrix<T, D>& mat_a, const SizeType ban
   DLAF_ASSERT(band_size >= 2, band_size);
   DLAF_ASSERT(mat_a.blockSize().rows() % band_size == 0, mat_a.blockSize().rows(), band_size);
 
-  return internal::ReductionToBand<B, D, T>::call(mat_a, band_size);
+  return ReductionToBand<B, D, T>::call(mat_a, band_size);
 }
 
 /// Reduce a distributed lower Hermitian matrix to symmetric band-diagonal form, with specified band_size.
@@ -113,6 +113,6 @@ Matrix<T, Device::CPU> reduction_to_band(comm::CommunicatorGrid grid, Matrix<T, 
   DLAF_ASSERT(band_size >= 2, band_size);
   DLAF_ASSERT(mat_a.blockSize().rows() % band_size == 0, mat_a.blockSize().rows(), band_size);
 
-  return internal::ReductionToBand<B, D, T>::call(grid, mat_a, band_size);
+  return ReductionToBand<B, D, T>::call(grid, mat_a, band_size);
 }
 }

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -36,7 +36,7 @@ namespace dlaf::eigensolver {
 /// @pre mat_a is a local matrix
 /// @pre mat_a.blockSize().rows() % band_size == 0
 template <Backend B, Device D, class T>
-Matrix<T, Device::CPU> reductionToBand(Matrix<T, D>& mat_a, const SizeType band_size) {
+Matrix<T, Device::CPU> reduction_to_band(Matrix<T, D>& mat_a, const SizeType band_size) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -103,8 +103,8 @@ v v v v * *
 /// @pre mat_a is distributed according to @p grid
 /// @pre mat_a.blockSize().rows() % band_size == 0
 template <Backend B, Device D, class T>
-Matrix<T, Device::CPU> reductionToBand(comm::CommunicatorGrid grid, Matrix<T, D>& mat_a,
-                                       const SizeType band_size) {
+Matrix<T, Device::CPU> reduction_to_band(comm::CommunicatorGrid grid, Matrix<T, D>& mat_a,
+                                         const SizeType band_size) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);

--- a/include/dlaf/eigensolver/tridiag_solver.h
+++ b/include/dlaf/eigensolver/tridiag_solver.h
@@ -18,8 +18,7 @@
 #include <dlaf/types.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace eigensolver {
+namespace dlaf::eigensolver::internal {
 
 /// Finds the eigenvalues and eigenvectors of the local symmetric tridiagonal matrix @p tridiag.
 ///
@@ -39,8 +38,8 @@ namespace eigensolver {
 /// @pre evals has equal tile and block sizes
 /// @pre evecs has equal tile and block sizes
 template <Backend backend, Device device, class T>
-void tridiag_solver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T>, device>& evals,
-                    Matrix<T, device>& evecs) {
+void tridiagonal_eigensolver(Matrix<BaseType<T>, Device::CPU>& tridiag,
+                             Matrix<BaseType<T>, device>& evals, Matrix<T, device>& evecs) {
   DLAF_ASSERT(matrix::local_matrix(tridiag), tridiag);
   DLAF_ASSERT(tridiag.distribution().size().cols() == 2, tridiag);
   DLAF_ASSERT(tridiag.distribution().blockSize().cols() == 2, tridiag);
@@ -65,7 +64,7 @@ void tridiag_solver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T
   DLAF_ASSERT(tridiag.distribution().size().rows() == evals.distribution().size().rows(),
               tridiag.distribution().size().rows(), evals.distribution().size().rows());
 
-  internal::TridiagSolver<backend, device, BaseType<T>>::call(tridiag, evals, evecs);
+  TridiagSolver<backend, device, BaseType<T>>::call(tridiag, evals, evecs);
 }
 
 /// Finds the eigenvalues and eigenvectors of the symmetric tridiagonal matrix @p tridiag stored locally
@@ -91,8 +90,8 @@ void tridiag_solver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T
 /// @pre evals has equal tile and block sizes
 /// @pre evecs has equal tile and block sizes
 template <Backend B, Device D, class T>
-void tridiag_solver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, Device::CPU>& tridiag,
-                    Matrix<BaseType<T>, D>& evals, Matrix<T, D>& evecs) {
+void tridiagonal_eigensolver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, Device::CPU>& tridiag,
+                             Matrix<BaseType<T>, D>& evals, Matrix<T, D>& evecs) {
   DLAF_ASSERT(matrix::local_matrix(tridiag), tridiag);
   DLAF_ASSERT(tridiag.distribution().size().cols() == 2, tridiag);
   DLAF_ASSERT(tridiag.distribution().blockSize().cols() == 2, tridiag);
@@ -117,8 +116,7 @@ void tridiag_solver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, Device::CPU
   DLAF_ASSERT(tridiag.distribution().size().rows() == evals.distribution().size().rows(), tridiag,
               evals);
 
-  internal::TridiagSolver<B, D, BaseType<T>>::call(grid, tridiag, evals, evecs);
+  TridiagSolver<B, D, BaseType<T>>::call(grid, tridiag, evals, evecs);
 }
 
-}
 }

--- a/include/dlaf/eigensolver/tridiag_solver.h
+++ b/include/dlaf/eigensolver/tridiag_solver.h
@@ -39,8 +39,8 @@ namespace eigensolver {
 /// @pre evals has equal tile and block sizes
 /// @pre evecs has equal tile and block sizes
 template <Backend backend, Device device, class T>
-void tridiagSolver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T>, device>& evals,
-                   Matrix<T, device>& evecs) {
+void tridiag_solver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T>, device>& evals,
+                    Matrix<T, device>& evecs) {
   DLAF_ASSERT(matrix::local_matrix(tridiag), tridiag);
   DLAF_ASSERT(tridiag.distribution().size().cols() == 2, tridiag);
   DLAF_ASSERT(tridiag.distribution().blockSize().cols() == 2, tridiag);
@@ -91,8 +91,8 @@ void tridiagSolver(Matrix<BaseType<T>, Device::CPU>& tridiag, Matrix<BaseType<T>
 /// @pre evals has equal tile and block sizes
 /// @pre evecs has equal tile and block sizes
 template <Backend B, Device D, class T>
-void tridiagSolver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, Device::CPU>& tridiag,
-                   Matrix<BaseType<T>, D>& evals, Matrix<T, D>& evecs) {
+void tridiag_solver(comm::CommunicatorGrid grid, Matrix<BaseType<T>, Device::CPU>& tridiag,
+                    Matrix<BaseType<T>, D>& evals, Matrix<T, D>& evecs) {
   DLAF_ASSERT(matrix::local_matrix(tridiag), tridiag);
   DLAF_ASSERT(tridiag.distribution().size().cols() == 2, tridiag);
   DLAF_ASSERT(tridiag.distribution().blockSize().cols() == 2, tridiag);

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -720,8 +720,9 @@ void mergeSubproblems(const SizeType i_begin, const SizeType i_split, const Size
   //
   // The eigenvectors resulting from the multiplication are already in the order of the eigenvalues as
   // prepared for the deflated system.
-  dlaf::multiplication::generalSubMatrix<B, D, T>(i_begin, i_end, blas::Op::NoTrans, blas::Op::NoTrans,
-                                                  T(1), ws.e1, ws.e2, T(0), ws.e0);
+  dlaf::multiplication::internal::generalSubMatrix<B, D, T>(i_begin, i_end, blas::Op::NoTrans,
+                                                            blas::Op::NoTrans, T(1), ws.e1, ws.e2, T(0),
+                                                            ws.e0);
 
   // Step #4: Final permutation to sort eigenvalues and eigenvectors
   //
@@ -1315,8 +1316,9 @@ void mergeDistSubproblems(comm::CommunicatorGrid grid,
   // The eigenvectors resulting from the multiplication are already in the order of the eigenvalues as
   // prepared for the deflated system.
   copy(idx_loc_begin, sz_loc_tiles, ws_hm.e2, ws.e2);
-  dlaf::multiplication::generalSubMatrix<B, D, T>(grid, row_task_chain, col_task_chain, i_begin, i_end,
-                                                  T(1), ws.e1, ws.e2, T(0), ws.e0);
+  dlaf::multiplication::internal::generalSubMatrix<B, D, T>(grid, row_task_chain, col_task_chain,
+                                                            i_begin, i_end, T(1), ws.e1, ws.e2, T(0),
+                                                            ws.e0);
 
   // Step #4: Final permutation to sort eigenvalues and eigenvectors
   //

--- a/include/dlaf/factorization/cholesky.h
+++ b/include/dlaf/factorization/cholesky.h
@@ -20,7 +20,6 @@
 #include <dlaf/util_matrix.h>
 
 namespace dlaf {
-namespace factorization {
 
 /// Cholesky factorization which computes the factorization of an Hermitian positive
 /// definite matrix A.
@@ -37,16 +36,16 @@ namespace factorization {
 /// @pre mat_a has equal tile and block sizes
 /// @pre mat_a is not distributed.
 template <Backend backend, Device device, class T>
-void cholesky(blas::Uplo uplo, Matrix<T, device>& mat_a) {
+void cholesky_factorization(blas::Uplo uplo, Matrix<T, device>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
   DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
 
   if (uplo == blas::Uplo::Lower)
-    internal::Cholesky<backend, device, T>::call_L(mat_a);
+    factorization::internal::Cholesky<backend, device, T>::call_L(mat_a);
   else
-    internal::Cholesky<backend, device, T>::call_U(mat_a);
+    factorization::internal::Cholesky<backend, device, T>::call_U(mat_a);
 }
 
 /// Cholesky factorization which computes the factorization of an Hermitian positive
@@ -65,7 +64,7 @@ void cholesky(blas::Uplo uplo, Matrix<T, device>& mat_a) {
 /// @pre mat_a has equal tile and block sizes
 /// @pre mat_a is distributed according to grid.
 template <Backend backend, Device device, class T>
-void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& mat_a) {
+void cholesky_factorization(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& mat_a) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -73,10 +72,9 @@ void cholesky(comm::CommunicatorGrid grid, blas::Uplo uplo, Matrix<T, device>& m
 
   // Method only for Lower triangular matrix
   if (uplo == blas::Uplo::Lower)
-    internal::Cholesky<backend, device, T>::call_L(grid, mat_a);
+    factorization::internal::Cholesky<backend, device, T>::call_L(grid, mat_a);
   else
-    internal::Cholesky<backend, device, T>::call_U(grid, mat_a);
+    factorization::internal::Cholesky<backend, device, T>::call_U(grid, mat_a);
 }
 
-}
 }

--- a/include/dlaf/factorization/cholesky/api.h
+++ b/include/dlaf/factorization/cholesky/api.h
@@ -12,9 +12,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/types.h>
 
-namespace dlaf {
-namespace factorization {
-namespace internal {
+namespace dlaf::factorization::internal {
 template <Backend backend, Device device, class T>
 struct Cholesky {
   static void call_L(Matrix<T, device>& mat_a);
@@ -38,6 +36,4 @@ DLAF_FACTORIZATION_CHOLESKY_ETI(extern, Backend::GPU, Device::GPU, double)
 DLAF_FACTORIZATION_CHOLESKY_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_FACTORIZATION_CHOLESKY_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
-}
-}
 }

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -30,9 +30,7 @@
 #include <dlaf/sender/traits.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace factorization {
-namespace internal {
+namespace dlaf::factorization::internal {
 
 namespace cholesky_l {
 template <Backend backend, class MatrixTileSender>
@@ -412,7 +410,5 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid grid, Matrix<T,
     panel.reset();
     panelT.reset();
   }
-}
-}
 }
 }

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -23,7 +23,7 @@
 #include <dlaf/multiplication/general/api.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf::multiplication {
+namespace dlaf::multiplication::internal {
 
 /// General sub-matrix multiplication implementation on local memory, computing
 /// C[a:b][a:b] = alpha * opA(A[a:b][a:b]) * opB(B[a:b][a:b]) + beta * C[a:b][a:b]

--- a/include/dlaf/multiplication/hermitian.h
+++ b/include/dlaf/multiplication/hermitian.h
@@ -19,7 +19,7 @@
 #include <dlaf/types.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf::multiplication {
+namespace dlaf {
 
 /// Hermitian Matrix multiplication implementation on local memory, computing C = beta C + alpha A B
 /// (when side == Left) or C + alpha B A (when side == Right), where A is a Hermitian matrix.
@@ -39,8 +39,8 @@ namespace dlaf::multiplication {
 /// @pre mat_a mat_b and mat_c are not distributed,
 /// @pre mat_a mat_b are multipliable and the result can be summed to mat_c.
 template <Backend B, Device D, class T>
-void hermitian(blas::Side side, blas::Uplo uplo, const T alpha, Matrix<const T, D>& mat_a,
-               Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
+void hermitian_multiplication(blas::Side side, blas::Uplo uplo, const T alpha, Matrix<const T, D>& mat_a,
+                              Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -55,7 +55,7 @@ void hermitian(blas::Side side, blas::Uplo uplo, const T alpha, Matrix<const T, 
                 mat_b, mat_c);
     switch (uplo) {
       case blas::Uplo::Lower:
-        return internal::Hermitian<B, D, T>::call_LL(alpha, mat_a, mat_b, beta, mat_c);
+        return multiplication::internal::Hermitian<B, D, T>::call_LL(alpha, mat_a, mat_b, beta, mat_c);
         break;
       case blas::Uplo::Upper:
         DLAF_UNIMPLEMENTED(uplo);
@@ -91,8 +91,9 @@ void hermitian(blas::Side side, blas::Uplo uplo, const T alpha, Matrix<const T, 
 /// @pre mat_a, mat_b and mat_c are distributed according to the grid,
 /// @pre mat_a mat_b are multipliable and the result can be summed to mat_c.
 template <Backend B, Device D, class T>
-void hermitian(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, const T alpha,
-               Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
+void hermitian_multiplication(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo,
+                              const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b,
+                              const T beta, Matrix<T, D>& mat_c) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -107,7 +108,8 @@ void hermitian(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, co
                 mat_b, mat_c);
     switch (uplo) {
       case blas::Uplo::Lower:
-        return internal::Hermitian<B, D, T>::call_LL(grid, alpha, mat_a, mat_b, beta, mat_c);
+        return multiplication::internal::Hermitian<B, D, T>::call_LL(grid, alpha, mat_a, mat_b, beta,
+                                                                     mat_c);
         break;
       case blas::Uplo::Upper:
         DLAF_UNIMPLEMENTED(uplo);

--- a/include/dlaf/multiplication/triangular.h
+++ b/include/dlaf/multiplication/triangular.h
@@ -20,7 +20,6 @@
 #include <dlaf/util_matrix.h>
 
 namespace dlaf {
-namespace multiplication {
 
 /// Triangular Matrix multiplication implementation on local memory, computing B = alpha op(A)  B
 /// (when side == Left) and B = alpha B op(A) (when side == Right)
@@ -41,8 +40,8 @@ namespace multiplication {
 /// @pre mat_a and mat_b are not distributed,
 /// @pre mat_a and mat_b are multipliable.
 template <Backend backend, Device device, class T>
-void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha,
-                Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
+void triangular_multiplication(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha,
+                               Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -55,18 +54,20 @@ void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, 
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LLN(diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_LLN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_LLT(op, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_LLT(op, diag, alpha, mat_a,
+                                                                           mat_b);
       }
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LUN(diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_LUN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_LUT(op, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_LUT(op, diag, alpha, mat_a,
+                                                                           mat_b);
       }
     }
   }
@@ -75,18 +76,20 @@ void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, 
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RLN(diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_RLN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_RLT(op, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_RLT(op, diag, alpha, mat_a,
+                                                                           mat_b);
       }
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RUN(diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_RUN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_RUT(op, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_RUT(op, diag, alpha, mat_a,
+                                                                           mat_b);
       }
     }
   }
@@ -111,8 +114,9 @@ void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, 
 /// @pre mat_a and mat_b are distributed according to the grid,
 /// @pre mat_a and mat_b are multipliable.
 template <Backend backend, Device device, class T>
-void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, blas::Op op,
-                blas::Diag diag, T alpha, Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
+void triangular_multiplication(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo,
+                               blas::Op op, blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
+                               Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -125,7 +129,8 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LLN(grid, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_LLN(grid, diag, alpha, mat_a,
+                                                                           mat_b);
       }
       else {
         // Left Lower Trans/ConjTrans
@@ -134,7 +139,8 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LUN(grid, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_LUN(grid, diag, alpha, mat_a,
+                                                                           mat_b);
       }
       else {
         // Left Upper Trans/ConjTrans
@@ -147,7 +153,8 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RLN(grid, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_RLN(grid, diag, alpha, mat_a,
+                                                                           mat_b);
       }
       else {
         // Right Lower Trans/ConjTrans
@@ -156,7 +163,8 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RUN(grid, diag, alpha, mat_a, mat_b);
+        multiplication::internal::Triangular<backend, device, T>::call_RUN(grid, diag, alpha, mat_a,
+                                                                           mat_b);
       }
       else {
         // Right Upper Trans/ConjTrans
@@ -164,7 +172,5 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
       }
     }
   }
-}
-
 }
 }

--- a/include/dlaf/multiplication/triangular/api.h
+++ b/include/dlaf/multiplication/triangular/api.h
@@ -14,9 +14,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/types.h>
 
-namespace dlaf {
-namespace multiplication {
-namespace internal {
+namespace dlaf::multiplication::internal {
 template <Backend backend, Device device, class T>
 struct Triangular {
   static void call_LLN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
@@ -60,6 +58,4 @@ DLAF_MULTIPLICATION_TRIANGULAR_ETI(extern, Backend::GPU, Device::GPU, double)
 DLAF_MULTIPLICATION_TRIANGULAR_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_MULTIPLICATION_TRIANGULAR_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
-}
-}
 }

--- a/include/dlaf/multiplication/triangular/impl.h
+++ b/include/dlaf/multiplication/triangular/impl.h
@@ -29,9 +29,7 @@
 #include <dlaf/sender/when_all_lift.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace multiplication {
-namespace internal {
+namespace dlaf::multiplication::internal {
 
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
@@ -720,8 +718,5 @@ void Triangular<backend, device, T>::call_RUN(comm::CommunicatorGrid grid, blas:
     a_panel.reset();
     b_panel.reset();
   }
-}
-
-}
 }
 }

--- a/include/dlaf/solver/triangular.h
+++ b/include/dlaf/solver/triangular.h
@@ -20,7 +20,6 @@
 #include <dlaf/util_matrix.h>
 
 namespace dlaf {
-namespace solver {
 
 /// Triangular Solve implementation on local memory, solving op(A) X = alpha B (when side == Left)
 /// or X op(A) = alpha B (when side == Right).
@@ -41,8 +40,8 @@ namespace solver {
 /// @pre mat_a and mat_b are not distributed,
 /// @pre mat_a and mat_b are multipliable.
 template <Backend backend, Device device, class T>
-void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha,
-                Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
+void triangular_solver(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, T alpha,
+                       Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -55,18 +54,18 @@ void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, 
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LLN(diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LLN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_LLT(op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LLT(op, diag, alpha, mat_a, mat_b);
       }
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LUN(diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LUN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_LUT(op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LUT(op, diag, alpha, mat_a, mat_b);
       }
     }
   }
@@ -75,18 +74,18 @@ void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, 
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RLN(diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RLN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_RLT(op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RLT(op, diag, alpha, mat_a, mat_b);
       }
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RUN(diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RUN(diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_RUT(op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RUT(op, diag, alpha, mat_a, mat_b);
       }
     }
   }
@@ -113,8 +112,9 @@ void triangular(blas::Side side, blas::Uplo uplo, blas::Op op, blas::Diag diag, 
 /// @pre matrix A and matrix B are distributed according to the grid,
 /// @pre matrix A and matrix B are multipliable.
 template <Backend backend, Device device, class T>
-void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, blas::Op op,
-                blas::Diag diag, T alpha, Matrix<const T, device>& mat_a, Matrix<T, device>& mat_b) {
+void triangular_solver(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, blas::Op op,
+                       blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
+                       Matrix<T, device>& mat_b) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -127,18 +127,18 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LLN(grid, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LLN(grid, diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_LLT(grid, op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LLT(grid, op, diag, alpha, mat_a, mat_b);
       }
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_LUN(grid, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LUN(grid, diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_LUT(grid, op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_LUT(grid, op, diag, alpha, mat_a, mat_b);
       }
     }
   }
@@ -147,22 +147,21 @@ void triangular(comm::CommunicatorGrid grid, blas::Side side, blas::Uplo uplo, b
 
     if (uplo == blas::Uplo::Lower) {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RLN(grid, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RLN(grid, diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_RLT(grid, op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RLT(grid, op, diag, alpha, mat_a, mat_b);
       }
     }
     else {
       if (op == blas::Op::NoTrans) {
-        internal::Triangular<backend, device, T>::call_RUN(grid, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RUN(grid, diag, alpha, mat_a, mat_b);
       }
       else {
-        internal::Triangular<backend, device, T>::call_RUT(grid, op, diag, alpha, mat_a, mat_b);
+        solver::internal::Triangular<backend, device, T>::call_RUT(grid, op, diag, alpha, mat_a, mat_b);
       }
     }
   }
 }
 
-}
 }

--- a/include/dlaf/solver/triangular/api.h
+++ b/include/dlaf/solver/triangular/api.h
@@ -14,9 +14,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/types.h>
 
-namespace dlaf {
-namespace solver {
-namespace internal {
+namespace dlaf::solver::internal {
 template <Backend backend, Device device, class T>
 struct Triangular {
   static void call_LLN(blas::Diag diag, T alpha, Matrix<const T, device>& mat_a,
@@ -68,6 +66,4 @@ DLAF_SOLVER_TRIANGULAR_ETI(extern, Backend::GPU, Device::GPU, double)
 DLAF_SOLVER_TRIANGULAR_ETI(extern, Backend::GPU, Device::GPU, std::complex<float>)
 DLAF_SOLVER_TRIANGULAR_ETI(extern, Backend::GPU, Device::GPU, std::complex<double>)
 #endif
-}
-}
 }

--- a/include/dlaf/solver/triangular/impl.h
+++ b/include/dlaf/solver/triangular/impl.h
@@ -31,9 +31,7 @@
 #include <dlaf/solver/triangular/api.h>
 #include <dlaf/util_matrix.h>
 
-namespace dlaf {
-namespace solver {
-namespace internal {
+namespace dlaf::solver::internal {
 namespace triangular_lln {
 template <Backend backend, class T, typename InSender, typename OutSender>
 void trsmBPanelTile(pika::execution::thread_priority priority, blas::Diag diag, T alpha,
@@ -1153,7 +1151,5 @@ void Triangular<backend, D, T>::call_RUT(comm::CommunicatorGrid grid, blas::Op o
     b_panel.reset();
     a_panel.reset();
   }
-}
-}
 }
 }

--- a/miniapp/miniapp_band_to_tridiag.cpp
+++ b/miniapp/miniapp_band_to_tridiag.cpp
@@ -117,10 +117,11 @@ struct BandToTridiagMiniapp {
         dlaf::common::Timer<> timeit;
         auto bench = [&]() {
           if (opts.local)
-            return dlaf::eigensolver::band_to_tridiag<Backend::MC>(opts.uplo, opts.b, matrix.get());
+            return dlaf::eigensolver::internal::band_to_tridiagonal<Backend::MC>(opts.uplo, opts.b,
+                                                                                 matrix.get());
           else
-            return dlaf::eigensolver::band_to_tridiag<Backend::MC>(comm_grid, opts.uplo, opts.b,
-                                                                   matrix.get());
+            return dlaf::eigensolver::internal::band_to_tridiagonal<Backend::MC>(comm_grid, opts.uplo,
+                                                                                 opts.b, matrix.get());
         };
         auto [trid, hhr] = bench();
 

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -130,11 +130,13 @@ struct BacktransformBandToTridiagMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::eigensolver::backTransformationBandToTridiag<backend, DefaultDevice_v<backend>, T>(
-              opts.b, mat_e.get(), mat_hh);
+          dlaf::eigensolver::bt_band_to_tridiag<backend, DefaultDevice_v<backend>, T>(opts.b,
+                                                                                      mat_e.get(),
+                                                                                      mat_hh);
         else
-          dlaf::eigensolver::backTransformationBandToTridiag<backend, DefaultDevice_v<backend>, T>(
-              comm_grid, opts.b, mat_e.get(), mat_hh);
+          dlaf::eigensolver::bt_band_to_tridiag<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.b,
+                                                                                      mat_e.get(),
+                                                                                      mat_hh);
 
         // wait and barrier for all ranks
         mat_e.get().waitLocalTiles();

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -130,13 +130,11 @@ struct BacktransformBandToTridiagMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::eigensolver::bt_band_to_tridiag<backend, DefaultDevice_v<backend>, T>(opts.b,
-                                                                                      mat_e.get(),
-                                                                                      mat_hh);
+          dlaf::eigensolver::internal::bt_band_to_tridiagonal<backend, DefaultDevice_v<backend>, T>(
+              opts.b, mat_e.get(), mat_hh);
         else
-          dlaf::eigensolver::bt_band_to_tridiag<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.b,
-                                                                                      mat_e.get(),
-                                                                                      mat_hh);
+          dlaf::eigensolver::internal::bt_band_to_tridiagonal<backend, DefaultDevice_v<backend>, T>(
+              comm_grid, opts.b, mat_e.get(), mat_hh);
 
         // wait and barrier for all ranks
         mat_e.get().waitLocalTiles();

--- a/miniapp/miniapp_bt_reduction_to_band.cpp
+++ b/miniapp/miniapp_bt_reduction_to_band.cpp
@@ -150,10 +150,10 @@ struct BacktransformBandToTridiagMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::eigensolver::backTransformationReductionToBand<backend, DefaultDevice_v<backend>, T>(
+          dlaf::eigensolver::bt_reduction_to_band<backend, DefaultDevice_v<backend>, T>(
               opts.b, mat_e.get(), mat_hh.get(), mat_taus);
         else
-          dlaf::eigensolver::backTransformationReductionToBand<backend, DefaultDevice_v<backend>, T>(
+          dlaf::eigensolver::bt_reduction_to_band<backend, DefaultDevice_v<backend>, T>(
               comm_grid, opts.b, mat_e.get(), mat_hh.get(), mat_taus);
 
         // wait and barrier for all ranks

--- a/miniapp/miniapp_bt_reduction_to_band.cpp
+++ b/miniapp/miniapp_bt_reduction_to_band.cpp
@@ -150,10 +150,10 @@ struct BacktransformBandToTridiagMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::eigensolver::bt_reduction_to_band<backend, DefaultDevice_v<backend>, T>(
+          dlaf::eigensolver::internal::bt_reduction_to_band<backend, DefaultDevice_v<backend>, T>(
               opts.b, mat_e.get(), mat_hh.get(), mat_taus);
         else
-          dlaf::eigensolver::bt_reduction_to_band<backend, DefaultDevice_v<backend>, T>(
+          dlaf::eigensolver::internal::bt_reduction_to_band<backend, DefaultDevice_v<backend>, T>(
               comm_grid, opts.b, mat_e.get(), mat_hh.get(), mat_taus);
 
         // wait and barrier for all ranks

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -140,10 +140,10 @@ struct choleskyMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::factorization::cholesky<backend, DefaultDevice_v<backend>, T>(opts.uplo, matrix.get());
+          dlaf::cholesky_factorization<backend, DefaultDevice_v<backend>, T>(opts.uplo, matrix.get());
         else
-          dlaf::factorization::cholesky<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,
-                                                                              matrix.get());
+          dlaf::cholesky_factorization<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,
+                                                                             matrix.get());
 
         // wait and barrier for all ranks
         matrix.get().waitLocalTiles();

--- a/miniapp/miniapp_cholesky.cpp
+++ b/miniapp/miniapp_cholesky.cpp
@@ -408,8 +408,7 @@ void check_cholesky(Matrix<T, Device::CPU>& A, Matrix<T, Device::CPU>& L, Commun
   const Index2D rank_result{0, 0};
 
   // 1. Compute the max norm of the original matrix in A
-  const auto norm_A =
-      dlaf::auxiliary::norm<dlaf::Backend::MC>(comm_grid, rank_result, lapack::Norm::Max, uplo, A);
+  const auto norm_A = dlaf::auxiliary::max_norm<dlaf::Backend::MC>(comm_grid, rank_result, uplo, A);
 
   // 2.
   // L is a lower triangular, reset values in the upper part (diagonal excluded)
@@ -421,8 +420,7 @@ void check_cholesky(Matrix<T, Device::CPU>& A, Matrix<T, Device::CPU>& L, Commun
   cholesky_diff(A, L, comm_grid);
 
   // 3. Compute the max norm of the difference (it has been compute in-place in A)
-  const auto norm_diff =
-      dlaf::auxiliary::norm<dlaf::Backend::MC>(comm_grid, rank_result, lapack::Norm::Max, uplo, A);
+  const auto norm_diff = dlaf::auxiliary::max_norm<dlaf::Backend::MC>(comm_grid, rank_result, uplo, A);
 
   // 4.
   // Evaluation of correctness is done just by the master rank

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -218,7 +218,7 @@ void checkEigensolver(CommunicatorGrid comm_grid, blas::Uplo uplo, Matrix<const 
   // Compute C = E D - A E
   Matrix<T, Device::CPU> C(E.distribution());
   dlaf::miniapp::scaleEigenvectors(evalues, E, C);
-  dlaf::multiplication::hermitian<Backend::MC>(comm_grid, blas::Side::Left, uplo, T{-1}, A, E, T{1}, C);
+  dlaf::hermitian_multiplication<Backend::MC>(comm_grid, blas::Side::Left, uplo, T{-1}, A, E, T{1}, C);
 
   // 3. Compute the max norm of the difference
   const auto norm_diff =

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -116,9 +116,9 @@ struct EigensolverMiniapp {
       dlaf::common::Timer<> timeit;
       auto bench = [&]() {
         if (opts.local)
-          return dlaf::eigensolver::eigensolver<backend>(opts.uplo, matrix->get());
+          return dlaf::hermitian_eigensolver<backend>(opts.uplo, matrix->get());
         else
-          return dlaf::eigensolver::eigensolver<backend>(comm_grid, opts.uplo, matrix->get());
+          return dlaf::hermitian_eigensolver<backend>(comm_grid, opts.uplo, matrix->get());
       };
       auto [eigenvalues, eigenvectors] = bench();
 

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -222,8 +222,7 @@ void checkEigensolver(CommunicatorGrid comm_grid, blas::Uplo uplo, Matrix<const 
 
   // 3. Compute the max norm of the difference
   const auto norm_diff =
-      dlaf::auxiliary::norm<dlaf::Backend::MC>(comm_grid, rank_result, lapack::Norm::Max,
-                                               blas::Uplo::General, C);
+      dlaf::auxiliary::max_norm<dlaf::Backend::MC>(comm_grid, rank_result, blas::Uplo::General, C);
 
   // 4.
   // Evaluation of correctness is done just by the master rank

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -233,8 +233,7 @@ void checkGenEigensolver(CommunicatorGrid comm_grid, blas::Uplo uplo, Matrix<con
   const TileElementIndex last_ev_el_tile = evalues.distribution().tileElementIndex(last_ev);
   const auto norm_A = std::max(std::norm(sync_wait(evalues.read(GlobalTileIndex{0, 0})).get()({0, 0})),
                                std::norm(sync_wait(evalues.read(last_ev_tile)).get()(last_ev_el_tile)));
-  const auto norm_B =
-      dlaf::auxiliary::norm<dlaf::Backend::MC>(comm_grid, rank_result, lapack::Norm::Max, uplo, B);
+  const auto norm_B = dlaf::auxiliary::max_norm<dlaf::Backend::MC>(comm_grid, rank_result, uplo, B);
 
   // 2.
   // Compute C = E D - A E
@@ -246,8 +245,7 @@ void checkGenEigensolver(CommunicatorGrid comm_grid, blas::Uplo uplo, Matrix<con
 
   // 3. Compute the max norm of the difference
   const auto norm_diff =
-      dlaf::auxiliary::norm<dlaf::Backend::MC>(comm_grid, rank_result, lapack::Norm::Max,
-                                               blas::Uplo::General, C);
+      dlaf::auxiliary::max_norm<dlaf::Backend::MC>(comm_grid, rank_result, blas::Uplo::General, C);
 
   // 4.
   // Evaluation of correctness is done just by the master rank

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -130,11 +130,11 @@ struct GenEigensolverMiniapp {
 
       dlaf::common::Timer<> timeit;
       auto bench = [&]() {
+        using dlaf::eigensolver::gen_eigensolver;
         if (opts.local)
-          return dlaf::eigensolver::genEigensolver<backend>(opts.uplo, matrix_a->get(), matrix_b->get());
+          return gen_eigensolver<backend>(opts.uplo, matrix_a->get(), matrix_b->get());
         else
-          return dlaf::eigensolver::genEigensolver<backend>(comm_grid, opts.uplo, matrix_a->get(),
-                                                            matrix_b->get());
+          return gen_eigensolver<backend>(comm_grid, opts.uplo, matrix_a->get(), matrix_b->get());
       };
       auto [eigenvalues, eigenvectors] = bench();
 

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -241,8 +241,8 @@ void checkGenEigensolver(CommunicatorGrid comm_grid, blas::Uplo uplo, Matrix<con
   Matrix<T, Device::CPU> C(E.distribution());
   Matrix<T, Device::CPU> C2(E.distribution());
   dlaf::miniapp::scaleEigenvectors(evalues, E, C2);
-  dlaf::multiplication::hermitian<Backend::MC>(comm_grid, blas::Side::Left, uplo, T{1}, B, C2, T{0}, C);
-  dlaf::multiplication::hermitian<Backend::MC>(comm_grid, blas::Side::Left, uplo, T{-1}, A, E, T{1}, C);
+  dlaf::hermitian_multiplication<Backend::MC>(comm_grid, blas::Side::Left, uplo, T{1}, B, C2, T{0}, C);
+  dlaf::hermitian_multiplication<Backend::MC>(comm_grid, blas::Side::Left, uplo, T{-1}, A, E, T{1}, C);
 
   // 3. Compute the max norm of the difference
   const auto norm_diff =

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -130,11 +130,12 @@ struct GenEigensolverMiniapp {
 
       dlaf::common::Timer<> timeit;
       auto bench = [&]() {
-        using dlaf::eigensolver::gen_eigensolver;
+        using dlaf::hermitian_generalized_eigensolver;
         if (opts.local)
-          return gen_eigensolver<backend>(opts.uplo, matrix_a->get(), matrix_b->get());
+          return hermitian_generalized_eigensolver<backend>(opts.uplo, matrix_a->get(), matrix_b->get());
         else
-          return gen_eigensolver<backend>(comm_grid, opts.uplo, matrix_a->get(), matrix_b->get());
+          return hermitian_generalized_eigensolver<backend>(comm_grid, opts.uplo, matrix_a->get(),
+                                                            matrix_b->get());
       };
       auto [eigenvalues, eigenvectors] = bench();
 

--- a/miniapp/miniapp_gen_to_std.cpp
+++ b/miniapp/miniapp_gen_to_std.cpp
@@ -131,12 +131,11 @@ struct GenToStdMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::eigensolver::gen_to_std<backend, DefaultDevice_v<backend>, T>(opts.uplo, matrix_a.get(),
-                                                                              matrix_b.get());
+          dlaf::eigensolver::internal::generalized_to_standard<backend, DefaultDevice_v<backend>, T>(
+              opts.uplo, matrix_a.get(), matrix_b.get());
         else
-          dlaf::eigensolver::gen_to_std<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,
-                                                                              matrix_a.get(),
-                                                                              matrix_b.get());
+          dlaf::eigensolver::internal::generalized_to_standard<backend, DefaultDevice_v<backend>, T>(
+              comm_grid, opts.uplo, matrix_a.get(), matrix_b.get());
 
         // wait and barrier for all ranks
         matrix_a.get().waitLocalTiles();

--- a/miniapp/miniapp_gen_to_std.cpp
+++ b/miniapp/miniapp_gen_to_std.cpp
@@ -131,12 +131,12 @@ struct GenToStdMiniapp {
 
         dlaf::common::Timer<> timeit;
         if (opts.local)
-          dlaf::eigensolver::genToStd<backend, DefaultDevice_v<backend>, T>(opts.uplo, matrix_a.get(),
-                                                                            matrix_b.get());
+          dlaf::eigensolver::gen_to_std<backend, DefaultDevice_v<backend>, T>(opts.uplo, matrix_a.get(),
+                                                                              matrix_b.get());
         else
-          dlaf::eigensolver::genToStd<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,
-                                                                            matrix_a.get(),
-                                                                            matrix_b.get());
+          dlaf::eigensolver::gen_to_std<backend, DefaultDevice_v<backend>, T>(comm_grid, opts.uplo,
+                                                                              matrix_a.get(),
+                                                                              matrix_b.get());
 
         // wait and barrier for all ranks
         matrix_a.get().waitLocalTiles();

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -114,9 +114,9 @@ struct reductionToBandMiniapp {
         dlaf::common::Timer<> timeit;
         auto bench = [&]() {
           if (opts.local)
-            return dlaf::eigensolver::reductionToBand<backend>(matrix, opts.b);
+            return dlaf::eigensolver::reduction_to_band<backend>(matrix, opts.b);
           else
-            return dlaf::eigensolver::reductionToBand<backend>(comm_grid, matrix, opts.b);
+            return dlaf::eigensolver::reduction_to_band<backend>(comm_grid, matrix, opts.b);
         };
         auto taus = bench();
 

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -114,9 +114,9 @@ struct reductionToBandMiniapp {
         dlaf::common::Timer<> timeit;
         auto bench = [&]() {
           if (opts.local)
-            return dlaf::eigensolver::reduction_to_band<backend>(matrix, opts.b);
+            return dlaf::eigensolver::internal::reduction_to_band<backend>(matrix, opts.b);
           else
-            return dlaf::eigensolver::reduction_to_band<backend>(comm_grid, matrix, opts.b);
+            return dlaf::eigensolver::internal::reduction_to_band<backend>(comm_grid, matrix, opts.b);
         };
         auto taus = bench();
 

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -142,12 +142,12 @@ struct triangularSolverMiniapp {
 
       dlaf::common::Timer<> timeit;
       if (opts.local)
-        dlaf::solver::triangular<backend, dlaf::DefaultDevice_v<backend>, T>(side, uplo, op, diag, alpha,
-                                                                             a.get(), b.get());
+        dlaf::triangular_solver<backend, dlaf::DefaultDevice_v<backend>, T>(side, uplo, op, diag, alpha,
+                                                                            a.get(), b.get());
       else
-        dlaf::solver::triangular<backend, dlaf::DefaultDevice_v<backend>, T>(comm_grid, side, uplo, op,
-                                                                             diag, alpha, a.get(),
-                                                                             b.get());
+        dlaf::triangular_solver<backend, dlaf::DefaultDevice_v<backend>, T>(comm_grid, side, uplo, op,
+                                                                            diag, alpha, a.get(),
+                                                                            b.get());
 
       sync_barrier();
 

--- a/miniapp/miniapp_tridiag_solver.cpp
+++ b/miniapp/miniapp_tridiag_solver.cpp
@@ -139,11 +139,11 @@ struct TridiagSolverMiniapp {
         DLAF_MPI_CHECK_ERROR(MPI_Barrier(world));
 
         dlaf::common::Timer<> timeit;
-        using dlaf::eigensolver::tridiag_solver;
+        using dlaf::eigensolver::internal::tridiagonal_eigensolver;
         if (opts.local)
-          tridiag_solver<backend>(tridiag, evals_mirror.get(), evecs_mirror.get());
+          tridiagonal_eigensolver<backend>(tridiag, evals_mirror.get(), evecs_mirror.get());
         else
-          tridiag_solver<backend>(comm_grid, tridiag, evals_mirror.get(), evecs_mirror.get());
+          tridiagonal_eigensolver<backend>(comm_grid, tridiag, evals_mirror.get(), evecs_mirror.get());
 
         // wait and barrier for all ranks
         tridiag.waitLocalTiles();

--- a/miniapp/miniapp_tridiag_solver.cpp
+++ b/miniapp/miniapp_tridiag_solver.cpp
@@ -139,11 +139,11 @@ struct TridiagSolverMiniapp {
         DLAF_MPI_CHECK_ERROR(MPI_Barrier(world));
 
         dlaf::common::Timer<> timeit;
-        using dlaf::eigensolver::tridiagSolver;
+        using dlaf::eigensolver::tridiag_solver;
         if (opts.local)
-          tridiagSolver<backend>(tridiag, evals_mirror.get(), evecs_mirror.get());
+          tridiag_solver<backend>(tridiag, evals_mirror.get(), evecs_mirror.get());
         else
-          tridiagSolver<backend>(comm_grid, tridiag, evals_mirror.get(), evecs_mirror.get());
+          tridiag_solver<backend>(comm_grid, tridiag, evals_mirror.get(), evecs_mirror.get());
 
         // wait and barrier for all ranks
         tridiag.waitLocalTiles();

--- a/src/c_api/eigensolver/eigensolver.h
+++ b/src/c_api/eigensolver/eigensolver.h
@@ -59,7 +59,7 @@ int hermitian_eigensolver(const int dlaf_context, const char uplo, T* a,
     MatrixMirror eigenvectors(eigenvectors_host);
     MatrixBaseMirror eigenvalues(eigenvalues_host);
 
-    dlaf::eigensolver::eigensolver<dlaf::Backend::Default, dlaf::Device::Default, T>(
+    dlaf::hermitian_eigensolver<dlaf::Backend::Default, dlaf::Device::Default, T>(
         communicator_grid, blas::char2uplo(uplo), matrix.get(), eigenvalues.get(), eigenvectors.get());
   }  // Destroy mirror
 

--- a/src/c_api/factorization/cholesky.h
+++ b/src/c_api/factorization/cholesky.h
@@ -46,8 +46,9 @@ int cholesky_factorization(const int dlaf_context, const char uplo, T* a,
   {
     MatrixMirror matrix(matrix_host);
 
-    dlaf::factorization::cholesky<dlaf::Backend::Default, dlaf::Device::Default, T>(
-        communicator_grid, blas::char2uplo(uplo), matrix.get());
+    dlaf::cholesky_factorization<dlaf::Backend::Default, dlaf::Device::Default, T>(communicator_grid,
+                                                                                   blas::char2uplo(uplo),
+                                                                                   matrix.get());
   }  // Destroy mirror
 
   matrix_host.waitLocalTiles();

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -59,7 +59,7 @@ TYPED_TEST(NormDistributedTest, EmptyMatrices) {
         for (const auto& norm_type : lapack_norms) {
           for (const auto& uplo : blas_uplos) {
             const NormT<TypeParam> norm =
-                auxiliary::norm<Backend::MC>(comm_grid, {0, 0}, norm_type, uplo, matrix);
+                auxiliary::max_norm<Backend::MC>(comm_grid, {0, 0}, uplo, matrix);
 
             if (Index2D{0, 0} == comm_grid.rank()) {
               EXPECT_NEAR(0, norm, std::numeric_limits<NormT<TypeParam>>::epsilon());
@@ -98,7 +98,8 @@ void set_and_test(CommunicatorGrid comm_grid, comm::Index2D rank, Matrix<T, Devi
   if (index.isIn(matrix.size()))
     modify_element(matrix, index, new_value);
 
-  const NormT<T> norm = auxiliary::norm<Backend::MC>(comm_grid, rank, norm_type, uplo, matrix);
+  ASSERT_EQ(lapack::Norm::Max, norm_type);
+  const NormT<T> norm = auxiliary::max_norm<Backend::MC>(comm_grid, rank, uplo, matrix);
 
   SCOPED_TRACE(::testing::Message() << "norm=" << norm_type << " uplo=" << uplo << " changed element="
                                     << index << " in matrix size=" << matrix.size()
@@ -131,7 +132,7 @@ TYPED_TEST(NormDistributedTest, NormMax) {
 
           const Index2D rank_result{comm_grid.size().rows() - 1, comm_grid.size().cols() - 1};
           const NormT<TypeParam> norm =
-              auxiliary::norm<Backend::MC>(comm_grid, rank_result, norm_type, uplo, matrix);
+              auxiliary::max_norm<Backend::MC>(comm_grid, rank_result, uplo, matrix);
 
           if (rank_result == comm_grid.rank()) {
             EXPECT_GE(norm, 0);

--- a/test/unit/auxiliary/mc/test_norm.cpp
+++ b/test/unit/auxiliary/mc/test_norm.cpp
@@ -44,7 +44,7 @@ const std::vector<lapack::Norm> lapack_norms({lapack::Norm::Fro, lapack::Norm::I
                                               lapack::Norm::One, lapack::Norm::Two});
 const std::vector<blas::Uplo> blas_uplos({blas::Uplo::Lower, blas::Uplo::Upper, blas::Uplo::General});
 
-TYPED_TEST(NormDistributedTest, EmptyMatrices) {
+TYPED_TEST(NormDistributedTest, MaxNorm_EmptyMatrix) {
   const std::vector<GlobalElementSize> sizes({{13, 0}, {0, 13}, {0, 0}});
   const std::vector<TileElementSize> block_sizes({{3, 3}, {5, 5}});
 
@@ -56,14 +56,12 @@ TYPED_TEST(NormDistributedTest, EmptyMatrices) {
         Distribution distribution(size, block_size, comm_grid.size(), comm_grid.rank(), src_rank_index);
         Matrix<TypeParam, Device::CPU> matrix(std::move(distribution));
 
-        for (const auto& norm_type : lapack_norms) {
-          for (const auto& uplo : blas_uplos) {
-            const NormT<TypeParam> norm =
-                auxiliary::max_norm<Backend::MC>(comm_grid, {0, 0}, uplo, matrix);
+        for (const auto& uplo : blas_uplos) {
+          const NormT<TypeParam> norm =
+              auxiliary::max_norm<Backend::MC>(comm_grid, {0, 0}, uplo, matrix);
 
-            if (Index2D{0, 0} == comm_grid.rank()) {
-              EXPECT_NEAR(0, norm, std::numeric_limits<NormT<TypeParam>>::epsilon());
-            }
+          if (Index2D{0, 0} == comm_grid.rank()) {
+            EXPECT_NEAR(0, norm, std::numeric_limits<NormT<TypeParam>>::epsilon());
           }
         }
       }
@@ -110,8 +108,8 @@ void set_and_test(CommunicatorGrid comm_grid, comm::Index2D rank, Matrix<T, Devi
   }
 }
 
-TYPED_TEST(NormDistributedTest, NormMax) {
-  const lapack::Norm norm_type = lapack::Norm::Max;
+TYPED_TEST(NormDistributedTest, MaxNorm_Correctness) {
+  constexpr lapack::Norm norm_type = lapack::Norm::Max;
 
   const std::vector<GlobalElementSize> sizes({{10, 10}});
   const std::vector<TileElementSize> block_sizes({{3, 3}, {5, 5}});

--- a/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
@@ -87,7 +87,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
   copy(reference, mat_a_h);
   mat_a_h.waitLocalTiles();
 
-  eigensolver::EigensolverResult<T, D> ret = [&]() {
+  EigensolverResult<T, D> ret = [&]() {
     const SizeType size = mat_a_h.size().rows();
     Matrix<BaseType<T>, D> eigenvalues(LocalElementSize(size, 1),
                                        TileElementSize(mat_a_h.blockSize().rows(), 1));
@@ -165,7 +165,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
 #endif
     }
 
-    return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
+    return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
   }();
 
   // Resume pika runtime suspended by C API for correctness checks

--- a/test/unit/eigensolver/test_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_band_to_tridiag.cpp
@@ -127,7 +127,7 @@ void testBandToTridiag(const blas::Uplo uplo, const SizeType band_size, const Si
 
   auto [mat_trid, mat_v] = [&]() {
     MatrixMirror<const T, D, Device::CPU> mat_a(mat_a_h);
-    return eigensolver::band_to_tridiag<Backend::MC>(uplo, band_size, mat_a.get());
+    return eigensolver::internal::band_to_tridiagonal<Backend::MC>(uplo, band_size, mat_a.get());
   }();
 
   if (m == 0)
@@ -147,7 +147,7 @@ void testBandToTridiag(CommunicatorGrid grid, blas::Uplo uplo, const SizeType ba
 
   auto [mat_trid, mat_v] = [&]() {
     MatrixMirror<const T, D, Device::CPU> mat_a(mat_a_h);
-    return eigensolver::band_to_tridiag<Backend::MC>(grid, uplo, band_size, mat_a.get());
+    return eigensolver::internal::band_to_tridiagonal<Backend::MC>(grid, uplo, band_size, mat_a.get());
   }();
 
   if (m == 0)

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -126,7 +126,7 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
 
   {
     MatrixMirror<T, D, Device::CPU> mat_e(mat_e_h);
-    eigensolver::bt_band_to_tridiag<B>(b, mat_e.get(), mat_hh);
+    eigensolver::internal::bt_band_to_tridiagonal<B>(b, mat_e.get(), mat_hh);
   }
 
   if (m == 0 || n == 0)
@@ -205,7 +205,7 @@ void testBacktransformation(comm::CommunicatorGrid grid, SizeType m, SizeType n,
 
   {
     MatrixMirror<T, D, Device::CPU> mat_e(mat_e_h);
-    eigensolver::bt_band_to_tridiag<B>(grid, b, mat_e.get(), mat_hh);
+    eigensolver::internal::bt_band_to_tridiagonal<B>(grid, b, mat_e.get(), mat_hh);
   }
 
   if (m == 0 || n == 0)

--- a/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
+++ b/test/unit/eigensolver/test_bt_band_to_tridiag.cpp
@@ -126,7 +126,7 @@ void testBacktransformation(SizeType m, SizeType n, SizeType mb, SizeType nb, co
 
   {
     MatrixMirror<T, D, Device::CPU> mat_e(mat_e_h);
-    eigensolver::backTransformationBandToTridiag<B>(b, mat_e.get(), mat_hh);
+    eigensolver::bt_band_to_tridiag<B>(b, mat_e.get(), mat_hh);
   }
 
   if (m == 0 || n == 0)
@@ -205,7 +205,7 @@ void testBacktransformation(comm::CommunicatorGrid grid, SizeType m, SizeType n,
 
   {
     MatrixMirror<T, D, Device::CPU> mat_e(mat_e_h);
-    eigensolver::backTransformationBandToTridiag<B>(grid, b, mat_e.get(), mat_hh);
+    eigensolver::bt_band_to_tridiag<B>(grid, b, mat_e.get(), mat_hh);
   }
 
   if (m == 0 || n == 0)

--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -184,7 +184,7 @@ void testBackTransformationReductionToBand(SizeType m, SizeType n, SizeType mb, 
   {
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
-    eigensolver::backTransformationReductionToBand<B, D, T>(b, mat_c.get(), mat_v.get(), mat_taus);
+    eigensolver::bt_reduction_to_band<B, D, T>(b, mat_c.get(), mat_v.get(), mat_taus);
   }
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };
@@ -222,7 +222,7 @@ void testBackTransformationReductionToBand(comm::CommunicatorGrid grid, SizeType
   {
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
-    eigensolver::backTransformationReductionToBand<B, D, T>(grid, b, mat_c.get(), mat_v.get(), mat_taus);
+    eigensolver::bt_reduction_to_band<B, D, T>(grid, b, mat_c.get(), mat_v.get(), mat_taus);
   }
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };

--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -184,7 +184,7 @@ void testBackTransformationReductionToBand(SizeType m, SizeType n, SizeType mb, 
   {
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
-    eigensolver::bt_reduction_to_band<B, D, T>(b, mat_c.get(), mat_v.get(), mat_taus);
+    eigensolver::internal::bt_reduction_to_band<B, D, T>(b, mat_c.get(), mat_v.get(), mat_taus);
   }
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };
@@ -222,7 +222,7 @@ void testBackTransformationReductionToBand(comm::CommunicatorGrid grid, SizeType
   {
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
-    eigensolver::bt_reduction_to_band<B, D, T>(grid, b, mat_c.get(), mat_v.get(), mat_taus);
+    eigensolver::internal::bt_reduction_to_band<B, D, T>(grid, b, mat_c.get(), mat_v.get(), mat_taus);
   }
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -88,15 +88,15 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
   Matrix<T, Device::CPU> mat_a_h(reference.distribution());
   copy(reference, mat_a_h);
 
-  eigensolver::EigensolverResult<T, D> ret = [&]() {
+  EigensolverResult<T, D> ret = [&]() {
     MatrixMirror<T, D, Device::CPU> mat_a(mat_a_h);
 
     if constexpr (allocation == Allocation::do_allocation) {
       if constexpr (isDistributed) {
-        return eigensolver::eigensolver<B>(grid..., uplo, mat_a.get());
+        return hermitian_eigensolver<B>(grid..., uplo, mat_a.get());
       }
       else {
-        return eigensolver::eigensolver<B>(uplo, mat_a.get());
+        return hermitian_eigensolver<B>(uplo, mat_a.get());
       }
     }
     else if constexpr (allocation == Allocation::use_preallocated) {
@@ -105,13 +105,13 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
                                          TileElementSize(mat_a_h.blockSize().rows(), 1));
       if constexpr (isDistributed) {
         Matrix<T, D> eigenvectors(GlobalElementSize(size, size), mat_a_h.blockSize(), grid...);
-        eigensolver::eigensolver<B>(grid..., uplo, mat_a.get(), eigenvalues, eigenvectors);
-        return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
+        hermitian_eigensolver<B>(grid..., uplo, mat_a.get(), eigenvalues, eigenvectors);
+        return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
       else {
         Matrix<T, D> eigenvectors(LocalElementSize(size, size), mat_a_h.blockSize());
-        eigensolver::eigensolver<B>(uplo, mat_a.get(), eigenvalues, eigenvectors);
-        return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
+        hermitian_eigensolver<B>(uplo, mat_a.get(), eigenvalues, eigenvectors);
+        return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
     }
   }();

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -162,10 +162,10 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
     MatrixMirror<T, D, Device::CPU> mat_b(mat_b_h);
     if constexpr (allocation == Allocation::do_allocation) {
       if constexpr (isDistributed) {
-        return eigensolver::gen_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get());
+        return hermitian_generalized_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get());
       }
       else {
-        return eigensolver::gen_eigensolver<B>(uplo, mat_a.get(), mat_b.get());
+        return hermitian_generalized_eigensolver<B>(uplo, mat_a.get(), mat_b.get());
       }
     }
     else if constexpr (allocation == Allocation::use_preallocated) {
@@ -174,13 +174,13 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
                                          TileElementSize(mat_a_h.blockSize().rows(), 1));
       if constexpr (isDistributed) {
         Matrix<T, D> eigenvectors(GlobalElementSize(size, size), mat_a_h.blockSize(), grid...);
-        eigensolver::gen_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get(), eigenvalues,
-                                        eigenvectors);
+        hermitian_generalized_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get(), eigenvalues,
+                                             eigenvectors);
         return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
       else {
         Matrix<T, D> eigenvectors(LocalElementSize(size, size), mat_a_h.blockSize());
-        eigensolver::gen_eigensolver<B>(uplo, mat_a.get(), mat_b.get(), eigenvalues, eigenvectors);
+        hermitian_generalized_eigensolver<B>(uplo, mat_a.get(), mat_b.get(), eigenvalues, eigenvectors);
         return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
     }

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -163,10 +163,10 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
     MatrixMirror<T, D, Device::CPU> mat_b(mat_b_h);
     if constexpr (allocation == Allocation::do_allocation) {
       if constexpr (isDistributed) {
-        return eigensolver::genEigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get());
+        return eigensolver::gen_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get());
       }
       else {
-        return eigensolver::genEigensolver<B>(uplo, mat_a.get(), mat_b.get());
+        return eigensolver::gen_eigensolver<B>(uplo, mat_a.get(), mat_b.get());
       }
     }
     else if constexpr (allocation == Allocation::use_preallocated) {
@@ -175,13 +175,13 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
                                          TileElementSize(mat_a_h.blockSize().rows(), 1));
       if constexpr (isDistributed) {
         Matrix<T, D> eigenvectors(GlobalElementSize(size, size), mat_a_h.blockSize(), grid...);
-        eigensolver::genEigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get(), eigenvalues,
-                                       eigenvectors);
+        eigensolver::gen_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get(), eigenvalues,
+                                        eigenvectors);
         return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
       else {
         Matrix<T, D> eigenvectors(LocalElementSize(size, size), mat_a_h.blockSize());
-        eigensolver::genEigensolver<B>(uplo, mat_a.get(), mat_b.get(), eigenvalues, eigenvectors);
+        eigensolver::gen_eigensolver<B>(uplo, mat_a.get(), mat_b.get(), eigenvalues, eigenvectors);
         return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
     }

--- a/test/unit/eigensolver/test_gen_eigensolver.cpp
+++ b/test/unit/eigensolver/test_gen_eigensolver.cpp
@@ -67,8 +67,7 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {
 template <class T, Device D, class... GridIfDistributed>
 void testGenEigensolverCorrectness(const blas::Uplo uplo, Matrix<const T, Device::CPU>& reference_a,
                                    Matrix<const T, Device::CPU>& reference_b,
-                                   eigensolver::EigensolverResult<T, D>& ret,
-                                   GridIfDistributed... grid) {
+                                   EigensolverResult<T, D>& ret, GridIfDistributed... grid) {
   // Note:
   // Wait for the algorithm to finish all scheduled tasks, because verification has MPI blocking
   // calls that might lead to deadlocks.
@@ -158,7 +157,7 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
   Matrix<T, Device::CPU> mat_b_h(reference_b.distribution());
   copy(reference_b, mat_b_h);
 
-  eigensolver::EigensolverResult<T, D> ret = [&]() {
+  EigensolverResult<T, D> ret = [&]() {
     MatrixMirror<T, D, Device::CPU> mat_a(mat_a_h);
     MatrixMirror<T, D, Device::CPU> mat_b(mat_b_h);
     if constexpr (allocation == Allocation::do_allocation) {
@@ -177,12 +176,12 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
         Matrix<T, D> eigenvectors(GlobalElementSize(size, size), mat_a_h.blockSize(), grid...);
         eigensolver::gen_eigensolver<B>(grid..., uplo, mat_a.get(), mat_b.get(), eigenvalues,
                                         eigenvectors);
-        return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
+        return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
       else {
         Matrix<T, D> eigenvectors(LocalElementSize(size, size), mat_a_h.blockSize());
         eigensolver::gen_eigensolver<B>(uplo, mat_a.get(), mat_b.get(), eigenvalues, eigenvectors);
-        return eigensolver::EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
+        return EigensolverResult<T, D>{std::move(eigenvalues), std::move(eigenvectors)};
       }
     }
   }();

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -74,7 +74,7 @@ void testGenToStdEigensolver(const blas::Uplo uplo, const SizeType m, const Size
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_t(mat_th);
 
-    eigensolver::gen_to_std<B>(uplo, mat_a.get(), mat_t.get());
+    eigensolver::internal::generalized_to_standard<B>(uplo, mat_a.get(), mat_t.get());
   }
 
   CHECK_MATRIX_NEAR(res_a, mat_ah, 0, 10 * (mat_ah.size().rows() + 1) * TypeUtilities<T>::error);
@@ -104,7 +104,7 @@ void testGenToStdEigensolver(comm::CommunicatorGrid grid, const blas::Uplo uplo,
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_t(mat_th);
 
-    eigensolver::gen_to_std<B>(grid, uplo, mat_a.get(), mat_t.get());
+    eigensolver::internal::generalized_to_standard<B>(grid, uplo, mat_a.get(), mat_t.get());
   }
 
   CHECK_MATRIX_NEAR(res_a, mat_ah, 0, 10 * (mat_ah.size().rows() + 1) * TypeUtilities<T>::error);

--- a/test/unit/eigensolver/test_gen_to_std.cpp
+++ b/test/unit/eigensolver/test_gen_to_std.cpp
@@ -74,7 +74,7 @@ void testGenToStdEigensolver(const blas::Uplo uplo, const SizeType m, const Size
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_t(mat_th);
 
-    eigensolver::genToStd<B>(uplo, mat_a.get(), mat_t.get());
+    eigensolver::gen_to_std<B>(uplo, mat_a.get(), mat_t.get());
   }
 
   CHECK_MATRIX_NEAR(res_a, mat_ah, 0, 10 * (mat_ah.size().rows() + 1) * TypeUtilities<T>::error);
@@ -104,7 +104,7 @@ void testGenToStdEigensolver(comm::CommunicatorGrid grid, const blas::Uplo uplo,
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_t(mat_th);
 
-    eigensolver::genToStd<B>(grid, uplo, mat_a.get(), mat_t.get());
+    eigensolver::gen_to_std<B>(grid, uplo, mat_a.get(), mat_t.get());
   }
 
   CHECK_MATRIX_NEAR(res_a, mat_ah, 0, 10 * (mat_ah.size().rows() + 1) * TypeUtilities<T>::error);

--- a/test/unit/eigensolver/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_reduction_to_band.cpp
@@ -326,7 +326,7 @@ void testReductionToBandLocal(const LocalElementSize size, const TileElementSize
 
   Matrix<T, Device::CPU> mat_local_taus = [&]() mutable {
     MatrixMirror<T, D, Device::CPU> mat_a(mat_a_h);
-    return eigensolver::reduction_to_band<B, D, T>(mat_a.get(), band_size);
+    return eigensolver::internal::reduction_to_band<B, D, T>(mat_a.get(), band_size);
   }();
 
   ASSERT_EQ(mat_local_taus.blockSize().rows(), block_size.rows());
@@ -397,7 +397,7 @@ void testReductionToBand(comm::CommunicatorGrid grid, const LocalElementSize siz
 
   Matrix<T, Device::CPU> mat_local_taus = [&]() {
     MatrixMirror<T, D, Device::CPU> matrix_a(matrix_a_h);
-    return eigensolver::reduction_to_band<B>(grid, matrix_a.get(), band_size);
+    return eigensolver::internal::reduction_to_band<B>(grid, matrix_a.get(), band_size);
   }();
 
   ASSERT_EQ(mat_local_taus.blockSize().rows(), block_size.rows());

--- a/test/unit/eigensolver/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_reduction_to_band.cpp
@@ -326,7 +326,7 @@ void testReductionToBandLocal(const LocalElementSize size, const TileElementSize
 
   Matrix<T, Device::CPU> mat_local_taus = [&]() mutable {
     MatrixMirror<T, D, Device::CPU> mat_a(mat_a_h);
-    return eigensolver::reductionToBand<B, D, T>(mat_a.get(), band_size);
+    return eigensolver::reduction_to_band<B, D, T>(mat_a.get(), band_size);
   }();
 
   ASSERT_EQ(mat_local_taus.blockSize().rows(), block_size.rows());
@@ -397,7 +397,7 @@ void testReductionToBand(comm::CommunicatorGrid grid, const LocalElementSize siz
 
   Matrix<T, Device::CPU> mat_local_taus = [&]() {
     MatrixMirror<T, D, Device::CPU> matrix_a(matrix_a_h);
-    return eigensolver::reductionToBand<B>(grid, matrix_a.get(), band_size);
+    return eigensolver::reduction_to_band<B>(grid, matrix_a.get(), band_size);
   }();
 
   ASSERT_EQ(mat_local_taus.blockSize().rows(), block_size.rows());

--- a/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
@@ -100,7 +100,8 @@ void solveDistributedLaplace1D(comm::CommunicatorGrid grid, SizeType n, SizeType
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
-    eigensolver::tridiag_solver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::internal::tridiagonal_eigensolver<B>(grid, tridiag, evals_mirror.get(),
+                                                      evecs_mirror.get());
   }
   if (n == 0)
     return;
@@ -221,7 +222,8 @@ void solveRandomTridiagMatrix(comm::CommunicatorGrid grid, SizeType n, SizeType 
     // Find eigenvalues and eigenvectors of the tridiagonal matrix.
     //
     // Note: this modifies `tridiag`
-    eigensolver::tridiag_solver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::internal::tridiagonal_eigensolver<B>(grid, tridiag, evals_mirror.get(),
+                                                      evecs_mirror.get());
   }
 
   if (n == 0)

--- a/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_distributed.cpp
@@ -100,7 +100,7 @@ void solveDistributedLaplace1D(comm::CommunicatorGrid grid, SizeType n, SizeType
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
-    eigensolver::tridiagSolver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiag_solver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
   }
   if (n == 0)
     return;
@@ -221,7 +221,7 @@ void solveRandomTridiagMatrix(comm::CommunicatorGrid grid, SizeType n, SizeType 
     // Find eigenvalues and eigenvectors of the tridiagonal matrix.
     //
     // Note: this modifies `tridiag`
-    eigensolver::tridiagSolver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiag_solver<B>(grid, tridiag, evals_mirror.get(), evecs_mirror.get());
   }
 
   if (n == 0)

--- a/test/unit/eigensolver/test_tridiag_solver_local.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_local.cpp
@@ -80,7 +80,7 @@ void solveLaplace1D(SizeType n, SizeType nb) {
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
-    eigensolver::tridiagSolver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiag_solver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
   }
   if (n == 0)
     return;
@@ -167,7 +167,7 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
     // Find eigenvalues and eigenvectors of the tridiagonal matrix.
     //
     // Note: this modifies `tridiag`
-    eigensolver::tridiagSolver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::tridiag_solver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
   }
 
   if (n == 0)

--- a/test/unit/eigensolver/test_tridiag_solver_local.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_local.cpp
@@ -80,7 +80,7 @@ void solveLaplace1D(SizeType n, SizeType nb) {
     matrix::MatrixMirror<RealParam, D, Device::CPU> evals_mirror(evals);
     matrix::MatrixMirror<T, D, Device::CPU> evecs_mirror(evecs);
 
-    eigensolver::tridiag_solver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::internal::tridiagonal_eigensolver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
   }
   if (n == 0)
     return;
@@ -167,7 +167,7 @@ void solveRandomTridiagMatrix(SizeType n, SizeType nb) {
     // Find eigenvalues and eigenvectors of the tridiagonal matrix.
     //
     // Note: this modifies `tridiag`
-    eigensolver::tridiag_solver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
+    eigensolver::internal::tridiagonal_eigensolver<B>(tridiag, evals_mirror.get(), evecs_mirror.get());
   }
 
   if (n == 0)

--- a/test/unit/factorization/test_cholesky.cpp
+++ b/test/unit/factorization/test_cholesky.cpp
@@ -68,7 +68,7 @@ void testCholesky(const blas::Uplo uplo, const SizeType m, const SizeType mb) {
 
   {
     MatrixMirror<T, D, Device::CPU> mat(mat_h);
-    factorization::cholesky<B, D, T>(uplo, mat.get());
+    cholesky_factorization<B, D, T>(uplo, mat.get());
   }
 
   CHECK_MATRIX_NEAR(res, mat_h, 4 * (mat_h.size().rows() + 1) * TypeUtilities<T>::error,
@@ -91,7 +91,7 @@ void testCholesky(comm::CommunicatorGrid grid, const blas::Uplo uplo, const Size
 
   {
     MatrixMirror<T, D, Device::CPU> mat(mat_h);
-    factorization::cholesky<B, D, T>(grid, uplo, mat.get());
+    cholesky_factorization<B, D, T>(grid, uplo, mat.get());
   }
 
   CHECK_MATRIX_NEAR(res, mat_h, 4 * (mat_h.size().rows() + 1) * TypeUtilities<T>::error,

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -87,8 +87,8 @@ void testGeneralMultiplication(const SizeType a, const SizeType b, const T alpha
     MatrixMirror<const T, D, Device::CPU> mat_b(mat_bh);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_ch);
 
-    multiplication::generalSubMatrix<B>(a, b, blas::Op::NoTrans, blas::Op::NoTrans, alpha, mat_a.get(),
-                                        mat_b.get(), beta, mat_c.get());
+    multiplication::internal::generalSubMatrix<B>(a, b, blas::Op::NoTrans, blas::Op::NoTrans, alpha,
+                                                  mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
   CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,
@@ -157,7 +157,8 @@ void testGeneralSubMultiplication(comm::CommunicatorGrid grid, const SizeType a,
     MatrixMirror<const T, D, Device::CPU> mat_b(mat_bh);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_ch);
 
-    multiplication::generalSubMatrix<B>(grid, a, b, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
+    multiplication::internal::generalSubMatrix<B>(grid, a, b, alpha, mat_a.get(), mat_b.get(), beta,
+                                                  mat_c.get());
   }
 
   CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,

--- a/test/unit/multiplication/test_multiplication_hermitian.cpp
+++ b/test/unit/multiplication/test_multiplication_hermitian.cpp
@@ -91,7 +91,7 @@ void testHermitianMultiplication(const blas::Side side, const blas::Uplo uplo, c
     MatrixMirror<T, D, Device::CPU> mat_b(mat_bh);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_ch);
 
-    multiplication::hermitian<B>(side, uplo, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
+    hermitian_multiplication<B>(side, uplo, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
   // SCOPED_TRACE cannot yield.
@@ -136,7 +136,7 @@ void testHermitianMultiplication(comm::CommunicatorGrid grid, const blas::Side s
     MatrixMirror<T, D, Device::CPU> mat_b(mat_bh);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_ch);
 
-    multiplication::hermitian<B>(grid, side, uplo, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
+    hermitian_multiplication<B>(grid, side, uplo, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
   // SCOPED_TRACE cannot yield.

--- a/test/unit/multiplication/test_multiplication_triangular.cpp
+++ b/test/unit/multiplication/test_multiplication_triangular.cpp
@@ -94,7 +94,7 @@ void testTriangularMultiplication(blas::Side side, blas::Uplo uplo, blas::Op op,
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_b(mat_bh);
 
-    multiplication::triangular<B>(side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
+    triangular_multiplication<B>(side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
   }
 
   CHECK_MATRIX_NEAR(res_b, mat_bh, 40 * (mat_bh.size().rows() + 1) * TypeUtilities<T>::error,
@@ -135,7 +135,7 @@ void testTriangularMultiplication(comm::CommunicatorGrid grid, blas::Side side, 
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_b(mat_bh);
 
-    multiplication::triangular<B, D, T>(grid, side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
+    triangular_multiplication<B, D, T>(grid, side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
   }
 
   CHECK_MATRIX_NEAR(res_b, mat_bh, 40 * (mat_bh.size().rows() + 1) * TypeUtilities<T>::error,

--- a/test/unit/solver/test_triangular.cpp
+++ b/test/unit/solver/test_triangular.cpp
@@ -93,7 +93,7 @@ void testTriangularSolver(blas::Side side, blas::Uplo uplo, blas::Op op, blas::D
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_b(mat_bh);
 
-    solver::triangular<B>(side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
+    triangular_solver<B>(side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
   }
 
   CHECK_MATRIX_NEAR(res_b, mat_bh, 40 * (mat_bh.size().rows() + 1) * TypeUtilities<T>::error,
@@ -131,7 +131,7 @@ void testTriangularSolver(comm::CommunicatorGrid grid, blas::Side side, blas::Up
     MatrixMirror<T, D, Device::CPU> mat_a(mat_ah);
     MatrixMirror<T, D, Device::CPU> mat_b(mat_bh);
 
-    solver::triangular<B, D, T>(grid, side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
+    triangular_solver<B, D, T>(grid, side, uplo, op, diag, alpha, mat_a.get(), mat_b.get());
   }
 
   CHECK_MATRIX_NEAR(res_b, mat_bh, 20 * (mat_bh.size().rows() + 1) * TypeUtilities<T>::error,


### PR DESCRIPTION
Close #940

As per discussion in https://confluence.cscs.ch/display/SCISWDEV/2023-07-20+algorithm+renaming+discussion

Decisions:
- B+ is the winning choice
- Move public functions to top-level `dlaf::` namespace
- Move eigensolver building blocks to internal  namespace
- Leave already internal algorithm implementations in their sub-namespaces (e.g. `dlaf::eigensolver::internal::Eigensolver`)

TODO:
- [x] hermitian_eigensolver
- [x] hermitian_generalized_eigensolver
- [x] cholesky_factorization
- [x] general_multiplication
- [x] triangular_multiplication
- [x] hermitian_multiplication
- [x] triangular_solver
- [x] max_norm
- [x] eigensolver::internal::generalized_to_standard
- [x] eigensolver::internal::reduction_to_band
- [x] eigensolver::internal::bt_reduction_to_band
- [x] eigensolver::internal::band_to_tridiagonal
- [x] eigensolver::internal::bt_band_to_tridiagonal
- [x] eigensolver::internal::tridiagonal_eigensolver