### PR TITLE
Enable Gemm (local) to be used with MatrixRef

### DIFF
--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -168,7 +168,9 @@ protected:
                << ", tile_size="  << matrix.tile_size()
                << ", tiles_grid=" << matrix.nr_tiles()
                << ", rank_index=" << matrix.rank_index()
-               << ", comm_grid="  << matrix.grid_size();
+               << ", comm_grid="  << matrix.grid_size()
+               << ", src_rank="   << matrix.distribution().source_rank_index()
+               << ", offset="     << matrix.distribution().offset();
     // clang-format on
   }
 

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -20,10 +20,49 @@
 #include <dlaf/matrix/distribution.h>
 #include <dlaf/matrix/index.h>
 #include <dlaf/matrix/matrix.h>
+#include <dlaf/matrix/matrix_ref.h>
 #include <dlaf/multiplication/general/api.h>
 #include <dlaf/util_matrix.h>
 
 namespace dlaf::multiplication::internal {
+
+/// General matrix multiplication implementation on local memory, computing
+/// C = alpha * opA(A) * opB(B) + beta * C
+///
+/// @param  opA specifies the form of opA(A) to be used in the matrix multiplication:
+///         \a (currently it is implemented just) NoTrans,
+/// @param  opB specifies the form of opB(B) to be used in the matrix multiplication:
+///         \a (currently it is implemented just) NoTrans,
+///
+/// @param  mat_a contains the input matrix A.
+/// @pre @p mat_a is not distributed
+///
+/// @param  mat_b contains the input matrix B.
+/// @pre @p mat_b is not distributed
+///
+/// @param  mat_c On entry it contains the input matrix C. On exit matrix will be overwritten with the
+/// result, while others are left untouched.
+/// @pre @p mat_c is not distributed
+///
+/// @pre multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB)
+/// @pre multipliable_sizes(mat_a.tile_size(), mat_b.tile_size(), mat_c.tile_size(), opA, opB)
+/// @pre multipliable_sizes(mat_a.tile_size_of({0, 0}), mat_b.tile_size_of({0, 0}),
+/// mat_c.tile_size_of({0, 0}), opA, opB)
+template <Backend B, Device D, class T>
+void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
+                   MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c) {
+  DLAF_ASSERT(matrix::local_matrix(mat_a), mat_a);
+  DLAF_ASSERT(matrix::local_matrix(mat_b), mat_b);
+  DLAF_ASSERT(matrix::local_matrix(mat_c), mat_c);
+
+  DLAF_ASSERT_HEAVY(matrix::multipliable(mat_a, mat_b, mat_c, blas::Op::NoTrans, blas::Op::NoTrans),
+                    mat_a, mat_b, mat_c);
+
+  if (opA == blas::Op::NoTrans && opB == blas::Op::NoTrans)
+    internal::General<B, D, T>::callNN(alpha, mat_a, mat_b, beta, mat_c);
+  else
+    DLAF_UNIMPLEMENTED(opA, opB);
+}
 
 /// General sub-matrix multiplication implementation on local memory, computing
 /// C[a:b][a:b] = alpha * opA(A[a:b][a:b]) * opB(B[a:b][a:b]) + beta * C[a:b][a:b]

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -30,9 +30,9 @@ namespace dlaf::multiplication::internal {
 /// C = alpha * opA(A) * opB(B) + beta * C
 ///
 /// @param  opA specifies the form of opA(A) to be used in the matrix multiplication:
-///         \a (currently it is implemented just) NoTrans,
+///         \a currently only NoTrans,
 /// @param  opB specifies the form of opB(B) to be used in the matrix multiplication:
-///         \a (currently it is implemented just) NoTrans,
+///         \a currently only NoTrans,
 ///
 /// @param  mat_a contains the input matrix A.
 /// @pre @p mat_a is not distributed
@@ -41,13 +41,13 @@ namespace dlaf::multiplication::internal {
 /// @pre @p mat_b is not distributed
 ///
 /// @param  mat_c On entry it contains the input matrix C. On exit matrix will be overwritten with the
-/// result, while others are left untouched.
+///         result, while others are left untouched.
 /// @pre @p mat_c is not distributed
 ///
 /// @pre multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size(), mat_b.tile_size(), mat_c.tile_size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size_of({0, 0}), mat_b.tile_size_of({0, 0}),
-/// mat_c.tile_size_of({0, 0}), opA, opB)
+///      mat_c.tile_size_of({0, 0}), opA, opB)
 template <Backend B, Device D, class T>
 void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
                    MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c) {

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -23,11 +23,9 @@ using dlaf::matrix::internal::MatrixRef;
 
 template <Backend B, Device D, class T>
 struct General {
-  /// @pre opA == blas::Op::NoTrans
-  /// @pre opB == blas::Op::NoTrans
-  /// @pre mat.disrtribution().offset() % mat.distribution().tile_size() == 0 (where mat in {mat_a, mat_b, mat_c})
-  static void callNN(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
-                     MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c);
+  /// @pre mat.distribution().offset() % mat.distribution().tile_size() == 0 (where mat in {mat_a, mat_b, mat_c})
+  static void callNN(const T alpha, MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b,
+                     const T beta, MatrixRef<T, D>& mat_c);
 };
 
 template <Backend B, Device D, class T>

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -23,6 +23,8 @@ using dlaf::matrix::internal::MatrixRef;
 
 template <Backend B, Device D, class T>
 struct General {
+  /// @pre opA == blas::Op::NoTrans
+  /// @pre opB == blas::Op::NoTrans
   /// @pre mat.disrtribution().offset() % mat.distribution().tile_size() == 0 (where mat in {mat_a, mat_b, mat_c})
   static void callNN(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
                      MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c);

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -23,7 +23,6 @@ using dlaf::matrix::internal::MatrixRef;
 
 template <Backend B, Device D, class T>
 struct General {
-  /// @pre mat.distribution().offset() % mat.distribution().tile_size() == 0 (where mat in {mat_a, mat_b, mat_c})
   static void callNN(const T alpha, MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b,
                      const T beta, MatrixRef<T, D>& mat_c);
 };

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -22,6 +22,13 @@ namespace internal {
 using dlaf::matrix::internal::MatrixRef;
 
 template <Backend B, Device D, class T>
+struct General {
+  /// @pre mat.disrtribution().offset() % mat.distribution().tile_size() == 0 (where mat in {mat_a, mat_b, mat_c})
+  static void callNN(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
+                     MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c);
+};
+
+template <Backend B, Device D, class T>
 struct GeneralSub {
   static void callNN(const SizeType i_tile_from, const SizeType i_tile_to, const blas::Op opA,
                      const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
@@ -30,14 +37,10 @@ struct GeneralSub {
                      common::Pipeline<comm::Communicator>& col_task_chain, const SizeType i_tile_from,
                      const SizeType i_tile_to, const T alpha, Matrix<const T, D>& mat_a,
                      Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c);
-
-  // Note: internal helper
-  static void callNN(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
-                     MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c);
 };
 
-// ETI
 #define DLAF_MULTIPLICATION_GENERAL_ETI(KWORD, BACKEND, DEVICE, DATATYPE) \
+  KWORD template struct General<BACKEND, DEVICE, DATATYPE>;               \
   KWORD template struct GeneralSub<BACKEND, DEVICE, DATATYPE>;
 
 DLAF_MULTIPLICATION_GENERAL_ETI(extern, Backend::MC, Device::CPU, float)

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -14,10 +14,12 @@
 
 #include <dlaf/common/pipeline.h>
 #include <dlaf/matrix/matrix.h>
+#include <dlaf/matrix/matrix_ref.h>
 #include <dlaf/types.h>
 
 namespace dlaf::multiplication {
 namespace internal {
+using dlaf::matrix::internal::MatrixRef;
 
 template <Backend B, Device D, class T>
 struct GeneralSub {
@@ -28,6 +30,10 @@ struct GeneralSub {
                      common::Pipeline<comm::Communicator>& col_task_chain, const SizeType i_tile_from,
                      const SizeType i_tile_to, const T alpha, Matrix<const T, D>& mat_a,
                      Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c);
+
+  // Note: internal helper
+  static void callNN(const blas::Op opA, const blas::Op opB, const T alpha, MatrixRef<const T, D>& mat_a,
+                     MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c);
 };
 
 // ETI

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -30,36 +30,34 @@ namespace dlaf::multiplication {
 namespace internal {
 
 template <Backend B, Device D, class T>
-void General<B, D, T>::callNN(const blas::Op opA, const blas::Op opB, const T alpha,
-                              MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b, const T beta,
-                              MatrixRef<T, D>& mat_c) {
+void General<B, D, T>::callNN(const T alpha, MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b,
+                              const T beta, MatrixRef<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
-  if (opA != blas::Op::NoTrans || opB != blas::Op::NoTrans)
-    DLAF_UNIMPLEMENTED(opA, opB);
-
   using matrix::multipliable_sizes;
-  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB),
+  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), blas::Op::NoTrans,
+                                       blas::Op::NoTrans),
                     "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(),
-                    mat_c.size(), opA, opB);
-  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(), opA,
-                                       opB),
+                    mat_c.size(), blas::Op::NoTrans, blas::Op::NoTrans);
+  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(),
+                                       blas::Op::NoTrans, blas::Op::NoTrans),
                     "Multiplication incompatible tile sizes.");
-  DLAF_ASSERT_HEAVY(mat_c.size().isEmpty() ||
-                        multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
-                                           mat_b.distribution().tileSize({0, 0}),
-                                           mat_c.distribution().tileSize({0, 0}), opA, opB),
+  DLAF_ASSERT_HEAVY(mat_c.size().isEmpty() || multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
+                                                                 mat_b.distribution().tileSize({0, 0}),
+                                                                 mat_c.distribution().tileSize({0, 0}),
+                                                                 blas::Op::NoTrans, blas::Op::NoTrans),
                     "Multiplication incompatible tile sizes in first row/col. "
                     "(Are you using a matrix with offset not aligned with tile?)");
 
   for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j) {
     for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i) {
       for (SizeType k = 0; k < mat_a.nrTiles().cols(); ++k) {
-        ex::start_detached(
-            dlaf::internal::whenAllLift(opA, opB, alpha, mat_a.read(GlobalTileIndex(i, k)),
-                                        mat_b.read(GlobalTileIndex(k, j)), k == 0 ? beta : T(1),
-                                        mat_c.readwrite(GlobalTileIndex(i, j))) |
-            tile::gemm(dlaf::internal::Policy<B>()));
+        ex::start_detached(dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha,
+                                                       mat_a.read(GlobalTileIndex(i, k)),
+                                                       mat_b.read(GlobalTileIndex(k, j)),
+                                                       k == 0 ? beta : T(1),
+                                                       mat_c.readwrite(GlobalTileIndex(i, j))) |
+                           tile::gemm(dlaf::internal::Policy<B>()));
       }
     }
   }

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -35,18 +35,22 @@ void General<B, D, T>::callNN(const blas::Op opA, const blas::Op opB, const T al
                               MatrixRef<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
+  if (opA != blas::Op::NoTrans || opB != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opA, opB);
+
   using matrix::multipliable_sizes;
-  DLAF_ASSERT(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB),
-              "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(), mat_c.size(), opA,
-              opB);
-  DLAF_ASSERT(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(), opA, opB),
-              "Multiplication incompatible tile sizes.");
-  DLAF_ASSERT(mat_c.size().isEmpty() ||
-                  multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
-                                     mat_b.distribution().tileSize({0, 0}),
-                                     mat_c.distribution().tileSize({0, 0}), opA, opB),
-              "Multiplication incompatible tile sizes in first row/col. "
-              "(Are you using a matrix with offset not aligned with tile?)");
+  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB),
+                    "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(),
+                    mat_c.size(), opA, opB);
+  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(), opA,
+                                       opB),
+                    "Multiplication incompatible tile sizes.");
+  DLAF_ASSERT_HEAVY(mat_c.size().isEmpty() ||
+                        multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
+                                           mat_b.distribution().tileSize({0, 0}),
+                                           mat_c.distribution().tileSize({0, 0}), opA, opB),
+                    "Multiplication incompatible tile sizes in first row/col. "
+                    "(Are you using a matrix with offset not aligned with tile?)");
 
   for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j) {
     for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i) {

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -39,10 +39,13 @@ void General<B, D, T>::callNN(const T alpha, MatrixRef<const T, D>& mat_a, Matri
                     mat_a, mat_b, mat_c);
 
   if (mat_a.nrTiles().cols() == 0) {
-    for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j)
-      for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i)
-        ex::start_detached(dlaf::internal::whenAllLift(beta, mat_c.readwrite(GlobalTileIndex(i, j))) |
-                           tile::scal(dlaf::internal::Policy<B>()));
+    // Note: if beta == 1, we optimize by not even scheduling anything
+    if (beta != T(1)) {
+      for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j)
+        for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i)
+          ex::start_detached(dlaf::internal::whenAllLift(beta, mat_c.readwrite(GlobalTileIndex(i, j))) |
+                             tile::scal(dlaf::internal::Policy<B>()));
+    }
     return;
   }
 

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -24,11 +24,42 @@
 #include <dlaf/matrix/panel.h>
 #include <dlaf/multiplication/general/api.h>
 #include <dlaf/sender/when_all_lift.h>
