### PR TITLE
Enable Gemm (distributed) to be used with MatrixRef

### DIFF
--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -68,28 +68,22 @@ void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, Matrix
 /// C = alpha * A * B + beta * C
 ///
 /// @param  mat_a contains the input matrix A.
-/// @pre @p mat_a is distributed according to @p grid
-///
 /// @param  mat_b contains the input matrix B.
-/// @pre @p mat_b is distributed according to @p grid
-///
 /// @param  mat_c On entry it contains the input matrix C. On exit matrix tiles in the range will be
 ///         overwritten with the result, while others are left untouched.
-/// @pre @p mat_c is distributed according to @p grid
 ///
+/// @pre @p mat_a, @p mat_b and @p mat_c are distributed the same way,
 /// @pre multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size(), mat_b.tile_size(), mat_c.tile_size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size_of({0, 0}), mat_b.tile_size_of({0, 0}),
 ///      mat_c.tile_size_of({0, 0}), opA, opB)
 template <Backend B, Device D, class T>
-void generalMatrix([[maybe_unused]] comm::CommunicatorGrid grid,
-                   common::Pipeline<comm::Communicator>& row_task_chain,
+void generalMatrix(common::Pipeline<comm::Communicator>& row_task_chain,
                    common::Pipeline<comm::Communicator>& col_task_chain, const T alpha,
                    MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b, const T beta,
                    MatrixRef<T, D>& mat_c) {
-  DLAF_ASSERT(matrix::equal_process_grid(mat_a, grid), mat_a, grid);
-  DLAF_ASSERT(matrix::equal_process_grid(mat_b, grid), mat_a, grid);
-  DLAF_ASSERT(matrix::equal_process_grid(mat_c, grid), mat_a, grid);
+  DLAF_ASSERT(matrix::same_process_grid(mat_c, mat_a), mat_c, mat_b);
+  DLAF_ASSERT(matrix::same_process_grid(mat_c, mat_b), mat_c, mat_b);
 
   DLAF_ASSERT_HEAVY(matrix::multipliable(mat_a, mat_b, mat_c, blas::Op::NoTrans, blas::Op::NoTrans),
                     mat_a, mat_b, mat_c);

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -64,6 +64,30 @@ void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, Matrix
     DLAF_UNIMPLEMENTED(opA, opB);
 }
 
+template <Backend B, Device D, class T>
+void generalMatrix([[maybe_unused]] comm::CommunicatorGrid grid,
+                   common::Pipeline<comm::Communicator>& row_task_chain,
+                   common::Pipeline<comm::Communicator>& col_task_chain, const SizeType a,
+                   const SizeType b, const T alpha, MatrixRef<const T, D>& mat_a,
+                   MatrixRef<const T, D>& mat_b, const T beta, MatrixRef<T, D>& mat_c) {
+  DLAF_ASSERT(equal_process_grid(mat_a, grid), mat_a, grid);
+  DLAF_ASSERT(equal_process_grid(mat_b, grid), mat_a, grid);
+  DLAF_ASSERT(equal_process_grid(mat_c, grid), mat_a, grid);
+
+  using matrix::multipliable_sizes;
+  DLAF_ASSERT(multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size()),
+              "Multiplication incompatible matrix sizes.", mat_a.size(), mat_b.size(), mat_c.size());
+  DLAF_ASSERT(multipliable_sizes(mat_a.blockSize(), mat_b.blockSize(), mat_c.blockSize()),
+              "Multiplication incompatible tile sizes.");
+  DLAF_ASSERT(mat_c.size().isEmpty() || multipliable_sizes(mat_a.distribution().tileSize({0, 0}),
+                                                           mat_b.distribution().tileSize({0, 0}),
+                                                           mat_c.distribution().tileSize({0, 0})),
+              "Multiplication incompatible tile sizes in first row/col. "
+              "(Are you using a matrix with offset not aligned with tile?)");
+
+  internal::General<B, D, T>::callNN(row_task_chain, col_task_chain, alpha, mat_a, mat_b, beta, mat_c);
+}
+
 /// General sub-matrix multiplication implementation on local memory, computing
 /// C[a:b][a:b] = alpha * opA(A[a:b][a:b]) * opB(B[a:b][a:b]) + beta * C[a:b][a:b]
 /// where [a:b] is the range of tiles starting from tile index @p a to tile index @p b (excluded)

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -72,7 +72,7 @@ void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, Matrix
 /// @param  mat_c On entry it contains the input matrix C. On exit matrix tiles in the range will be
 ///         overwritten with the result, while others are left untouched.
 ///
