### PR TITLE
Panel: add limited functionality for Matrix with offset

### DIFF
--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -296,7 +296,10 @@ public:
   }
 
 protected:
-  Matrix(Distribution distribution) : internal::MatrixBase{std::move(distribution)} {}
+  Matrix(Distribution distribution) : internal::MatrixBase{std::move(distribution)} {
+    DLAF_ASSERT((distribution.offset() == GlobalElementIndex{0, 0}), "not supported",
+                distribution.offset());
+  }
   struct SubPipelineTag {};
   Matrix(Matrix& mat, const SubPipelineTag) noexcept : MatrixBase(mat.distribution()) {
     setUpSubPipelines(mat);

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -146,7 +146,7 @@ struct Panel<axis, const T, D, StoreTransposed::No> {
   void setRange(GlobalTileIndex start_idx, GlobalTileIndex end_idx) noexcept {
     DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
-    DLAF_ASSERT(!isBoundToMatrixWithSubTileOffset(), "not supported.");
+    DLAF_ASSERT(!isBoundToMatrixWithOffset(), "not supported.");
 
     initRange(std::move(start_idx), std::move(end_idx));
   }
@@ -162,7 +162,7 @@ struct Panel<axis, const T, D, StoreTransposed::No> {
   void setRangeStart(const GlobalTileIndex& start_idx) noexcept {
     DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
-    DLAF_ASSERT(!isBoundToMatrixWithSubTileOffset(), "not supported.");
+    DLAF_ASSERT(!isBoundToMatrixWithOffset(), "not supported.");
 
     start_ = start_idx.get(coord);
     start_local_ = dist_matrix_.nextLocalTileFromGlobalTile<coord>(start_);
@@ -175,7 +175,7 @@ struct Panel<axis, const T, D, StoreTransposed::No> {
   void setRangeStart(const GlobalElementIndex& start) noexcept {
     DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
-    DLAF_ASSERT(!isBoundToMatrixWithSubTileOffset(), "not supported.");
+    DLAF_ASSERT(!isBoundToMatrixWithOffset(), "not supported.");
 
     start_ = dist_matrix_.globalTileFromGlobalElement<coord>(start.get(coord));
     start_local_ = dist_matrix_.nextLocalTileFromGlobalTile<coord>(start_);
@@ -201,7 +201,7 @@ struct Panel<axis, const T, D, StoreTransposed::No> {
   void setRangeEnd(GlobalTileIndex end_idx) noexcept {
     DLAF_ASSERT_MODERATE(!hasBeenUsed(), hasBeenUsed());
 
-    DLAF_ASSERT(!isBoundToMatrixWithSubTileOffset(), "not supported.");
+    DLAF_ASSERT(!isBoundToMatrixWithOffset(), "not supported.");
 
     end_ = end_idx.get(coord);
     end_local_ = dist_matrix_.nextLocalTileFromGlobalTile<coord>(end_);
@@ -304,12 +304,12 @@ struct Panel<axis, const T, D, StoreTransposed::No> {
 protected:
   using ReadWriteSenderType = typename BaseT::ReadWriteSenderType;
 
-  bool isBoundToMatrixWithSubTileOffset() const noexcept {
+  bool isBoundToMatrixWithOffset() const noexcept {
     return dist_matrix_.offset() != GlobalElementIndex{0, 0};
   }
 
   bool isFirstGlobalTileFull() const {
-    return start_offset_ == 0 && !isBoundToMatrixWithSubTileOffset();
+    return start_offset_ == 0 && !isBoundToMatrixWithOffset();
   }
 
   bool isFirstGlobalTile(const LocalTileIndex& index) const {


### PR DESCRIPTION
Panel currently has a lot of functionalities, but they do not take into account the use-case of a Panel bound to a Matrix with an offset (i.e. top-left tile is not complete).

Since we are going to refactor Panel using new facilities, this PR aims at just making it work in limited conditions also in case Matrix has an offset.

In particular, range utilities (`setRangeStart`, `setRangeEnd`, ...) are disabled in case the matrix which the panel bounds to has an offset not aligned with tile.

Morevoer, this PR adds a couple of asserts where tile and block size difference might not work: specifically for `Panel` and `Matrix`.

Thanks @rasolca for supporting me in doing this on-spot change.

TODO:
- [x] add a basic test for checking that `Panel` works also with `MatrixRef` (with offset)