### PR TITLE
Fix data race in `test_pipeline`

### DIFF
--- a/test/unit/common/test_pipeline.cpp
+++ b/test/unit/common/test_pipeline.cpp
@@ -810,7 +810,11 @@ TEST(SubPipeline, RandomAccess) {
       // of senders stored in accesses. No accesses should be done yet at this point since they depend
       // on the first access completing.
       ASSERT_GE(state.spawn_count, 1);
-      ASSERT_GE(state.spawn_count, state.accesses.size());
+      {
+        std::lock_guard l(state.accesses_mutex);
+        ASSERT_GE(state.spawn_count, state.accesses.size());
+      }
+
       EXPECT_EQ(state.access_count.load(), 0);
 
       // After the first access is done there can be one or more accesses done


### PR DESCRIPTION
Reading the size of the `accesses` vector races with pushing items into the vector. The pushing is done under a lock, but reading the size was not done under a lock, and doing so is considered a data race (there are no guarantees on what the size will return while the vector is being modified). This only applies to the case when subpipelines are accessed in new tasks, not inline, but I've added the lock for both cases to keep things simple. See https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/4700071344751697/7514005670787789/-/jobs/6223967358 (view the full log) for the report by thread sanitizer.