### PR TITLE
Correctly move callable `f` in `Unwrapping` call operator

### DIFF
--- a/include/dlaf/common/unwrap.h
+++ b/include/dlaf/common/unwrap.h
@@ -56,9 +56,15 @@ struct Unwrapping {
   std::decay_t<F> f;
 
   template <typename... Ts>
-  auto operator()(Ts&&... ts)
-      -> decltype(std::move(f)(Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...)) {
+  auto operator()(Ts&&... ts) && -> decltype(std::move(f)(
+      Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...)) {
     return std::move(f)(Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...);
+  }
+
+  template <typename... Ts>
+  auto operator()(
+      Ts&&... ts) & -> decltype(f(Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...)) {
+    return f(Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...);
   }
 };
 

--- a/include/dlaf/matrix/copy_tile.h
+++ b/include/dlaf/matrix/copy_tile.h
@@ -176,7 +176,7 @@ DLAF_MAKE_SENDER_ALGORITHM_OVERLOADS(dlaf::internal::TransformDispatchType::Plai
 template <Device Destination>
 struct Duplicate {
   template <typename T, Device Source, typename... Ts>
-  Tile<T, Destination> operator()(const Tile<const T, Source>& source, Ts&&... ts) {
+  Tile<T, Destination> operator()(const Tile<const T, Source>& source, Ts&&... ts) const {
     auto source_size = source.size();
     dlaf::memory::MemoryView<T, Destination> mem_view(source_size.linear_size());
     Tile<T, Destination> destination(source_size, std::move(mem_view), source_size.rows());
@@ -196,7 +196,7 @@ struct Duplicate {
 template <Device Destination>
 struct DuplicateNoCopy {
   template <typename T, Device Source>
-  Tile<T, Destination> operator()(const Tile<const T, Source>& source) {
+  Tile<T, Destination> operator()(const Tile<const T, Source>& source) const {
     auto source_size = source.size();
     dlaf::memory::MemoryView<T, Destination> mem_view(source_size.linear_size());
     Tile<T, Destination> destination(source_size, std::move(mem_view), source_size.rows());


### PR DESCRIPTION
The previous implementation was potentially buggy for cases when the `Unwrapping` call operator is called more than once, since `f` was for the actual call.

As far as I could tell we're not actually affected by this bug since we only ever call the `Unwrapping` call operator once.

This splits the call operator into two `&&` and `&` qualified overloads, with the latter not moving `f`. Note that the latter is not `const&` because that would fail with wrapped call operators that are not const-qualified. The `Duplicate` call operator was one such call operator. I've changed the latter to be const-qualified but I've also left the `Unwrapping` call operator as `&` in case we introduce other call operators that actually need to be non-const.

@aurianer you can apply the same change in #930 to `ConsumeRvalues`.