### PR TITLE
Make C API functions `noexcept`

### DIFF
--- a/include/dlaf_c/eigensolver/eigensolver.h
+++ b/include/dlaf_c/eigensolver/eigensolver.h
@@ -33,24 +33,26 @@
 /// @param z Local part of the global matrix \f$\mathbf{Z}\f$
 /// @param dlaf_descz DLA-Future descriptor of the global matrix \f$\mathbf{Z}\f$
 /// @return 0 if the eigensolver completed normally
-DLAF_EXTERN_C int dlaf_symmetric_eigensolver_s(
-    const int dlaf_context, const char uplo, float* a, const struct DLAF_descriptor dlaf_desca, float* w,
-    float* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_symmetric_eigensolver_s(const int dlaf_context, const char uplo, float* a,
+                                               const struct DLAF_descriptor dlaf_desca, float* w,
+                                               float* z,
+                                               const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_symmetric_eigensolver_s
-DLAF_EXTERN_C int dlaf_symmetric_eigensolver_d(
-    const int dlaf_context, const char uplo, double* a, const struct DLAF_descriptor dlaf_desca,
-    double* w, double* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_symmetric_eigensolver_d(const int dlaf_context, const char uplo, double* a,
+                                               const struct DLAF_descriptor dlaf_desca, double* w,
+                                               double* z,
+                                               const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_symmetric_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_eigensolver_c(
     const int dlaf_context, const char uplo, dlaf_complex_c* a, const struct DLAF_descriptor dlaf_desca,
-    float* w, dlaf_complex_c* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+    float* w, dlaf_complex_c* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_symmetric_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_eigensolver_z(
     const int dlaf_context, const char uplo, dlaf_complex_z* a, const struct DLAF_descriptor dlaf_desca,
-    double* w, dlaf_complex_z* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+    double* w, dlaf_complex_z* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -87,23 +89,21 @@ DLAF_EXTERN_C int dlaf_hermitian_eigensolver_z(
 /// @param[out] info 0 if the eigensolver completed normally
 DLAF_EXTERN_C void dlaf_pssyevd(const char uplo, const int n, float* a, const int ia, const int ja,
                                 const int desca[9], float* w, float* z, const int iz, const int jz,
-                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int descz[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pssyevd
 DLAF_EXTERN_C void dlaf_pdsyevd(const char uplo, const int n, double* a, const int ia, const int ja,
                                 const int desca[9], double* w, double* z, const int iz, const int jz,
-                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int descz[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pssyevd
 DLAF_EXTERN_C void dlaf_pcheevd(const char uplo, const int n, dlaf_complex_c* a, const int ia,
                                 const int ja, const int desca[9], float* w, dlaf_complex_c* z,
-                                const int iz, const int jz, const int descz[9],
-                                int* info) DLAF_NOEXCEPT_CPP;
+                                const int iz, const int jz, const int descz[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pssyevd
 DLAF_EXTERN_C void dlaf_pzheevd(const char uplo, const int n, dlaf_complex_z* a, const int ia,
                                 const int ja, const int desca[9], double* w, dlaf_complex_z* z,
-                                const int iz, const int jz, const int descz[9],
-                                int* info) DLAF_NOEXCEPT_CPP;
+                                const int iz, const int jz, const int descz[9], int* info) DLAF_NOEXCEPT;
 
 #endif

--- a/include/dlaf_c/eigensolver/eigensolver.h
+++ b/include/dlaf_c/eigensolver/eigensolver.h
@@ -33,24 +33,24 @@
 /// @param z Local part of the global matrix \f$\mathbf{Z}\f$
 /// @param dlaf_descz DLA-Future descriptor of the global matrix \f$\mathbf{Z}\f$
 /// @return 0 if the eigensolver completed normally
-DLAF_EXTERN_C int dlaf_symmetric_eigensolver_s(const int dlaf_context, const char uplo, float* a,
-                                               const struct DLAF_descriptor dlaf_desca, float* w,
-                                               float* z, const struct DLAF_descriptor dlaf_descz);
+DLAF_EXTERN_C int dlaf_symmetric_eigensolver_s(
+    const int dlaf_context, const char uplo, float* a, const struct DLAF_descriptor dlaf_desca, float* w,
+    float* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_symmetric_eigensolver_s
-DLAF_EXTERN_C int dlaf_symmetric_eigensolver_d(const int dlaf_context, const char uplo, double* a,
-                                               const struct DLAF_descriptor dlaf_desca, double* w,
-                                               double* z, const struct DLAF_descriptor dlaf_descz);
+DLAF_EXTERN_C int dlaf_symmetric_eigensolver_d(
+    const int dlaf_context, const char uplo, double* a, const struct DLAF_descriptor dlaf_desca,
+    double* w, double* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_symmetric_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_eigensolver_c(
     const int dlaf_context, const char uplo, dlaf_complex_c* a, const struct DLAF_descriptor dlaf_desca,
-    float* w, dlaf_complex_c* z, const struct DLAF_descriptor dlaf_descz);
+    float* w, dlaf_complex_c* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_symmetric_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_eigensolver_z(
     const int dlaf_context, const char uplo, dlaf_complex_z* a, const struct DLAF_descriptor dlaf_desca,
-    double* w, dlaf_complex_z* z, const struct DLAF_descriptor dlaf_descz);
+    double* w, dlaf_complex_z* z, const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -87,21 +87,23 @@ DLAF_EXTERN_C int dlaf_hermitian_eigensolver_z(
 /// @param[out] info 0 if the eigensolver completed normally
 DLAF_EXTERN_C void dlaf_pssyevd(const char uplo, const int n, float* a, const int ia, const int ja,
                                 const int desca[9], float* w, float* z, const int iz, const int jz,
-                                const int descz[9], int* info);
+                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pssyevd
 DLAF_EXTERN_C void dlaf_pdsyevd(const char uplo, const int n, double* a, const int ia, const int ja,
                                 const int desca[9], double* w, double* z, const int iz, const int jz,
-                                const int descz[9], int* info);
+                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pssyevd
 DLAF_EXTERN_C void dlaf_pcheevd(const char uplo, const int n, dlaf_complex_c* a, const int ia,
                                 const int ja, const int desca[9], float* w, dlaf_complex_c* z,
-                                const int iz, const int jz, const int descz[9], int* info);
+                                const int iz, const int jz, const int descz[9],
+                                int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pssyevd
 DLAF_EXTERN_C void dlaf_pzheevd(const char uplo, const int n, dlaf_complex_z* a, const int ia,
                                 const int ja, const int desca[9], double* w, dlaf_complex_z* z,
-                                const int iz, const int jz, const int descz[9], int* info);
+                                const int iz, const int jz, const int descz[9],
+                                int* info) DLAF_NOEXCEPT_CPP;
 
 #endif

--- a/include/dlaf_c/eigensolver/gen_eigensolver.h
+++ b/include/dlaf_c/eigensolver/gen_eigensolver.h
@@ -38,25 +38,25 @@
 DLAF_EXTERN_C int dlaf_symmetric_generalized_eigensolver_s(
     const int dlaf_context, const char uplo, float* a, const struct DLAF_descriptor dlaf_desca, float* b,
     const struct DLAF_descriptor dlaf_descb, float* w, float* z,
-    const struct DLAF_descriptor dlaf_descz);
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_symmetric_generalized_eigensolver_s
 DLAF_EXTERN_C int dlaf_symmetric_generalized_eigensolver_d(
     const int dlaf_context, const char uplo, double* a, const struct DLAF_descriptor dlaf_desca,
     double* b, const struct DLAF_descriptor dlaf_descb, double* w, double* z,
-    const struct DLAF_descriptor dlaf_descz);
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_symmetric_generalized_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_c(
     const int dlaf_context, const char uplo, dlaf_complex_c* a, const struct DLAF_descriptor dlaf_desca,
     dlaf_complex_c* b, const struct DLAF_descriptor dlaf_descb, float* w, dlaf_complex_c* z,
-    const struct DLAF_descriptor dlaf_descz);
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_symmetric_generalized_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_z(
     const int dlaf_context, const char uplo, dlaf_complex_z* a, const struct DLAF_descriptor dlaf_desca,
     dlaf_complex_z* b, const struct DLAF_descriptor dlaf_descb, double* w, dlaf_complex_z* z,
-    const struct DLAF_descriptor dlaf_descz);
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -101,24 +101,26 @@ DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_z(
 DLAF_EXTERN_C void dlaf_pssygvx(const char uplo, const int n, float* a, const int ia, const int ja,
                                 const int desca[9], float* b, const int ib, const int jb,
                                 const int descb[9], float* w, float* z, const int iz, const int jz,
-                                const int descz[9], int* info);
+                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pssygvx
 DLAF_EXTERN_C void dlaf_pdsygvx(const char uplo, const int n, double* a, const int ia, const int ja,
                                 const int desca[9], double* b, const int ib, const int jb,
                                 const int descb[9], double* w, double* z, const int iz, const int jz,
-                                const int descz[9], int* info);
+                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pssygvx
 DLAF_EXTERN_C void dlaf_pchegvx(const char uplo, const int n, dlaf_complex_c* a, const int ia,
                                 const int ja, const int desca[9], dlaf_complex_c* b, const int ib,
                                 const int jb, const int descb[9], float* w, dlaf_complex_c* z,
-                                const int iz, const int jz, const int descz[9], int* info);
+                                const int iz, const int jz, const int descz[9],
+                                int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pssygvx
 DLAF_EXTERN_C void dlaf_pzhegvx(const char uplo, const int n, dlaf_complex_z* a, const int ia,
                                 const int ja, const int desca[9], dlaf_complex_z* b, const int ib,
                                 const int jb, const int descb[9], double* w, dlaf_complex_z* z,
-                                const int iz, const int jz, const int descz[9], int* info);
+                                const int iz, const int jz, const int descz[9],
+                                int* info) DLAF_NOEXCEPT_CPP;
 
 #endif

--- a/include/dlaf_c/eigensolver/gen_eigensolver.h
+++ b/include/dlaf_c/eigensolver/gen_eigensolver.h
@@ -38,25 +38,25 @@
 DLAF_EXTERN_C int dlaf_symmetric_generalized_eigensolver_s(
     const int dlaf_context, const char uplo, float* a, const struct DLAF_descriptor dlaf_desca, float* b,
     const struct DLAF_descriptor dlaf_descb, float* w, float* z,
-    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_symmetric_generalized_eigensolver_s
 DLAF_EXTERN_C int dlaf_symmetric_generalized_eigensolver_d(
     const int dlaf_context, const char uplo, double* a, const struct DLAF_descriptor dlaf_desca,
     double* b, const struct DLAF_descriptor dlaf_descb, double* w, double* z,
-    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_symmetric_generalized_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_c(
     const int dlaf_context, const char uplo, dlaf_complex_c* a, const struct DLAF_descriptor dlaf_desca,
     dlaf_complex_c* b, const struct DLAF_descriptor dlaf_descb, float* w, dlaf_complex_c* z,
-    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_symmetric_generalized_eigensolver_s
 DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_z(
     const int dlaf_context, const char uplo, dlaf_complex_z* a, const struct DLAF_descriptor dlaf_desca,
     dlaf_complex_z* b, const struct DLAF_descriptor dlaf_descb, double* w, dlaf_complex_z* z,
-    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT_CPP;
+    const struct DLAF_descriptor dlaf_descz) DLAF_NOEXCEPT;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -101,26 +101,24 @@ DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_z(
 DLAF_EXTERN_C void dlaf_pssygvx(const char uplo, const int n, float* a, const int ia, const int ja,
                                 const int desca[9], float* b, const int ib, const int jb,
                                 const int descb[9], float* w, float* z, const int iz, const int jz,
-                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int descz[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pssygvx
 DLAF_EXTERN_C void dlaf_pdsygvx(const char uplo, const int n, double* a, const int ia, const int ja,
                                 const int desca[9], double* b, const int ib, const int jb,
                                 const int descb[9], double* w, double* z, const int iz, const int jz,
-                                const int descz[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int descz[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pssygvx
 DLAF_EXTERN_C void dlaf_pchegvx(const char uplo, const int n, dlaf_complex_c* a, const int ia,
                                 const int ja, const int desca[9], dlaf_complex_c* b, const int ib,
                                 const int jb, const int descb[9], float* w, dlaf_complex_c* z,
-                                const int iz, const int jz, const int descz[9],
-                                int* info) DLAF_NOEXCEPT_CPP;
+                                const int iz, const int jz, const int descz[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pssygvx
 DLAF_EXTERN_C void dlaf_pzhegvx(const char uplo, const int n, dlaf_complex_z* a, const int ia,
                                 const int ja, const int desca[9], dlaf_complex_z* b, const int ib,
                                 const int jb, const int descb[9], double* w, dlaf_complex_z* z,
-                                const int iz, const int jz, const int descz[9],
-                                int* info) DLAF_NOEXCEPT_CPP;
+                                const int iz, const int jz, const int descz[9], int* info) DLAF_NOEXCEPT;
 
 #endif

--- a/include/dlaf_c/factorization/cholesky.h
+++ b/include/dlaf_c/factorization/cholesky.h
@@ -29,24 +29,22 @@
 /// @param a Local part of the global matrix \f$\mathbf{A}\f$
 /// @param dlaf_desca DLA-Future descriptor of the global matrix \f$\mathbf{A}\f$
 /// @return 0 if the factorization completed normally
-DLAF_EXTERN_C int dlaf_cholesky_factorization_s(
-    const int dlaf_context, const char uplo, float* a,
-    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_cholesky_factorization_s(const int dlaf_context, const char uplo, float* a,
+                                                const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_cholesky_factorization_s
-DLAF_EXTERN_C int dlaf_cholesky_factorization_d(
-    const int dlaf_context, const char uplo, double* a,
-    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_cholesky_factorization_d(const int dlaf_context, const char uplo, double* a,
+                                                const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_cholesky_factorization_s
-DLAF_EXTERN_C int dlaf_cholesky_factorization_c(
-    const int dlaf_context, const char uplo, dlaf_complex_c* a,
-    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_cholesky_factorization_c(const int dlaf_context, const char uplo,
+                                                dlaf_complex_c* a,
+                                                const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_cholesky_factorization_s
-DLAF_EXTERN_C int dlaf_cholesky_factorization_z(
-    const int dlaf_context, const char uplo, dlaf_complex_z* a,
-    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_cholesky_factorization_z(const int dlaf_context, const char uplo,
+                                                dlaf_complex_z* a,
+                                                const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -74,18 +72,18 @@ DLAF_EXTERN_C int dlaf_cholesky_factorization_z(
 /// @param desca ScaLAPACK array descriptor of the global matrix \f$\mathbf{A}\f$
 /// @param[out] info 0 if the factorization completed normally
 DLAF_EXTERN_C void dlaf_pspotrf(const char uplo, const int n, float* a, const int ia, const int ja,
-                                const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int desca[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pspotrf
 DLAF_EXTERN_C void dlaf_pdpotrf(const char uplo, const int n, double* a, const int ia, const int ja,
-                                const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int desca[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pspotrf
 DLAF_EXTERN_C void dlaf_pcpotrf(const char uplo, const int n, dlaf_complex_c* a, const int ia,
-                                const int ja, const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int ja, const int desca[9], int* info) DLAF_NOEXCEPT;
 
 /// @copydoc dlaf_pspotrf
 DLAF_EXTERN_C void dlaf_pzpotrf(const char uplo, const int n, dlaf_complex_z* a, const int ia,
-                                const int ja, const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
+                                const int ja, const int desca[9], int* info) DLAF_NOEXCEPT;
 
 #endif

--- a/include/dlaf_c/factorization/cholesky.h
+++ b/include/dlaf_c/factorization/cholesky.h
@@ -29,22 +29,24 @@
 /// @param a Local part of the global matrix \f$\mathbf{A}\f$
 /// @param dlaf_desca DLA-Future descriptor of the global matrix \f$\mathbf{A}\f$
 /// @return 0 if the factorization completed normally
-DLAF_EXTERN_C int dlaf_cholesky_factorization_s(const int dlaf_context, const char uplo, float* a,
-                                                const struct DLAF_descriptor dlaf_desca);
+DLAF_EXTERN_C int dlaf_cholesky_factorization_s(
+    const int dlaf_context, const char uplo, float* a,
+    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_cholesky_factorization_s
-DLAF_EXTERN_C int dlaf_cholesky_factorization_d(const int dlaf_context, const char uplo, double* a,
-                                                const struct DLAF_descriptor dlaf_desca);
+DLAF_EXTERN_C int dlaf_cholesky_factorization_d(
+    const int dlaf_context, const char uplo, double* a,
+    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_cholesky_factorization_s
-DLAF_EXTERN_C int dlaf_cholesky_factorization_c(const int dlaf_context, const char uplo,
-                                                dlaf_complex_c* a,
-                                                const struct DLAF_descriptor dlaf_desca);
+DLAF_EXTERN_C int dlaf_cholesky_factorization_c(
+    const int dlaf_context, const char uplo, dlaf_complex_c* a,
+    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_cholesky_factorization_s
-DLAF_EXTERN_C int dlaf_cholesky_factorization_z(const int dlaf_context, const char uplo,
-                                                dlaf_complex_z* a,
-                                                const struct DLAF_descriptor dlaf_desca);
+DLAF_EXTERN_C int dlaf_cholesky_factorization_z(
+    const int dlaf_context, const char uplo, dlaf_complex_z* a,
+    const struct DLAF_descriptor dlaf_desca) DLAF_NOEXCEPT_CPP;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -72,18 +74,18 @@ DLAF_EXTERN_C int dlaf_cholesky_factorization_z(const int dlaf_context, const ch
 /// @param desca ScaLAPACK array descriptor of the global matrix \f$\mathbf{A}\f$
 /// @param[out] info 0 if the factorization completed normally
 DLAF_EXTERN_C void dlaf_pspotrf(const char uplo, const int n, float* a, const int ia, const int ja,
-                                const int desca[9], int* info);
+                                const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pspotrf
 DLAF_EXTERN_C void dlaf_pdpotrf(const char uplo, const int n, double* a, const int ia, const int ja,
-                                const int desca[9], int* info);
+                                const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pspotrf
 DLAF_EXTERN_C void dlaf_pcpotrf(const char uplo, const int n, dlaf_complex_c* a, const int ia,
-                                const int ja, const int desca[9], int* info);
+                                const int ja, const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
 
 /// @copydoc dlaf_pspotrf
 DLAF_EXTERN_C void dlaf_pzpotrf(const char uplo, const int n, dlaf_complex_z* a, const int ia,
-                                const int ja, const int desca[9], int* info);
+                                const int ja, const int desca[9], int* info) DLAF_NOEXCEPT_CPP;
 
 #endif

--- a/include/dlaf_c/grid.h
+++ b/include/dlaf_c/grid.h
@@ -28,7 +28,7 @@
 /// @param npcol Number of process columns in the communicator grid
 /// @param order Grid ordering
 /// @return DLA-Future context
-DLAF_EXTERN_C int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order) DLAF_NOEXCEPT;
 
 /// Free communicator grid for the given context
 ///
@@ -36,7 +36,7 @@ DLAF_EXTERN_C int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char ord
 /// created a BLACS grid with blacs_gridinit you still need to call blacs_gridexit
 ///
 /// @param context BLACS or DLA-Future context associated to the grid being released
-DLAF_EXTERN_C void dlaf_free_grid(int context) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C void dlaf_free_grid(int context) DLAF_NOEXCEPT;
 
 /// Determine grid ordering
 ///
@@ -52,7 +52,7 @@ DLAF_EXTERN_C void dlaf_free_grid(int context) DLAF_NOEXCEPT_CPP;
 /// @param mypcol Process column of the calling process
 /// @return Grid order ("R" for row-major, "C" cor column-major)
 DLAF_EXTERN_C char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow,
-                                 int mypcol) DLAF_NOEXCEPT_CPP;
+                                 int mypcol) DLAF_NOEXCEPT;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -68,6 +68,6 @@ DLAF_EXTERN_C char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow
 /// blacs_gridinit). Grids created with blacs_gridmap are not supported.
 ///
 /// @param blacs_ctxt BLACS context
-DLAF_EXTERN_C void dlaf_create_grid_from_blacs(int blacs_ctxt) DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C void dlaf_create_grid_from_blacs(int blacs_ctxt) DLAF_NOEXCEPT;
 
 #endif

--- a/include/dlaf_c/grid.h
+++ b/include/dlaf_c/grid.h
@@ -28,7 +28,7 @@
 /// @param npcol Number of process columns in the communicator grid
 /// @param order Grid ordering
 /// @return DLA-Future context
-DLAF_EXTERN_C int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order);
+DLAF_EXTERN_C int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order) DLAF_NOEXCEPT_CPP;
 
 /// Free communicator grid for the given context
 ///
@@ -36,7 +36,7 @@ DLAF_EXTERN_C int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char ord
 /// created a BLACS grid with blacs_gridinit you still need to call blacs_gridexit
 ///
 /// @param context BLACS or DLA-Future context associated to the grid being released
-DLAF_EXTERN_C void dlaf_free_grid(int context);
+DLAF_EXTERN_C void dlaf_free_grid(int context) DLAF_NOEXCEPT_CPP;
 
 /// Determine grid ordering
 ///
@@ -51,7 +51,8 @@ DLAF_EXTERN_C void dlaf_free_grid(int context);
 /// @param myprow Process row of the calling process
 /// @param mypcol Process column of the calling process
 /// @return Grid order ("R" for row-major, "C" cor column-major)
-DLAF_EXTERN_C char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow, int mypcol);
+DLAF_EXTERN_C char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow,
+                                 int mypcol) DLAF_NOEXCEPT_CPP;
 
 #ifdef DLAF_WITH_SCALAPACK
 
@@ -67,6 +68,6 @@ DLAF_EXTERN_C char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow
 /// blacs_gridinit). Grids created with blacs_gridmap are not supported.
 ///
 /// @param blacs_ctxt BLACS context
-DLAF_EXTERN_C void dlaf_create_grid_from_blacs(int blacs_ctxt);
+DLAF_EXTERN_C void dlaf_create_grid_from_blacs(int blacs_ctxt) DLAF_NOEXCEPT_CPP;
 
 #endif

--- a/include/dlaf_c/init.h
+++ b/include/dlaf_c/init.h
@@ -25,11 +25,11 @@
 /// @param argc_dlaf Number of arguments for DLA-Future
 /// @param argv_dlaf Arguments for DLA-Future
 DLAF_EXTERN_C void dlaf_initialize(int argc_pika, const char** argv_pika, int argc_dlaf,
-                                   const char** argv_dlaf) DLAF_NOEXCEPT_CPP;
+                                   const char** argv_dlaf) DLAF_NOEXCEPT;
 
 /// Finalize DLA-Future and pika runtime
 ///
 /// @post The pika runtime is finalized and stopped when this function returns
 ///
 /// @remark If DLA-Future has already been finalized, this function does nothing
-DLAF_EXTERN_C void dlaf_finalize() DLAF_NOEXCEPT_CPP;
+DLAF_EXTERN_C void dlaf_finalize() DLAF_NOEXCEPT;

--- a/include/dlaf_c/init.h
+++ b/include/dlaf_c/init.h
@@ -25,11 +25,11 @@
 /// @param argc_dlaf Number of arguments for DLA-Future
 /// @param argv_dlaf Arguments for DLA-Future
 DLAF_EXTERN_C void dlaf_initialize(int argc_pika, const char** argv_pika, int argc_dlaf,
-                                   const char** argv_dlaf);
+                                   const char** argv_dlaf) DLAF_NOEXCEPT_CPP;
 
 /// Finalize DLA-Future and pika runtime
 ///
 /// @post The pika runtime is finalized and stopped when this function returns
 ///
 /// @remark If DLA-Future has already been finalized, this function does nothing
-DLAF_EXTERN_C void dlaf_finalize();
+DLAF_EXTERN_C void dlaf_finalize() DLAF_NOEXCEPT_CPP;

--- a/include/dlaf_c/utils.h
+++ b/include/dlaf_c/utils.h
@@ -13,9 +13,11 @@
 /// @file
 
 #ifdef __cplusplus
-#define DLAF_EXTERN_C extern "C"
+#define DLAF_EXTERN_C     extern "C"
+#define DLAF_NOEXCEPT_CPP noexcept
 #else
 #define DLAF_EXTERN_C
+#define DLAF_NOEXCEPT_CPP
 #endif
 
 #ifdef __cplusplus
@@ -39,4 +41,5 @@ typedef double complex dlaf_complex_z;  ///< Double precision complex number
 /// @param desc ScaLAPACK descriptor
 /// @return DLA-Future descriptor
 DLAF_EXTERN_C struct DLAF_descriptor make_dlaf_descriptor(const int m, const int n, const int i,
-                                                          const int j, const int desc[9]);
+                                                          const int j,
+                                                          const int desc[9]) DLAF_NOEXCEPT_CPP;

--- a/include/dlaf_c/utils.h
+++ b/include/dlaf_c/utils.h
@@ -13,11 +13,11 @@
 /// @file
 
 #ifdef __cplusplus
-#define DLAF_EXTERN_C     extern "C"
-#define DLAF_NOEXCEPT_CPP noexcept
+#define DLAF_EXTERN_C extern "C"
+#define DLAF_NOEXCEPT noexcept
 #else
 #define DLAF_EXTERN_C
-#define DLAF_NOEXCEPT_CPP
+#define DLAF_NOEXCEPT
 #endif
 
 #ifdef __cplusplus
@@ -41,5 +41,4 @@ typedef double complex dlaf_complex_z;  ///< Double precision complex number
 /// @param desc ScaLAPACK descriptor
 /// @return DLA-Future descriptor
 DLAF_EXTERN_C struct DLAF_descriptor make_dlaf_descriptor(const int m, const int n, const int i,
-                                                          const int j,
-                                                          const int desc[9]) DLAF_NOEXCEPT_CPP;
+                                                          const int j, const int desc[9]) DLAF_NOEXCEPT;

--- a/src/c_api/eigensolver/eigensolver.cpp
+++ b/src/c_api/eigensolver/eigensolver.cpp
@@ -18,25 +18,25 @@
 
 int dlaf_symmetric_eigensolver_s(const int dlaf_context, const char uplo, float* a,
                                  const struct DLAF_descriptor dlaf_desca, float* w, float* z,
-                                 const struct DLAF_descriptor dlaf_descz) {
+                                 const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_eigensolver<float>(dlaf_context, uplo, a, dlaf_desca, w, z, dlaf_descz);
 }
 
 int dlaf_symmetric_eigensolver_d(const int dlaf_context, const char uplo, double* a,
                                  const struct DLAF_descriptor dlaf_desca, double* w, double* z,
-                                 const struct DLAF_descriptor dlaf_descz) {
+                                 const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_eigensolver<double>(dlaf_context, uplo, a, dlaf_desca, w, z, dlaf_descz);
 }
 
 int dlaf_hermitian_eigensolver_c(const int dlaf_context, const char uplo, dlaf_complex_c* a,
                                  const struct DLAF_descriptor dlaf_desca, float* w, dlaf_complex_c* z,
-                                 const struct DLAF_descriptor dlaf_descz) {
+                                 const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_eigensolver<std::complex<float>>(dlaf_context, uplo, a, dlaf_desca, w, z, dlaf_descz);
 }
 
 int dlaf_hermitian_eigensolver_z(const int dlaf_context, const char uplo, dlaf_complex_z* a,
                                  const struct DLAF_descriptor dlaf_desca, double* w, dlaf_complex_z* z,
-                                 const struct DLAF_descriptor dlaf_descz) {
+                                 const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_eigensolver<std::complex<double>>(dlaf_context, uplo, a, dlaf_desca, w, z,
                                                      dlaf_descz);
 }
@@ -44,25 +44,26 @@ int dlaf_hermitian_eigensolver_z(const int dlaf_context, const char uplo, dlaf_c
 #ifdef DLAF_WITH_SCALAPACK
 
 void dlaf_pssyevd(const char uplo, const int m, float* a, const int ia, const int ja, const int desca[9],
-                  float* w, float* z, const int iz, const int jz, const int descz[9], int* info) {
+                  float* w, float* z, const int iz, const int jz, const int descz[9],
+                  int* info) noexcept {
   pxheevd<float>(uplo, m, a, ia, ja, desca, w, z, iz, jz, descz, *info);
 }
 
 void dlaf_pdsyevd(const char uplo, const int m, double* a, const int ia, const int ja,
                   const int desca[9], double* w, double* z, const int iz, const int jz,
-                  const int descz[9], int* info) {
+                  const int descz[9], int* info) noexcept {
   pxheevd<double>(uplo, m, a, ia, ja, desca, w, z, iz, jz, descz, *info);
 }
 
 void dlaf_pcheevd(const char uplo, const int m, dlaf_complex_c* a, const int ia, const int ja,
                   const int desca[9], float* w, dlaf_complex_c* z, const int iz, const int jz,
-                  const int descz[9], int* info) {
+                  const int descz[9], int* info) noexcept {
   pxheevd<std::complex<float>>(uplo, m, a, ia, ja, desca, w, z, iz, jz, descz, *info);
 }
 
 void dlaf_pzheevd(const char uplo, const int m, dlaf_complex_z* a, const int ia, const int ja,
                   const int desca[9], double* w, dlaf_complex_z* z, const int iz, const int jz,
-                  const int descz[9], int* info) {
+                  const int descz[9], int* info) noexcept {
   pxheevd<std::complex<double>>(uplo, m, a, ia, ja, desca, w, z, iz, jz, descz, *info);
 }
 

--- a/src/c_api/eigensolver/eigensolver.cpp
+++ b/src/c_api/eigensolver/eigensolver.cpp
@@ -8,13 +8,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "eigensolver.h"
-
 #include <complex>
 
 #include <dlaf_c/eigensolver/eigensolver.h>
 #include <dlaf_c/init.h>
 #include <dlaf_c/utils.h>
+
+#include "eigensolver.h"
 
 int dlaf_symmetric_eigensolver_s(const int dlaf_context, const char uplo, float* a,
                                  const struct DLAF_descriptor dlaf_desca, float* w, float* z,

--- a/src/c_api/eigensolver/gen_eigensolver.cpp
+++ b/src/c_api/eigensolver/gen_eigensolver.cpp
@@ -21,7 +21,7 @@
 int dlaf_symmetric_generalized_eigensolver_s(const int dlaf_context, const char uplo, float* a,
                                              const struct DLAF_descriptor dlaf_desca, float* b,
                                              const struct DLAF_descriptor dlaf_descb, float* w, float* z,
-                                             const struct DLAF_descriptor dlaf_descz) {
+                                             const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_generalized_eigensolver<float>(dlaf_context, uplo, a, dlaf_desca, b, dlaf_descb, w, z,
                                                   dlaf_descz);
 }
@@ -29,7 +29,8 @@ int dlaf_symmetric_generalized_eigensolver_s(const int dlaf_context, const char 
 int dlaf_symmetric_generalized_eigensolver_d(const int dlaf_context, const char uplo, double* a,
                                              const struct DLAF_descriptor dlaf_desca, double* b,
                                              const struct DLAF_descriptor dlaf_descb, double* w,
-                                             double* z, const struct DLAF_descriptor dlaf_descz) {
+                                             double* z,
+                                             const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_generalized_eigensolver<double>(dlaf_context, uplo, a, dlaf_desca, b, dlaf_descb, w,
                                                    z, dlaf_descz);
 }
@@ -38,7 +39,7 @@ int dlaf_hermitian_generalized_eigensolver_c(const int dlaf_context, const char 
                                              const struct DLAF_descriptor dlaf_desca, dlaf_complex_c* b,
                                              const struct DLAF_descriptor dlaf_descb, float* w,
                                              dlaf_complex_c* z,
-                                             const struct DLAF_descriptor dlaf_descz) {
+                                             const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_generalized_eigensolver<std::complex<float>>(dlaf_context, uplo, a, dlaf_desca, b,
                                                                 dlaf_descb, w, z, dlaf_descz);
 }
@@ -47,7 +48,7 @@ int dlaf_hermitian_generalized_eigensolver_z(const int dlaf_context, const char 
                                              const struct DLAF_descriptor dlaf_desca, dlaf_complex_z* b,
                                              const struct DLAF_descriptor dlaf_descb, double* w,
                                              dlaf_complex_z* z,
-                                             const struct DLAF_descriptor dlaf_descz) {
+                                             const struct DLAF_descriptor dlaf_descz) noexcept {
   return hermitian_generalized_eigensolver<std::complex<double>>(dlaf_context, uplo, a, dlaf_desca, b,
                                                                  dlaf_descb, w, z, dlaf_descz);
 }
@@ -56,27 +57,28 @@ int dlaf_hermitian_generalized_eigensolver_z(const int dlaf_context, const char 
 
 void dlaf_pssygvx(const char uplo, const int m, float* a, const int ia, const int ja, const int desca[9],
                   float* b, const int ib, const int jb, const int descb[9], float* w, float* z,
-                  const int iz, const int jz, const int descz[9], int* info) {
+                  const int iz, const int jz, const int descz[9], int* info) noexcept {
   pxhegvx<float>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
 void dlaf_pdsygvx(const char uplo, const int m, double* a, const int ia, const int ja,
                   const int desca[9], double* b, const int ib, const int jb, const int descb[9],
-                  double* w, double* z, const int iz, const int jz, const int descz[9], int* info) {
+                  double* w, double* z, const int iz, const int jz, const int descz[9],
+                  int* info) noexcept {
   pxhegvx<double>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
 void dlaf_pchegvx(const char uplo, const int m, dlaf_complex_c* a, const int ia, const int ja,
                   const int desca[9], dlaf_complex_c* b, const int ib, const int jb, const int descb[9],
                   float* w, dlaf_complex_c* z, const int iz, const int jz, const int descz[9],
-                  int* info) {
+                  int* info) noexcept {
   pxhegvx<std::complex<float>>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
 void dlaf_pzhegvx(const char uplo, const int m, dlaf_complex_z* a, const int ia, const int ja,
                   const int desca[9], dlaf_complex_z* b, const int ib, const int jb, const int descb[9],
                   double* w, dlaf_complex_z* z, const int iz, const int jz, const int descz[9],
-                  int* info) {
+                  int* info) noexcept {
   pxhegvx<std::complex<double>>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 

--- a/src/c_api/eigensolver/gen_eigensolver.cpp
+++ b/src/c_api/eigensolver/gen_eigensolver.cpp
@@ -8,8 +8,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "gen_eigensolver.h"
-
 #include <complex>
 
 #include <dlaf_c/eigensolver/gen_eigensolver.h>
@@ -17,6 +15,7 @@
 #include <dlaf_c/utils.h>
 
 #include "dlaf_c/desc.h"
+#include "gen_eigensolver.h"
 
 int dlaf_symmetric_generalized_eigensolver_s(const int dlaf_context, const char uplo, float* a,
                                              const struct DLAF_descriptor dlaf_desca, float* b,

--- a/src/c_api/factorization/cholesky.cpp
+++ b/src/c_api/factorization/cholesky.cpp
@@ -8,10 +8,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "cholesky.h"
-
 #include <dlaf_c/factorization/cholesky.h>
 #include <dlaf_c/utils.h>
+
+#include "cholesky.h"
 
 int dlaf_cholesky_factorization_s(const int dlaf_context, const char uplo, float* a,
                                   const DLAF_descriptor dlaf_desca) noexcept {

--- a/src/c_api/factorization/cholesky.cpp
+++ b/src/c_api/factorization/cholesky.cpp
@@ -14,44 +14,44 @@
 #include <dlaf_c/utils.h>
 
 int dlaf_cholesky_factorization_s(const int dlaf_context, const char uplo, float* a,
-                                  const DLAF_descriptor dlaf_desca) {
+                                  const DLAF_descriptor dlaf_desca) noexcept {
   return cholesky_factorization<float>(dlaf_context, uplo, a, dlaf_desca);
 }
 
 int dlaf_cholesky_factorization_d(const int dlaf_context, const char uplo, double* a,
-                                  const DLAF_descriptor dlaf_desca) {
+                                  const DLAF_descriptor dlaf_desca) noexcept {
   return cholesky_factorization<double>(dlaf_context, uplo, a, dlaf_desca);
 }
 
 int dlaf_cholesky_factorization_c(const int dlaf_context, const char uplo, dlaf_complex_c* a,
-                                  const DLAF_descriptor dlaf_desca) {
+                                  const DLAF_descriptor dlaf_desca) noexcept {
   return cholesky_factorization<std::complex<float>>(dlaf_context, uplo, a, dlaf_desca);
 }
 
 int dlaf_cholesky_factorization_z(const int dlaf_context, const char uplo, dlaf_complex_z* a,
-                                  const DLAF_descriptor dlaf_desca) {
+                                  const DLAF_descriptor dlaf_desca) noexcept {
   return cholesky_factorization<std::complex<double>>(dlaf_context, uplo, a, dlaf_desca);
 }
 
 #ifdef DLAF_WITH_SCALAPACK
 
 void dlaf_pspotrf(const char uplo, const int n, float* a, const int ia, const int ja, const int desca[9],
-                  int* info) {
+                  int* info) noexcept {
   pxpotrf<float>(uplo, n, a, ia, ja, desca, *info);
 }
 
 void dlaf_pdpotrf(const char uplo, const int n, double* a, const int ia, const int ja,
-                  const int desca[9], int* info) {
+                  const int desca[9], int* info) noexcept {
   pxpotrf<double>(uplo, n, a, ia, ja, desca, *info);
 }
 
 void dlaf_pcpotrf(const char uplo, const int n, dlaf_complex_c* a, const int ia, const int ja,
-                  const int desca[9], int* info) {
+                  const int desca[9], int* info) noexcept {
   pxpotrf<std::complex<float>>(uplo, n, a, ia, ja, desca, *info);
 }
 
 void dlaf_pzpotrf(const char uplo, const int n, dlaf_complex_z* a, const int ia, const int ja,
-                  const int desca[9], int* info) {
+                  const int desca[9], int* info) noexcept {
   pxpotrf<std::complex<double>>(uplo, n, a, ia, ja, desca, *info);
 }
 

--- a/src/c_api/grid.cpp
+++ b/src/c_api/grid.cpp
@@ -24,7 +24,7 @@
 
 std::unordered_map<int, dlaf::comm::CommunicatorGrid> dlaf_grids;
 
-int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order) {
+int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order) noexcept {
   // dlaf_context starts from INT_MAX to reduce the likelihood of clashes with blacs contexts
   // blacs starts to number contexts from 0
   int dlaf_context = std::numeric_limits<int>::max() - static_cast<int>(std::size(dlaf_grids));
@@ -38,11 +38,11 @@ int dlaf_create_grid(MPI_Comm comm, int nprow, int npcol, char order) {
   return dlaf_context;
 }
 
-void dlaf_free_grid(int ctxt) {
+void dlaf_free_grid(int ctxt) noexcept {
   dlaf_grids.erase(ctxt);
 }
 
-char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow, int mypcol) {
+char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow, int mypcol) noexcept {
   int rank;
   MPI_Comm_rank(comm, &rank);
 
@@ -69,7 +69,7 @@ char grid_ordering(MPI_Comm comm, int nprow, int npcol, int myprow, int mypcol) 
 
 #ifdef DLAF_WITH_SCALAPACK
 
-void dlaf_create_grid_from_blacs(int blacs_ctxt) {
+void dlaf_create_grid_from_blacs(int blacs_ctxt) noexcept {
   int system_ctxt;
   int get_blacs_contxt = 10;  // SGET_BLACSCONTXT == 10
   Cblacs_get(blacs_ctxt, get_blacs_contxt, &system_ctxt);

--- a/src/c_api/grid.cpp
+++ b/src/c_api/grid.cpp
@@ -8,8 +8,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include "grid.h"
-
 #include <limits>
 
 #include <mpi.h>
@@ -20,6 +18,7 @@
 
 #include "blacs.h"
 #include "dlaf/communication/error.h"
+#include "grid.h"
 #include "utils.h"
 
 std::unordered_map<int, dlaf::comm::CommunicatorGrid> dlaf_grids;

--- a/src/c_api/init.cpp
+++ b/src/c_api/init.cpp
@@ -18,7 +18,8 @@
 
 static bool dlaf_initialized = false;
 
-void dlaf_initialize(int argc_pika, const char** argv_pika, int argc_dlaf, const char** argv_dlaf) {
+void dlaf_initialize(int argc_pika, const char** argv_pika, int argc_dlaf,
+                     const char** argv_dlaf) noexcept {
   if (!dlaf_initialized) {
     pika::program_options::options_description desc("");
     desc.add(dlaf::getOptionsDescription());
@@ -43,7 +44,7 @@ void dlaf_initialize(int argc_pika, const char** argv_pika, int argc_dlaf, const
   }
 }
 
-void dlaf_finalize() {
+void dlaf_finalize() noexcept {
   if (dlaf_initialized) {
     pika::resume();
     pika::finalize();

--- a/src/c_api/utils.cpp
+++ b/src/c_api/utils.cpp
@@ -19,7 +19,7 @@
 #include "utils.h"
 
 struct DLAF_descriptor make_dlaf_descriptor(const int m, const int n, const int i, const int j,
-                                            const int desc[9]) {
+                                            const int desc[9]) noexcept {
   DLAF_ASSERT(i == 1, i);
   DLAF_ASSERT(j == 1, j);
 


### PR DESCRIPTION
Adds a macro `DLAF_NOEXCEPT_CPP` (bikeshedding on the name welcome) which expands to `noexcept` in C++ mode and nothing in C mode. I've applied this to the C API function declarations in headers in `dlaf.c_api`. I've made the function definitions unconditionally `noexcept` since they're always built in C++ mode.

I have not touched the test wrappers since they are in `.c` files and built in C mode. I have also not done anything to the blacs declarations since they're just declarations.