### PR TITLE
Use pika 0.22.2 in CI

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -34,7 +34,7 @@ stages:
     reports:
       dotenv: build.env
   variables:
-    SPACK_SHA: ce81175cf30ce31b769c03561b0123de6e9e7cc4
+    SPACK_SHA: 79df065730ca24f5fc47d38cd44aab6760f18f26
     SPACK_DLAF_REPO: ./spack
     DOCKER_BUILD_ARGS: '[
         "BASE_IMAGE",

--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -27,7 +27,7 @@ packages:
       - '~openmp'
       - '~rocm'
   intel-oneapi-mkl:
-    variants:
+    require:
       - 'threads=openmp'
   openblas:
     variants:

--- a/ci/docker/release-cpu-serial.yaml
+++ b/ci/docker/release-cpu-serial.yaml
@@ -25,5 +25,5 @@ spack:
       variants:
         - 'build_type=Release'
     intel-oneapi-mkl:
-      require:
+      require::
         - 'threads=none'


### PR DESCRIPTION
I believe I've fixed the issue in the change in 0.22.0 that was reverted in 0.22.1 (https://github.com/pika-org/pika/pull/872). Before running CI with the fix I want to verify that I can still trigger the failures with 0.22.0. I'll be updating this PR along with changes to pika as I get closer to pika 0.22.2. pika 0.22.2 doesn't exist yet.