-
-#include "dlaf/util_matrix.h"
+#include <dlaf/util_matrix.h>
 
 namespace dlaf::multiplication {
 namespace internal {
+
+template <Backend B, Device D, class T>
+void General<B, D, T>::callNN(const blas::Op opA, const blas::Op opB, const T alpha,
+                              MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b, const T beta,
+                              MatrixRef<T, D>& mat_c) {
+  namespace ex = pika::execution::experimental;
+
+  using matrix::multipliable_sizes;
+  DLAF_ASSERT(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB),
+              "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(), mat_c.size(), opA,
+              opB);
+  DLAF_ASSERT(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(), opA, opB),
+              "Multiplication incompatible tile sizes.");
+  DLAF_ASSERT(mat_c.size().isEmpty() ||
+                  multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
+                                     mat_b.distribution().tileSize({0, 0}),
+                                     mat_c.distribution().tileSize({0, 0}), opA, opB),
+              "Multiplication incompatible tile sizes in first row/col. "
+              "(Are you using a matrix with offset not aligned with tile?)");
+
+  for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j) {
+    for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i) {
+      for (SizeType k = 0; k < mat_a.nrTiles().cols(); ++k) {
+        ex::start_detached(
+            dlaf::internal::whenAllLift(opA, opB, alpha, mat_a.read(GlobalTileIndex(i, k)),
+                                        mat_b.read(GlobalTileIndex(k, j)), k == 0 ? beta : T(1),
+                                        mat_c.readwrite(GlobalTileIndex(i, j))) |
+            tile::gemm(dlaf::internal::Policy<B>()));
+      }
+    }
+  }
+}
 
 template <Backend B, Device D, class T>
 void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_end, const blas::Op opA,
