### PR TITLE
Fix DLAF version export in master

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -353,6 +353,14 @@ configure_package_config_file(
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+write_basic_package_version_file(
+  DLAFConfigVersion.cmake
+  VERSION ${PACKAGE_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,13 +354,10 @@ configure_package_config_file(
 )
 
 write_basic_package_version_file(
-  DLAFConfigVersion.cmake
-  VERSION ${PACKAGE_VERSION}
-  COMPATIBILITY AnyNewerVersion
+  DLAFConfigVersion.cmake VERSION ${PACKAGE_VERSION} COMPATIBILITY AnyNewerVersion
 )
 
-install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfigVersion.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/DLAFConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
 )


### PR DESCRIPTION
As noted by @albestro, https://github.com/eth-cscs/DLA-Future/pull/1016 reverted some of the changes introduced by https://github.com/eth-cscs/DLA-Future/pull/1121. The latter PR has been cherry picked for the `0.4.1` release, therefore this problem does not affect the latest release. However, `master` is missing the installation of `DLAFConfigVersion.cmake`.