### PR TITLE
Add explicit transfer before then in tridiag solver local merge implentation

### DIFF
--- a/include/dlaf/eigensolver/tridiag_solver/merge.h
+++ b/include/dlaf/eigensolver/tridiag_solver/merge.h
@@ -1007,9 +1007,11 @@ void multiplyEigenvectors(const SizeType sub_offset, const SizeType n, const Siz
   // └───┴────────┴────┘  └────────────┴────┘
 
   namespace ex = pika::execution::experimental;
+  using pika::execution::thread_priority;
 
   ex::start_detached(
       ex::when_all(std::forward<KSender>(k), std::forward<UDLSenders>(n_udl)) |
+      ex::transfer(dlaf::internal::getBackendScheduler<Backend::MC>(thread_priority::high)) |
       ex::then([sub_offset, n, n_upper, n_lower, e0 = e0.subPipeline(), e1 = e1.subPipelineConst(),
                 e2 = e2.subPipelineConst()](const SizeType k, std::array<std::size_t, 3> n_udl) mutable {
         using dlaf::matrix::internal::MatrixRef;


### PR DESCRIPTION
In https://github.com/eth-cscs/DLA-Future/pull/998 we explicitly added a transfer before the `then` in https://github.com/eth-cscs/DLA-Future/blob/a5e67511288d442eadfd1f80aa1ad80eabedf33e/include/dlaf/eigensolver/tridiag_solver/merge.h#L1744 for reasons that neither @albestro nor I can full remember, but it was at a high level related to lifetimes of pipelines. We didn't do the same for the local case, and I'm adding an explicit `transfer` in this PR before the local `then` for consistency and to avoid surprises in the future (this does not explicitly fix any known bugs). It's generally good to be explicit about where to continue after a `when_all`. I've kept the high priority from the distributed case.