### PR TITLE
Fix scal usage in eigensolver tests

### DIFF
--- a/test/include/dlaf_test/eigensolver/test_eigensolver_correctness.h
+++ b/test/include/dlaf_test/eigensolver/test_eigensolver_correctness.h
@@ -60,9 +60,8 @@ void testEigensolverCorrectness(const blas::Uplo uplo, Matrix<const T, Device::C
   }();
 
   // eigenvalues are contiguous in the mat_local buffer
-  BaseType<T>* evals_start = mat_evalues_local.ptr({0, 0});
-  BaseType<T>* evals_end = evals_start + m;
-  EXPECT_TRUE(std::is_sorted(evals_start, evals_end));
+  const BaseType<T>* evals_start = mat_evalues_local.ptr({0, 0});
+  EXPECT_TRUE(std::is_sorted(evals_start, evals_start + m));
 
   MatrixLocal<T> workspace({m, m}, reference.blockSize());
 

--- a/test/include/dlaf_test/eigensolver/test_eigensolver_correctness.h
+++ b/test/include/dlaf_test/eigensolver/test_eigensolver_correctness.h
@@ -17,6 +17,7 @@
 
 #include <pika/init.hpp>
 
+#include <dlaf/blas/scal.h>
 #include <dlaf/common/single_threaded_blas.h>
 #include <dlaf/communication/communicator_grid.h>
 #include <dlaf/matrix/matrix.h>

--- a/test/include/dlaf_test/eigensolver/test_gen_eigensolver_correctness.h
+++ b/test/include/dlaf_test/eigensolver/test_gen_eigensolver_correctness.h
@@ -17,6 +17,7 @@
 
 #include <pika/init.hpp>
 
+#include <dlaf/blas/scal.h>
 #include <dlaf/common/single_threaded_blas.h>
 #include <dlaf/communication/communicator_grid.h>
 #include <dlaf/eigensolver/eigensolver.h>

--- a/test/include/dlaf_test/eigensolver/test_gen_eigensolver_correctness.h
+++ b/test/include/dlaf_test/eigensolver/test_gen_eigensolver_correctness.h
@@ -63,9 +63,8 @@ void testGenEigensolverCorrectness(const blas::Uplo uplo, Matrix<const T, Device
   }();
 
   // eigenvalues are contiguous in the mat_local buffer
-  BaseType<T>* evals_start = mat_evalues_local.ptr({0, 0});
-  BaseType<T>* evals_end = evals_start + m;
-  EXPECT_TRUE(std::is_sorted(evals_start, evals_end));
+  const BaseType<T>* evals_start = mat_evalues_local.ptr({0, 0});
+  EXPECT_TRUE(std::is_sorted(evals_start, evals_start + m));
 
   MatrixLocal<T> mat_be_local({m, m}, reference_a.blockSize());
 


### PR DESCRIPTION
Checking the codecov report I realized that the mix real-complex version of scal was not used in tests. (Was used only in miniapps)

As a bonus I addressed some late comments to #1039 made by @albestro.