### PR TITLE
Added srun_args option to miniapps.py

### DIFF
--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -670,7 +670,19 @@ class StrongScaling:
         self.rpn_preamble = None
 
     # add one/multiple runs
-    def add(self, miniapp, lib, build_dir, params, nruns, suffix="", extra_flags="", env="", dtype="d", srun_args=""):
+    def add(
+        self,
+        miniapp,
+        lib,
+        build_dir,
+        params,
+        nruns,
+        suffix="",
+        extra_flags="",
+        env="",
+        dtype="d",
+        srun_args="",
+    ):
         if "rpn" not in params:
             raise KeyError("params dictionary should contain the key 'rpn'")
 

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -99,7 +99,7 @@ class JobText:
     # and env command are the strings returned by command_gen(system=self.system, nodes=self.nodes, **args)
     # Note: if rpn was None at initialization any value for rpn can be given
     #       otherwise rpn has to match with the valeu wgiven at initialization.
-    def addCommand(self, command_gen, **args):
+    def addCommand(self, command_gen, srun_args, **args):
         rpn = args["rpn"]
         if self.rpn != None and self.rpn != rpn:
             raise ValueError(
@@ -112,7 +112,7 @@ class JobText:
         if "Extra subs" in self.system:
             subs = self.system["Extra subs"](subs)
 
-        run_cmd = self.system["Run command"].format(**subs).strip()
+        run_cmd = self.system["Run command"].format(srun_args=srun_args, **subs).strip()
         [command, env] = command_gen(system=self.system, nodes=self.nodes, **args)
 
         self.job_text += "\n" + f"{env} {run_cmd} {command}".strip()
@@ -670,7 +670,7 @@ class StrongScaling:
         self.rpn_preamble = None
 
     # add one/multiple runs
-    def add(self, miniapp, lib, build_dir, params, nruns, suffix="", extra_flags="", env="", dtype="d"):
+    def add(self, miniapp, lib, build_dir, params, nruns, suffix="", extra_flags="", env="", dtype="d", srun_args=""):
         if "rpn" not in params:
             raise KeyError("params dictionary should contain the key 'rpn'")
 
@@ -706,6 +706,7 @@ class StrongScaling:
                 "extra_flags": extra_flags,
                 "env": env,
                 "dtype": dtype,
+                "srun_args": srun_args,
             }
         )
 
@@ -735,6 +736,7 @@ class StrongScaling:
                     extra_flags=run["extra_flags"],
                     env=run["env"],
                     dtype=run["dtype"],
+                    srun_args=run["srun_args"],
                     **param,
                 )
         return job_text
@@ -792,6 +794,7 @@ class WeakScaling:
         extra_flags="",
         env="",
         dtype="d",
+        srun_args="",
     ):
         if "rpn" not in params:
             raise KeyError("params dictionary should contain the key 'rpn'")
@@ -833,6 +836,7 @@ class WeakScaling:
                 "extra_flags": extra_flags,
                 "env": env,
                 "dtype": dtype,
+                "srun_args": srun_args,
             }
         )
 
@@ -874,6 +878,7 @@ class WeakScaling:
                         extra_flags=run["extra_flags"],
                         env=run["env"],
                         dtype=run["dtype"],
+                        srun_args=run["srun_args"],
                         **param,
                         **weak_param,
                     )

