### PR TITLE
Update clang-format and black version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,7 @@
 ---
-# For clang-format version 15!
+# For clang-format version 18!
 
 Language:        Cpp
-
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
@@ -11,53 +10,67 @@ AlignConsecutiveAssignments:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveBitFields:
   Enabled:         true
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveDeclarations:
   Enabled:         false
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveMacros:
   Enabled:         true
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
+  AlignFunctionPointers: false
   PadOperators:    true
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
 AlignEscapedNewlines: Left
 AlignOperands:   Align
-AlignTrailingComments: true
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: After
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: Never
   AfterEnum:       false
+  AfterExternBlock: false
   AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
-  AfterExternBlock: false
   BeforeCatch:     true
   BeforeElse:      true
   BeforeLambdaBody: false
@@ -66,26 +79,26 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Never
 BreakBeforeBinaryOperators: None
 BreakBeforeConceptDeclarations: Allowed
 BreakBeforeBraces: Custom
-BreakInheritanceList: BeforeColon
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: false
 ColumnLimit:     105
 CommentPragmas:  '^ IWYU pragma:'
-QualifierAlignment: Left
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: Always
-PackConstructorInitializers: BinPack
 FixNamespaceComments: false
 ForEachMacros:
   - foreach
@@ -126,44 +139,64 @@ IncludeCategories:
 IncludeIsMainRegex: '_disabled$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
-IndentCaseLabels: true
 IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
 IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 InsertBraces:    false
+InsertNewlineAtEOF: true
+IntegerLiteralSeparator:
+  Binary:          -1
+  BinaryMinDigits: 0
+  Decimal:         -1
+  DecimalMinDigits: 0
+  Hex:             -1
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
+LineEnding:      LF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 2500
 PenaltyBreakComment: 1500
 PenaltyBreakFirstLessLess: 500
 PenaltyBreakOpenParenthesis: 50
+PenaltyBreakScopeResolution: 500
 PenaltyBreakString: 10000
 PenaltyBreakTemplateDeclaration: 500
 PenaltyExcessCharacter: 100
-PenaltyReturnTypeOnItsOwnLine: 1000
 PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
 PPIndentWidth:   -1
+QualifierAlignment: Left
 ReferenceAlignment: Pointer
 ReflowComments:  true
 RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: true
 RequiresClausePosition: WithPreceding
+RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 10
+SkipMacroDefinitionBody: false
 SortIncludes:    CaseInsensitive
-SortUsingDeclarations: true
+SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
@@ -177,27 +210,36 @@ SpaceBeforeParensOptions:
   AfterFunctionDeclarationName: false
   AfterIfMacros:   true
   AfterOverloadedOperator: false
+  AfterPlacementOperator: false
   AfterRequiresInClause: false
   AfterRequiresInExpression: false
   BeforeNonEmptyParentheses: false
-SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles:  Never
-SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
 SpacesInLineCommentPrefix:
   Minimum:         1
   Maximum:         -1
-SpacesInParentheses: false
+SpacesInParens:  Never
 SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: After
 Standard:        Latest
 TabWidth:        8
-UseCRLF:         false
+TypeNames:
+  - ElementType
+  - GlobalElementIndex
+  - GlobalElementSize
+  - GlobalTileIndex
+  - GlobalTileSize
+  - LocalElementIndex
+  - LocalElementSize
+  - LocalTileIndex
+  - LocalTileSize
+  - SizeType
+  - TileElementIndex
+  - TileElementSize
 UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
 ...

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+# Reformat with clang-format-18
+e92ebf89c466f3291f7e61134c37c996e2e94a3f
+
 # Reformat with clang-format-15
 7f35ac9fe6710addbf1003de547e272f329ec1c1
 

--- a/.github/format.sh
+++ b/.github/format.sh
@@ -22,7 +22,7 @@ do
 
   case $FILE in
     *.cpp|*.h|*.h.in|*.tpp|*.cu)
-      clang-format-15 -i --style=file $FILE
+      clang-format-18 -i --style=file $FILE
       # The following is needed for regions in which clang-format is disabled.
       # Note: clang-format removes trailing spaces even in disabled regions.
       # Check if tab are present.

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends clang-format-15 python3 python3-pip
-          pip3 install --break-system-packages black==23.03.0
+          sudo apt-get install --no-install-recommends clang-format-18 python3 python3-pip
+          pip3 install --break-system-packages black==24.4.2
           pip3 install --break-system-packages cmakelang==0.6.13
 
       - name: Fetch master

--- a/include/dlaf/common/callable_object.h
+++ b/include/dlaf/common/callable_object.h
@@ -26,12 +26,12 @@
 /// that all required overloads are found relative to the namespace where the
 /// macro is used.
 
