### PR TITLE
Improve release script

### DIFF
--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -53,7 +53,7 @@ echo "Sanity checking release"
 sanity_errors=0
 
 printf "Checking that the git repository is in a clean state... "
-if git status --porcelain ; then
+if [[ `git status --porcelain` ]] ; then
     echo "ERROR"
     sanity_errors=$((sanity_errors + 1))
 else

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -121,7 +121,7 @@ else
     git tag --annotate "${VERSION_FULL_TAG}" --message="${VERSION_TITLE}"
 fi
 
-remote=$(git remote -v | grep github.com:eth-cscs\/DLA-Future.git | cut -f1 | uniq)
+remote=$(git remote -v | grep "github.com[:/]eth-cscs/DLA-Future.git" | cut -f1 | uniq)
 if [[ "$(git ls-remote --tags --refs $remote | grep -o ${VERSION_FULL_TAG})" == "${VERSION_FULL_TAG}" ]]; then
     echo "Tag already exists remotely."
 else

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -52,6 +52,14 @@ echo "Sanity checking release"
 
 sanity_errors=0
 
+printf "Checking that the git repository is in a clean state... "
+if git status --porcelain ; then
+    echo "ERROR"
+    sanity_errors=$((sanity_errors + 1))
+else
+    echo "OK"
+fi
+
 printf "Checking that %s has an entry for %s... " "${changelog_path}" "${VERSION_FULL}"
 if grep "## DLA-Future ${VERSION_FULL}" "${changelog_path}"; then
     echo "OK"

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -36,10 +36,10 @@ else
     RELEASE_BRANCH="version_${VERSION_MAJOR}.${VERSION_MINOR}"
 fi
 
-if ! [[ "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]]; then
-    echo "Not on release branch (expected \"$RELEASE_BRANCH\", currently on \"${CURRENT_BRANCH}\"). Not continuing to make release."
-    exit 1
-fi
+# if ! [[ "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]]; then
+#     echo "Not on release branch (expected \"$RELEASE_BRANCH\", currently on \"${CURRENT_BRANCH}\"). Not continuing to make release."
+#     exit 1
+# fi
 
 changelog_path="CHANGELOG.md"
 readme_path="README.md"
@@ -53,11 +53,11 @@ echo "Sanity checking release"
 sanity_errors=0
 
 printf "Checking that the git repository is in a clean state... "
-if [[ `git status --porcelain` ]] ; then
+if [[ $(git status --porcelain | wc -l) -eq 0  ]] ; then
+    echo "OK"
+else
     echo "ERROR"
     sanity_errors=$((sanity_errors + 1))
-else
-    echo "OK"
 fi
 
 printf "Checking that %s has an entry for %s... " "${changelog_path}" "${VERSION_FULL}"

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -36,10 +36,10 @@ else
     RELEASE_BRANCH="version_${VERSION_MAJOR}.${VERSION_MINOR}"
 fi
 
-# if ! [[ "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]]; then
-#     echo "Not on release branch (expected \"$RELEASE_BRANCH\", currently on \"${CURRENT_BRANCH}\"). Not continuing to make release."
-#     exit 1
-# fi
+if ! [[ "$CURRENT_BRANCH" == "$RELEASE_BRANCH" ]]; then
+    echo "Not on release branch (expected \"$RELEASE_BRANCH\", currently on \"${CURRENT_BRANCH}\"). Not continuing to make release."
+    exit 1
+fi
 
 changelog_path="CHANGELOG.md"
 readme_path="README.md"


### PR DESCRIPTION
* Add support for HTTPS (alongside SSH) as `git` operations protocol
* Add check on `git status` (no un-committed changes allowed)

For DLA-Future-Fortran I used [`gh`](https://cli.github.com/) instead of [`hub`](https://hub.github.com/) used here. `gh` is an official GitHub product, and can simplify authentication. Do we want to switch to it? See [gh-vs-hub](https://github.com/cli/cli/blob/trunk/docs/gh-vs-hub.md) for more context. 