--- a/scripts/systems.py
+++ b/scripts/systems.py
@@ -37,7 +37,7 @@ cscs["daint-mc"] = {
     "Allowed rpns": [1, 2],
     "Multiple rpn in same job": True,
     "GPU": False,
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -68,7 +68,7 @@ cscs["daint-gpu"] = {
     "Allowed rpns": [1],
     "Multiple rpn in same job": True,
     "GPU": True,
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -99,7 +99,7 @@ cscs["eiger"] = {
     "Allowed rpns": [1, 2, 4, 8],
     "Multiple rpn in same job": True,
     "GPU": False,
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -132,14 +132,46 @@ cscs["hohgant-nvgpu"] = {
     "Multiple rpn in same job": True,
     "GPU": True,
     # Based on nvidia-smi topo --matrix
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=mask_cpu:ffff000000000000ffff000000000000,ffff000000000000ffff00000000,ffff000000000000ffff0000,ffff000000000000ffff gpu2ranks_slurm_cuda",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:ffff000000000000ffff000000000000,ffff000000000000ffff00000000,ffff000000000000ffff0000,ffff000000000000ffff gpu2ranks_slurm_cuda",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
 #SBATCH --time={time_min}
 #SBATCH --nodes={nodes}
 #SBATCH --partition=nvgpu
-#SBATCH --exclude=nid[002024-002025,002028-002029]
+#SBATCH --hint=multithread
+#SBATCH --output=output.txt
+#SBATCH --error=error.txt
+
+# Env
+export MPICH_MAX_THREAD_SAFETY=multiple
+export MIMALLOC_EAGER_COMMIT_DELAY=0
+export MIMALLOC_LARGE_OS_PAGES=1
+
+# Debug
+module list &> modules_{bs_name}.txt
+printenv > env_{bs_name}.txt
+
+# Commands
+""",
+}
+
+# NOTE: Here is assumed that `gpu2ranks_slurm_cuda` is in PATH!
+#       modify "Run command" if it is not the case.
+cscs["clariden-nvgpu"] = {
+    "Cores": 64,
+    "Threads per core": 2,
+    "Allowed rpns": [4],
+    "Multiple rpn in same job": True,
+    "GPU": True,
+    # Based on nvidia-smi topo --matrix
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:ffff000000000000ffff000000000000,ffff000000000000ffff00000000,ffff000000000000ffff0000,ffff000000000000ffff gpu2ranks_slurm_cuda",
+    "Batch preamble": """
+#!/bin/bash -l
+#SBATCH --job-name={run_name}_{nodes}
+#SBATCH --time={time_min}
+#SBATCH --nodes={nodes}
+#SBATCH --partition=nvgpu
 #SBATCH --hint=multithread
 #SBATCH --output=output.txt
 #SBATCH --error=error.txt
@@ -165,10 +197,39 @@ cscs["hohgant-amdgpu"] = {
     "Allowed rpns": [8],
     "Multiple rpn in same job": True,
     "GPU": True,
-    # Based on
-    # https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/distribution-binding/#gpu-binding
-    # and rocm-smi --showtoponuma
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=mask_cpu:ff00000000000000ff000000000000,ff00000000000000ff00000000000000,ff00000000000000ff0000,ff00000000000000ff000000,ff00000000000000ff,ff00000000000000ff00,ff00000000000000ff00000000,ff00000000000000ff0000000000 gpu2ranks_slurm_hip",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:ff00000000000000ff000000000000,ff00000000000000ff00000000000000,ff00000000000000ff0000,ff00000000000000ff000000,ff00000000000000ff,ff00000000000000ff00,ff00000000000000ff00000000,ff00000000000000ff0000000000 gpu2ranks_slurm_hip",
+    "Batch preamble": """
+#!/bin/bash -l
+#SBATCH --job-name={run_name}_{nodes}
+#SBATCH --time={time_min}
+#SBATCH --nodes={nodes}
+#SBATCH --partition=amdgpu
+#SBATCH --hint=multithread
+#SBATCH --output=output.txt
+#SBATCH --error=error.txt
+
+# Env
+export MPICH_MAX_THREAD_SAFETY=multiple
+export MIMALLOC_EAGER_COMMIT_DELAY=0
+export MIMALLOC_LARGE_OS_PAGES=1
+
+# Debug
+module list &> modules_{bs_name}.txt
+printenv > env_{bs_name}.txt
+
+# Commands
+""",
+}
+
+# NOTE: Here is assumed that `gpu2ranks_slurm_hip` is in PATH!
+#       modify "Run command" if it is not the case.
+cscs["clariden-amdgpu"] = {
+    "Cores": 64,
+    "Threads per core": 2,
+    "Allowed rpns": [8],
+    "Multiple rpn in same job": True,
+    "GPU": True,
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:ff00000000000000ff000000000000,ff00000000000000ff00000000000000,ff00000000000000ff0000,ff00000000000000ff000000,ff00000000000000ff,ff00000000000000ff00,ff00000000000000ff00000000,ff00000000000000ff0000000000 gpu2ranks_slurm_hip",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -200,7 +261,7 @@ csc["lumi-cpu"] = {
     "Allowed rpns": [1, 2, 4, 8],
     "Multiple rpn in same job": True,
     "GPU": False,
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -236,7 +297,7 @@ csc["lumi-gpu"] = {
     # Based on
     # https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/distribution-binding/#gpu-binding
     # and rocm-smi --show-topo
-    "Run command": "srun -u -n {total_ranks} --cpu-bind=mask_cpu:fe00000000000000fe000000000000,fe00000000000000fe00000000000000,fe00000000000000fe0000,fe00000000000000fe000000,fe00000000000000fe,fe00000000000000fe00,fe00000000000000fe00000000,fe00000000000000fe0000000000 gpu2ranks_slurm_hip",
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:fe00000000000000fe000000000000,fe00000000000000fe00000000000000,fe00000000000000fe0000,fe00000000000000fe000000,fe00000000000000fe,fe00000000000000fe00,fe00000000000000fe00000000,fe00000000000000fe0000000000 gpu2ranks_slurm_hip",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -260,90 +321,4 @@ printenv > env_{bs_name}.txt
 
 # Commands
 """,
-}
-
-cineca = {}
-
-
-def extraSubsMarconi(params):
-    if params["nodes"] <= 16:
-        params["qos"] = "normal"
-    else:
-        params["qos"] = "m100_qos_bprod"
-
-    # This configuration was suggested by the user support and used for the benchmarks.
-    # It looks strange that the computation should be constrained to only half the cores in the node.
-    # Extra investigations are needed.
-    if "rpn" in params:
-        if params["rpn"] == 1:
-            params["socket_PE"] = 16
-        else:
-            params["socket_PE"] = 8
-    return params
-
-
-cineca["m100_cpu"] = {
-    "Cores": 32,
-    "Threads per core": 4,
-    "Allowed rpns": [2, 4],
-    "Multiple rpn in same job": False,
-    "GPU": False,
-    "sleep": 5,
-    "Run command": "mpirun --rank-by core --map-by socket:PE={socket_PE}",
-    "Batch preamble": """
-#!/bin/bash -l
-#SBATCH --job-name={run_name}_{nodes}
-#SBATCH --time={time_min}
-#SBATCH --nodes={nodes}
-#SBATCH --ntasks-per-node={rpn}
-#SBATCH --cpus-per-task={threads_per_rank}
-#SBATCH --partition=m100_usr_prod
-#SBATCH --account=cin_staff
-#SBATCH --qos={qos}
-#SBATCH --output=output.txt
-#SBATCH --error=error.txt
-
-# Debug
-module list &> modules_{bs_name}.txt
-printenv > env_{bs_name}.txt
-
-# Commands
-""",
-    "Extra subs": extraSubsMarconi,
-}
-
-# NOTE: Here is assumed that `gpu2ranks_ompi` is in PATH!
-#       modify "Run command" if it is not the case.
-cineca["m100"] = {
-    "Cores": 32,
-    "Threads per core": 4,
-    "Allowed rpns": [2, 4],
-    "Multiple rpn in same job": False,
-    "GPU": True,
-    "sleep": 5,
-    "Run command": "mpirun --rank-by core --map-by socket:PE={socket_PE} gpu2ranks_ompi",
-    "Batch preamble": """
-#!/bin/bash -l
-#SBATCH --job-name={run_name}_{nodes}
-#SBATCH --time={time_min}
-#SBATCH --nodes={nodes}
-#SBATCH --ntasks-per-node={rpn}
-#SBATCH --cpus-per-task={threads_per_rank}
-#SBATCH --partition=m100_usr_prod
-#SBATCH --gres=gpu:{rpn}
-#SBATCH --account=cin_staff
-#SBATCH --qos={qos}
-#SBATCH --output=output.txt
-#SBATCH --error=error.txt
-
-# Debug
-module list &> modules_{bs_name}.txt
-printenv > env_{bs_name}.txt
-
-# NOTE: It is assumed that `gpu2ranks_ompi` is in PATH!
-#       modify "Run command" in `systems.py` if it is not the case.
-
-# Commands
-""",
-    "Extra subs": extraSubsMarconi,
 }


### PR DESCRIPTION
The option is useful to specify the `--uenv` option when there is the need to mount a stackinator squashfs without modifying the `system.py` configuration each time.

Note:
- removed marconi-m100 system (EOL)
- added clariden