### PR TITLE
Fix precompiled headers build

### DIFF
--- a/ci/docker/debug-cuda-scalapack.yaml
+++ b/ci/docker/debug-cuda-scalapack.yaml
@@ -18,7 +18,7 @@ spack:
       true
 
   specs:
-    - dla-future@master build_type=Debug +cuda +miniapps +scalapack +ci-test +hdf5
+    - dla-future@master build_type=Debug +cuda +miniapps +scalapack +ci-test +hdf5 +pch
 
   packages:
     all:

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -167,6 +167,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         default=False,
         description="Check number of spawned threads in CI (Advanced usage).",
     )
+
+    variant("pch", default=False, description="Enable precompiled headers.")
     ###
 
     def cmake_args(self):
@@ -298,6 +300,8 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         ### Variants available only in the DLAF repo spack package
         if "+ci-check-threads" in spec:
             args.append(self.define("DLAF_TEST_PREFLAGS", "check-threads"))
+
+        args.append(self.define_from_variant("DLAF_WITH_PRECOMPILED_HEADERS", "pch"))
         ###
 
         # MINIAPPS

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -7,5 +7,6 @@
 // Please, refer to the LICENSE file in the root directory.
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// This file is intentionally empty. It is used for the precompiled headers
-// target.
+
+// It makes the linker happy.
+int main() {}


### PR DESCRIPTION
I accidentally end up building with `DLAF_WITH_PRECOMPILED_HEADERS` when I faced this error

```bash
ialberto@daint105:~/workspace/dla-future.master/build-gpu> ninja dlaf.pch_exe
[1/1] Linking CXX executable src/dlaf.pch_exe
FAILED: src/dlaf.pch_exe
: && /project/csstaff/ialberto/opt/spack-daint/lib/spack/env/case-insensitive/CC -O2 -g -DNDEBUG -pthread -Wl,-lstdc++fs -Wl,-z,defs -fvisibility=hidden -gz src/CMakeFiles/dlaf.pch_exe.dir/dummy.cpp.o src/CMakeFiles/dlaf.pch_exe.dir/dummy.c.o -o src/dlaf.pch_exe  -Wl,-rpath,/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/pika-0.24.0-3ffp63gse4arykov5lqfvtxlbcizxurt/lib64:/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/mimalloc-2.1.2-jnuakfdhri3vtpomqfvjudomcqb5vs7b/lib64:/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/hwloc-2.9.1-umciffc276gxr5xjg63uh2kcwtp42fvx/lib:/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64:/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/lapackpp-2023.11.05-iwqitwa5pepgyvpagytdvbaow7wh3lra/lib64:/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/blaspp-2023.11.05-hcccnba6uimx6scyck7tujifktta43nv/lib64:/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/hdf5-1.14.3-xms4am33tuov57rfsidnebnseicdr5up/lib  -m64 -L/project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/lib -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/pika-0.24.0-3ffp63gse4arykov5lqfvtxlbcizxurt/lib64/libpika.so.0.24.0  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/mimalloc-2.1.2-jnuakfdhri3vtpomqfvjudomcqb5vs7b/lib64/libmimalloc.so.2.1  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/hwloc-2.9.1-umciffc276gxr5xjg63uh2kcwtp42fvx/lib/libhwloc.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libcusolver.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libcublas.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libculibos.a  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libcublasLt.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libcusparse.so  -latomic  -lrt  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libcudart.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/lapackpp-2023.11.05-iwqitwa5pepgyvpagytdvbaow7wh3lra/lib64/liblapackpp.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/blaspp-2023.11.05-hcccnba6uimx6scyck7tujifktta43nv/lib64/libblaspp.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/mkl/2024.0/lib/libmkl_scalapack_lp64.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/mkl/2024.0/lib/libmkl_cdft_core.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/mkl/2024.0/lib/libmkl_gf_lp64.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/mkl/2024.0/lib/libmkl_sequential.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/mkl/2024.0/lib/libmkl_core.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/intel-oneapi-mkl-2024.0.0-5ibuwehkykfoicua3gqfxh56dtrx7uyt/mkl/2024.0/lib/libmkl_blacs_intelmpi_lp64.so  /opt/cray/pe/mpt/7.7.18/gni/mpich-gnu/8.2/lib/libmpich.so  -lpthread  -lm  /usr/lib64/libdl.so  /opt/gcc/11.2.0/snos/lib64/libgomp.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/umpire-2024.02.0-bqph3c62c3btxrubssa2q2vzukdak7pm/lib64/libumpire.a  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/camp-2024.02.0-taonagxrzo2x4tpcdxrynz222ewoxv2w/lib/libcamp.a  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/fmt-10.2.1-4zxoeuyyoqlhxumbnli2dbj6npuc7ems/lib64/libfmt.a  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/cuda-11.8.0-kffo4e4lxlqpkycnwnzp3pezipuxpql7/lib64/libcudart_static.a  /usr/lib64/librt.so  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/hdf5-1.14.3-xms4am33tuov57rfsidnebnseicdr5up/lib/libhdf5_cpp.so.310.0.3  /project/csstaff/ialberto/opt/spack-daint/opt/spack/cray-cnl7-haswell/gcc-11.2.0/hdf5-1.14.3-xms4am33tuov57rfsidnebnseicdr5up/lib/libhdf5.so.310.3.0  -ldl && :
/usr/bin/ld: /usr/lib/../lib64/crt1.o: in function `_start':
/home/abuild/rpmbuild/BUILD/glibc-2.26/csu/../sysdeps/x86_64/start.S:110: undefined reference to `main'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

This is the first thing that came to my mind to fix it, but I'm open to other suggestion of better/correct solution (I didn't investigate why I never faced it before but now it shows up)