### PR TITLE
Add zenodo DOI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pipeline status](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/commits/master) [![codecov](https://codecov.io/gh/eth-cscs/DLA-Future/branch/master/graph/badge.svg)](https://codecov.io/gh/eth-cscs/DLA-Future)
+[![zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.10518288.svg)](https://doi.org/10.5281/zenodo.10518288) [![pipeline status](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/badges/master/pipeline.svg)](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/commits/master) [![codecov](https://codecov.io/gh/eth-cscs/DLA-Future/branch/master/graph/badge.svg)](https://codecov.io/gh/eth-cscs/DLA-Future)
 
 # Distributed Linear Algebra from the Future
 


### PR DESCRIPTION
This only adds a badge that points to the "concept" DOI, but we could think about adding a "Citing" section and possibly links to specific versions.

See https://zenodo.org/help/versioning for a bit of background on how the zenodo's DOIs work. https://zenodo.org/records/10518289 is the DOI specific to 0.4.0. https://zenodo.org/records/10518288 is a "concept" DOI, meaning it represents all versions, and will always resolve to the latest version if you try to actually view it.

Preview of the README is here: https://github.com/msimberg/DLA-Future/blob/649b136cb31f2c7ff3e6e8f881a6a50d28f55938/README.md.