### PR TITLE
Add release procedure and release script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-project(DLAF VERSION 0.1.0)
+project(DLAF VERSION 0.4.1)
 
 # ---------------------------------------------------------------------------
 # CMake configurations

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -18,7 +18,8 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
 
 1. Update the minimum required versions if necessary.
 
-1. Add a link to the documentation for the release. The documentation will be generated automatically after the release has been made.
+1. Add a link to the documentation for the release. The documentation will be generated automatically
+   after the `vx.y.z` tag has been created and pushed.
 
 1. Create a release on GitHub using the script `scripts/roll_release.sh`. This
    script automatically tags the release with the corresponding release number.  You'll need to set

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -2,9 +2,8 @@
 
 DLA-Future follows [Semantic Versioning](https://semver.org).
 
-1. For minor and major releases: create and check out a new branch at an
-   appropriate point on `main` with the name `release-major.minor`.  `major` and `minor` should be the
-   major and minor versions of the release. For patch releases: check out the corresponding
+1. For minor and major releases: check out the `master` branch. All changes required for the release are
+   added to `master` via pull requests. For patch releases: check out the corresponding
    `release-major.minor` branch.
 
 1. Write release notes in `CHANGELOG.md`. Check for issues and pull requests for the release on the

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -34,6 +34,7 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
 
 1. Synchronize [upstream spack
    package](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/dla-future/package.py)
-   with local repository.
+   with local repository. Exclude blocks delimited by `###` comments. These are only intended for the
+   internal spack package.
 
 1. Delete your `GITHUB_TOKEN` if created only for the release.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -30,6 +30,8 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
 
 1. Modify the release procedure if necessary.
 
+1. Update spack recipe in `spack/packages/dla-future/package.py` adding the new release.
+
 1. Synchronize [upstream spack
    package](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/dla-future/package.py)
    with local repository.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -13,7 +13,7 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
    updates, documentation updates, or utility script updates. All list entries and paragraphs must be on
    a single line for correct formatting on GitHub.
 
-1. Make sure the version is set correctly in `CMakeLists.txt`.
+1. Update the version in `CMakeLists.txt`.
 
 1. When making a post-1.0.0 major release, remove deprecated functionality if
    appropriate.
@@ -28,10 +28,6 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
    `GITHUB_TOKEN` or both `GITHUB_USER` and `GITHUB_PASSWORD` for the hub release command. When creating
    a `GITHUB_TOKEN`, the only access necessary is `public_repo`.
 
-1. Merge release branch into `master` (with `--no-ff`).
-
-1. Modify the release procedure if necessary.
-
 1. Update spack recipe in `spack/packages/dla-future/package.py` adding the new release.
 
 1. Synchronize [upstream spack
@@ -40,3 +36,5 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
    internal spack package.
 
 1. Delete your `GITHUB_TOKEN` if created only for the release.
+
+1. Modify the release procedure if necessary.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -1,0 +1,36 @@
+# Release procedure for DLA-Future
+
+DLA-Future follows [Semantic Versioning](https://semver.org).
+
+1. For minor and major releases: create and check out a new branch at an
+   appropriate point on `main` with the name `release-major.minor`.  `major` and `minor` should be the
+   major and minor versions of the release. For patch releases: check out the corresponding
+   `release-major.minor` branch.
+
+1. Write release notes in `CHANGELOG.md`. Check for issues and pull requests for the release on the
+   [DLA-F Planning board](https://github.com/orgs/eth-cscs/projects/1). All list entries and paragraphs
+   must be on a single line for correct formatting on GitHub.
+
+1. Make sure the version is set correctly in `CMakeLists.txt`.
+
+1. When making a post-1.0.0 major release, remove deprecated functionality if
+   appropriate.
+
+1. Update the minimum required versions if necessary.
+
+1. Add a link to the documentation for the release. The documentation will be generated automatically after the release has been made.
+
+1. Create a release on GitHub using the script `scripts/roll_release.sh`. This
+   script automatically tags the release with the corresponding release number.  You'll need to set
+   `GITHUB_TOKEN` or both `GITHUB_USER` and `GITHUB_PASSWORD` for the hub release command. When creating
+   a `GITHUB_TOKEN`, the only access necessary is `public_repo`.
+
+1. Merge release branch into `master` (with `--no-ff`).
+
+1. Modify the release procedure if necessary.
+
+1. Synchronize [upstream spack
+   package](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/dla-future/package.py)
+   with local repository.
+
+1. Delete your `GITHUB_TOKEN` if created only for the release.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -8,8 +8,11 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
    `release-major.minor` branch.
 
 1. Write release notes in `CHANGELOG.md`. Check for issues and pull requests for the release on the
-   [DLA-F Planning board](https://github.com/orgs/eth-cscs/projects/1). All list entries and paragraphs
-   must be on a single line for correct formatting on GitHub.
+   [DLA-F Planning board](https://github.com/orgs/eth-cscs/projects/1). Make sure to include changes that
+   may affect users, such as API changes, bugfixes, performance improvements, dependency updates. Changes
+   that do not directly affect users may be left out, such as CI changes, miscellaneous spack package
+   updates, documentation updates, or utility script updates. All list entries and paragraphs must be on
+   a single line for correct formatting on GitHub.
 
 1. Make sure the version is set correctly in `CMakeLists.txt`.
 

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# This script tags a release locally and creates a release on GitHub. It relies
+# on the hub command line tool (https://hub.github.com/).
+
+set -o errexit
+
+VERSION_MAJOR=$(sed -n 's/project(DLAF VERSION \([0-9]\+\)\.[0-9]\+\.[0-9]\+)/\1/p' CMakeLists.txt)
+VERSION_MINOR=$(sed -n 's/project(DLAF VERSION [0-9]\+\.\([0-9]\+\)\.[0-9]\+)/\1/p' CMakeLists.txt)
+VERSION_PATCH=$(sed -n 's/project(DLAF VERSION [0-9]\+\.[0-9]\+\.\([0-9]\+\))/\1/p' CMakeLists.txt)
+VERSION_FULL="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+VERSION_FULL_TAG="v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+VERSION_TITLE="DLA-Future ${VERSION_FULL}"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+RELEASE_BRANCH="release-${VERSION_MAJOR}.${VERSION_MINOR}"
+
+if ! which hub >/dev/null 2>&1; then
+    echo "Hub not installed on this system (see https://hub.github.com/). Exiting."
+    exit 1
+fi
+
+if ! [[ "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]]; then
+    echo "Not on release branch (expected \"$RELEASE_BRANCH\", currently on \"${CURRENT_BRANCH}\"). Not continuing to make release."
+    exit 1
+fi
+
+changelog_path="CHANGELOG.md"
+readme_path="README.md"
+
+echo "You are about to tag and create a final release on GitHub."
+
+echo ""
+echo "Sanity checking release"
+
+sanity_errors=0
+
+printf "Checking that %s has an entry for %s... " "${changelog_path}" "${VERSION_FULL}"
+if grep "## DLA-Future ${VERSION_FULL}" "${changelog_path}"; then
+    echo "OK"
+else
+    echo "Missing"
+    sanity_errors=$((sanity_errors + 1))
+fi
+
+printf "Checking that %s has a documentation entry for %s... " "${readme_path}" "${VERSION_FULL}"
+if grep "^- \[Documentation of \`${VERSION_FULL_TAG}\`\](https://eth-cscs.github.io/DLA-Future/${VERSION_FULL_TAG}" "${readme_path}"; then
+    echo "OK"
+else
+    echo "Missing"
+    sanity_errors=$((sanity_errors + 1))
+fi
+exit 0
+
+if [[ ${sanity_errors} -gt 0 ]]; then
+    echo "Found ${sanity_errors} error(s). Fix it/them and try again."
+    exit 1
+fi
+
+# Extract the changelog for this version
+VERSION_DESCRIPTION=$(
+    # Find the correct heading and print everything from there to the end of the file
+    awk "/^## DLA-Future ${VERSION_FULL}/,EOF" ${changelog_path} |
+        # Remove the heading
+        tail -n+3 |
+        # Find the next heading or the end of the file and print everything until that heading
+        sed '/^## /Q'
+)
+
+echo ""
+echo "The version is: ${VERSION_FULL}"
+echo "The version title is: ${VERSION_TITLE}"
+echo "The version description is:"
+echo "${VERSION_DESCRIPTION}"
+
+echo "Do you want to continue?"
+select yn in "Yes" "No"; do
+    case $yn in
+    Yes) break ;;
+    No) exit ;;
+    esac
+done
+
+if [[ -z "${GITHUB_USER}" || -z "${GITHUB_PASSWORD}" ]] && [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "Need GITHUB_USER and GITHUB_PASSWORD or only GITHUB_TOKEN to be set to use hub release."
+    exit 1
+fi
+
+echo ""
+if [[ "$(git tag -l ${VERSION_FULL_TAG})" == "${VERSION_FULL_TAG}" ]]; then
+    echo "Tag already exists locally."
+else
+    echo "Tagging release."
+    git tag --annotate "${VERSION_FULL_TAG}" --message="${VERSION_TITLE}"
+fi
+
+remote=$(git remote -v | grep github.com:eth-cscs\/DLA-Future.git | cut -f1 | uniq)
+if [[ "$(git ls-remote --tags --refs $remote | grep -o ${VERSION_FULL_TAG})" == "${VERSION_FULL_TAG}" ]]; then
+    echo "Tag already exists remotely."
+else
+    echo "Pushing tag to $remote."
+    git push $remote "${VERSION_FULL_TAG}"
+fi
+
+echo ""
+echo "Creating release."
+hub release create \
+    --message="${VERSION_TITLE}" \
+    --message="${VERSION_DESCRIPTION}" \
+    "${VERSION_FULL_TAG}"

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -59,7 +59,6 @@ else
     echo "Missing"
     sanity_errors=$((sanity_errors + 1))
 fi
-exit 0
 
 if [[ ${sanity_errors} -gt 0 ]]; then
     echo "Found ${sanity_errors} error(s). Fix it/them and try again."

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -22,11 +22,18 @@ VERSION_FULL="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
 VERSION_FULL_TAG="v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
 VERSION_TITLE="DLA-Future ${VERSION_FULL}"
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-RELEASE_BRANCH="release-${VERSION_MAJOR}.${VERSION_MINOR}"
 
 if ! which hub >/dev/null 2>&1; then
     echo "Hub not installed on this system (see https://hub.github.com/). Exiting."
     exit 1
+fi
+
+# Major and minor releases are made directly from master. Patch releases are branched out from the major
+# and minor releases with a release-X.Y branch.
+if [[ "${VERSION_PATCH}" -eq 0 ]]; then
+    RELEASE_BRANCH="master"
+else
+    RELEASE_BRANCH="release-${VERSION_MAJOR}.${VERSION_MINOR}"
 fi
 
 if ! [[ "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]]; then

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -72,7 +72,10 @@ VERSION_DESCRIPTION=$(
         # Remove the heading
         tail -n+3 |
         # Find the next heading or the end of the file and print everything until that heading
-        sed '/^## /Q'
+        sed '/^## /Q' |
+        # Move headings one level up, i.e. transform ### to ##, ## to #, etc. There should be no
+        # top-level heading in the file except for "# Changelog".
+        sed 's/^##/#/'
 )
 
 echo ""


### PR DESCRIPTION
This adds a release procedure, based on pika's release procedure: https://github.com/pika-org/pika/blob/124d4996853f5a63cc08b6dcb77800c5ad65de60/RELEASE_PROCEDURE.rst. I've trimmed out some parts that we haven't been doing in DLA-Future, but we can of course start doing them. See the pika release procedure for a comparison.

This also adds a script that helps making a release (also based on pika's version of it). The script:
- checks that you're on the right branch
- prints what release you're about to make
- checks that there's a changelog entry and that the documentation link has been added
- tags a release
- pushes the release with the changelog entry using https://github.com/docker/hub-tool

https://github.com/eth-cscs/DLA-Future/pull/1126 actually adds the changelog for 0.4.1, the first release to use the script.

This is meant as a starting point and will likely (should) evolve as we improve the release process.