### PR TITLE
Fix empty case for `copy`

### DIFF
--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -88,10 +88,22 @@ void copy(MatrixRef<const T, Source>& src, MatrixRef<T, Destination>& dst) {
       return;
   }
 
+  DLAF_ASSERT(src.size() == dst.size(), src.size(), dst.size());
+  DLAF_ASSERT(src.tile_size() == dst.tile_size(), src.tile_size(), dst.tile_size());
+
+  DLAF_ASSERT(dlaf::matrix::same_process_grid(src, dst), src, dst);
+
+  if (!local_matrix(src)) {
+    DLAF_ASSERT(src.block_size() == dst.block_size(), src.block_size(), dst.block_size());
+    DLAF_ASSERT(src.source_rank_index() == dst.source_rank_index(), src.source_rank_index(),
+                dst.source_rank_index());
+  }
+
+  if (src.nr_tiles().isEmpty())
+    return;
+
   DLAF_ASSERT(src.distribution().tile_size_of({0, 0}) == dst.distribution().tile_size_of({0, 0}),
               src.distribution().tile_size_of({0, 0}), dst.distribution().tile_size_of({0, 0}));
-  DLAF_ASSERT(src.size() == dst.size(), src.size(), dst.size());
-  DLAF_ASSERT(src.block_size() == dst.block_size(), src.block_size(), dst.block_size());
 
   const dlaf::internal::Policy<matrix::internal::CopyBackend_v<Source, Destination>> policy;
   for (SizeType j = 0; j < src.distribution().local_nr_tiles().cols(); ++j) {

--- a/include/dlaf/matrix/matrix_base.h
+++ b/include/dlaf/matrix/matrix_base.h
@@ -75,6 +75,11 @@ public:
     return distribution_.rank_index();
   }
 