-/// @pre @p mat_a, @p mat_b and @p mat_c are distributed the same way,
+/// @pre @p mat_a, @p mat_b and @p mat_c are distributed according to the same grid,
 /// @pre multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size(), mat_b.tile_size(), mat_c.tile_size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size_of({0, 0}), mat_b.tile_size_of({0, 0}),

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -72,7 +72,7 @@ void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, Matrix
 /// @param  mat_c On entry it contains the input matrix C. On exit matrix tiles in the range will be
 ///         overwritten with the result, while others are left untouched.
 ///
-/// @pre @p mat_a, @p mat_b and @p mat_c are distributed according to the same grid,
+/// @pre @p mat_a, @p mat_b and @p mat_c are distributed on the same grid,
 /// @pre multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size(), mat_b.tile_size(), mat_c.tile_size(), opA, opB)
 /// @pre multipliable_sizes(mat_a.tile_size_of({0, 0}), mat_b.tile_size_of({0, 0}),

--- a/include/dlaf/multiplication/general.h
+++ b/include/dlaf/multiplication/general.h
@@ -64,6 +64,23 @@ void generalMatrix(const blas::Op opA, const blas::Op opB, const T alpha, Matrix
     DLAF_UNIMPLEMENTED(opA, opB);
 }
 
