### PR TITLE
TridiagSolver: fix missing sort in the deflation

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/kernels.h
+++ b/include/dlaf/eigensolver/tridiag_solver/kernels.h
@@ -275,11 +275,6 @@ void initIndexTileAsync(SizeType tile_row, TileSender&& tile) {
 
 #ifdef DLAF_WITH_GPU
 
-// Returns the number of non-deflated entries
-void stablePartitionIndexOnDevice(SizeType n, const ColType* c_ptr, const SizeType* in_ptr,
-                                  SizeType* out_ptr, SizeType* host_k_ptr, SizeType* device_k_ptr,
-                                  whip::stream_t stream);
-
 template <class T>
 void mergeIndicesOnDevice(const SizeType* begin_ptr, const SizeType* split_ptr, const SizeType* end_ptr,
                           SizeType* out_ptr, const T* v_ptr, whip::stream_t stream);

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -388,7 +388,7 @@ std::vector<GivensRotation<T>> applyDeflationToArrays(T rho, T tol, const SizeTy
     // `s` is not negated.
     //
     // [1] LAPACK 3.10.0, file dlaed2.f, line 393
-    T r = std::sqrt(z1 * z1 + z2 * z2);
+    T r = std::hypot(z1, z2);
     T c = z1 / r;
     T s = z2 / r;
 

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -248,8 +248,9 @@ auto calcTolerance(const SizeType i_begin, const SizeType i_end, Matrix<const T,
 // `in_ptr` on entry.
 //
 template <class T>
-SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType* c_ptr, const T* d0_ptr,
-                                                const SizeType* in_ptr, SizeType* out_ptr) {
+SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType* c_ptr,
+                                                const T* evals_ptr, const SizeType* in_ptr,
+                                                SizeType* out_ptr) {
   // Get the number of non-deflated entries
   SizeType k = 0;
   for (SizeType i = 0; i < n; ++i) {
@@ -262,11 +263,11 @@ SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType*
   for (SizeType i = 0; i < n; ++i) {
     const SizeType ii = in_ptr[i];
     if (c_ptr[ii] == ColType::Deflated) {
-      const T a = d0_ptr[ii];
+      const T a = evals_ptr[ii];
 
       SizeType j = i2;
       for (; j > k; --j) {
-        const T b = d0_ptr[out_ptr[j - 1]];
+        const T b = evals_ptr[out_ptr[j - 1]];
         if (a > b) {
           break;
         }
@@ -283,55 +284,31 @@ SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType*
   return k;
 }
 
-template <class T, Device D>
+template <class T>
 auto stablePartitionIndexForDeflation(const SizeType i_begin, const SizeType i_end,
-                                      Matrix<const ColType, D>& c, Matrix<const T, D>& d0,
-                                      Matrix<const SizeType, D>& in, Matrix<SizeType, D>& out) {
+                                      Matrix<const ColType, Device::CPU>& c,
+                                      Matrix<const T, Device::CPU>& evals,
+                                      Matrix<const SizeType, Device::CPU>& in,
+                                      Matrix<SizeType, Device::CPU>& out) {
   namespace ex = pika::execution::experimental;
   namespace di = dlaf::internal;
 
-  constexpr auto backend = dlaf::DefaultBackend_v<D>;
-
   const SizeType n = problemSize(i_begin, i_end, in.distribution());
-  if constexpr (D == Device::CPU) {
-    auto part_fn = [n](const auto& c_tiles_futs, const auto& d0_tiles_fut, const auto& in_tiles_futs,
-                       const auto& out_tiles) {
-      const TileElementIndex zero_idx(0, 0);
-      const ColType* c_ptr = c_tiles_futs[0].get().ptr(zero_idx);
-      const T* d0_ptr = d0_tiles_fut[0].get().ptr(zero_idx);
-      const SizeType* in_ptr = in_tiles_futs[0].get().ptr(zero_idx);
-      SizeType* out_ptr = out_tiles[0].ptr(zero_idx);
+  auto part_fn = [n](const auto& c_tiles_futs, const auto& evals_tiles_fut, const auto& in_tiles_futs,
+                     const auto& out_tiles) {
+    const TileElementIndex zero_idx(0, 0);
+    const ColType* c_ptr = c_tiles_futs[0].get().ptr(zero_idx);
+    const T* evals_ptr = evals_tiles_fut[0].get().ptr(zero_idx);
+    const SizeType* in_ptr = in_tiles_futs[0].get().ptr(zero_idx);
+    SizeType* out_ptr = out_tiles[0].ptr(zero_idx);
 
-      return stablePartitionIndexForDeflationArrays(n, c_ptr, d0_ptr, in_ptr, out_ptr);
-    };
+    return stablePartitionIndexForDeflationArrays(n, c_ptr, evals_ptr, in_ptr, out_ptr);
+  };
 
-    TileCollector tc{i_begin, i_end};
-    return ex::when_all(ex::when_all_vector(tc.read(c)), ex::when_all_vector(tc.read(d0)),
-                        ex::when_all_vector(tc.read(in)), ex::when_all_vector(tc.readwrite(out))) |
-           di::transform(di::Policy<backend>(), std::move(part_fn));
-  }
-  else {
-#ifdef DLAF_WITH_GPU
-    auto part_fn = [n](const auto& c_tiles_futs, const auto& in_tiles_futs, const auto& out_tiles,
-                       auto& host_k, auto& device_k) {
-      const TileElementIndex zero_idx(0, 0);
-      const ColType* c_ptr = c_tiles_futs[0].get().ptr(zero_idx);
-      const SizeType* in_ptr = in_tiles_futs[0].get().ptr(zero_idx);
-      SizeType* out_ptr = out_tiles[0].ptr(zero_idx);
-
-      return ex::just(n, c_ptr, in_ptr, out_ptr, host_k(), device_k()) |
-             di::transform(di::Policy<backend>(), stablePartitionIndexOnDevice) |
-             ex::then([&host_k]() { return *host_k(); });
-    };
-
-    TileCollector tc{i_begin, i_end};
-    return ex::when_all(ex::when_all_vector(tc.read(c)), ex::when_all_vector(tc.read(in)),
-                        ex::when_all_vector(tc.readwrite(out)),
-                        ex::just(memory::MemoryChunk<SizeType, Device::CPU>{1},
-                                 memory::MemoryChunk<SizeType, Device::GPU>{1})) |
-           ex::let_value(std::move(part_fn));
-#endif
-  }
+  TileCollector tc{i_begin, i_end};
+  return ex::when_all(ex::when_all_vector(tc.read(c)), ex::when_all_vector(tc.read(evals)),
+                      ex::when_all_vector(tc.read(in)), ex::when_all_vector(tc.readwrite(out))) |
+         di::transform(di::Policy<Backend::MC>(), std::move(part_fn));
 }
 
 template <Device D>

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -295,7 +295,7 @@ SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType*
         }
         out_ptr[j] = out_ptr[j - 1];
       }
-      // and put the current one in the first place found where all greater values have been moved right
+      // and insert the current index in the empty place, such that eigenvalues are sorted.
       out_ptr[j] = ii;
       ++i2;
     }

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -264,21 +264,16 @@ SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType*
     if (c_ptr[ii] == ColType::Deflated) {
       const T a = d0_ptr[ii];
 
-      for (SizeType j = i2; j >= k; --j) {
-        if (j == k) {
-          out_ptr[j] = ii;
-          ++i2;
+      SizeType j = i2;
+      for (; j > k; --j) {
+        const T b = d0_ptr[out_ptr[j - 1]];
+        if (a > b) {
+          break;
         }
-        else {
-          const T b = d0_ptr[out_ptr[j - 1]];
-          if (a > b) {
-            out_ptr[j] = ii;
-            ++i2;
-            break;
-          }
-          out_ptr[j] = out_ptr[j - 1];
-        }
+        out_ptr[j] = out_ptr[j - 1];
       }
+      out_ptr[j] = ii;
+      ++i2;
     }
     else {
       out_ptr[i1] = ii;

--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -287,7 +287,7 @@ SizeType stablePartitionIndexForDeflationArrays(const SizeType n, const ColType*
       const T a = evals_ptr[ii];
 
       SizeType j = i2;
-      // shift all greater values to the end of the currently sorted array (shift just indices)
+      // shift to right all greater values (shift just indices)
       for (; j > k; --j) {
         const T b = evals_ptr[out_ptr[j - 1]];
         if (a > b) {

--- a/test/unit/eigensolver/test_tridiag_solver_merge.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_merge.cpp
@@ -89,6 +89,7 @@ TEST(StablePartitionIndexOnDeflated, FullRange) {
   const TileElementSize bk(nb, 1);
 
   Matrix<ColType, Device::CPU> c(sz, bk);
+  Matrix<double, Device::CPU> vals(sz, bk);
   Matrix<SizeType, Device::CPU> in(sz, bk);
   Matrix<SizeType, Device::CPU> out(sz, bk);
 
@@ -100,12 +101,15 @@ TEST(StablePartitionIndexOnDeflated, FullRange) {
   dlaf::matrix::util::set(c, [&c_arr](GlobalElementIndex i) { return c_arr[to_sizet(i.row())]; });
 
   // f, u, d, d, l, u, l, f, d, l
+  std::vector<double> vals_arr{1, 4, 2, 3, 0, 5, 6, 7, 8, 9};
   std::vector<SizeType> in_arr{1, 4, 2, 3, 0, 5, 6, 7, 8, 9};
+  dlaf::matrix::util::set(vals,
+                          [&vals_arr](GlobalElementIndex i) { return vals_arr[to_sizet(i.row())]; });
   dlaf::matrix::util::set(in, [&in_arr](GlobalElementIndex i) { return in_arr[to_sizet(i.row())]; });
 
   const SizeType i_begin = 0;
   const SizeType i_end = 4;
-  auto k = stablePartitionIndexForDeflation(i_begin, i_end, c, in, out);
+  auto k = stablePartitionIndexForDeflation(i_begin, i_end, c, vals, in, out);
 
   ASSERT_TRUE(tt::sync_wait(std::move(k)) == 7);
 

--- a/test/unit/eigensolver/test_tridiag_solver_merge.cpp
+++ b/test/unit/eigensolver/test_tridiag_solver_merge.cpp
@@ -82,7 +82,7 @@ TYPED_TEST(TridiagEigensolverMergeTest, SortIndex) {
 }
 
 TEST(StablePartitionIndexOnDeflated, FullRange) {
-  const SizeType n = 10;
+  constexpr SizeType n = 10;
   const SizeType nb = 3;
 
   const LocalElementSize sz(n, 1);
@@ -93,6 +93,14 @@ TEST(StablePartitionIndexOnDeflated, FullRange) {
   Matrix<SizeType, Device::CPU> in(sz, bk);
   Matrix<SizeType, Device::CPU> out(sz, bk);
 
+  // Note:
+  // UpperHalf  -> u
+  // Dense      -> f
+  // LowerHalf  -> l
+  // Deflated   -> d
+
+  // | 0| 1| 2| 3| 4| 5| 6| 7| 8| 9| initial
+  // | l| f|d1|d2| u| u| l| f|d3| l| c_arr
   std::vector<ColType> c_arr{ColType::LowerHalf, ColType::Dense,     ColType::Deflated,
                              ColType::Deflated,  ColType::UpperHalf, ColType::UpperHalf,
                              ColType::LowerHalf, ColType::Dense,     ColType::Deflated,
@@ -100,25 +108,47 @@ TEST(StablePartitionIndexOnDeflated, FullRange) {
   DLAF_ASSERT(c_arr.size() == to_sizet(n), n);
   dlaf::matrix::util::set(c, [&c_arr](GlobalElementIndex i) { return c_arr[to_sizet(i.row())]; });
 
-  // f, u, d, d, l, u, l, f, d, l
-  std::vector<double> vals_arr{1, 4, 2, 3, 0, 5, 6, 7, 8, 9};
-  std::vector<SizeType> in_arr{1, 4, 2, 3, 0, 5, 6, 7, 8, 9};
+  // | 1| 4| 2| 3| 0| 5| 6| 7| 8| 9| in_arr
+  // | f| u|d1|d2| l| u| l| f|d3| l| c_arr permuted by in_arr
+  std::array<SizeType, n> in_arr{1, 4, 2, 3, 0, 5, 6, 7, 8, 9};
+  dlaf::matrix::util::set(in, [&in_arr](GlobalElementIndex i) { return in_arr[to_sizet(i.row())]; });
+
+  // | 0| 1| 2| 3| 4| 5| 6| 7| 8| 9| initial
+  // |30|10| 2| 3|20|40|50|60| 1|70| vals_arr
+  //
+  // | 1| 4| 2| 3| 0| 5| 6| 7| 8| 9| in_arr
+  // | f| u|d1|d2| l| u| l| f|d3| l| c_arr permuted by in_arr
+  // |10|20| 2| 3|30|40|50|60| 1|70| vals_arr permuted by in_arr
+  std::array<double, n> vals_arr{30, 10, 2, 3, 20, 40, 50, 60, 1, 70};
   dlaf::matrix::util::set(vals,
                           [&vals_arr](GlobalElementIndex i) { return vals_arr[to_sizet(i.row())]; });
-  dlaf::matrix::util::set(in, [&in_arr](GlobalElementIndex i) { return in_arr[to_sizet(i.row())]; });
 
   const SizeType i_begin = 0;
   const SizeType i_end = 4;
   auto k = stablePartitionIndexForDeflation(i_begin, i_end, c, vals, in, out);
 
-  ASSERT_TRUE(tt::sync_wait(std::move(k)) == 7);
+  // | 0| 1| 2| 3| 4| 5| 6| 7| 8| 9| initial
+  // | l| f|d1|d2| u| u| l| f|d3| l| c_arr
+  // |30|10| 2| 3|20|40|50|60| 1|70| vals_arr
+  //
+  // | 1| 4| 0| 5| 6| 7| 9| 8| 2| 3| out_arr
+  // | f| u| l| u| l| f| l|d3|d1|d2| c_arr permuted by out_arr
+  // |10|20|30|40|50|60|70| 1| 2| 3| vals_arr permuted by out_arr
 
-  // f u l u l f l d d d
-  std::vector<SizeType> expected_out_arr{1, 4, 0, 5, 6, 7, 9, 2, 3, 8};
+  const SizeType k_value = tt::sync_wait(std::move(k));
+  ASSERT_TRUE(k_value == 7);
+
+  std::array<SizeType, n> expected_out_arr{1, 4, 0, 5, 6, 7, 9, 8, 2, 3};
   auto expected_out = [&expected_out_arr](GlobalElementIndex i) {
     return expected_out_arr[to_sizet(i.row())];
   };
   CHECK_MATRIX_EQ(expected_out, out);
+
+  const SizeType* out_ptr = tt::sync_wait(out.read(LocalTileIndex(0, 0))).get().ptr();
+  EXPECT_TRUE(std::is_sorted(out_ptr + k_value, out_ptr + n,
+                             [&vals_arr](const SizeType i, const SizeType j) {
+                               return vals_arr[to_sizet(i)] < vals_arr[to_sizet(j)];
+                             }));
 }
 
 TYPED_TEST(TridiagEigensolverMergeTest, Deflation) {


### PR DESCRIPTION
(probable fix for #953)

Deflation process might produce changes in the order of deflated eigenvalues, and the part taking care of keeping them sorted was not implemented in our version. So, deflated eigenvalues were not always sorted correctly and this ended up with wrong results or `NaN` values. (See [dlaed2](https://github.com/Reference-LAPACK/lapack/blob/9138a876297c5393a847de7f6fd763ccd4982be1/SRC/dlaed2.f#L409-L420) for more details)

Thanks to @RMeli and @rasolca for the investigation and the support in fixing this.

In addition to the bug fix, this introduces also `std::hypot` for avoiding possible numerical errors in the deflation step (it has been preferred the `cppstd` one over the lapack `dlapy2`, without any strong reason).

Another change is about removal of unused GPU kernels related to this step (namely `stablePartitionIndexOnDevice` and related).

TODO:
- [x] Add some note/doc about the change
- [x] Improve test for `stablePartitionIndexForDeflation`
- [x] Open issue about improving tests for tridiag solver or at least add the check in `miniapp_tridiag_solver`