### PR TITLE
Fix precompiled headers with C files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,31 +113,31 @@ if(DLAF_WITH_PRECOMPILED_HEADERS)
   # We create two separate targets whose precompiled headers will be reused, one
   # for libraries and one for executables. Separate targets are needed because
   # the compilation flags for executables and libraries may differ.
-  add_library(dlaf.pch_lib OBJECT dummy.cpp)
+  add_library(dlaf.pch_lib OBJECT dummy.cpp dummy.c)
   target_link_libraries(dlaf.pch_lib PRIVATE dlaf.prop dlaf.prop_private)
   target_add_warnings(dlaf.pch_lib)
 
-  add_executable(dlaf.pch_exe dummy.cpp)
+  add_executable(dlaf.pch_exe dummy.cpp dummy.c)
   target_link_libraries(dlaf.pch_exe PRIVATE dlaf.prop dlaf.prop_private)
   target_add_warnings(dlaf.pch_exe)
 
   set(precompiled_headers
       <mpi.h>
-      $<$<BOOL:${DLAF_WITH_CUDA}>:<pika/cuda.hpp$<ANGLE-R>>
-      <pika/execution.hpp>
-      <pika/mutex.hpp>
-      <pika/program_options.hpp>
-      <pika/runtime.hpp>
-      <pika/thread.hpp>
-      <blas.hh>
+      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:${DLAF_WITH_CUDA}>>:<pika/cuda.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<pika/execution.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<pika/mutex.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<pika/program_options.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<pika/runtime.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<pika/thread.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<blas.hh$<ANGLE-R>>
       # We exclude lapack.hh because it pulls in complex.h and defines I as a
       # macro. I is a commonly used e.g. as template parameter names and defining
       # it as a macro breaks compilation. Undefining I for the precompiled header
       # is a bigger hassle than excluding the header since it's a cheap header to
       # compile.
-      # <lapack.hh>
-      <umpire/Allocator.hpp>
-      <umpire/ResourceManager.hpp>
+      # $<$<COMPILE_LANGUAGE:CXX>:<lapack.hh$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<umpire/Allocator.hpp$<ANGLE-R>>
+      $<$<COMPILE_LANGUAGE:CXX>:<umpire/ResourceManager.hpp$<ANGLE-R>>
       $<$<BOOL:${DLAF_WITH_CUDA}>:<cublas_v2.h$<ANGLE-R>>
       $<$<BOOL:${DLAF_WITH_CUDA}>:<cuda_runtime.h$<ANGLE-R>>
       $<$<BOOL:${DLAF_WITH_CUDA}>:<cusolverDn.h$<ANGLE-R>>

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -1,0 +1,14 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2023, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// This file is intentionally empty. It is used for the precompiled headers
+// target.
+
+// Silences -Wpedantic: ISO C forbids an empty translation unit
+void dlaf_empty();


### PR DESCRIPTION
Works around https://github.com/eth-cscs/DLA-Future/issues/950 with https://stackoverflow.com/questions/68735830/cmake-precompiled-headers-issue-with-mixed-c-c-project. Note that it's not enough to have a C header in the list of precompiled headers. The executable/library also has to have at least one C file for the `.h` precompiled header to be generated. In C-mode `-Wpedantic` also warns about an empty translation unit so I've added a dummy function declaration to the `dummy.c` file as well.