+/// General sub-matrix distributed multiplication, computing
+/// C = alpha * A * B + beta * C
+///
+/// @param  mat_a contains the input matrix A.
+/// @pre @p mat_a is distributed according to @p grid
+///
+/// @param  mat_b contains the input matrix B.
+/// @pre @p mat_b is distributed according to @p grid
+///
+/// @param  mat_c On entry it contains the input matrix C. On exit matrix tiles in the range will be
+///         overwritten with the result, while others are left untouched.
+/// @pre @p mat_c is distributed according to @p grid
+///
+/// @pre multipliable_sizes(mat_a.size(), mat_b.size(), mat_c.size(), opA, opB)
+/// @pre multipliable_sizes(mat_a.tile_size(), mat_b.tile_size(), mat_c.tile_size(), opA, opB)
+/// @pre multipliable_sizes(mat_a.tile_size_of({0, 0}), mat_b.tile_size_of({0, 0}),
+///      mat_c.tile_size_of({0, 0}), opA, opB)
 template <Backend B, Device D, class T>
 void generalMatrix([[maybe_unused]] comm::CommunicatorGrid grid,
                    common::Pipeline<comm::Communicator>& row_task_chain,

--- a/include/dlaf/multiplication/general/api.h
+++ b/include/dlaf/multiplication/general/api.h
@@ -25,6 +25,10 @@ template <Backend B, Device D, class T>
 struct General {
   static void callNN(const T alpha, MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b,
                      const T beta, MatrixRef<T, D>& mat_c);
+  static void callNN(common::Pipeline<comm::Communicator>& row_task_chain,
+                     common::Pipeline<comm::Communicator>& col_task_chain, const T alpha,
+                     MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b, const T beta,
+                     MatrixRef<T, D>& mat_c);
 };
 
 template <Backend B, Device D, class T>

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -61,6 +61,82 @@ void General<B, D, T>::callNN(const T alpha, MatrixRef<const T, D>& mat_a, Matri
 }
 
 template <Backend B, Device D, class T>
+void General<B, D, T>::callNN(common::Pipeline<comm::Communicator>& row_task_chain,
+                              common::Pipeline<comm::Communicator>& col_task_chain, const T alpha,
+                              MatrixRef<const T, D>& mat_a, MatrixRef<const T, D>& mat_b, const T beta,
+                              MatrixRef<T, D>& mat_c) {
+  namespace ex = pika::execution::experimental;
+
+  if (mat_c.size().isEmpty())
+    return;
+
+  const matrix::Distribution& dist_a = mat_a.distribution();
+  const matrix::Distribution& dist_b = mat_b.distribution();
+  const matrix::Distribution& dist_c = mat_c.distribution();
+  const auto rank = dist_c.rankIndex();
+
+  constexpr std::size_t n_workspaces = 2;
+  common::RoundRobin<matrix::Panel<Coord::Col, T, D>> panelsA(n_workspaces, dist_c);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> panelsB(n_workspaces, dist_c);
+
+  DLAF_ASSERT_HEAVY(mat_a.nrTiles().cols() == mat_b.nrTiles().rows(), mat_a.nrTiles(), mat_b.nrTiles());
+
+  // This loops over the global indices for k, because every rank has to participate in communication
+  for (SizeType k = 0; k < mat_a.nrTiles().cols(); ++k) {
+    auto& panelA = panelsA.nextResource();
+    auto& panelB = panelsB.nextResource();
+
+    if (k == 0 || k == mat_a.nrTiles().cols() - 1) {
+      DLAF_ASSERT_HEAVY(dist_a.tileSize<Coord::Col>(k) == dist_b.tileSize<Coord::Row>(k),
+                        dist_a.tileSize<Coord::Col>(k), dist_b.tileSize<Coord::Row>(k));
+      const SizeType kSize = dist_a.tileSize<Coord::Col>(k);
+      panelA.setWidth(kSize);
+      panelB.setHeight(kSize);
+    }
+
+    // Setup the column workspace for the root ranks, i.e. the ones in the current col
+    const auto rank_k_col = dist_a.rankGlobalTile<Coord::Col>(k);
+    if (rank_k_col == rank.col()) {
+      const auto k_local = dist_a.template localTileFromGlobalTile<Coord::Col>(k);
+      for (SizeType i = 0; i < dist_c.localNrTiles().rows(); ++i) {
+        const LocalTileIndex ik(i, k_local);
+        panelA.setTile(ik, mat_a.read(ik));
+      }
+    }
+    // Setup the row workspace for the root ranks, i.e. the ones in the current row
+    const auto rank_k_row = dist_b.rankGlobalTile<Coord::Row>(k);
+    if (rank_k_row == rank.row()) {
+      const auto k_local = dist_b.template localTileFromGlobalTile<Coord::Row>(k);
+      for (SizeType j = 0; j < dist_c.localNrTiles().cols(); ++j) {
+        const LocalTileIndex kj(k_local, j);
+        panelB.setTile(kj, mat_b.read(kj));
+      }
+    }
+
+    // Broadcast both column and row panel from root to others (row-wise and col-wise, respectively)
+    broadcast(rank_k_col, panelA, row_task_chain);
+    broadcast(rank_k_row, panelB, col_task_chain);
+
+    // This is the core loop where the k step performs the update over the entire local matrix using
+    // the col and row workspaces.
+    // Everything needed for the update is available locally thanks to previous broadcasts.
+    for (SizeType i = 0; i < dist_c.localNrTiles().rows(); ++i) {
+      for (SizeType j = 0; j < dist_c.localNrTiles().cols(); ++j) {
+        const LocalTileIndex ij(i, j);
+
+        ex::start_detached(dlaf::internal::whenAllLift(blas::Op::NoTrans, blas::Op::NoTrans, alpha,
+                                                       panelA.read(ij), panelB.read(ij),
+                                                       k == 0 ? beta : T(1), mat_c.readwrite(ij)) |
+                           tile::gemm(dlaf::internal::Policy<B>()));
+      }
+    }
+
+    panelA.reset();
+    panelB.reset();
+  }
+}
+
+template <Backend B, Device D, class T>
 void GeneralSub<B, D, T>::callNN(const SizeType idx_begin, const SizeType idx_end, const blas::Op opA,
                                  const blas::Op opB, const T alpha, Matrix<const T, D>& mat_a,
                                  Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {

--- a/include/dlaf/multiplication/general/impl.h
+++ b/include/dlaf/multiplication/general/impl.h
@@ -76,8 +76,8 @@ void General<B, D, T>::callNN(common::Pipeline<comm::Communicator>& row_task_cha
   const auto rank = dist_c.rankIndex();
 
   constexpr std::size_t n_workspaces = 2;
-  common::RoundRobin<matrix::Panel<Coord::Col, T, D>> panelsA(n_workspaces, dist_c);
-  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> panelsB(n_workspaces, dist_c);
+  common::RoundRobin<matrix::Panel<Coord::Col, T, D>> panelsA(n_workspaces, dist_a);
+  common::RoundRobin<matrix::Panel<Coord::Row, T, D>> panelsB(n_workspaces, dist_b);
 
   DLAF_ASSERT_HEAVY(mat_a.nrTiles().cols() == mat_b.nrTiles().rows(), mat_a.nrTiles(), mat_b.nrTiles());
 

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -79,7 +79,7 @@ bool equal_process_grid(const MatrixLike<const T, D>& m, const comm::Communicato
   return m.commGridSize() == g.size() && m.rankIndex() == g.rank();
 }
 
-/// Returns true if the matrix is distributed on the communication grid.
+/// Returns true if the two matrices are distributed on the same grid
 template <template <class, Device> class MatrixLikeA, template <class, Device> class MatrixLikeB,
           class T, Device D1, Device D2>
 bool same_process_grid(const MatrixLikeA<const T, D1>& a, const MatrixLikeB<const T, D2>& b) noexcept {

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -74,8 +74,8 @@ bool local_matrix(const MatrixLike<const T, D>& m) noexcept {
 }
 
 /// Returns true if the matrix is distributed on the communication grid.
-template <class T, Device D>
-bool equal_process_grid(const Matrix<const T, D>& m, const comm::CommunicatorGrid& g) noexcept {
+template <template <class, Device> class MatrixLike, class T, Device D>
+bool equal_process_grid(const MatrixLike<const T, D>& m, const comm::CommunicatorGrid& g) noexcept {
   return m.commGridSize() == g.size() && m.rankIndex() == g.rank();
 }
 

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -146,37 +146,6 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
                     2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error);
 }
 
-template <Coord coord>
-comm::IndexT_MPI alignSubRankIndex(const Distribution& dist_in, const GlobalElementIndex& offset_in,
-                                   const TileElementSize& blocksize_out,
-                                   const GlobalElementIndex& offset_out) {
-  const SizeType blocksize = blocksize_out.get<coord>();
-  DLAF_ASSERT(dist_in.block_size().get<coord>() == blocksize, dist_in.block_size().get<coord>(),
-              blocksize);
-
-  const SizeType grid_size = dist_in.grid_size().get<coord>();
-
-  if (!offset_in.isIn(dist_in.size()))
-    return grid_size / 2;
-
-  const auto pos_mod = [](const auto& a, const auto& b) {
-    const auto mod = a % b;
-    return (mod >= 0) ? mod : (mod + b);
-  };
-
-  const SizeType sub_rank = dist_in.rank_global_element<coord>(offset_in.get<coord>());
-  const SizeType offset_rank(offset_out.get<coord>() / blocksize);
-
-  return pos_mod(sub_rank - offset_rank, grid_size);
-}
-
-comm::Index2D alignSubRankIndex(const Distribution& dist_in, const GlobalElementIndex& offset_in,
-                                const TileElementSize& blocksize_out,
-                                const GlobalElementIndex& offset_out) {
-  return {alignSubRankIndex<Coord::Row>(dist_in, offset_in, blocksize_out, offset_out),
-          alignSubRankIndex<Coord::Col>(dist_in, offset_in, blocksize_out, offset_out)};
-}
-
 template <class T, Backend B, Device D>
 void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& config,
                                comm::CommunicatorGrid& grid) {

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -216,8 +216,8 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
     // Note: currently it is implemented just the NoTrans/NoTrans case
     ASSERT_EQ(config.opA, blas::Op::NoTrans);
     ASSERT_EQ(config.opB, blas::Op::NoTrans);
-    multiplication::internal::General<B, D, T>::callNN(mpi_row_chain, mpi_col_chain, alpha, mat_sub_a,
-                                                       mat_sub_b, beta, mat_sub_c);
+    multiplication::internal::generalMatrix<B>(grid, mpi_row_chain, mpi_col_chain, alpha, mat_sub_a,
+                                               mat_sub_b, beta, mat_sub_c);
   }
 
   const auto fullValuesResult = mix_values(config.sub_c(), subValuesResult, fullValuesC);

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -209,8 +209,8 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
     // Note: currently it is implemented just the NoTrans/NoTrans case
     ASSERT_EQ(config.opA, blas::Op::NoTrans);
     ASSERT_EQ(config.opB, blas::Op::NoTrans);
-    multiplication::internal::generalMatrix<B>(grid, mpi_row_chain, mpi_col_chain, alpha, mat_sub_a,
-                                               mat_sub_b, beta, mat_sub_c);
+    multiplication::internal::generalMatrix<B>(mpi_row_chain, mpi_col_chain, alpha, mat_sub_a, mat_sub_b,
+                                               beta, mat_sub_c);
   }
 
   const auto fullValuesResult = mix_values(config.sub_c(), subValuesResult, fullValuesC);

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -163,9 +163,11 @@ void testGeneralMultiplication(const T alpha, const T beta, const GemmConfig& co
   const matrix::Distribution dist_c(config.full_c(), blocksize_c, grid.size(), grid.rank(), src_rank_c);
 
   const comm::IndexT_MPI rank_aligned_row =
-      alignSubRankIndex<Coord::Row>(dist_c, config.sub_c().origin, blocksize_a, config.sub_a().origin);
+      align_sub_rank_index<Coord::Row>(dist_c, config.sub_c().origin, blocksize_a,
+                                       config.sub_a().origin);
   const comm::IndexT_MPI rank_aligned_col =
-      alignSubRankIndex<Coord::Col>(dist_c, config.sub_c().origin, blocksize_b, config.sub_b().origin);
+      align_sub_rank_index<Coord::Col>(dist_c, config.sub_c().origin, blocksize_b,
+                                       config.sub_b().origin);
 
   // Note:
   // GEMM(NoTrans, NoTrans) requires:

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -245,8 +245,7 @@ std::vector<GemmConfig> sub_gemm_configs = {
     // single-tile
     {blas::Op::NoTrans, blas::Op::NoTrans, 8, 8, 11, 10, 9, 13, {{2, 1}}, {{1, 1}}, {{0, 0}}},
     // multi-tile
-    // TODO check this, I suspect a problem/limit with panel offset
-    // {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5, {{7, 1}}, {{11, 10}}, {{4, 2}}},
+    {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5, {{7, 1}}, {{11, 10}}, {{4, 2}}},
     {blas::Op::NoTrans, blas::Op::NoTrans, 12, 20, 11, 3, 4, 5, {{6, 10}}, {{5, 8}}, {{9, 12}}},
 };
 

--- a/test/unit/multiplication/test_multiplication_general.cpp
+++ b/test/unit/multiplication/test_multiplication_general.cpp
@@ -402,7 +402,7 @@ void testGeneralSubMultiplication(comm::CommunicatorGrid grid, const SizeType a,
                     2 * (mat_ah.size().cols() + 1) * TypeUtilities<T>::error);
 }
 
-TYPED_TEST(GeneralMultiplicationDistTestMC, CorrectnessDistributedWithMatrixRef) {
+TYPED_TEST(GeneralMultiplicationDistTestMC, CorrectnessDistributed) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
@@ -415,7 +415,7 @@ TYPED_TEST(GeneralMultiplicationDistTestMC, CorrectnessDistributedWithMatrixRef)
   }
 }
 
-TYPED_TEST(GeneralMultiplicationDistTestMC, CorrectnessDistributedWithMatrixRefSub) {
+TYPED_TEST(GeneralMultiplicationDistTestMC, CorrectnessDistributedSub) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
@@ -441,7 +441,7 @@ TYPED_TEST(GeneralSubMultiplicationDistTestMC, CorrectnessDistributed) {
 }
 
 #ifdef DLAF_WITH_GPU
-TYPED_TEST(GeneralMultiplicationDistTestGPU, CorrectnessDistributedWithMatrixRef) {
+TYPED_TEST(GeneralMultiplicationDistTestGPU, CorrectnessDistributed) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 
@@ -454,7 +454,7 @@ TYPED_TEST(GeneralMultiplicationDistTestGPU, CorrectnessDistributedWithMatrixRef
   }
 }
 
-TYPED_TEST(GeneralMultiplicationDistTestGPU, CorrectnessDistributedWithMatrixRefSub) {
+TYPED_TEST(GeneralMultiplicationDistTestGPU, CorrectnessDistributedSub) {
   constexpr TypeParam alpha = TypeUtilities<TypeParam>::element(-1.3, .5);
   constexpr TypeParam beta = TypeUtilities<TypeParam>::element(-2.6, .7);
 


### PR DESCRIPTION
Implementation has been copied from the GeneralSub case, but it has been refined and cleaned up (thanks to MatrixRef functionalities). More importantly, the GeneralSub implementation was constrained to just work with square sub-matrices, while now this constraint has been removed.

TODO
- [x] #969 (change base after it gets merged)
- [x] #1047
- [x] Add documentation
- [x] Add tests
- [x] Use new snake_case functions in implementation