### PR TITLE
Move release script from hub to  gh

### DIFF
--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -25,10 +25,11 @@ DLA-Future follows [Semantic Versioning](https://semver.org).
 1. Add a link to the documentation for the release in `DOCUMENTATION.md` and update the link in `README.md`.
    The documentation will be generated automatically after the `vx.y.z` tag has been created and pushed.
 
+1. Ensure you have `gh` ([GitHub CLI](https://cli.github.com)) installed. Run `gh auth login` to authenticate
+   with your GitHub account, or set `GITHUB_TOKEN` to a token with `public_repo` access.
+
 1. Create a release on GitHub using the script `scripts/roll_release.sh`. This
-   script automatically tags the release with the corresponding release number.  You'll need to set
-   `GITHUB_TOKEN` or both `GITHUB_USER` and `GITHUB_PASSWORD` for the hub release command. When creating
-   a `GITHUB_TOKEN`, the only access necessary is `public_repo`.
+   script automatically tags the release with the corresponding release number.
 
 1. Update spack recipe in `spack/packages/dla-future/package.py` adding the new release.
 

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -11,7 +11,7 @@
 #
 
 # This script tags a release locally and creates a release on GitHub. It relies
-# on the hub command line tool (https://hub.github.com/).
+# on the GitHub CLI (https://cli.github.com).
 
 set -o errexit
 
@@ -24,8 +24,8 @@ VERSION_TITLE="DLA-Future ${VERSION_FULL}"
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 RELEASE_DATE=$(date '+%Y-%m-%d')
 
-if ! which hub >/dev/null 2>&1; then
-    echo "Hub not installed on this system (see https://hub.github.com/). Exiting."
+if ! which gh >/dev/null 2>&1; then
+    echo "GitHub CLI not installed on this system (see https://cli.github.com). Exiting."
     exit 1
 fi
 
@@ -134,11 +134,6 @@ select yn in "Yes" "No"; do
     esac
 done
 
-if [[ -z "${GITHUB_USER}" || -z "${GITHUB_PASSWORD}" ]] && [[ -z "${GITHUB_TOKEN}" ]]; then
-    echo "Need GITHUB_USER and GITHUB_PASSWORD or only GITHUB_TOKEN to be set to use hub release."
-    exit 1
-fi
-
 echo ""
 if [[ "$(git tag -l ${VERSION_FULL_TAG})" == "${VERSION_FULL_TAG}" ]]; then
     echo "Tag already exists locally."
@@ -157,7 +152,6 @@ fi
 
 echo ""
 echo "Creating release."
-hub release create \
-    --message="${VERSION_TITLE}" \
-    --message="${VERSION_DESCRIPTION}" \
-    "${VERSION_FULL_TAG}"
+gh release create "${VERSION_FULL_TAG}" \
+   --title "${VERSION_TITLE}" \
+   --notes "${VERSION_DESCRIPTION}"


### PR DESCRIPTION
Move release script from [`hub`](https://hub.github.com) to the official GitHub CLI [`gh`](https://cli.github.com).

`gh` is also used in DLA-Future-Fortran.