+  /// Returns the 2D rank index of the process that stores the top-left tile of the matrix
+  const comm::Index2D& source_rank_index() const noexcept {
+    return distribution_.source_rank_index();
+  }
+
   /// Returns the size of the communicator grid associated to the matrix.
   const comm::Size2D& grid_size() const noexcept {
     return distribution_.grid_size();

--- a/include/dlaf/util_matrix.h
+++ b/include/dlaf/util_matrix.h
@@ -81,8 +81,8 @@ bool equal_process_grid(const Matrix<const T, D>& m, const comm::CommunicatorGri
 
 /// Returns true if the matrix is distributed on the communication grid.
 template <template <class, Device> class MatrixLikeA, template <class, Device> class MatrixLikeB,
-          class T, Device D>
-bool same_process_grid(const MatrixLikeA<const T, D>& a, const MatrixLikeB<const T, D>& b) noexcept {
+          class T, Device D1, Device D2>
+bool same_process_grid(const MatrixLikeA<const T, D1>& a, const MatrixLikeB<const T, D2>& b) noexcept {
   return a.commGridSize() == b.commGridSize() && a.rankIndex() == b.rankIndex();
 }
 

--- a/test/include/dlaf_test/matrix/util_matrix.h
+++ b/test/include/dlaf_test/matrix/util_matrix.h
@@ -102,6 +102,48 @@ auto mix_values(const dlaf::matrix::internal::SubMatrixSpec& sub_spec,
   };
 }
 
+/// Return source_rank_index along @t coord so that sub-matrix with origin at @p offset_in in @p dist_in
+/// and the one in @p offset_out with @p blocksize_out will have the top-left tile allocated on the same rank.
+///
+/// @pre dist_in.block_size().get<coord>() == blocksize_out.get<coord>()
+template <Coord coord>
+comm::IndexT_MPI align_sub_rank_index(const Distribution& dist_in, const GlobalElementIndex& offset_in,
+                                      const TileElementSize& blocksize_out,
+                                      const GlobalElementIndex& offset_out) {
+  const SizeType blocksize = blocksize_out.get<coord>();
+  DLAF_ASSERT(dist_in.block_size().get<coord>() == blocksize, dist_in.block_size().get<coord>(),
+              blocksize);
+
+  const SizeType grid_size = dist_in.grid_size().get<coord>();
+
+  // Note:
+  // if the sub-matrix has an origin outside the parent matrix, any rank is ok, since the sub-matrix
+  // cannot exist.
+  if (!offset_in.isIn(dist_in.size()))
+    return grid_size / 2;
+
+  const auto pos_mod = [](const auto& a, const auto& b) {
+    const auto mod = a % b;
+    return (mod >= 0) ? mod : (mod + b);
+  };
+
+  const SizeType sub_rank = dist_in.rank_global_element<coord>(offset_in.get<coord>());
+  const SizeType offset_rank(offset_out.get<coord>() / blocksize);
+
+  return pos_mod(sub_rank - offset_rank, grid_size);
+}
+
+/// Return source_rank_index so that sub-matrix with origin at @p offset_in in @p dist_in and the one in
+/// @p offset_out with @p blocksize_out will have the top-left tile allocated on the same rank.
+///
+/// @pre dist_in.block_size() == blocksize_out
+comm::Index2D align_sub_rank_index(const Distribution& dist_in, const GlobalElementIndex& offset_in,
+                                   const TileElementSize& blocksize_out,
+                                   const GlobalElementIndex& offset_out) {
+  return {align_sub_rank_index<Coord::Row>(dist_in, offset_in, blocksize_out, offset_out),
+          align_sub_rank_index<Coord::Col>(dist_in, offset_in, blocksize_out, offset_out)};
+}
+
 namespace internal {
 
 /// Checks the elements of the matrix.

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -159,6 +159,10 @@ bool isFullMatrix(const Distribution& dist_full, const matrix::internal::SubMatr
 }
 
 const std::vector<SubMatrixCopyConfig> sub_configs{
+    // empty-matrix
+    {{10, 10}, {10, 10}, {3, 3}, {3, 3}, {3, 3}, {0, 0}},
+    {{10, 10}, {10, 10}, {3, 3}, {3, 3}, {3, 3}, {2, 0}},
+    {{10, 10}, {10, 10}, {3, 3}, {3, 3}, {3, 3}, {0, 2}},
     // full-matrix
     {{10, 10}, {10, 10}, {3, 3}, {0, 0}, {0, 0}, {10, 10}},
     // sub-matrix
@@ -232,11 +236,6 @@ TYPED_TEST(MatrixCopyTest, SubMatrixCPUDistributed) {
           align_sub_rank_index(dist_in, test.sub_origin_in, test.tile_size, test.sub_origin_out);
       const Distribution dist_out(test.full_out, test.tile_size, comm_grid.size(), comm_grid.rank(),
                                   out_src_rank);
-
-      EXPECT_EQ(dist_in.template rank_global_element<Coord::Row>(test.sub_origin_in.row()),
-                dist_out.template rank_global_element<Coord::Row>(test.sub_origin_out.row()));
-      EXPECT_EQ(dist_in.template rank_global_element<Coord::Col>(test.sub_origin_in.col()),
-                dist_out.template rank_global_element<Coord::Col>(test.sub_origin_out.col()));
 
       testSubMatrix<TypeParam>(test, dist_in, dist_out);
     }
@@ -324,11 +323,6 @@ TYPED_TEST(MatrixCopyTest, SubMatrixGPUDistributed) {
           align_sub_rank_index(dist_in, test.sub_origin_in, test.tile_size, test.sub_origin_out);
       const Distribution dist_out(test.full_out, test.tile_size, comm_grid.size(), comm_grid.rank(),
                                   out_src_rank);
-
-      EXPECT_EQ(dist_in.template rank_global_element<Coord::Row>(test.sub_origin_in.row()),
-                dist_out.template rank_global_element<Coord::Row>(test.sub_origin_out.row()));
-      EXPECT_EQ(dist_in.template rank_global_element<Coord::Col>(test.sub_origin_in.col()),
-                dist_out.template rank_global_element<Coord::Col>(test.sub_origin_out.col()));
 
       testSubMatrixOnGPU<TypeParam>(test, dist_in, dist_out);
     }


### PR DESCRIPTION
Fix problem realised in https://github.com/eth-cscs/DLA-Future/pull/951#pullrequestreview-1753551403 with empty sub-matrices.

- Add quick return for empty case
- Add some empty test-cases
- Extend `copy` assertions to cover both local and distributed case

Other changes required:
- `align_sub_rank_index` changes and improvements
- `same_process_grid` should work also with Matrices on different Devices
- `MatrixBase::source_rank_index()` was missing (there was just deprecated camelCase version)