### PR TITLE
Improve eigensolver tests

### DIFF
--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -229,6 +229,18 @@ void set(Matrix<T, Device::CPU>& matrix, ElementGetter el_f, const blas::Op op) 
   set(matrix, el_op_f);
 }
 
+/// Set the elements of the matrix.
+///
+/// The diagonal elements are set to 1 and the other elements to 0.
+template <class T>
+void set_identity(Matrix<T, Device::CPU>& matrix) {
+  set(matrix, [](const GlobalElementIndex& ij) {
+    if (ij.row() == ij.col())
+      return T{1};
+    return T{0};
+  });
+}
+
 /// Set the matrix with random values whose absolute values are less than 1.
 ///
 /// Values will be random numbers in:

--- a/test/include/dlaf_test/eigensolver/test_eigensolver_correctness.h
+++ b/test/include/dlaf_test/eigensolver/test_eigensolver_correctness.h
@@ -58,6 +58,11 @@ void testEigensolverCorrectness(const blas::Uplo uplo, Matrix<const T, Device::C
     return allGather(blas::Uplo::General, mat_e.get(), grid...);
   }();
 
+  // eigenvalues are contiguous in the mat_local buffer
+  BaseType<T>* evals_start = mat_evalues_local.ptr({0, 0});
+  BaseType<T>* evals_end = evals_start + m;
+  EXPECT_TRUE(std::is_sorted(evals_start, evals_end));
+
   MatrixLocal<T> workspace({m, m}, reference.blockSize());
 
   dlaf::common::internal::SingleThreadedBlasScope single;

--- a/test/include/dlaf_test/eigensolver/test_gen_eigensolver_correctness.h
+++ b/test/include/dlaf_test/eigensolver/test_gen_eigensolver_correctness.h
@@ -61,6 +61,11 @@ void testGenEigensolverCorrectness(const blas::Uplo uplo, Matrix<const T, Device
     return allGather(blas::Uplo::General, mat_e.get(), grid...);
   }();
 
+  // eigenvalues are contiguous in the mat_local buffer
+  BaseType<T>* evals_start = mat_evalues_local.ptr({0, 0});
+  BaseType<T>* evals_end = evals_start + m;
+  EXPECT_TRUE(std::is_sorted(evals_start, evals_end));
+
   MatrixLocal<T> mat_be_local({m, m}, reference_a.blockSize());
 
   dlaf::common::internal::SingleThreadedBlasScope single;


### PR DESCRIPTION
Eigensolver tests now check that the eigenvalues are sorted. (tridiagonal, full, generalized)

Added an eigensolver test with identity matrix.

(This new test is enough to reproduce one of the CP2K problems with `202310/develop`)