### PR TITLE
Add clang 15 CI configuration

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 include:
   - local: 'ci/cpu/clang12_release.yml'
   - local: 'ci/cpu/clang13_release_cxx20.yml'
+  - local: 'ci/cpu/clang15_release.yml'
   - local: 'ci/cpu/gcc11_codecov.yml'
   - local: 'ci/cpu/gcc11_release.yml'
   - local: 'ci/cpu/gcc11_release_stdexec.yml'

--- a/ci/cpu/clang15_release.yml
+++ b/ci/cpu/clang15_release.yml
@@ -1,0 +1,29 @@
+include:
+  - local: 'ci/common-ci.yml'
+
+cpu clang15 release deps:
+  extends: .build_deps_common
+  variables:
+    EXTRA_APTGET: "clang-15"
+    COMPILER: clang@15.0.7
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/release-cpu-serial.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_PATH/cpu-clang15-release/build
+
+cpu clang15 release build:
+  extends:
+    - .build_common
+    - .build_for_daint-mc
+  needs:
+    - cpu clang15 release deps
+  variables:
+    DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/cpu-clang15-release/deploy:$CI_COMMIT_SHA
+
+cpu clang15 release test:
+  extends: .run_common
+  needs:
+    - cpu clang15 release build
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: cpu clang15 release build

--- a/ci/docker/release-cpu-serial.yaml
+++ b/ci/docker/release-cpu-serial.yaml
@@ -1,0 +1,26 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2023, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+spack:
+  include:
+  - common.yaml
+
+  view: false
+  concretizer:
+    unify:
+      true
+
+  specs:
+    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=none ^mpich
+
+  packages:
+    all:
+      variants:
+        - 'build_type=Release'


### PR DESCRIPTION
Given #1017 and #1027, I would suggest that we add at least a clang 15 CI configuration. With the base image of ubuntu 22.04 clang 15 is the newest we can get, but we can also go with clang 16 if we use a different base image for this configuration.

https://github.com/eth-cscs/DLA-Future/pull/853#issuecomment-1551027826 is still an issue, so I've added a separate environment where BLAS threading is disabled. https://github.com/spack/spack/issues/38509 is still open on the spack side. If that gets resolved we can eventually enable threading also on this CI configuration.