### PR TITLE
Fix compilation flags

### DIFF
--- a/cmake/DLAF_AddTargetWarnings.cmake
+++ b/cmake/DLAF_AddTargetWarnings.cmake
@@ -44,7 +44,7 @@ macro(target_add_warnings target_name)
             -Wshorten-64-to-32
             -Wsign-conversion
             -Wstring-conversion>
-            $<$<NOT:${IS_CUDA_NVCC}>:-pedantic-errors>
+            $<$<NOT:${IS_CUDA_NVCC}>:-pedantic>
             # googletest macro problem
             # must specify at least one argument for '...' parameter of variadic macro
             $<${IS_COMPILER_CLANG}:-Wno-gnu-zero-variadic-macro-arguments>


### PR DESCRIPTION
Use `-pedantic` instead of `-pedantic-errors`.

Note: in the CI with `-Werror` pedantic warnings are still reported as error.