### PR TITLE
Print warning when MPI pool is unintentionally not used

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -190,6 +190,16 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
                            "umpire-device-memory-pool-initial-bytes");
   cfg.mpi_pool = (pika::resource::pool_exists("mpi")) ? "mpi" : "default";
 
+  // Warn if not using MPI pool without --dlaf:no-mpi-pool
+  int ntasks;
+  DLAF_MPI_CHECK_ERROR(MPI_Comm_size(MPI_COMM_WORLD, &ntasks));
+  if (ntasks != 1 && cfg.mpi_pool == "default" && !vm["dlaf:no-mpi-pool"].as<bool>()) {
+    std::cerr << "Warning! DLA-Future is not using the \"mpi\" pika thread pool for "
+                 "MPI communication but --dlaf:no-mpi-pool is not set. This may "
+                 "indicate a bug in DLA-Future or pika. Performance may be degraded."
+              << std::endl;
+  }
+
   // update tune parameters
   //
   // NOTE: Environment variables should omit the DLAF_ prefix and command line options the dlaf: prefix.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -191,13 +191,17 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
   cfg.mpi_pool = (pika::resource::pool_exists("mpi")) ? "mpi" : "default";
 
   // Warn if not using MPI pool without --dlaf:no-mpi-pool
-  int ntasks;
-  DLAF_MPI_CHECK_ERROR(MPI_Comm_size(MPI_COMM_WORLD, &ntasks));
-  if (ntasks != 1 && cfg.mpi_pool == "default" && !vm["dlaf:no-mpi-pool"].as<bool>()) {
-    std::cerr << "Warning! DLA-Future is not using the \"mpi\" pika thread pool for "
-                 "MPI communication but --dlaf:no-mpi-pool is not set. This may "
-                 "indicate a bug in DLA-Future or pika. Performance may be degraded."
-              << std::endl;
+  int mpi_initialized;
+  DLAF_MPI_CHECK_ERROR(MPI_Initialized(&mpi_initialized));
+  if (mpi_initialized) {
+    int ntasks;
+    DLAF_MPI_CHECK_ERROR(MPI_Comm_size(MPI_COMM_WORLD, &ntasks));
+    if (ntasks != 1 && cfg.mpi_pool == "default" && !vm["dlaf:no-mpi-pool"].as<bool>()) {
+      std::cerr << "Warning! DLA-Future is not using the \"mpi\" pika thread pool for "
+                   "MPI communication but --dlaf:no-mpi-pool is not set. This may "
+                   "indicate a bug in DLA-Future or pika. Performance may be degraded."
+                << std::endl;
+    }
   }
 
   // update tune parameters

--- a/test/src/gtest_mpipika_main.cpp
+++ b/test/src/gtest_mpipika_main.cpp
@@ -50,10 +50,10 @@
 
 #include <gtest/gtest.h>
 
-GTEST_API_ int test_main(int argc, char** argv) {
+GTEST_API_ int test_main(pika::program_options::variables_map& vm) {
   std::printf("Running main() from gtest_mpipika_main.cpp\n");
   auto ret = [&] {
-    dlaf::ScopedInitializer init(argc, argv);
+    dlaf::ScopedInitializer init(vm);
     return RUN_ALL_TESTS();
   }();
   pika::finalize();

--- a/test/src/gtest_pika_main.cpp
+++ b/test/src/gtest_pika_main.cpp
@@ -42,15 +42,16 @@
 #include <cstdio>
 
 #include <pika/init.hpp>
+#include <pika/program_options.hpp>
 
 #include <dlaf/init.h>
 
 #include <gtest/gtest.h>
 
-GTEST_API_ int test_main(int argc, char** argv) {
+GTEST_API_ int test_main(pika::program_options::variables_map& vm) {
   std::printf("Running main() from gtest_pika_main.cpp\n");
   auto ret = [&] {
-    dlaf::ScopedInitializer init(argc, argv);
+    dlaf::ScopedInitializer init(vm);
     return RUN_ALL_TESTS();
   }();
   pika::finalize();


### PR DESCRIPTION
Fixes #165.

Warns if using more than one rank, no MPI pool, and `--dlaf:no-mpi-pool` was _not_ used. This would indicate that the resource partitioner was not correctly initialized to use the MPI pool.

Also fixes parsing of command line options in tests. When `pika_main` takes `argc` and `argv` it contains all the command line options that were not yet parsed by pika, including the added DLA-Future command line options. It's not really ideal that this is even possible, but I'm not sure yet how to deal with this better.