### PR TITLE
Use pika@main in CI

### DIFF
--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -29,3 +29,6 @@ packages:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040
     buildable: false
+  pika:
+    version:
+      - main


### PR DESCRIPTION
This is not meant for merging. It's a final sanity check that all the current CI configurations work as expected after https://github.com/pika-org/pika/pull/774 was merged.