### PR TITLE
Fix coverage tests

### DIFF
--- a/ci/docker/debug-cpu.yaml
+++ b/ci/docker/debug-cpu.yaml
@@ -28,3 +28,5 @@ spack:
       variants:
         - 'build_type=Debug'
         - 'malloc=system'
+    umpire:
+      require: '@2022.03.1'

--- a/ci/docker/debug-cuda.yaml
+++ b/ci/docker/debug-cuda.yaml
@@ -28,3 +28,5 @@ spack:
       variants:
         - 'build_type=Debug'
         - 'malloc=system'
+    umpire:
+      require: '@2022.03.1'


### PR DESCRIPTION
Umpire added the compiler option `-fcompare-debug-second` which breaks coverage.

Force Umpire version 2022.03.1 to avoid the problem. 

Note: Opened issue in Umpire: https://github.com/LLNL/Umpire/issues/852