### PR TITLE
Remove unecessary `GIT_SUBMODULE_STRATEGY` from CI

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -16,7 +16,6 @@ stages:
   stage: build
   timeout: 6 hours
   variables:
-    GIT_SUBMODULE_STRATEGY: recursive
     SPACK_SHA: 566754440f9dfed9accd25db7f1a67b0cd074fcd
     SPACK_DLAF_REPO: ./spack
   before_script:


### PR DESCRIPTION
DLA-Future doesn't seems to use git submodules, I think this CI option can be safely removed.