### PR TITLE
Revise spack environments

### DIFF
--- a/ci/cuda/gcc11_release_scalapack.yml
+++ b/ci/cuda/gcc11_release_scalapack.yml
@@ -15,7 +15,7 @@ cuda gcc11 release scalapack build:
     - .build_common
     - .build_for_daint-gpu
   needs:
-    - cuda gcc11 release deps
+    - cuda gcc11 release scalapack deps
   variables:
     DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc11-scalapack-release/deploy:$CI_COMMIT_SHA
 

--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -11,14 +11,31 @@
 packages:
   all:
     target: [x86_64]
+  # Set intel MKL as default blas, lapack and scalapack provider.
+  # Can be overwritten in environments if needed.
+  blas:
+    require: 'intel-mkl'
+  lapack:
+    require: 'intel-mkl'
+  scalapack:
+    require: 'intel-mkl'
+  mpi:
+    require: 'mpich'
   blaspp:
     variants:
       - '~cuda'
       - '~openmp'
       - '~rocm'
+  intel-mkl:
+    variants:
+      - 'threads=openmp'
+  openblas:
+    variants:
+      - 'threads=openmp'
   mpich:
-    version:
-      - 3.4.2
+    # Requirement for ABI compatibility on the test system
+    require:
+      - '@3.4.2'
     variants:
       - '~fortran'
       - '~libxml2'

--- a/ci/docker/debug-cpu-stdexec.yaml
+++ b/ci/docker/debug-cpu-stdexec.yaml
@@ -18,9 +18,18 @@ spack:
       true
 
   specs:
-    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=openmp ^mpich ^pika+stdexec ^stdexec@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main
+    - dla-future@master build_type=Debug +miniapps +ci-test +ci-check-threads
 
   packages:
     all:
       variants:
+        - 'build_type=Release'
+    pika:
+      require:
+        - '+stdexec'
+        - 'build_type=Debug'
+        - 'malloc=system'
+    stdexec:
+      require:
+        - '@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main'
         - 'build_type=Debug'

--- a/ci/docker/debug-cpu.yaml
+++ b/ci/docker/debug-cpu.yaml
@@ -18,15 +18,22 @@ spack:
       true
 
   specs:
-    - dla-future@master build_type=Debug +miniapps +ci-test +ci-check-threads ^openblas threads=openmp ^mpich
+    - dla-future@master build_type=Debug +miniapps +ci-test +ci-check-threads
 
   packages:
     all:
       variants:
         - 'build_type=Release'
+    blas:
+      require:: 'openblas'
+    lapack:
+      require:: 'openblas'
     pika:
-      variants:
+      require:
         - 'build_type=Debug'
         - 'malloc=system'
+    # For correct code coverage
+    # https://github.com/eth-cscs/DLA-Future/pull/1002
     umpire:
-      require: '@2022.03.1'
+      require:
+        - '@2022.03.1'

--- a/ci/docker/debug-cuda-scalapack.yaml
+++ b/ci/docker/debug-cuda-scalapack.yaml
@@ -18,13 +18,22 @@ spack:
       true
 
   specs:
-    - dla-future@master build_type=Debug +cuda +miniapps +scalapack +ci-test +hdf5 ^openblas threads=openmp ^mpich+fortran
+    - dla-future@master build_type=Debug +cuda +miniapps +scalapack +ci-test +hdf5
 
   packages:
     all:
       variants:
         - 'build_type=Release'
+    blas:
+      require:: 'openblas'
+    lapack:
+      require:: 'openblas'
+    scalapack:
+      require:: 'netlib-scalapack'
+    mpich:
+      require:
+        - '+fortran'
     pika:
-      variants:
+      require:
         - 'build_type=Debug'
         - 'malloc=system'

--- a/ci/docker/debug-cuda.yaml
+++ b/ci/docker/debug-cuda.yaml
@@ -18,15 +18,17 @@ spack:
       true
 
   specs:
-    - dla-future@master build_type=Debug +cuda +miniapps +ci-test ^openblas threads=openmp ^mpich
+    - dla-future@master build_type=Debug +cuda +miniapps +ci-test
 
   packages:
     all:
       variants:
         - 'build_type=Release'
     pika:
