### PR TITLE
Fix compilation with GCC 13

### DIFF
--- a/include/dlaf/blas/scal.h
+++ b/include/dlaf/blas/scal.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <complex>
+#include <cstdint>
 
 /// @file
 /// Provides overloads for mixed real complex variants of scal missing in blaspp.

--- a/src/blas/scal.cpp
+++ b/src/blas/scal.cpp
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
+#include <cstdint>
+
 #include <blas/config.h>
 #include <blas/mangling.h>
 


### PR DESCRIPTION
libstdc++ 13 removed many internal includes, leading to some includes that were previously transitively included to not be included at all. `cstdint` missing in `scal.cpp` actually triggers a compilation error. See https://github.com/spack/spack/issues/41408 for more details.