### PR TITLE
Release script improvements

### DIFF
--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -15,6 +15,7 @@
 
 set -o errexit
 
+REPO="eth-cscs/DLA-Future"
 VERSION_MAJOR=$(sed -n 's/project(DLAF VERSION \([0-9]\+\)\.[0-9]\+\.[0-9]\+)/\1/p' CMakeLists.txt)
 VERSION_MINOR=$(sed -n 's/project(DLAF VERSION [0-9]\+\.\([0-9]\+\)\.[0-9]\+)/\1/p' CMakeLists.txt)
 VERSION_PATCH=$(sed -n 's/project(DLAF VERSION [0-9]\+\.[0-9]\+\.\([0-9]\+\))/\1/p' CMakeLists.txt)
@@ -158,5 +159,6 @@ fi
 echo ""
 echo "Creating release."
 gh release create "${VERSION_FULL_TAG}" \
-   --title "${VERSION_TITLE}" \
-   --notes "${VERSION_DESCRIPTION}"
+    --repo "${REPO}" \
+    --title "${VERSION_TITLE}" \
+    --notes "${VERSION_DESCRIPTION}"

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -29,6 +29,11 @@ if ! which gh >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! gh auth status >/dev/null 2>&1; then
+    echo 'gh is not logged in. Run `gh auth login` to authenticate with your GitHub account, or set `GITHUB_TOKEN` to a token with `public_repo` access. Exiting.'
+    exit 1
+fi
+
 # Major and minor releases are made directly from master. Patch releases are branched out from the major
 # and minor releases with a version_X.Y branch.
 if [[ "${VERSION_PATCH}" -eq 0 ]]; then


### PR DESCRIPTION
- Check that user is authenticated before proceeding with release
- Be explicit about repo (otherwise `gh` will not make the release if there's no default repo set, as I had the first time I tried this version of the script)

I've tested the first point, but not the second.

@RMeli will you port this over to DLA-Future-Fortran or would you like a PR?