### PR TITLE
miniapp benchmarks: add a template for job launch to allow srun alternative

### DIFF
--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -10,7 +10,7 @@
 
 from itertools import product
 from math import ceil, sqrt
-from os import makedirs
+from os import makedirs, environ
 from os.path import expanduser, isfile
 from time import sleep
 from pathlib import Path
@@ -138,10 +138,14 @@ class JobText:
         launch_cmd = self.system["Launch command"]
         # fstring substitution of vars in launch_cmd
         launch_cmd = launch_cmd.format(job_path=job_path, job_file=job_file)
-        print(f"Submitting : {launch_cmd}")
+        # get default SHELL if not specified
+        shell = environ["SHELL"]
+        if shell==None:
+            raise ValueError(f"no $SHELL environemt variable found")
+        print(f"Submitting : {launch_cmd} using shell {shell}")
 
-        process = Popen(f"{launch_cmd}", shell=True, executable="/bin/bash", universal_newlines=True,
-                  stdin=PIPE, stdout=PIPE, stderr=PIPE ) 
+        process = Popen(f"{launch_cmd}", shell=True, executable=shell, universal_newlines=True,
+                  stdin=PIPE, stdout=PIPE, stderr=PIPE )
         # sleep to not overload the scheduler
         sleep(1)
 

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -144,7 +144,7 @@ class JobText:
         launch_cmd = launch_cmd.format(job_path=job_path, job_file=job_file)
         # get default SHELL if not specified
         shell = environ["SHELL"]
-        if shell == None:
+        if shell is None:
             raise ValueError(f"no $SHELL environemt variable found")
         print(f"Submitting : {launch_cmd} using shell {shell}")
 

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -10,10 +10,11 @@
 
 from itertools import product
 from math import ceil, sqrt
-from os import makedirs, system
+from os import makedirs
 from os.path import expanduser, isfile
 from time import sleep
 from pathlib import Path
+from subprocess import Popen, PIPE
 
 
 # Finds two factors of `n` that are as close to each other as possible.
@@ -134,8 +135,13 @@ class JobText:
             print(f"Created : {job_file}")
             return
 
-        print(f"Submitting : {job_file}")
-        system(f"sbatch --chdir={job_path} {job_file}")
+        launch_cmd = self.system["Launch command"]
+        # fstring substitution of vars in launch_cmd
+        launch_cmd = launch_cmd.format(job_path=job_path, job_file=job_file)
+        print(f"Submitting : {launch_cmd}")
+
+        process = Popen(f"{launch_cmd}", shell=True, executable="/bin/bash", universal_newlines=True,
+                  stdin=PIPE, stdout=PIPE, stderr=PIPE ) 
         # sleep to not overload the scheduler
         sleep(1)
 

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -149,7 +149,7 @@ class JobText:
         print(f"Submitting : {launch_cmd} using shell {shell}")
 
         process = Popen(
-            f"{launch_cmd}",
+            launch_cmd,
             shell=True,
             executable=shell,
             universal_newlines=True,

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -57,7 +57,11 @@ def _computeResourcesNeeded(system, nodes, rpn):
 # return the list containing the values of total_ranks, cores_per_rank, threads_per_rank.
 def _computeResourcesNeededList(system, nodes, rpn):
     resources = _computeResourcesNeeded(system, nodes, rpn)
-    return [resources["total_ranks"], resources["cores_per_rank"], resources["threads_per_rank"]]
+    return [
+        resources["total_ranks"],
+        resources["cores_per_rank"],
+        resources["threads_per_rank"],
+    ]
 
 
 def _err_msg(lib):
@@ -140,12 +144,19 @@ class JobText:
         launch_cmd = launch_cmd.format(job_path=job_path, job_file=job_file)
         # get default SHELL if not specified
         shell = environ["SHELL"]
-        if shell==None:
+        if shell == None:
             raise ValueError(f"no $SHELL environemt variable found")
         print(f"Submitting : {launch_cmd} using shell {shell}")
 
-        process = Popen(f"{launch_cmd}", shell=True, executable=shell, universal_newlines=True,
-                  stdin=PIPE, stdout=PIPE, stderr=PIPE )
+        process = Popen(
+            f"{launch_cmd}",
+            shell=True,
+            executable=shell,
+            universal_newlines=True,
+            stdin=PIPE,
+            stdout=PIPE,
+            stderr=PIPE,
+        )
         # sleep to not overload the scheduler
         sleep(1)
 
@@ -739,7 +750,12 @@ class StrongScaling:
 
         job = self.job
         job_text = JobText(
-            job["system"], job["run_name"], nodes, job["time"], job["bs_name"], self.rpn_preamble
+            job["system"],
+            job["run_name"],
+            nodes,
+            job["time"],
+            job["bs_name"],
+            self.rpn_preamble,
         )
         for run in self.runs:
             product_params = _dictProduct(run["params"])
@@ -873,7 +889,12 @@ class WeakScaling:
 
         job = self.job
         job_text = JobText(
-            job["system"], job["run_name"], nodes, self.getTime(nodes), job["bs_name"], self.rpn_preamble
+            job["system"],
+            job["run_name"],
+            nodes,
+            self.getTime(nodes),
+            job["bs_name"],
+            self.rpn_preamble,
         )
 
         for run in self.runs:

--- a/scripts/systems.py
+++ b/scripts/systems.py
@@ -38,6 +38,7 @@ cscs["daint-mc"] = {
     "Multiple rpn in same job": True,
     "GPU": False,
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -69,6 +70,7 @@ cscs["daint-gpu"] = {
     "Multiple rpn in same job": True,
     "GPU": True,
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -100,6 +102,7 @@ cscs["eiger"] = {
     "Multiple rpn in same job": True,
     "GPU": False,
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -133,6 +136,7 @@ cscs["clariden-nvgpu"] = {
     "GPU": True,
     # Based on nvidia-smi topo --matrix
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:ffff000000000000ffff000000000000,ffff000000000000ffff00000000,ffff000000000000ffff0000,ffff000000000000ffff gpu2ranks_slurm_cuda",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -165,6 +169,7 @@ cscs["clariden-amdgpu"] = {
     "Multiple rpn in same job": True,
     "GPU": True,
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:ff00000000000000ff000000000000,ff00000000000000ff00000000000000,ff00000000000000ff0000,ff00000000000000ff000000,ff00000000000000ff,ff00000000000000ff00,ff00000000000000ff00000000,ff00000000000000ff0000000000 gpu2ranks_slurm_hip",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -197,6 +202,7 @@ csc["lumi-cpu"] = {
     "Multiple rpn in same job": True,
     "GPU": False,
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank}",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}
@@ -233,6 +239,7 @@ csc["lumi-gpu"] = {
     # https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/distribution-binding/#gpu-binding
     # and rocm-smi --show-topo
     "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=mask_cpu:fe00000000000000fe000000000000,fe00000000000000fe00000000000000,fe00000000000000fe0000,fe00000000000000fe000000,fe00000000000000fe,fe00000000000000fe00,fe00000000000000fe00000000,fe00000000000000fe0000000000 gpu2ranks_slurm_hip",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
     "Batch preamble": """
 #!/bin/bash -l
 #SBATCH --job-name={run_name}_{nodes}


### PR DESCRIPTION
The systems have a "launch command" template that is filled out with the job name etc and can be customized for other batch/launch methods

The current scripts assume that srun is used, but some systems may require a different method of invocation