### PR TITLE
Add error message for invalid grid context in C API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -123,7 +123,7 @@ IncludeCategories:
     Priority:        5
     SortPriority:    0
     CaseSensitive:   false
-IncludeIsMainRegex: '(test)?$'
+IncludeIsMainRegex: '_disabled$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseLabels: true

--- a/src/c_api/eigensolver/eigensolver.h
+++ b/src/c_api/eigensolver/eigensolver.h
@@ -24,7 +24,6 @@
 #include <dlaf_c/grid.h>
 
 #include "../blacs.h"
-#include "../grid.h"
 #include "../utils.h"
 
 template <typename T>
@@ -43,7 +42,7 @@ int hermitian_eigensolver(const int dlaf_context, const char uplo, T* a,
 
   pika::resume();
 
-  auto communicator_grid = dlaf_grids.at(dlaf_context);
+  auto communicator_grid = grid_from_context(dlaf_context);
 
   auto [distribution_a, layout_a] = distribution_and_layout(dlaf_desca, communicator_grid);
   auto [distribution_z, layout_z] = distribution_and_layout(dlaf_descz, communicator_grid);

--- a/src/c_api/eigensolver/gen_eigensolver.h
+++ b/src/c_api/eigensolver/gen_eigensolver.h
@@ -24,7 +24,6 @@
 #include <dlaf_c/grid.h>
 
 #include "../blacs.h"
-#include "../grid.h"
 #include "../utils.h"
 
 template <typename T>
@@ -46,7 +45,7 @@ int hermitian_generalized_eigensolver(const int dlaf_context, const char uplo, T
 
   pika::resume();
 
-  auto communicator_grid = dlaf_grids.at(dlaf_context);
+  auto communicator_grid = grid_from_context(dlaf_context);
 
   auto [distribution_a, layout_a] = distribution_and_layout(dlaf_desca, communicator_grid);
   auto [distribution_b, layout_b] = distribution_and_layout(dlaf_descb, communicator_grid);

--- a/src/c_api/factorization/cholesky.h
+++ b/src/c_api/factorization/cholesky.h
@@ -24,7 +24,6 @@
 #include <dlaf_c/utils.h>
 
 #include "../blacs.h"
-#include "../grid.h"
 #include "../utils.h"
 
 template <typename T>
@@ -37,7 +36,7 @@ int cholesky_factorization(const int dlaf_context, const char uplo, T* a,
 
   pika::resume();
 
-  auto communicator_grid = dlaf_grids.at(dlaf_context);
+  auto communicator_grid = grid_from_context(dlaf_context);
 
   auto [distribution, layout] = distribution_and_layout(dlaf_desca, communicator_grid);
 

--- a/src/c_api/utils.cpp
+++ b/src/c_api/utils.cpp
@@ -17,6 +17,7 @@
 
 #include "grid.h"
 #include "utils.h"
+
 struct DLAF_descriptor make_dlaf_descriptor(const int m, const int n, const int i, const int j,
                                             const int desc[9]) {
   DLAF_ASSERT(i == 1, i);

--- a/src/c_api/utils.cpp
+++ b/src/c_api/utils.cpp
@@ -53,11 +53,11 @@ dlaf::comm::CommunicatorGrid& grid_from_context(int dlaf_context) {
     return dlaf_grids.at(dlaf_context);
   }
   catch (const std::out_of_range& e) {
-    std::stringstream s;
-    s << "[Error] No DLA-Future grid for context " << dlaf_context << ".\n";
-    s << "[Info]  Make sure you called dlaf_create_grid() or dlaf_create_grid_from_blacs().\n";
+    std::stringstream ss;
+    ss << "[ERROR] No DLA-Future grid for context " << dlaf_context << ". ";
+    ss << "Did you forget to call dlaf_create_grid() or dlaf_create_grid_from_blacs()?\n";
 
-    std::cerr << s.str() << std::flush;
+    std::cerr << ss.str() << std::flush;
 
     std::terminate();
   }

--- a/src/c_api/utils.cpp
+++ b/src/c_api/utils.cpp
@@ -8,8 +8,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "utils.h"
-
 #include <iostream>
 #include <stdexcept>
 
@@ -18,7 +16,7 @@
 #include <dlaf_c/utils.h>
 
 #include "grid.h"
-
+#include "utils.h"
 struct DLAF_descriptor make_dlaf_descriptor(const int m, const int n, const int i, const int j,
                                             const int desc[9]) {
   DLAF_ASSERT(i == 1, i);

--- a/src/c_api/utils.cpp
+++ b/src/c_api/utils.cpp
@@ -49,7 +49,7 @@ dlaf::common::Ordering char2order(const char order) {
                                       : dlaf::common::Ordering::RowMajor;
 }
 
-dlaf::comm::CommunicatorGrid grid_from_context(int dlaf_context) {
+dlaf::comm::CommunicatorGrid& grid_from_context(int dlaf_context) {
   try {
     return dlaf_grids.at(dlaf_context);
   }

--- a/src/c_api/utils.cpp
+++ b/src/c_api/utils.cpp
@@ -10,9 +10,14 @@
 
 #include "utils.h"
 
+#include <iostream>
+#include <stdexcept>
+
 #include <dlaf/communication/communicator_grid.h>
 #include <dlaf_c/desc.h>
 #include <dlaf_c/utils.h>
+
+#include "grid.h"
 
 struct DLAF_descriptor make_dlaf_descriptor(const int m, const int n, const int i, const int j,
                                             const int desc[9]) {
@@ -42,4 +47,19 @@ std::tuple<dlaf::matrix::Distribution, dlaf::matrix::LayoutInfo> distribution_an
 dlaf::common::Ordering char2order(const char order) {
   return order == 'C' or order == 'c' ? dlaf::common::Ordering::ColumnMajor
                                       : dlaf::common::Ordering::RowMajor;
+}
+
+dlaf::comm::CommunicatorGrid grid_from_context(int dlaf_context) {
+  try {
+    return dlaf_grids.at(dlaf_context);
+  }
+  catch (const std::out_of_range& e) {
+    std::stringstream s;
+    s << "[Error] No DLA-Future grid for context " << dlaf_context << ".\n";
+    s << "[Info]  Make sure you called dlaf_create_grid() or dlaf_create_grid_from_blacs().\n";
+
+    std::cerr << s.str() << std::flush;
+
+    std::terminate();
+  }
 }

--- a/src/c_api/utils.h
+++ b/src/c_api/utils.h
@@ -8,8 +8,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <stdexcept>
-
 #include <dlaf/communication/communicator_grid.h>
 #include <dlaf/matrix/distribution.h>
 #include <dlaf/matrix/layout_info.h>

--- a/src/c_api/utils.h
+++ b/src/c_api/utils.h
@@ -19,4 +19,4 @@ std::tuple<dlaf::matrix::Distribution, dlaf::matrix::LayoutInfo> distribution_an
 
 dlaf::common::Ordering char2order(const char order);
 
-dlaf::comm::CommunicatorGrid grid_from_context(int dlaf_context);
+dlaf::comm::CommunicatorGrid& grid_from_context(int dlaf_context);

--- a/src/c_api/utils.h
+++ b/src/c_api/utils.h
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <stdexcept>
+
 #include <dlaf/communication/communicator_grid.h>
 #include <dlaf/matrix/distribution.h>
 #include <dlaf/matrix/layout_info.h>
@@ -16,3 +18,5 @@ std::tuple<dlaf::matrix::Distribution, dlaf::matrix::LayoutInfo> distribution_an
     const struct DLAF_descriptor dlaf_desc, dlaf::comm::CommunicatorGrid& grid);
 
 dlaf::common::Ordering char2order(const char order);
+
+dlaf::comm::CommunicatorGrid grid_from_context(int dlaf_context);


### PR DESCRIPTION
If an invalid DLA-Future context is passed to the C API, the following error is printed
```
[Error] No DLA-Future grid for context 123456789.
[Info]  Make sure you called dlaf_create_grid() or dlaf_create_grid_from_blacs().
```
and the program terminates.

Close #1008.