-#define DLAF_MAKE_CALLABLE_OBJECT(fname)                                                    \
-  constexpr struct fname##_t {                                                              \
-    template <typename... Ts>                                                               \
-    auto operator()(Ts&&... ts) const noexcept(noexcept((fname) (std::forward<Ts>(ts)...))) \
-        -> decltype((fname) (std::forward<Ts>(ts)...)) {                                    \
-      return (fname) (std::forward<Ts>(ts)...);                                             \
-    }                                                                                       \
-  } fname##_o {                                                                             \
+#define DLAF_MAKE_CALLABLE_OBJECT(fname)                                                              \
+  constexpr struct fname##_t {                                                                        \
+    template <typename... Ts>                                                                         \
+    auto operator()(Ts&&... ts) const noexcept(                                                       \
+        noexcept((fname) (std::forward<Ts>(ts)...))) -> decltype((fname) (std::forward<Ts>(ts)...)) { \
+      return (fname) (std::forward<Ts>(ts)...);                                                       \
+    }                                                                                                 \
+  } fname##_o {                                                                                       \
   }

--- a/include/dlaf/common/pipeline.h
+++ b/include/dlaf/common/pipeline.h
@@ -57,7 +57,7 @@ public:
     }
 
     return *this;
-  };
+  }
 
   Pipeline(const Pipeline&) = delete;
   Pipeline& operator=(const Pipeline&) = delete;

--- a/include/dlaf/common/source_location.h
+++ b/include/dlaf/common/source_location.h
@@ -26,8 +26,10 @@ namespace internal {
 ///
 /// It uses DLAF_FUNCTION_NAME that it is set to \_\_PRETTY_FUNCTION\_\_ or \_\_func\_\_ depending on
 /// availability of the former one.
-#define SOURCE_LOCATION() \
-  ::dlaf::common::internal::source_location { __FILE__, __LINE__, DLAF_FUNCTION_NAME }
+#define SOURCE_LOCATION()                     \
+  ::dlaf::common::internal::source_location { \
+    __FILE__, __LINE__, DLAF_FUNCTION_NAME    \
+  }
 
 /// Anticipation of std::source_location from C++20.
 ///

--- a/include/dlaf/common/unwrap.h
+++ b/include/dlaf/common/unwrap.h
@@ -59,7 +59,7 @@ struct Unwrapping {
 
   template <typename... Ts>
   auto operator()(Ts&&... ts) && -> decltype(std::move(f)(
-      Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...)) {
+                                     Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...)) {
     return std::move(f)(Unwrapper<std::decay_t<Ts>>::unwrap(std::forward<Ts>(ts))...);
   }
 

--- a/include/dlaf/communication/kernels/internal/all_reduce.h
+++ b/include/dlaf/communication/kernels/internal/all_reduce.h
@@ -69,7 +69,7 @@ template <Device DCommIn, Device DCommOut, class T, Device DIn, Device DOut>
   auto all_reduce_final = [reduce_op, pcomm = std::move(pcomm),
                            tile_in = std::move(tile_in)](const auto& tile_out_comm) mutable {
     auto all_reduce = [reduce_op, pcomm = std::move(pcomm),
-                       &tile_out_comm](auto const& tile_in_comm) mutable {
+                       &tile_out_comm](const auto& tile_in_comm) mutable {
       return whenAllLift(std::move(pcomm), reduce_op, std::cref(tile_in_comm),
                          std::cref(tile_out_comm)) |
              transformMPI(allReduce_o);

--- a/include/dlaf/matrix/tile.h
+++ b/include/dlaf/matrix/tile.h
@@ -230,7 +230,7 @@ public:
 
   Tile(Tile&& rhs) noexcept : data_(std::move(rhs.data_)), dep_tracker_(std::move(rhs.dep_tracker_)) {
     rhs.dep_tracker_ = std::monostate();
-  };
+  }
 
   /// Destroys the Tile.
   ///
@@ -303,7 +303,7 @@ private:
     return memory::MemoryView<T, D>(tile.data_.memoryView(),
                                     spec.size.isEmpty() ? 0 : tile.data_.linearIndex(spec.origin),
                                     tile.data_.linearSize(spec.size, tile.ld()));
-  };
+  }
 
   Tile(const TileElementSize& size, const memory::MemoryView<ElementType, D>& memory_view,
        SizeType ld) noexcept