@@ -42,37 +73,6 @@ void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_en
         ex::start_detached(
             dlaf::internal::whenAllLift(opA, opB, alpha, mat_a.read(GlobalTileIndex(i, k)),
                                         mat_b.read(GlobalTileIndex(k, j)), k == idx_begin ? beta : T(1),
-                                        mat_c.readwrite(GlobalTileIndex(i, j))) |
-            tile::gemm(dlaf::internal::Policy<B>()));
-      }
-    }
-  }
-}
-
-template <Backend B, Device D, class T>
-void GeneralSub<B, D, T>::callNN(const blas::Op opA, const blas::Op opB, const T alpha,
-                                 MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b,
-                                 const T beta, MatrixRef<T, D>& mat_c) {
-  namespace ex = pika::execution::experimental;
-
-  using matrix::multipliable_sizes;
-  DLAF_ASSERT(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB),
-              "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(), mat_c.size(), opA,
-              opB);
-  DLAF_ASSERT(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(), opA, opB),
-              "Multiplication incompatible tile sizes.");
-  DLAF_ASSERT(
-      mat_c.size().isEmpty() || multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
-                                                   mat_b.distribution().tileSize({0, 0}),
-                                                   mat_c.distribution().tileSize({0, 0}), opA, opB),
-      "Multiplication incompatible tile sizes in first row/col. (Are you using a matrix with offset?)");
-
-  for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j) {
-    for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i) {
-      for (SizeType k = 0; k < mat_a.nrTiles().cols(); ++k) {
-        ex::start_detached(
-            dlaf::internal::whenAllLift(opA, opB, alpha, mat_a.read(GlobalTileIndex(i, k)),
-                                        mat_b.read(GlobalTileIndex(k, j)), k == 0 ? beta : T(1),
                                         mat_c.readwrite(GlobalTileIndex(i, j))) |
             tile::gemm(dlaf::internal::Policy<B>()));
       }

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -34,20 +34,8 @@ void General<B, D, T>::callNN(const T alpha, MatrixRef<const T, D>& mat_a, Matri
                               const T beta, MatrixRef<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
-  using matrix::multipliable_sizes;
-  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), blas::Op::NoTrans,
-                                       blas::Op::NoTrans),
-                    "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(),
-                    mat_c.size(), blas::Op::NoTrans, blas::Op::NoTrans);
-  DLAF_ASSERT_HEAVY(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize(),
-                                       blas::Op::NoTrans, blas::Op::NoTrans),
-                    "Multiplication incompatible tile sizes.");
-  DLAF_ASSERT_HEAVY(mat_c.size().isEmpty() || multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
-                                                                 mat_b.distribution().tileSize({0, 0}),
-                                                                 mat_c.distribution().tileSize({0, 0}),
-                                                                 blas::Op::NoTrans, blas::Op::NoTrans),
-                    "Multiplication incompatible tile sizes in first row/col. "
-                    "(Are you using a matrix with offset not aligned with tile?)");
+  DLAF_ASSERT_HEAVY(matrix::multipliable(mat_a, mat_b, mat_c, blas::Op::NoTrans, blas::Op::NoTrans),
+                    mat_a, mat_b, mat_c);
 
   for (SizeType j = 0; j < mat_c.nrTiles().cols(); ++j) {
     for (SizeType i = 0; i < mat_c.nrTiles().rows(); ++i) {

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -35,9 +35,6 @@ void General<B, D, T>::callNN(const T alpha, MatrixRef<const T, D>& mat_a, Matri
                               const T beta, MatrixRef<T, D>& mat_c) {
   namespace ex = pika::execution::experimental;
 
-  DLAF_ASSERT_HEAVY(matrix::multipliable(mat_a, mat_b, mat_c, blas::Op::NoTrans, blas::Op::NoTrans),
-                    mat_a, mat_b, mat_c);
-
   if (mat_a.nrTiles().cols() == 0) {
     // Note: if beta == 1, we optimize by not even scheduling anything
     if (beta != T(1)) {

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -115,10 +115,9 @@ bool multipliable(const MatrixLikeA<const T, D>& a, const MatrixLikeB<const T, D
     return isSizeOk;
 
   const bool allSameGrid = same_process_grid(a, b) && same_process_grid(b, c);
-  const bool isTileSizeOk =
-      multipliable_sizes(a.tile_size(), b.tile_size(), c.tile_size(), opA, opB);
-  const bool isOffsetOk =
-      multipliable_sizes(a.tile_size_of({0, 0}), b.tile_size_of({0, 0}), c.tile_size_of({0, 0}), opA, opB);
+  const bool isTileSizeOk = multipliable_sizes(a.tile_size(), b.tile_size(), c.tile_size(), opA, opB);
+  const bool isOffsetOk = multipliable_sizes(a.tile_size_of({0, 0}), b.tile_size_of({0, 0}),
+                                             c.tile_size_of({0, 0}), opA, opB);
 
   if (local_matrix(c))
     return allSameGrid && isSizeOk && isTileSizeOk && isOffsetOk;

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -68,8 +68,8 @@ bool equal_blocksize(const Matrix<const T, D1>& lhs, Matrix<const T, D2>& rhs) n
 }
 
 /// Returns true if the matrix is local to a process.
-template <class T, Device D>
-bool local_matrix(const Matrix<const T, D>& m) noexcept {
+template <template <class, Device> class MatrixLike, class T, Device D>
+bool local_matrix(const MatrixLike<const T, D>& m) noexcept {
   return m.commGridSize() == comm::Size2D(1, 1);
 }
 
@@ -77,6 +77,13 @@ bool local_matrix(const Matrix<const T, D>& m) noexcept {
 template <class T, Device D>
 bool equal_process_grid(const Matrix<const T, D>& m, const comm::CommunicatorGrid& g) noexcept {
   return m.commGridSize() == g.size() && m.rankIndex() == g.rank();
+}
+
+/// Returns true if the matrix is distributed on the communication grid.
+template <template <class, Device> class MatrixLikeA, template <class, Device> class MatrixLikeB,
+          class T, Device D>
+bool same_process_grid(const MatrixLikeA<const T, D>& a, const MatrixLikeB<const T, D>& b) noexcept {
+  return a.commGridSize() == b.commGridSize() && a.rankIndex() == b.rankIndex();
 }
 
 /// Returns true if the matrices are distributed the same way.
@@ -98,11 +105,26 @@ bool multipliable_sizes(common::Size2D<IndexT, Tag> a, common::Size2D<IndexT, Ta
 }
 
 /// Returns true if matrices `a`, `b` and `c` have matrix multipliable sizes and block sizes.
-template <class T, Device D>
-bool multipliable(const Matrix<const T, D>& a, const Matrix<const T, D>& b, const Matrix<const T, D>& c,
-                  const blas::Op opA, const blas::Op opB) noexcept {
-  return multipliable_sizes(a.size(), b.size(), c.size(), opA, opB) &&
-         multipliable_sizes(a.block_size(), b.block_size(), c.block_size(), opA, opB);
+template <template <class, Device> class MatrixLikeA, template <class, Device> class MatrixLikeB,
+          template <class, Device> class MatrixLikeC, class T, Device D>
+bool multipliable(const MatrixLikeA<const T, D>& a, const MatrixLikeB<const T, D>& b,
+                  const MatrixLikeC<const T, D>& c, const blas::Op opA, const blas::Op opB) noexcept {
+  const bool isSizeOk = multipliable_sizes(a.size(), b.size(), c.size(), opA, opB);
+
+  if (a.size().isEmpty() || c.size().isEmpty())
+    return isSizeOk;
+
+  const bool allSameGrid = same_process_grid(a, b) && same_process_grid(b, c);
+  const bool isTileSizeOk =
+      multipliable_sizes(a.tile_size(), b.tile_size(), c.tile_size(), opA, opB);
+  const bool isOffsetOk =
+      multipliable_sizes(a.tile_size_of({0, 0}), b.tile_size_of({0, 0}), c.tile_size_of({0, 0}), opA, opB);
+
+  if (local_matrix(c))
+    return allSameGrid && isSizeOk && isTileSizeOk && isOffsetOk;
+
+  // TODO distributed (fix offset)
+  return allSameGrid && isSizeOk && isTileSizeOk && isOffsetOk;
 }
 
 namespace util {

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -26,6 +26,48 @@
 namespace dlaf::matrix::test {
 
 template <class T>
+auto getMatrixMatrixMultiplication(const SizeType k, const T alpha, const T beta, const blas::Op opA,
+                                   const blas::Op opB) {
+  using dlaf::test::TypeUtilities;
+
+  if (opA != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opA);
+  if (opB != blas::Op::NoTrans)
+    DLAF_UNIMPLEMENTED(opB);
+
+  auto elA = [](const GlobalElementIndex ik) {
+    const double i = ik.row();
+    const double k = ik.col();
+
+    return TypeUtilities<T>::polar((i + 1) / (k + .5), 2 * i - k);
+  };
+
+  auto elB = [](const GlobalElementIndex kj) {
+    const double k = kj.row();
+    const double j = kj.col();
+
+    return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
+  };
+
+  auto elC = [k](const GlobalElementIndex ij) {
+    const double i = ij.row();
+    const double j = ij.col();
+
+    return TypeUtilities<T>::polar((i + k + 1) / (j + 5), i + j + k);
+  };
+
+  auto elR = [k, alpha, beta](const GlobalElementIndex ij) {
+    const double i = ij.row();
+    const double j = ij.col();
+
+    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * k, (2 * i) + j) +
+           beta * TypeUtilities<T>::polar((i + k + 1) / (j + 5), k + i + j);
+  };
+
+  return std::make_tuple<>(elA, elB, elC, elR);
+}
+
+template <class T>
 auto getSubMatrixMatrixMultiplication(const SizeType a, const SizeType b,
                                       [[maybe_unused]] const SizeType m,
                                       [[maybe_unused]] const SizeType n, const SizeType k, const T alpha,

--- a/test/include/dlaf_test/matrix/util_generic_blas.h
+++ b/test/include/dlaf_test/matrix/util_generic_blas.h
@@ -25,46 +25,72 @@
 
 namespace dlaf::matrix::test {
 
-template <class T>
-auto getMatrixMatrixMultiplication(const SizeType k, const T alpha, const T beta, const blas::Op opA,
-                                   const blas::Op opB) {
+namespace internal {
+template <class ElementGetter>
+auto opValFunc(ElementGetter&& val, const blas::Op op) {
+  std::function op_val = val;
+  switch (op) {
+    case blas::Op::NoTrans:
+      break;
+    case blas::Op::Trans: {
+      op_val = [&val](auto i) {
+        i.transpose();
+        return val(i);
+      };
+      break;
+    }
+    case blas::Op::ConjTrans: {
+      op_val = [&val](auto i) {
+        i.transpose();
+        return dlaf::conj(val(i));
+      };
+      break;
+    }
+  }
+  return op_val;
+}
+}
+
+template <class ElementIndex, class T>
+auto getMatrixMatrixMultiplication(const blas::Op opA, const blas::Op opB, const SizeType k,
+                                   const T alpha, const T beta) {
   using dlaf::test::TypeUtilities;
 
-  if (opA != blas::Op::NoTrans)
-    DLAF_UNIMPLEMENTED(opA);
-  if (opB != blas::Op::NoTrans)
-    DLAF_UNIMPLEMENTED(opB);
+  // Note: The tile elements are chosen such that:
+  // - op_a(a)_ik = .9 * (i+1) / (k+.5) * exp(I*(2*i-k)),
+  // - op_b(b)_kj = .8 * (k+.5) / (j+2) * exp(I*(k+j)),
+  // - c_ij = 1.2 * i / (j+1) * exp(I*(-i+j)),
+  // where I = 0 for real types or I is the complex unit for complex types.
+  // Therefore the result should be:
+  // res_ij = beta * c_ij + Sum_k(alpha * op_a(a)_ik * op_b(b)_kj)
+  //        = beta * c_ij + gamma * (i+1) / (j+2) * exp(I*(2*i+j)),
+  // where gamma = .72 * k * alpha.
 
-  auto elA = [](const GlobalElementIndex ik) {
-    const double i = ik.row();
-    const double k = ik.col();
-
-    return TypeUtilities<T>::polar((i + 1) / (k + .5), 2 * i - k);
+  auto el_op_a = [](const ElementIndex& index) {
+    const double i = index.row();
+    const double k = index.col();
+    return TypeUtilities<T>::polar(.9 * (i + 1) / (k + .5), 2 * i - k);
+  };
+  auto el_op_b = [](const ElementIndex& index) {
+    const double k = index.row();
+    const double j = index.col();
+    return TypeUtilities<T>::polar(.8 * (k + .5) / (j + 2), k + j);
+  };
+  auto el_c = [](const ElementIndex& index) {
+    const double i = index.row();
+    const double j = index.col();
+    return TypeUtilities<T>::polar(1.2 * i / (j + 1), -i + j);
   };
 
-  auto elB = [](const GlobalElementIndex kj) {
-    const double k = kj.row();
-    const double j = kj.col();
-
-    return TypeUtilities<T>::polar((k + .5) / (j + 2), k + j);
+  const T gamma = TypeUtilities<T>::element(.72 * k, 0) * alpha;
+  auto res_c = [beta, el_c, gamma](const ElementIndex& index) {
+    const double i = index.row();
+    const double j = index.col();
+    return beta * el_c(index) + gamma * TypeUtilities<T>::polar((i + 1) / (j + 2), 2 * i + j);
   };
 
-  auto elC = [k](const GlobalElementIndex ij) {
-    const double i = ij.row();
-    const double j = ij.col();
-
-    return TypeUtilities<T>::polar((i + k + 1) / (j + 5), i + j + k);
-  };
-
-  auto elR = [k, alpha, beta](const GlobalElementIndex ij) {
-    const double i = ij.row();
-    const double j = ij.col();
-
-    return alpha * TypeUtilities<T>::polar((i + 1) / (j + 2) * k, (2 * i) + j) +
-           beta * TypeUtilities<T>::polar((i + k + 1) / (j + 5), k + i + j);
-  };
-
-  return std::make_tuple<>(elA, elB, elC, elR);
+  using internal::opValFunc;
+  return std::make_tuple<>(opValFunc(el_op_a, opA), opValFunc(el_op_b, opB), el_c, res_c);
 }
 
 template <class T>

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -78,6 +78,24 @@ void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
   }
 }
 
+template <class ElementGetter>
+auto subValues(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
+  return [fullValues, offset = sizeFromOrigin(offset)](const GlobalElementIndex& ij) {
+    return fullValues(ij + offset);
+  };
+}
+
+template <class OutsideElementGetter, class InsideElementGetter>
+auto mixValues(const dlaf::matrix::internal::SubMatrixSpec& sub_spec, InsideElementGetter&& insideValues,
+               OutsideElementGetter&& outsideValues) {
+  return [outsideValues, insideValues, sub_spec](const GlobalElementIndex& ij) {
+    if (ij.isInSub(sub_spec.origin, sub_spec.size))
+      return insideValues(ij - common::sizeFromOrigin(sub_spec.origin));
+    else
+      return outsideValues(ij);
+  };
+}
+
 namespace internal {
 
 /// Checks the elements of the matrix.

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -78,6 +78,8 @@ void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
   }
 }
 
+/// Returns an ElementGetter that given @p fullValues, it returns values like if origin has been changed
+/// to sub-martix starting at @p offset.
 template <class ElementGetter>
 auto subValues(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
   return [fullValues, offset = sizeFromOrigin(offset)](const GlobalElementIndex& ij) {
@@ -85,6 +87,9 @@ auto subValues(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
   };
 }
 
+/// Returns an ElementGetter that returns values of a matrix like if:
+/// - sub-matrix defined by @p sub_spec is set with @p insideValues
+/// - the rest of the matrix is set with @p outsideValues
 template <class OutsideElementGetter, class InsideElementGetter>
 auto mixValues(const dlaf::matrix::internal::SubMatrixSpec& sub_spec, InsideElementGetter&& insideValues,
                OutsideElementGetter&& outsideValues) {

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -82,7 +82,7 @@ void set(MatrixType<T, Device::CPU>& mat, ElementGetter el) {
 /// Returns an ElementGetter that given @p fullValues, it returns values like if origin has been changed
 /// to sub-martix starting at @p offset.
 template <class ElementGetter>
-auto subValues(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
+auto sub_values(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
   return [fullValues, offset = sizeFromOrigin(offset)](const GlobalElementIndex& ij) {
     return fullValues(ij + offset);
   };
@@ -92,8 +92,8 @@ auto subValues(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
 /// - sub-matrix defined by @p sub_spec is set with @p insideValues
 /// - the rest of the matrix is set with @p outsideValues
 template <class OutsideElementGetter, class InsideElementGetter>
-auto mixValues(const dlaf::matrix::internal::SubMatrixSpec& sub_spec, InsideElementGetter&& insideValues,
-               OutsideElementGetter&& outsideValues) {
+auto mix_values(const dlaf::matrix::internal::SubMatrixSpec& sub_spec,
+                InsideElementGetter&& insideValues, OutsideElementGetter&& outsideValues) {
   return [outsideValues, insideValues, sub_spec](const GlobalElementIndex& ij) {
     if (ij.isInSub(sub_spec.origin, sub_spec.size))
       return insideValues(ij - common::sizeFromOrigin(sub_spec.origin));

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -23,6 +23,7 @@
 #include <dlaf/matrix/distribution.h>
 #include <dlaf/matrix/layout_info.h>
 #include <dlaf/matrix/matrix.h>
+#include <dlaf/matrix/matrix_ref.h>
 #include <dlaf/util_math.h>
 
 #include <gtest/gtest.h>

--- a/test/include/dlaf_test/matrix/util_tile_blas.h
+++ b/test/include/dlaf_test/matrix/util_tile_blas.h
@@ -26,35 +26,6 @@ namespace dlaf {
 namespace matrix {
 namespace test {
 
-namespace internal {
-template <class ElementGetter>
-auto opValFunc(ElementGetter& val, const blas::Op op) {
-  std::function<decltype(val(std::declval<TileElementIndex>()))(TileElementIndex)> op_val;
-  switch (op) {
-    case blas::Op::NoTrans:
-      op_val = [&val](TileElementIndex i) { return val(i); };
-      break;
-
-    case blas::Op::Trans: {
-      op_val = [&val](TileElementIndex i) {
-        i.transpose();
-        return val(i);
-      };
-      break;
-    }
-
-    case blas::Op::ConjTrans: {
-      op_val = [&val](TileElementIndex i) {
-        i.transpose();
-        return dlaf::conj(val(i));
-      };
-      break;
-    }
-  }
-  return op_val;
-}
-}
-
 /// Sets the elements of the tile.
 ///
 /// The (i, j)-element of the tile is set to val({i, j}) if op == NoTrans,

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -281,7 +281,7 @@ void testSubMatrixOnGPU(const SubMatrixCopyConfig& test, const matrix::Distribut
   Matrix<T, Device::GPU> mat_out_gpu(dist_out, layout_out, mem_out_gpu());
 
   // Note: currently `subPipeline`-ing does not support sub-matrices
-  if (isFullMatrix(dist_in, test.sub_in()) {
+  if (isFullMatrix(dist_in, test.sub_in())) {
     set(mat_in, inputValues<T>);
     set(mat_out, outputValues<T>);
 

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -135,15 +135,23 @@ TYPED_TEST(MatrixCopyTest, FullMatrixGPU) {
 #endif
 
 struct SubMatrixCopyConfig {
-  GlobalElementSize full_in;
-  GlobalElementSize full_out;
+  const GlobalElementSize full_in;
+  const GlobalElementSize full_out;
 
-  TileElementSize tile_size;
+  const TileElementSize tile_size;
 
-  GlobalElementIndex sub_origin_in;
-  GlobalElementIndex sub_origin_out;
+  const GlobalElementIndex sub_origin_in;
+  const GlobalElementIndex sub_origin_out;
 
-  GlobalElementSize sub_size;
+  const GlobalElementSize sub_size;
+
+  matrix::internal::SubMatrixSpec sub_in() const noexcept {
+    return {sub_origin_in, sub_size};
+  }
+
+  matrix::internal::SubMatrixSpec sub_out() const noexcept {
+    return {sub_origin_out, sub_size};
+  }
 };
 
 comm::Index2D alignSubRankIndex(const Distribution& dist_in, const GlobalElementIndex& offset_in,
@@ -163,27 +171,8 @@ comm::Index2D alignSubRankIndex(const Distribution& dist_in, const GlobalElement
           pos_mod(sub_rank.col() - static_cast<comm::IndexT_MPI>(offset_rank.col()), grid_size.cols())};
 }
 
-bool isFullMatrix(const Distribution& dist_full, const GlobalElementIndex& sub_origin,
-                  const GlobalElementSize& sub_size) noexcept {
-  return sub_origin == GlobalElementIndex{0, 0} && sub_size == dist_full.size();
-}
-
-template <class ElementGetter>
-auto subValues(ElementGetter&& fullValues, const GlobalElementIndex& offset) {
-  return [fullValues, offset = sizeFromOrigin(offset)](const GlobalElementIndex& ij) {
-    return fullValues(ij + offset);
-  };
-}
-
-template <class OutsideElementGetter, class InsideElementGetter>
-auto mixValues(const GlobalElementIndex& offset, const GlobalElementSize& sub_size,
-               InsideElementGetter&& insideValues, OutsideElementGetter&& outsideValues) {
-  return [outsideValues, insideValues, offset, sub_size](const GlobalElementIndex& ij) {
-    if (ij.isInSub(offset, sub_size))
-      return insideValues(ij - common::sizeFromOrigin(offset));
-    else
-      return outsideValues(ij);
-  };
+bool isFullMatrix(const Distribution& dist_full, const matrix::internal::SubMatrixSpec& sub) noexcept {
+  return sub.origin == GlobalElementIndex{0, 0} && sub.size == dist_full.size();
 }
 
 const std::vector<SubMatrixCopyConfig> sub_configs{
@@ -208,7 +197,7 @@ void testSubMatrix(const SubMatrixCopyConfig& test, const matrix::Distribution& 
   Matrix<T, Device::CPU> mat_out(dist_out, layout_out, mem_out());
 
   // Note: currently `subPipeline`-ing does not support sub-matrices
-  if (isFullMatrix(dist_in, test.sub_origin_in, test.sub_size)) {
+  if (isFullMatrix(dist_in, test.sub_in())) {
     set(mat_in, inputValues<T>);
     set(mat_out, outputValues<T>);
 
@@ -227,16 +216,15 @@ void testSubMatrix(const SubMatrixCopyConfig& test, const matrix::Distribution& 
   set(mat_out, outputValues<T>);
 
   using matrix::internal::MatrixRef;
-  MatrixRef<const T, Device::CPU> mat_sub_src(mat_in, {test.sub_origin_in, test.sub_size});
-  MatrixRef<T, Device::CPU> mat_sub_dst(mat_out, {test.sub_origin_out, test.sub_size});
+  MatrixRef<const T, Device::CPU> mat_sub_src(mat_in, test.sub_in());
+  MatrixRef<T, Device::CPU> mat_sub_dst(mat_out, test.sub_out());
 
   copy(mat_sub_src, mat_sub_dst);
 
   const auto subMatrixValues = subValues(inputValues<T>, test.sub_origin_in);
   CHECK_MATRIX_NEAR(subMatrixValues, mat_sub_dst, 0, TypeUtilities<T>::error);
 
-  const auto fullMatrixWithSubMatrixValues =
-      mixValues(test.sub_origin_out, test.sub_size, subMatrixValues, outputValues<T>);
+  const auto fullMatrixWithSubMatrixValues = mixValues(test.sub_out(), subMatrixValues, outputValues<T>);
   CHECK_MATRIX_NEAR(fullMatrixWithSubMatrixValues, mat_out, 0, TypeUtilities<T>::error);
 }
 
@@ -293,7 +281,7 @@ void testSubMatrixOnGPU(const SubMatrixCopyConfig& test, const matrix::Distribut
   Matrix<T, Device::GPU> mat_out_gpu(dist_out, layout_out, mem_out_gpu());
 
   // Note: currently `subPipeline`-ing does not support sub-matrices
-  if (isFullMatrix(dist_in, test.sub_origin_in, test.sub_size)) {
+  if (isFullMatrix(dist_in, test.sub_in()) {
     set(mat_in, inputValues<T>);
     set(mat_out, outputValues<T>);
 
@@ -315,10 +303,10 @@ void testSubMatrixOnGPU(const SubMatrixCopyConfig& test, const matrix::Distribut
   set(mat_out, outputValues<T>);
 
   using matrix::internal::MatrixRef;
-  MatrixRef<const T, Device::CPU> mat_sub_src(mat_in, {test.sub_origin_in, test.sub_size});
-  MatrixRef<T, Device::GPU> mat_sub_gpu1(mat_in_gpu, {test.sub_origin_in, test.sub_size});
-  MatrixRef<T, Device::GPU> mat_sub_gpu2(mat_out_gpu, {test.sub_origin_out, test.sub_size});
-  MatrixRef<T, Device::CPU> mat_sub_dst(mat_out, {test.sub_origin_out, test.sub_size});
+  MatrixRef<const T, Device::CPU> mat_sub_src(mat_in, test.sub_in());
+  MatrixRef<T, Device::GPU> mat_sub_gpu1(mat_in_gpu, test.sub_in());
+  MatrixRef<T, Device::GPU> mat_sub_gpu2(mat_out_gpu, test.sub_out());
+  MatrixRef<T, Device::CPU> mat_sub_dst(mat_out, test.sub_out());
 
   copy(mat_sub_src, mat_sub_gpu1);
   copy(mat_sub_gpu1, mat_sub_gpu2);
@@ -327,8 +315,7 @@ void testSubMatrixOnGPU(const SubMatrixCopyConfig& test, const matrix::Distribut
   const auto subMatrixValues = subValues(inputValues<T>, test.sub_origin_in);
   CHECK_MATRIX_NEAR(subMatrixValues, mat_sub_dst, 0, TypeUtilities<T>::error);
 
-  const auto fullMatrixWithSubMatrixValues =
-      mixValues(test.sub_origin_out, test.sub_size, subMatrixValues, outputValues<T>);
+  const auto fullMatrixWithSubMatrixValues = mixValues(test.sub_out(), subMatrixValues, outputValues<T>);
   CHECK_MATRIX_NEAR(fullMatrixWithSubMatrixValues, mat_out, 0, TypeUtilities<T>::error);
 }
 

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -221,10 +221,11 @@ void testSubMatrix(const SubMatrixCopyConfig& test, const matrix::Distribution& 
 
   copy(mat_sub_src, mat_sub_dst);
 
-  const auto subMatrixValues = subValues(inputValues<T>, test.sub_origin_in);
+  const auto subMatrixValues = sub_values(inputValues<T>, test.sub_origin_in);
   CHECK_MATRIX_NEAR(subMatrixValues, mat_sub_dst, 0, TypeUtilities<T>::error);
 
-  const auto fullMatrixWithSubMatrixValues = mixValues(test.sub_out(), subMatrixValues, outputValues<T>);
+  const auto fullMatrixWithSubMatrixValues =
+      mix_values(test.sub_out(), subMatrixValues, outputValues<T>);
   CHECK_MATRIX_NEAR(fullMatrixWithSubMatrixValues, mat_out, 0, TypeUtilities<T>::error);
 }
 
@@ -312,10 +313,11 @@ void testSubMatrixOnGPU(const SubMatrixCopyConfig& test, const matrix::Distribut
   copy(mat_sub_gpu1, mat_sub_gpu2);
   copy(mat_sub_gpu2, mat_sub_dst);
 
-  const auto subMatrixValues = subValues(inputValues<T>, test.sub_origin_in);
+  const auto subMatrixValues = sub_values(inputValues<T>, test.sub_origin_in);
   CHECK_MATRIX_NEAR(subMatrixValues, mat_sub_dst, 0, TypeUtilities<T>::error);
 
-  const auto fullMatrixWithSubMatrixValues = mixValues(test.sub_out(), subMatrixValues, outputValues<T>);
+  const auto fullMatrixWithSubMatrixValues =
+      mix_values(test.sub_out(), subMatrixValues, outputValues<T>);
   CHECK_MATRIX_NEAR(fullMatrixWithSubMatrixValues, mat_out, 0, TypeUtilities<T>::error);
 }
 

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -127,7 +127,8 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
     // Note: currently it is implemented just the NoTrans/NoTrans case
     ASSERT_EQ(config.opA, blas::Op::NoTrans);
     ASSERT_EQ(config.opB, blas::Op::NoTrans);
-    multiplication::internal::General<B, D, T>::callNN(alpha, mat_sub_a, mat_sub_b, beta, mat_sub_c);
+    multiplication::internal::generalMatrix<B>(config.opA, config.opB, alpha, mat_sub_a, mat_sub_b, beta,
+                                               mat_sub_c);
   }
 
   const auto fullValuesResult = mix_values(config.sub_c(), subValuesResult, fullValuesC);

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -119,6 +119,9 @@ std::vector<GemmConfig> gemm_configs = {
 
     // full
     {blas::Op::NoTrans, blas::Op::NoTrans, 3, 3, 3, 3, 3, 3},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 8, 8, 11, 10, 9, 13},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 3, 2, 4, 1, 1, 1},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 6, 9, 8, 2, 3, 4},
     {blas::Op::NoTrans, blas::Op::NoTrans, 21, 21, 21, 3, 4, 5},
     {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5},
     {blas::Op::NoTrans, blas::Op::NoTrans, 8, 8, 11, 3, 3, 5},

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -152,11 +152,33 @@ std::vector<GemmConfig> gemm_configs = {
     {blas::Op::NoTrans, blas::Op::NoTrans, 8, 8, 11, 3, 3, 5},
 };
 
+std::vector<GemmConfig> sub_gemm_configs = {
+    // empty matrices
+    {blas::Op::NoTrans, blas::Op::NoTrans, 0, 0, 7, 3, 6, 2, {{1, 2}}, {{2, 3}}, {{3, 4}}},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 26, 0, 7, 3, 6, 2, {{1, 2}}, {{2, 3}}, {{3, 4}}},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 0, 13, 7, 3, 6, 2, {{1, 2}}, {{2, 3}}, {{3, 4}}},
+    // k = 0
+    {blas::Op::NoTrans, blas::Op::NoTrans, 26, 13, 0, 3, 6, 2, {{1, 2}}, {{2, 3}}, {{3, 4}}},
+    // single-tile
+    {blas::Op::NoTrans, blas::Op::NoTrans, 8, 8, 11, 10, 9, 13, {{2, 1}}, {{1, 1}}, {{0, 0}}},
+    // multi-tile
+    {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5, {{7, 1}}, {{11, 10}}, {{4, 2}}},
+};
+
 TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRef) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
   for (const GemmConfig& test_config : gemm_configs) {
+    testGeneralMultiplication<TypeParam, Backend::MC, Device::CPU>(alpha, beta, test_config);
+  }
+}
+
+TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRefSub) {
+  constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
+  constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+
+  for (const GemmConfig& test_config : sub_gemm_configs) {
     testGeneralMultiplication<TypeParam, Backend::MC, Device::CPU>(alpha, beta, test_config);
   }
 }
@@ -167,6 +189,15 @@ TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalWithMatrixRef) {
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
   for (const GemmConfig& test_config : gemm_configs) {
+    testGeneralMultiplication<TypeParam, Backend::GPU, Device::GPU>(alpha, beta, test_config);
+  }
+}
+
+TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalWithMatrixRefSub) {
+  constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
+  constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+
+  for (const GemmConfig& test_config : sub_gemm_configs) {
     testGeneralMultiplication<TypeParam, Backend::GPU, Device::GPU>(alpha, beta, test_config);
   }
 }

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -106,8 +106,8 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
     multiplication::internal::General<B, D, T>::callNN(alpha, mat_sub_a, mat_sub_b, beta, mat_sub_c);
   }
 
-  CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,
-                    40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error);
+  CHECK_MATRIX_NEAR(refResult, mat_ch, 2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error,
+                    2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error);
 }
 
 std::vector<GemmConfig> gemm_configs = {
@@ -195,8 +195,8 @@ void testGeneralSubMultiplication(const SizeType a, const SizeType b, const T al
                                                   mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
-  CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,
-                    40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error);
+  CHECK_MATRIX_NEAR(refResult, mat_ch, 2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error,
+                    2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error);
 }
 
 TYPED_TEST(GeneralSubMultiplicationTestMC, CorrectnessLocal) {
@@ -250,8 +250,8 @@ void testGeneralSubMultiplication(comm::CommunicatorGrid grid, const SizeType a,
                                                   mat_c.get());
   }
 
-  CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,
-                    40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error);
+  CHECK_MATRIX_NEAR(refResult, mat_ch, 2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error,
+                    2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error);
 }
 
 TYPED_TEST(GeneralSubMultiplicationDistTestMC, CorrectnessDistributed) {

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -123,11 +123,11 @@ TYPED_TEST(GeneralSubMultiplicationTestMC, CorrectnessLocal) {
 }
 
 #ifdef DLAF_WITH_GPU
-TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocal) {
+TYPED_TEST(GeneralSubMultiplicationTestGPU, CorrectnessLocal) {
   for (const auto& [m, mb, a, b] : sizes) {
     const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
     const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
-    testGeneralMultiplication<TypeParam, Backend::GPU, Device::GPU>(a, b, alpha, beta, m, mb);
+    testGeneralSubMultiplication<TypeParam, Backend::GPU, Device::GPU>(a, b, alpha, beta, m, mb);
   }
 }
 #endif
@@ -235,10 +235,10 @@ void testGeneralSubMultiplication(dlaf::matrix::internal::SubMatrixSpec sub_spec
 }
 
 TYPED_TEST(GeneralSubMultiplicationTestMC, MatrixRefCorrectnessLocal) {
-  for (const auto& [m, mb, a, b] : sizes) {
-    const TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
-    const TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+  constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
+  constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
+  for (const auto& [m, mb, a, b] : sizes) {
     const SizeType a_el = a * mb;
     const SizeType b_el = std::min(b * mb, m);
     dlaf::matrix::internal::SubMatrixSpec spec{GlobalElementIndex{a_el, a_el},
@@ -248,13 +248,16 @@ TYPED_TEST(GeneralSubMultiplicationTestMC, MatrixRefCorrectnessLocal) {
 }
 
 #ifdef DLAF_WITH_GPU
-TYPED_TEST(GeneralMultiplicationTestGPU, MatrixRefCorrectnessLocal) {
+TYPED_TEST(GeneralSubMultiplicationTestGPU, MatrixRefCorrectnessLocal) {
+  constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
+  constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
+
   for (const auto& [m, mb, a, b] : sizes) {
     const SizeType a_el = a * mb;
     const SizeType b_el = std::min(b * mb, m);
     dlaf::matrix::internal::SubMatrixSpec spec{GlobalElementIndex{a_el, a_el},
                                                GlobalElementSize{b_el - a_el, b_el - a_el}};
-    testGeneralMultiplication<TypeParam, Backend::GPU, Device::GPU>(spec, alpha, beta, m, mb);
+    testGeneralSubMultiplication<TypeParam, Backend::GPU, Device::GPU>(spec, alpha, beta, m, mb);
   }
 }
 #endif

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -110,32 +110,35 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
                     40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error);
 }
 
-std::vector<GemmConfig> full_gemm_configs = {
+std::vector<GemmConfig> gemm_configs = {
     // empty matrices
-    GemmConfig{blas::Op::NoTrans, blas::Op::NoTrans, 0, 0, 7, 3, 6, 2},
-    GemmConfig{blas::Op::NoTrans, blas::Op::NoTrans, 20, 0, 7, 3, 6, 2},
-    GemmConfig{blas::Op::NoTrans, blas::Op::NoTrans, 0, 20, 7, 3, 6, 2},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 0, 0, 7, 3, 6, 2},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 26, 0, 7, 3, 6, 2},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 0, 13, 7, 3, 6, 2},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 26, 13, 0, 3, 6, 2},
 
     // full
-    GemmConfig{blas::Op::NoTrans, blas::Op::NoTrans, 21, 21, 21, 3, 3, 3},
-    GemmConfig{blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 3, 3, 3, 3, 3, 3},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 21, 21, 21, 3, 4, 5},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 8, 8, 11, 3, 3, 5},
 };
 
-TYPED_TEST(GeneralMultiplicationTestMC, MatrixRefCorrectnessLocalFull) {
+TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRef) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
-  for (const GemmConfig& test_config : full_gemm_configs) {
+  for (const GemmConfig& test_config : gemm_configs) {
     testGeneralMultiplication<TypeParam, Backend::MC, Device::CPU>(alpha, beta, test_config);
   }
 }
 
 #ifdef DLAF_WITH_GPU
-TYPED_TEST(GeneralMultiplicationTestGPU, MatrixRefCorrectnessLocalFull) {
+TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalWithMatrixRef) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
-  for (const GemmConfig& test_config : full_gemm_configs) {
+  for (const GemmConfig& test_config : gemm_configs) {
     testGeneralMultiplication<TypeParam, Backend::GPU, Device::GPU>(alpha, beta, test_config);
   }
 }

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -166,7 +166,7 @@ std::vector<GemmConfig> sub_gemm_configs = {
     {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5, {{7, 1}}, {{11, 10}}, {{4, 2}}},
 };
 
-TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRef) {
+TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocal) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
@@ -175,7 +175,7 @@ TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRef) {
   }
 }
 
-TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRefSub) {
+TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalSub) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
@@ -185,7 +185,7 @@ TYPED_TEST(GeneralMultiplicationTestMC, CorrectnessLocalWithMatrixRefSub) {
 }
 
 #ifdef DLAF_WITH_GPU
-TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalWithMatrixRef) {
+TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocal) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
@@ -194,7 +194,7 @@ TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalWithMatrixRef) {
   }
 }
 
-TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalWithMatrixRefSub) {
+TYPED_TEST(GeneralMultiplicationTestGPU, CorrectnessLocalSub) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -100,8 +100,10 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
     MatrixRef<const T, D> mat_sub_b(mat_b.get(), {{0, 0}, mat_bh.size()});
     MatrixRef<T, D> mat_sub_c(mat_c.get(), {{0, 0}, mat_ch.size()});
 
-    multiplication::internal::General<B, D, T>::callNN(config.opA, config.opB, alpha, mat_sub_a,
-                                                       mat_sub_b, beta, mat_sub_c);
+    // Note: currently it is implemented just the NoTrans/NoTrans case
+    ASSERT_EQ(config.opA, blas::Op::NoTrans);
+    ASSERT_EQ(config.opB, blas::Op::NoTrans);
+    multiplication::internal::General<B, D, T>::callNN(alpha, mat_sub_a, mat_sub_b, beta, mat_sub_c);
   }
 
   CHECK_MATRIX_NEAR(refResult, mat_ch, 40 * (mat_ch.size().rows() + 1) * TypeUtilities<T>::error,

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -78,7 +78,8 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
   using dlaf::matrix::internal::MatrixRef;
 
   auto [refA, refB, refC, refResult] =
-      matrix::test::getMatrixMatrixMultiplication(config.k, alpha, beta, config.opA, config.opB);
+      matrix::test::getMatrixMatrixMultiplication<GlobalElementIndex, T>(config.opA, config.opB,
+                                                                         config.k, alpha, beta);
 
   auto setMatrix = [&](auto elSetter, const LocalElementSize size, const TileElementSize block_size) {
     Matrix<T, Device::CPU> matrix(size, block_size);

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -107,9 +107,9 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
       matrix::test::getMatrixMatrixMultiplication<GlobalElementIndex, T>(config.opA, config.opB,
                                                                          config.k, alpha, beta);
 
-  const auto fullValuesA = mixValues(config.sub_a(), subValuesA, [](auto) { return T(-99); });
-  const auto fullValuesB = mixValues(config.sub_b(), subValuesB, [](auto) { return T(-99); });
-  const auto fullValuesC = mixValues(config.sub_c(), subValuesC, [](auto) { return T(-99); });
+  const auto fullValuesA = mix_values(config.sub_a(), subValuesA, [](auto) { return T(-99); });
+  const auto fullValuesB = mix_values(config.sub_b(), subValuesB, [](auto) { return T(-99); });
+  const auto fullValuesC = mix_values(config.sub_c(), subValuesC, [](auto) { return T(-99); });
 
   Matrix<const T, Device::CPU> mat_ah = setMatrix(fullValuesA, config.full_a(), {config.mb, config.kb});
   Matrix<const T, Device::CPU> mat_bh = setMatrix(fullValuesB, config.full_b(), {config.kb, config.nb});
@@ -130,7 +130,7 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
     multiplication::internal::General<B, D, T>::callNN(alpha, mat_sub_a, mat_sub_b, beta, mat_sub_c);
   }
 
-  const auto fullValuesResult = mixValues(config.sub_c(), subValuesResult, fullValuesC);
+  const auto fullValuesResult = mix_values(config.sub_c(), subValuesResult, fullValuesC);
   CHECK_MATRIX_NEAR(fullValuesResult, mat_ch, 2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error,
                     2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error);
 }


### PR DESCRIPTION
This PR partially address #915 (just local variant)

- `gemm` (local) implementation working with MatrixRef (only, at the moment) with related tests for both full and sub-matrix test-cases
- introduces `scal` tile extension
- basic refactoring(=adaptation) of `local_matrix` and `multipliable` assert + introduction of `same_process_grid`
- refactor test helper for sub-matrices (`subValues` and `mixValues`)
- minor: `MatrixBase` string representation also print information about `source_rank_index` and `offset`

TODO
+ [x] Check preconditions
+ [x] Extend the test
+ [x] Move the new function in the right place (see following note)
+ [x] Evaluate how to deal with `multipliable` assertion (separate it from algorithm details)
+ [x] Test also with ROCm (mainly if `scal` workaround of using `gemm` with nullptr works there too)

Note: `GeneralSub` was intended to work on submatrices, while now the `sub-matrix` concept is hidden by `MatrixRef`. For this reason, the new gemm helper might just be considered a full general multiplication, and it might be moved in `multiplication::general::General` (or something like that).