### PR TITLE
Prepare for `pika::start/finalize` cleanup in pika 0.21.0

### DIFF
--- a/src/c_api/init.cpp
+++ b/src/c_api/init.cpp
@@ -27,8 +27,13 @@ void dlaf_initialize(int argc_pika, const char** argv_pika, int argc_dlaf, const
     pika::init_params params;
     params.rp_callback = dlaf::initResourcePartitionerHandler;
     params.desc_cmdline = desc;
+    // After pika 0.21.0 pika::start reports errors only by exception and returns void
+#if PIKA_VERSION_FULL >= 0x001500
+    pika::start(argc_pika, argv_pika, params);
+#else
     auto pika_started = pika::start(nullptr, argc_pika, argv_pika, params);
     DLAF_ASSERT(pika_started, pika_started);
+#endif
 
     // DLA-Future initialization
     dlaf::initialize(argc_dlaf, argv_dlaf);

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -144,7 +144,8 @@ int precedence_main(int, char*[]) {
     EXPECT_EQ(command_line_option_val, cfg.num_hp_gpu_streams_per_thread);
   }
 
-  return pika::finalize();
+  pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 TEST_P(InitTest, Precedence) {
@@ -212,7 +213,8 @@ int vm_no_command_line_option_main(pika::program_options::variables_map& vm) {
     EXPECT_EQ(command_line_option_val, cfg.num_hp_gpu_streams_per_thread);
   }
 
-  return pika::finalize();
+  pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 TEST_P(InitTest, VariablesMapNoCommandLineOption) {
@@ -239,7 +241,8 @@ int vm_command_line_option_main(pika::program_options::variables_map& vm) {
     EXPECT_EQ(command_line_option_val, cfg.num_hp_gpu_streams_per_thread);
   }
 
-  return pika::finalize();
+  pika::finalize();
+  return EXIT_SUCCESS;
 }
 
 TEST_P(InitTest, VariablesMapCommandLineOption) {


### PR DESCRIPTION
https://github.com/pika-org/pika/pull/825 will change the return types of `pika::start` and `pika::finalize` from `int` to `void`, because the return value has no significance. The only functions that retain the `int` return value are `pika::init` and `pika::stop` because they can return the return value of `pika_main`, if `pika_main` is used (otherwise `0`).

This prepares DLA-Future in a compatible way for the change. Since the return value of `pika::finalize` never was anything but `0` I'm ignoring the return value regardless of pika version. For `pika::start` I'm keeping the check of the return value for pika 0.20.0 and older because there are cases where non-zero values signal an error. From pika 0.21.0 all errors are reported as exceptions and the return type is `void`.