--- a/include/dlaf/sender/transform_mpi.h
+++ b/include/dlaf/sender/transform_mpi.h
@@ -48,8 +48,8 @@ template <typename F>
 struct MPICallHelper {
   std::decay_t<F> f;
   template <typename... Ts>
-  auto operator()(Ts&&... ts)
-      -> decltype(std::move(f)(dlaf::common::internal::unwrap(ts)..., std::declval<MPI_Request*>())) {
+  auto operator()(Ts&&... ts) -> decltype(std::move(f)(dlaf::common::internal::unwrap(ts)...,
+                                                       std::declval<MPI_Request*>())) {
     MPI_Request req;
     auto is_request_completed = [&req] {
       int flag;

--- a/include/dlaf/util_math.h
+++ b/include/dlaf/util_math.h
@@ -79,8 +79,8 @@ template <typename IntType>
 constexpr IntType ceilDiv(const IntType num, const IntType den);
 #else
 template <typename IntType>
-constexpr auto ceilDiv(const IntType num, const IntType den)
-    -> std::enable_if_t<std::is_integral_v<IntType>, IntType> {
+constexpr auto ceilDiv(const IntType num,
+                       const IntType den) -> std::enable_if_t<std::is_integral_v<IntType>, IntType> {
   return (num + den - 1) / den;
 }
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -112,21 +112,21 @@ template <class T>
 struct parseFromString {
   static std::optional<T> call(const std::string& val) {
     return val;
-  };
+  }
 };
 
 template <>
 struct parseFromString<std::size_t> {
   static std::optional<std::size_t> call(const std::string& var) {
     return std::stoull(var);
-  };
+  }
 };
 
 template <>
 struct parseFromString<SizeType> {
   static std::optional<SizeType> call(const std::string& var) {
     return std::stoll(var);
-  };
+  }
 };
 
 template <>
@@ -137,7 +137,7 @@ struct parseFromString<bool> {
     if (is_one_of_ignore_case(var, {"OFF", "FALSE", "NO", "0"}))
       return false;
     return std::nullopt;
-  };
+  }
 
 private:
   static bool is_one_of_ignore_case(std::string value, const std::array<std::string, 4>& values) {

--- a/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
@@ -81,10 +81,9 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
   const TileElementSize block_size(mb, mb);
 
   Matrix<const T, Device::CPU> reference = [&]() {
-    auto reference = [&]() -> auto{
+    auto reference = [&]() -> auto {
       return Matrix<T, Device::CPU>(GlobalElementSize(m, m), block_size, grid);
-    }
-    ();
+    }();
     matrix::util::set_random_hermitian(reference);
     return reference;
   }();

--- a/test/unit/communication/test_comm_matrix.cpp
+++ b/test/unit/communication/test_comm_matrix.cpp
@@ -41,9 +41,8 @@ TEST(BcastMatrixTest, TransformMPIRW) {
     start_detached(when_all(ccomm.exclusive(), mat.readwrite(index)) |
                    comm::internal::transformMPI(comm::internal::sendBcast_o));
     mat.readwrite(index) |
-        transformDetach(internal::Policy<Backend::MC>(), [sz](matrix::Tile<double, Device::CPU> tile) {
-          tile({sz - 1, 0}) = 2.;
-        });
+        transformDetach(internal::Policy<Backend::MC>(),
+                        [sz](matrix::Tile<double, Device::CPU> tile) { tile({sz - 1, 0}) = 2.; });
     EXPECT_EQ(2., sync_wait(mat.read(index)).get()({sz - 1, 0}));
   }
   else {
@@ -72,9 +71,8 @@ TEST(BcastMatrixTest, TransformMPIRO) {
     start_detached(when_all(ccomm.exclusive(), mat.read(index)) |
                    comm::internal::transformMPI(comm::internal::sendBcast_o));
     mat.readwrite(index) |
-        transformDetach(internal::Policy<Backend::MC>(), [sz](matrix::Tile<double, Device::CPU> tile) {
-          tile({sz - 1, 0}) = 2.;
-        });
+        transformDetach(internal::Policy<Backend::MC>(),
+                        [sz](matrix::Tile<double, Device::CPU> tile) { tile({sz - 1, 0}) = 2.; });
     EXPECT_EQ(2., sync_wait(mat.read(index)).get()({sz - 1, 0}));
   }
   else {

--- a/test/unit/eigensolver/test_eigensolver.cpp
+++ b/test/unit/eigensolver/test_eigensolver.cpp
@@ -83,13 +83,12 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
   const TileElementSize block_size(mb, mb);
 
   Matrix<const T, Device::CPU> reference = [&]() {
-    auto reference = [&]() -> auto{
+    auto reference = [&]() -> auto {
       if constexpr (isDistributed)
         return Matrix<T, Device::CPU>(GlobalElementSize(m, m), block_size, grid...);
       else
         return Matrix<T, Device::CPU>(LocalElementSize(m, m), block_size);
-    }
-    ();
+    }();
     switch (type) {
       case MatrixType::identity:
         matrix::util::set_identity(reference);

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -66,12 +66,12 @@ T inputValues(const GlobalElementIndex& index) noexcept {
   const SizeType i = index.row();
   const SizeType j = index.col();
   return TypeUtilities<T>::element(i + j / 1024., j - i / 128.);
-};
+}
 
 template <class T>
 T outputValues(const GlobalElementIndex&) noexcept {
   return TypeUtilities<T>::element(13, 26);
-};
+}
 
 TYPED_TEST(MatrixCopyTest, FullMatrixCPU) {
   using dlaf::matrix::util::set;

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -65,7 +65,7 @@ GlobalElementSize globalTestSize(const LocalElementSize& size, const comm::Size2
 GlobalElementSize globalSquareTestSize(const LocalElementSize& size, const comm::Size2D& grid_size) {
   auto k = std::max(grid_size.rows(), grid_size.cols());
   return GlobalElementSize{size.rows() * k, size.cols() * k};
-};
+}
 
 TYPED_TEST(MatrixUtilsTest, Set0) {
   for (auto& comm_grid : this->commGrids()) {


### PR DESCRIPTION
Newer clang-format checks newlines at EOF.

⚠️ Should not be squash-merged!