### PR TITLE
Use address, undefined behaviour, and leak sanitizers in CI

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 include:
+  - local: 'ci/cpu/asan_ubsan_lsan.yml'
   - local: 'ci/cpu/clang12_release.yml'
   - local: 'ci/cpu/clang13_release_cxx20.yml'
   - local: 'ci/cpu/clang14_release_stdexec.yml'

--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -34,7 +34,7 @@ stages:
     reports:
       dotenv: build.env
   variables:
-    SPACK_SHA: 79df065730ca24f5fc47d38cd44aab6760f18f26
+    SPACK_SHA: be4eae3fa86308bb9a476d217dd716e088bfe4e1
     SPACK_DLAF_REPO: ./spack
     DOCKER_BUILD_ARGS: '[
         "BASE_IMAGE",

--- a/ci/cpu/asan_ubsan_lsan.yml
+++ b/ci/cpu/asan_ubsan_lsan.yml
@@ -1,0 +1,36 @@
+include:
+  - local: 'ci/common-ci.yml'
+
+cpu asan ubsan lsan deps:
+  extends: .build_deps_common
+  variables:
+    EXTRA_APTGET: "clang-15 libomp-15-dev"
+    COMPILER: clang@15
+    USE_MKL: "ON"
+    SPACK_ENVIRONMENT: ci/docker/asan-ubsan-lsan.yaml
+    BUILD_IMAGE: $CSCS_REGISTRY_PATH/cpu-asan-ubsan-lsan/build
+
+cpu asan ubsan lsan build:
+  extends:
+    - .build_common
+    - .build_for_daint-mc
+  needs:
+    - cpu asan ubsan lsan deps
+  variables:
+    DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/cpu-asan-ubsan-lsan/deploy:$CI_COMMIT_SHA
+    # For symbolizing stacktraces with llvm-symbolizer
+    EXTRA_APTGET_DEPLOY: "llvm-15"
+
+cpu asan ubsan lsan test:
+  extends: .run_common
+  needs:
+    - cpu asan ubsan lsan build
+  variables:
+    ASAN_OPTIONS: "fast_unwind_on_malloc=0:strict_string_checks=1:detect_leaks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1"
+    UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+    # Override use of libSegFault, not necessary with sanitizers
+    LD_PRELOAD: ""
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: cpu asan ubsan lsan build

--- a/ci/docker/asan-ubsan-lsan.yaml
+++ b/ci/docker/asan-ubsan-lsan.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master build_type=RelWithDebInfo cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" cflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined -shared-libsan" +miniapps +ci-test
+    - dla-future@master build_type=RelWithDebInfo cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" cflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined" +miniapps +ci-test
 
   packages:
     all:
@@ -28,3 +28,4 @@ spack:
       require:
         - 'build_type=RelWithDebInfo'
         - 'malloc=system'
+        - '+sanitizers'

--- a/ci/docker/asan-ubsan-lsan.yaml
+++ b/ci/docker/asan-ubsan-lsan.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" cflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined -shared-libsan" +miniapps +ci-test
+    - dla-future@master build_type=RelWithDebInfo cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" cflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined -shared-libsan" +miniapps +ci-test
 
   packages:
     all:
@@ -26,4 +26,5 @@ spack:
         - 'build_type=Release'
     pika:
       require:
+        - 'build_type=RelWithDebInfo'
         - 'malloc=system'

--- a/ci/docker/asan-ubsan-lsan.yaml
+++ b/ci/docker/asan-ubsan-lsan.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined -shared-libsan" +miniapps +ci-test
+    - dla-future@master cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" cflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined -shared-libsan" +miniapps +ci-test
 
   packages:
     all:

--- a/ci/docker/asan-ubsan-lsan.yaml
+++ b/ci/docker/asan-ubsan-lsan.yaml
@@ -23,7 +23,7 @@ spack:
   packages:
     all:
       variants:
-        - 'build_type=RelWithDebInfo'
+        - 'build_type=Release'
     pika:
       require:
         - 'malloc=system'

