### PR TITLE
Use static priority scheduler and `pika::execution::thread_priority::boost` priority threads for MPI

### DIFF
--- a/include/dlaf/sender/transform_mpi.h
+++ b/include/dlaf/sender/transform_mpi.h
@@ -88,7 +88,9 @@ template <typename F, typename Sender,
 [[nodiscard]] decltype(auto) transformMPI(F&& f, Sender&& sender) {
   namespace ex = pika::execution::experimental;
 
-  return ex::transfer(std::forward<Sender>(sender), dlaf::internal::getMPIScheduler()) |
+  return ex::transfer(std::forward<Sender>(sender),
+                      ex::with_priority(dlaf::internal::getMPIScheduler(),
+                                        pika::execution::thread_priority::boost)) |
          ex::then(dlaf::common::internal::ConsumeRvalues{MPICallHelper{std::forward<F>(f)}});
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -363,7 +363,7 @@ void initResourcePartitionerHandler(pika::resource::partitioner& rp,
 
   // Create a thread pool with a single core that we will use for all
   // communication related tasks
-  rp.create_thread_pool("mpi", pika::resource::scheduling_policy::local_priority_fifo, mode);
+  rp.create_thread_pool("mpi", pika::resource::scheduling_policy::static_priority, mode);
   rp.add_resource(rp.numa_domains()[0].cores()[0].pus()[0], "mpi");
 }
 }


### PR DESCRIPTION
Changes the priority for MPI tasks to `thread_priority::boost`, to give higher priority to the submission of MPI communication, but then fall back to normal priority for polling. Also changes to the `static_priority` scheduler for the MPI pool since it only has a single thread. I haven't benchmarked this in isolation and doubt that it makes much of a difference, but it's a bit more appropriate than the default `local_priority_fifo` since no work stealing needs to happen.