### PR TITLE
Update stdexec to `48c52df0f81c6151eecf4f39fa5eed2dc0216204`

### DIFF
--- a/ci/docker/release-cpu-stdexec.yaml
+++ b/ci/docker/release-cpu-stdexec.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=openmp ^mpich ^pika+stdexec ^stdexec@git.7a47a4aa411c1ca9adfcb152c28cc3dd7b156b4d=main
+    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=openmp ^mpich ^pika+stdexec ^stdexec@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main
 
   packages:
     all:


### PR DESCRIPTION
Companion to https://github.com/pika-org/pika/pull/733. Contains fixes to allow #945 to compile with stdexec. Will also need fixes from pika.