### PR TITLE
Print tune parameters with `--dlaf:print-config`

### DIFF
--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -28,6 +28,11 @@ namespace dlaf {
 /// Holds configuration values that can be used to customize DLA-Future through
 /// dlaf::initialize.
 struct configuration {
+  // NOTE: Remember to update the following if you add or change parameters below:
+  // - The operator<< overload in init.cpp
+  // - updateConfiguration in init.cpp to update the value from command line options and environment
+  //   values
+  // - getOptionsDescription to add a corresponding command line option
   std::size_t num_np_gpu_streams_per_thread = 3;
   std::size_t num_hp_gpu_streams_per_thread = 3;
   std::size_t umpire_host_memory_pool_initial_bytes = 1 << 30;

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -12,6 +12,7 @@
 /// @file
 
 #include <cstdint>
+#include <iosfwd>
 
 #include <pika/runtime.hpp>
 
@@ -68,6 +69,7 @@ struct TuneParameters {
   SizeType bt_band_to_tridiag_hh_apply_group_size = 64;
 };
 
+std::ostream& operator<<(std::ostream& os, const TuneParameters& params);
 TuneParameters& getTuneParameters();
 
 }

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -57,6 +57,12 @@ namespace dlaf {
 ///
 /// Note: debug parameters should not be considered as part of the public API
 struct TuneParameters {
+  // NOTE: Remember to update the following if you add or change parameters below:
+  // - Documentation in the docstring above
+  // - The operator<< overload in tune.cpp
+  // - updateConfiguration in init.cpp to update the value from command line options and environment
+  //   values
+  // - getOptionsDescription to add a corresponding command line option
   bool debug_dump_trisolver_data = false;
   std::size_t red2band_panel_nworkers =
       std::max<std::size_t>(1, pika::resource::get_thread_pool("default").get_os_thread_count() / 2);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -277,6 +277,8 @@ void initialize(const pika::program_options::variables_map& vm, const configurat
   if (vm.count("dlaf:print-config") > 0) {
     std::cout << "DLA-Future configuration options:" << std::endl;
     std::cout << cfg << std::endl;
+    std::cout << "DLA-Future tune parameters at startup:" << std::endl;
+    std::cout << getTuneParameters() << std::endl;
     std::cout << std::endl;
   }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -155,6 +155,9 @@ struct parseFromCommandLine {
 template <class T>
 void updateConfigurationValue(const pika::program_options::variables_map& vm, T& var,
                               const std::string& env_var, const std::string& cmdline_option) {
+  DLAF_ASSERT(env_var.find("DLAF") == std::string::npos, env_var);
+  DLAF_ASSERT(cmdline_option.find("dlaf") == std::string::npos, cmdline_option);
+
   const std::string dlaf_env_var = "DLAF_" + env_var;
   char* env_var_value = std::getenv(dlaf_env_var.c_str());
   if (env_var_value) {
@@ -188,6 +191,9 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
   cfg.mpi_pool = (pika::resource::pool_exists("mpi")) ? "mpi" : "default";
 
   // update tune parameters
+  //
+  // NOTE: Environment variables should omit the DLAF_ prefix and command line options the dlaf: prefix.
+  // These are added automatically by updateConfigurationValue.
   auto& param = getTuneParameters();
   updateConfigurationValue(vm, param.red2band_panel_nworkers, "RED2BAND_PANEL_NWORKERS",
                            "red2band-panel-nworkers");

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -19,6 +19,7 @@ TuneParameters& getTuneParameters() {
 }
 
 std::ostream& operator<<(std::ostream& os, const TuneParameters& params) {
+  os << "  red2band_panel_nworkers = " << params.red2band_panel_nworkers << std::endl;
   os << "  red2band_barrier_busy_wait_us = " << params.red2band_barrier_busy_wait_us << std::endl;
   os << "  tridiag_rank1_nworkers = " << params.tridiag_rank1_nworkers << std::endl;
   os << "  tridiag_rank1_barrier_busy_wait_us = " << params.tridiag_rank1_barrier_busy_wait_us

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -18,4 +18,17 @@ TuneParameters& getTuneParameters() {
   return params;
 }
 
+std::ostream& operator<<(std::ostream& os, const TuneParameters& params) {
+  os << "  red2band_barrier_busy_wait_us = " << params.red2band_barrier_busy_wait_us << std::endl;
+  os << "  tridiag_rank1_nworkers = " << params.tridiag_rank1_nworkers << std::endl;
+  os << "  tridiag_rank1_barrier_busy_wait_us = " << params.tridiag_rank1_barrier_busy_wait_us
+     << std::endl;
+  os << "  eigensolver_min_band = " << params.eigensolver_min_band << std::endl;
+  os << "  band_to_tridiag_1d_block_size_base = " << params.band_to_tridiag_1d_block_size_base
+     << std::endl;
+  os << "  bt_band_to_tridiag_hh_apply_group_size = " << params.bt_band_to_tridiag_hh_apply_group_size
+     << std::endl;
+  return os;
+}
+
 }


### PR DESCRIPTION
From the `--dlaf:print-config` perspective, the tune parameters and config options are the same. Should we print them together (in one block) or separate them (with a heading?).