### PR TITLE
Add santis benchmarking configuration

### DIFF
--- a/scripts/systems.py
+++ b/scripts/systems.py
@@ -193,6 +193,38 @@ printenv > env_{bs_name}.txt
 """,
 }
 
+# NOTE: Here is assumed that `gpu2ranks_slurm_cuda` is in PATH!
+#       modify "Run command" if it is not the case.
+cscs["santis"] = {
+    "Cores": 288,
+    "Threads per core": 1,
+    "Allowed rpns": [4],
+    "Multiple rpn in same job": True,
+    "GPU": True,
+    "Run command": "srun -u {srun_args} -n {total_ranks} --cpu-bind=core -c {threads_per_rank} gpu2ranks_slurm_cuda",
+    "Launch command": "sbatch --chdir={job_path} {job_file}",
+    "Batch preamble": """
+#!/bin/bash -l
+#SBATCH --job-name={run_name}_{nodes}
+#SBATCH --time={time_min}
+#SBATCH --nodes={nodes}
+#SBATCH --hint=multithread
+#SBATCH --output=output.txt
+#SBATCH --error=error.txt
+
+# Env
+export MPICH_OPT_THREAD_SYNC=0 # Required to work around MPICH bug
+export MIMALLOC_EAGER_COMMIT_DELAY=0
+export MIMALLOC_LARGE_OS_PAGES=1
+
+# Debug
+module list &> modules_{bs_name}.txt
+printenv > env_{bs_name}.txt
+
+# Commands
+""",
+}
+
 csc = {}
 
 csc["lumi-cpu"] = {


### PR DESCRIPTION
I had this lying around in my local repository. We'll probably need to adjust it over time, but this should serve as a starting point.

I've included the `MPICH_OPT_THREAD_SYNC=0` option since there is currently no known working version of MPICH which doesn't require it. I've left `--cpu-bind=core` and `--hint=multithread` to mirror other configurations, but I think they could be removed since there's no hyperthreading on Grace.