### PR TITLE
Reduce compilation time of `with_temporary_tile` with more type-erasure

### DIFF
--- a/include/dlaf/sender/with_temporary_tile.h
+++ b/include/dlaf/sender/with_temporary_tile.h
@@ -137,11 +137,12 @@ auto withTemporaryTile(InSender&& in_sender, F&& f) {
                       // directly.
                       auto copy_sender = [&]() {
                         if constexpr (bool(copy_from_destination)) {
-                          return whenAllLift(std::move(f_sender), std::cref(temp), std::cref(in)) |
-                                 copy(Policy<copy_backend>(thread_priority::high));
+                          return ex::make_unique_any_sender(
+                              whenAllLift(std::move(f_sender), std::cref(temp), std::cref(in)) |
+                              copy(Policy<copy_backend>(thread_priority::high)));
                         }
                         else {
-                          return std::move(f_sender);
+                          return ex::make_unique_any_sender(std::move(f_sender));
                         }
                       }();
                       // Send the input tile to continuations if the tile is


### PR DESCRIPTION
To help with slow compile times in #1105. I tested this on GPU runs on LUMI and it seems to have no impact on performance at least there.