### PR TITLE
Output CSV data for all miniapps

### DIFF
--- a/miniapp/miniapp_band_to_tridiag.cpp
+++ b/miniapp/miniapp_band_to_tridiag.cpp
@@ -141,7 +141,7 @@ struct BandToTridiagMiniapp {
       }
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << gigaflops << "GFlop/s"
@@ -149,6 +149,24 @@ struct BandToTridiagMiniapp {
                   << dlaf::internal::FormatShort{opts.uplo} << " " << matrix_host.size() << " "
                   << matrix_host.blockSize() << " " << opts.b << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "uplo, " << dlaf::internal::FormatShort{opts.uplo}.value << ", "
+                    << "matrixsize, " << matrix_host.size().rows() << ", "
+                    << "blocksize, " << matrix_host.blockSize().rows() << ", "
+                    << "band_size, " << opts.b << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
 
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||

--- a/miniapp/miniapp_bt_band_to_tridiag.cpp
+++ b/miniapp/miniapp_bt_band_to_tridiag.cpp
@@ -152,13 +152,30 @@ struct BacktransformBandToTridiagMiniapp {
       }
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << gigaflops << "GFlop/s"
                   << " " << dlaf::internal::FormatShort{opts.type} << " " << mat_e_host.size() << " "
                   << mat_e_host.blockSize() << " " << opts.b << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "matrixsize, " << mat_e_host.size().rows() << ", "
+                    << "blocksize, " << mat_e_host.blockSize().rows() << ", "
+                    << "band_size, " << opts.b << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
 
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||

--- a/miniapp/miniapp_bt_reduction_to_band.cpp
+++ b/miniapp/miniapp_bt_reduction_to_band.cpp
@@ -172,14 +172,30 @@ struct BacktransformBandToTridiagMiniapp {
       }
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << gigaflops << "GFlop/s"
                   << " " << dlaf::internal::FormatShort{opts.type} << " " << mat_e_host.size() << " "
                   << mat_e_host.blockSize() << " " << opts.b << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
-
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "matrixsize, " << mat_e_host.size().rows() << ", "
+                    << "blocksize, " << mat_e_host.blockSize().rows() << ", "
+                    << "band_size, " << opts.b << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||
           opts.do_check == dlaf::miniapp::CheckIterFreq::All) {

--- a/miniapp/miniapp_eigensolver.cpp
+++ b/miniapp/miniapp_eigensolver.cpp
@@ -183,7 +183,7 @@ struct EigensolverMiniapp {
       matrix.reset();
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << dlaf::internal::FormatShort{opts.type}
@@ -192,7 +192,24 @@ struct EigensolverMiniapp {
                   << dlaf::eigensolver::internal::getBandSize(matrix_host.blockSize().rows()) << " "
                   << comm_grid.size() << " " << pika::get_os_thread_count() << " " << backend
                   << std::endl;
-
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "uplo, " << dlaf::internal::FormatShort{opts.uplo}.value << ", "
+                    << "matrixsize, " << matrix_host.size().rows() << ", "
+                    << "blocksize, " << matrix_host.blockSize().rows() << ", "
+                    << "bandsize, "
+                    << dlaf::eigensolver::internal::getBandSize(matrix_host.blockSize().rows()) << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||
           opts.do_check == dlaf::miniapp::CheckIterFreq::All) {

--- a/miniapp/miniapp_gen_eigensolver.cpp
+++ b/miniapp/miniapp_gen_eigensolver.cpp
@@ -148,7 +148,7 @@ struct GenEigensolverMiniapp {
       matrix_b.reset();
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << dlaf::internal::FormatShort{opts.type}
@@ -157,7 +157,24 @@ struct GenEigensolverMiniapp {
                   << dlaf::eigensolver::internal::getBandSize(matrix_a_host.blockSize().rows()) << " "
                   << comm_grid.size() << " " << pika::get_os_thread_count() << " " << backend
                   << std::endl;
-
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "uplo, " << dlaf::internal::FormatShort{opts.uplo}.value << ", "
+                    << "matrixsize, " << matrix_a_host.size().rows() << ", "
+                    << "blocksize, " << matrix_a_host.blockSize().rows() << ", "
+                    << "bandsize, "
+                    << dlaf::eigensolver::internal::getBandSize(matrix_a_host.blockSize().rows()) << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||
           opts.do_check == dlaf::miniapp::CheckIterFreq::All) {

--- a/miniapp/miniapp_gen_to_std.cpp
+++ b/miniapp/miniapp_gen_to_std.cpp
@@ -151,7 +151,7 @@ struct GenToStdMiniapp {
       }
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << gigaflops << "GFlop/s"
@@ -159,7 +159,23 @@ struct GenToStdMiniapp {
                   << dlaf::internal::FormatShort{opts.uplo} << " " << matrix_a_host.size() << " "
                   << matrix_a_host.blockSize() << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
-
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "uplo, " << dlaf::internal::FormatShort{opts.uplo}.value << ", "
+                    << "matrixsize, " << matrix_a_host.size().rows() << ", "
+                    << "blocksize, " << matrix_a_host.blockSize().rows() << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||
           opts.do_check == dlaf::miniapp::CheckIterFreq::All) {

--- a/miniapp/miniapp_reduction_to_band.cpp
+++ b/miniapp/miniapp_reduction_to_band.cpp
@@ -203,7 +203,7 @@ struct reductionToBandMiniapp {
                     << "GFlops, " << gigaflops << ", "
                     << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
                     << "matrixsize, " << matrix_host.size().rows() << ", "
-                    << "blocksize, " << block_size.rows() << ", "
+                    << "blocksize, " << matrix_host.blockSize().rows() << ", "
                     << "band_size, " << opts.b << ", "
                     << "comm_rows, " << comm_grid.size().rows() << ", "
                     << "comm_cols, " << comm_grid.size().cols() << ", "

--- a/miniapp/miniapp_triangular_solver.cpp
+++ b/miniapp/miniapp_triangular_solver.cpp
@@ -164,6 +164,25 @@ struct triangularSolverMiniapp {
                   << dlaf::internal::FormatShort{opts.op} << dlaf::internal::FormatShort{opts.diag}
                   << " " << bh.size() << " " << bh.blockSize() << " " << comm_grid.size() << " "
                   << pika::get_os_thread_count() << " " << backend << std::endl;
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "GFlops, " << gigaflops << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "size, " << dlaf::internal::FormatShort{opts.side}.value << ", "
+                    << "uplo, " << dlaf::internal::FormatShort{opts.uplo}.value << ", "
+                    << "op, " << dlaf::internal::FormatShort{opts.op}.value << ", "
+                    << "diag, " << dlaf::internal::FormatShort{opts.diag}.value << ", "
+                    << "matrixsize, " << bh.size().rows() << ", "
+                    << "blocksize, " << bh.blockSize().rows() << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
       }
 
       b.copyTargetToSource();

--- a/miniapp/miniapp_tridiag_solver.cpp
+++ b/miniapp/miniapp_tridiag_solver.cpp
@@ -159,12 +159,27 @@ struct TridiagSolverMiniapp {
       }
 
       // print benchmark results
-      if (0 == world.rank() && run_index >= 0)
+      if (0 == world.rank() && run_index >= 0) {
         std::cout << "[" << run_index << "]"
                   << " " << elapsed_time << "s"
                   << " " << dlaf::internal::FormatShort{opts.type} << " " << tridiag.size() << " "
                   << tridiag.blockSize() << " " << comm_grid.size() << " " << pika::get_os_thread_count()
                   << " " << backend << std::endl;
+        if (opts.csv_output) {
+          // CSV formatted output with column names that can be read by pandas to simplify
+          // post-processing CSVData{-version}, value_0, title_0, value_1, title_1
+          std::cout << "CSVData-2, "
+                    << "run, " << run_index << ", "
+                    << "time, " << elapsed_time << ", "
+                    << "type, " << dlaf::internal::FormatShort{opts.type}.value << ", "
+                    << "matrixsize, " << tridiag.size().rows() << ", "
+                    << "blocksize, " << tridiag.blockSize().rows() << ", "
+                    << "comm_rows, " << comm_grid.size().rows() << ", "
+                    << "comm_cols, " << comm_grid.size().cols() << ", "
+                    << "threads, " << pika::get_os_thread_count() << ", "
+                    << "backend, " << backend << ", " << opts.info << std::endl;
+        }
+      }
 
       // (optional) run test
       if ((opts.do_check == dlaf::miniapp::CheckIterFreq::Last && run_index == (opts.nruns - 1)) ||


### PR DESCRIPTION
Certain benchmarks may benefit from additional plotting info present in the output, rather than embedded in the directory name or launch script - this PR is an extension of #809 - it adds CSV support to all the miniapps, rather than just a selected subset.  