--- a/ci/docker/asan-ubsan-lsan.yaml
+++ b/ci/docker/asan-ubsan-lsan.yaml
@@ -1,0 +1,29 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+spack:
+  include:
+  - /spack_environment/common.yaml
+
+  view: false
+  concretizer:
+    unify:
+      true
+
+  specs:
+    - dla-future@master cxxflags="-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined -fno-omit-frame-pointer" ldflags="-fsanitize=address -fsanitize=undefined -shared-libsan" +miniapps +ci-test
+
+  packages:
+    all:
+      variants:
+        - 'build_type=RelWithDebInfo'
+    pika:
+      require:
+        - 'malloc=system'

--- a/ci/docker/deploy.Dockerfile
+++ b/ci/docker/deploy.Dockerfile
@@ -39,6 +39,8 @@ RUN pushd ${SOURCE}/miniapp && \
 # Prune and bundle binaries
 RUN mkdir ${BUILD}-tmp && cd ${BUILD} && \
     export TEST_BINARIES=`PATH=${SOURCE}/ci:$PATH ctest --show-only=json-v1 | jq '.tests | map(.command | .[] | select(contains("check-threads") | not)) | .[]' | tr -d \"` && \
+    LIBASAN=$(find /usr/lib -name libclang_rt.asan-x86_64.so) && \
+    if [[ -n "${LIBASAN}" ]]; then export LD_LIBRARY_PATH=$(dirname ${LIBASAN}):${LD_LIBRARY_PATH}; fi && \
     echo "Binary sizes:" && \
     ls -lh ${TEST_BINARIES} && \
     ls -lh src/lib* && \

--- a/test/unit/test_util_math.cpp
+++ b/test/unit/test_util_math.cpp
@@ -139,6 +139,7 @@ TYPED_TEST(MathUtilTest, ptrdiff_t_Arithmetic_Sum) {
   constexpr auto arithmetic_size = sizeof(SizeType);
 
   TypeParam a, b;
+  ArithmeticT c = std::numeric_limits<ArithmeticT>::max() / 2;
 
   if (type_size < arithmetic_size) {
     a = std::numeric_limits<TypeParam>::max();
@@ -155,8 +156,8 @@ TYPED_TEST(MathUtilTest, ptrdiff_t_Arithmetic_Sum) {
   }
 
   {
-    auto expected_result = static_cast<ArithmeticT>(a) + std::numeric_limits<ArithmeticT>::max();
-    EXPECT_EQ(expected_result, util::ptrdiff_t::sum(a, std::numeric_limits<ArithmeticT>::max()));
+    auto expected_result = static_cast<ArithmeticT>(a) + c;
+    EXPECT_EQ(expected_result, util::ptrdiff_t::sum(a, c));
   }
 }
 
@@ -168,7 +169,7 @@ TYPED_TEST(MathUtilTest, ptrdiff_t_Arithmetic_Mul) {
 
   TypeParam a, b;
 
-  if (type_size < arithmetic_size) {
+  if (type_size * 2 < arithmetic_size) {
     a = std::numeric_limits<TypeParam>::max();
     b = std::numeric_limits<TypeParam>::max();
   }


### PR DESCRIPTION
This adds a pipeline with address, undefined behaviour, and leak sanitizer. Leak sanitizer is enabled by default with address sanitizer (and explicitly with `detect_leaks=1`). I've added exactly one pipeline which uses clang 15 (the newest clang available in the currently used base image) with `RelWithDebInfo` (debug symbols are useful for reporting errors, but so are optimizations to make sure we run something at least slightly resembling a release build).

As far as I can tell address sanitizer reported no failures. The option `detect_stack_use_after_return` is explicitly disabled (it's also disabled by default) because it causes errors that seem to be failures within address sanitizer itself. These failures also appear in pika's CI where I've also disabled the option. The failures may point to a real issue in pika, but I don't know yet what so I'm keeping the option off to get something useful into CI.

pika also has an option to reduce the chances of false positives with sanitizers but this is not yet in the spack package. I will enable this option in a follow-up PR.

Undefined behaviour sanitizer reported integer overflows in the `test_util_math` test, which I've changed to avoid overflows.

I've disabled `libSegFault` for the sanitizer builds since the sanitizers will report segmentation faults anyway.