-      variants:
+      require:
         - 'build_type=Debug'
         - 'malloc=system'
+    # For correct code coverage
+    # https://github.com/eth-cscs/DLA-Future/pull/1002
     umpire:
       require: '@2022.03.1'

--- a/ci/docker/debug-cuda.yaml
+++ b/ci/docker/debug-cuda.yaml
@@ -24,6 +24,10 @@ spack:
     all:
       variants:
         - 'build_type=Release'
+    blas:
+      require:: 'openblas'
+    lapack:
+      require:: 'openblas'
     pika:
       require:
         - 'build_type=Debug'

--- a/ci/docker/release-cpu-serial.yaml
+++ b/ci/docker/release-cpu-serial.yaml
@@ -18,9 +18,12 @@ spack:
       true
 
   specs:
-    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=none ^mpich
+    - dla-future@master +miniapps +ci-test +ci-check-threads
 
   packages:
     all:
       variants:
         - 'build_type=Release'
+    intel-mkl:
+      require:
+        - 'threads=none'

--- a/ci/docker/release-cpu-stdexec.yaml
+++ b/ci/docker/release-cpu-stdexec.yaml
@@ -18,9 +18,15 @@ spack:
       true
 
   specs:
-    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=openmp ^mpich ^pika +stdexec ^stdexec@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main
+    - dla-future@master +miniapps +ci-test +ci-check-threads
 
   packages:
     all:
       variants:
         - 'build_type=Release'
+    pika:
+      require:
+        - '+stdexec'
+    stdexec:
+      require:
+        - '@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main'

--- a/ci/docker/release-cpu.yaml
+++ b/ci/docker/release-cpu.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master +miniapps +ci-test +ci-check-threads ^intel-mkl threads=openmp ^mpich
+    - dla-future@master +miniapps +ci-test +ci-check-threads
 
   packages:
     all:

--- a/ci/docker/release-cuda-scalapack.yaml
+++ b/ci/docker/release-cuda-scalapack.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master +cuda +miniapps +scalapack +ci-test ^intel-mkl threads=openmp ^mpich
+    - dla-future@master +cuda +miniapps +scalapack +ci-test
 
   packages:
     all:

--- a/ci/docker/release-cuda.yaml
+++ b/ci/docker/release-cuda.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master +cuda +miniapps +ci-test ^intel-mkl threads=openmp ^mpich
+    - dla-future@master +cuda +miniapps +ci-test
 
   packages:
     all:

--- a/ci/docker/release-rocm533-stdexec.yaml
+++ b/ci/docker/release-rocm533-stdexec.yaml
@@ -27,15 +27,20 @@ spack:
       - cxxstd=17
       - amdgpu_target=gfx90a:xnack-
     pika:
-      require: '+stdexec'
+      require:
+        - '+stdexec'
     stdexec:
-      require: '@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main'
+      require:
+        - '@git.48c52df0f81c6151eecf4f39fa5eed2dc0216204=main'
     blas:
-      require: openblas
+      require:: openblas
     lapack:
-      require: openblas
-    mpi:
-      require: mpich ~rocm device=ch3 netmod=tcp
+      require:: openblas
+    mpich:
+      require:
+        - '~rocm'
+        - 'device=ch3'
+        - 'netmod=tcp'
     llvm-amdgpu:
       externals:
       - spec: llvm-amdgpu@5.3.3 ~rocm-device-libs

--- a/ci/docker/release-rocm533.yaml
+++ b/ci/docker/release-rocm533.yaml
@@ -27,11 +27,14 @@ spack:
       - cxxstd=17
       - amdgpu_target=gfx90a:xnack-
     blas:
-      require: openblas
+      require:: openblas
     lapack:
-      require: openblas
-    mpi:
-      require: mpich ~rocm device=ch3 netmod=tcp
+      require:: openblas
+    mpich:
+      require:
+        - '~rocm'
+        - 'device=ch3'
+        - 'netmod=tcp'
     llvm-amdgpu:
       externals:
       - spec: llvm-amdgpu@5.3.3 ~rocm-device-libs


### PR DESCRIPTION
Spack changed the way in which providers are selected, which impact our scalapack CI configs.

E.g. https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/jobs/5602008308 where netlib-scalapack is used instead of MKL.