### PR TITLE
Bump spack commit to use pika 0.22.0 in CI

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -34,7 +34,7 @@ stages:
     reports:
       dotenv: build.env
   variables:
-    SPACK_SHA: ce81175cf30ce31b769c03561b0123de6e9e7cc4
+    SPACK_SHA: e46f3803adbcbe64301e8340e4cb584c29da7a9b
     SPACK_DLAF_REPO: ./spack
     DOCKER_BUILD_ARGS: '[
         "BASE_IMAGE",


### PR DESCRIPTION
I may have broken DLA-Future with the latest release of pika (thanks @RMeli!). Testing what CI says about this.