### PR TITLE
Update CI to use whip 0.3.0

### DIFF
--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -46,3 +46,6 @@ packages:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040
     buildable: false
+  whip:
+    require:
+      - '@main'


### PR DESCRIPTION
0.3.0 isn't yet released, so testing with `whip@main` for now.