### PR TITLE
Fix warning about strict prototypes in precompiled headers `dummy.c`

### DIFF
--- a/src/dummy.c
+++ b/src/dummy.c
@@ -11,4 +11,4 @@
 // target.
 
 // Silences -Wpedantic: ISO C forbids an empty translation unit
-void dlaf_empty();
+void dlaf_empty(void);


### PR DESCRIPTION
clang starting with version 15 warns about C functions that don't declare their arguments (with `-Wstrict-prototypes`, see https://godbolt.org/z/YbjY14d74). Explicitly specifying that `dummy` takes no arguments with `void` silences the warning.