### PR TITLE
Fix C API tests configuration

### DIFF
--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -209,7 +209,7 @@ function(DLAF_addTest test_target_name)
     string(REPLACE ";" "\", \"" PIKA_EXTRA_ARGS_LIST_CAPI "${_PIKA_EXTRA_ARGS_LIST_CAPI}")
 
     configure_file(
-      ${PROJECT_SOURCE_DIR}/test/include/dlaf_c_test/config.h.in 
+      ${PROJECT_SOURCE_DIR}/test/include/dlaf_c_test/config.h.in
       ${CMAKE_CURRENT_BINARY_DIR}/${test_target_name}_config.h
     )
 

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -209,7 +209,7 @@ function(DLAF_addTest test_target_name)
     string(REPLACE ";" "\", \"" PIKA_EXTRA_ARGS_LIST_CAPI "${_PIKA_EXTRA_ARGS_LIST_CAPI}")
 
     configure_file(
-      ${PROJECT_SOURCE_DIR}/test/include/dlaf_c_test/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h
+      ${PROJECT_SOURCE_DIR}/test/include/dlaf_c_test/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/${test_target_name}_config.h
     )
 
   endif()

--- a/cmake/DLAF_AddTest.cmake
+++ b/cmake/DLAF_AddTest.cmake
@@ -209,7 +209,8 @@ function(DLAF_addTest test_target_name)
     string(REPLACE ";" "\", \"" PIKA_EXTRA_ARGS_LIST_CAPI "${_PIKA_EXTRA_ARGS_LIST_CAPI}")
 
     configure_file(
-      ${PROJECT_SOURCE_DIR}/test/include/dlaf_c_test/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/${test_target_name}_config.h
+      ${PROJECT_SOURCE_DIR}/test/include/dlaf_c_test/config.h.in 
+      ${CMAKE_CURRENT_BINARY_DIR}/${test_target_name}_config.h
     )
 
   endif()

--- a/test/include/dlaf_c_test/c_api_helpers.h
+++ b/test/include/dlaf_c_test/c_api_helpers.h
@@ -21,12 +21,11 @@
 #include <dlaf_c/init.h>
 #include <dlaf_c_test/blacs.h>
 
-#include "config.h"
-
 enum class API { dlaf, scalapack };
 
 template <API api>
-int c_api_test_inititialize(const dlaf::comm::CommunicatorGrid& grid) {
+int c_api_test_inititialize(int pika_argc, const char* pika_argv[], int dlaf_argc,
+                            const char* dlaf_argv[], const dlaf::comm::CommunicatorGrid& grid) {
   dlaf_initialize(pika_argc, pika_argv, dlaf_argc, dlaf_argv);
 
   char grid_order = grid_ordering(MPI_COMM_WORLD, grid.size().rows(), grid.size().cols(),

--- a/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
@@ -21,6 +21,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf_c_test/c_api_helpers.h>
 
+#include "test_eigensolver_c_api_config.h"
 #include "test_eigensolver_c_api_wrapper.h"
 
 #include <gtest/gtest.h>
@@ -66,7 +67,7 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {
 template <class T, Backend B, Device D, API api>
 void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
                      CommunicatorGrid& grid) {
-  auto dlaf_context = c_api_test_inititialize<api>(grid);
+  auto dlaf_context = c_api_test_inititialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
 
   // In normal use the runtime is resumed by the C API call
   // The pika runtime is suspended by dlaf_initialize

--- a/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
@@ -19,6 +19,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf_c_test/c_api_helpers.h>
 
+#include "test_gen_eigensolver_c_api_config.h"
 #include "test_gen_eigensolver_c_api_wrapper.h"
 
 #include <gtest/gtest.h>
@@ -64,7 +65,7 @@ const std::vector<std::tuple<SizeType, SizeType, SizeType>> sizes = {
 template <class T, Backend B, Device D, API api>
 void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
                         CommunicatorGrid& grid) {
-  auto dlaf_context = c_api_test_inititialize<api>(grid);
+  auto dlaf_context = c_api_test_inititialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
 
   // In normal use the runtime is resumed by the C API call
   // The pika runtime is suspended by dlaf_initialize

--- a/test/unit/c_api/factorization/test_cholesky_c_api.cpp
+++ b/test/unit/c_api/factorization/test_cholesky_c_api.cpp
@@ -19,6 +19,7 @@
 #include <dlaf/matrix/matrix.h>
 #include <dlaf_c_test/c_api_helpers.h>
 
+#include "test_cholesky_c_api_config.h"
 #include "test_cholesky_c_api_wrapper.h"
 
 #include <dlaf_test/comm_grids/grids_6_ranks.h>
@@ -58,7 +59,7 @@ const std::vector<std::tuple<SizeType, SizeType>> sizes = {
 template <class T, Backend B, Device D, API api>
 void testCholesky(comm::CommunicatorGrid& grid, const blas::Uplo uplo, const SizeType m,
                   const SizeType mb) {
-  auto dlaf_context = c_api_test_inititialize<api>(grid);
+  auto dlaf_context = c_api_test_inititialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
 
   // In normal use the runtime is resumed by the C API call
   // The pika runtime is suspended by dlaf_initialize


### PR DESCRIPTION
Closes #1115 by
* De-coupling `c_api_helpers.h` from test configuration
* Generating per-target test configuration