### PR TITLE
Fix dependency of `DLAF_WITH_MPI_GPU_FORCE_CONTIGUOUS` on `DLAF_WITH_MPI_GPU_AWARE` CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ cmake_dependent_option(
 )
 cmake_dependent_option(
   DLAF_WITH_MPI_GPU_FORCE_CONTIGUOUS "Force GPU buffers to be contiguous before communicating" ON
-  "DLAF_WITH_MPI_GPU_SUPPORT" OFF
+  "DLAF_WITH_MPI_GPU_AWARE" OFF
 )
 option(DLAF_WITH_HDF5 "Enable HDF5 support" OFF)
 mark_as_advanced(DLAF_WITH_HDF5)


### PR DESCRIPTION
I missed one spot in #1102.