### PR TITLE
Rename pxhegvx to pxhegvd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## DLA-Future 0.Y.Z
+
+### Changes
+
+- Renamed ScaLAPACK-like generalized eigensolvers `pXsygvx`/`pXhegvx` to `pXsygvd`/`pXhegvd`
+
 ## DLA-Future 0.5.0
 
 ### Changes

--- a/include/dlaf_c/eigensolver/gen_eigensolver.h
+++ b/include/dlaf_c/eigensolver/gen_eigensolver.h
@@ -98,25 +98,25 @@ DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_z(
 /// submatrix \f$\mathbf{A}\f$, has to be 1
 /// @param descz ScaLAPACK array descriptor of the global matrix \f$\mathbf{Z}\f$
 /// @param[out] info 0 if the eigensolver completed normally
-DLAF_EXTERN_C void dlaf_pssygvx(const char uplo, const int n, float* a, const int ia, const int ja,
+DLAF_EXTERN_C void dlaf_pssygvd(const char uplo, const int n, float* a, const int ia, const int ja,
                                 const int desca[9], float* b, const int ib, const int jb,
                                 const int descb[9], float* w, float* z, const int iz, const int jz,
                                 const int descz[9], int* info) DLAF_NOEXCEPT;
 
-/// @copydoc dlaf_pssygvx
-DLAF_EXTERN_C void dlaf_pdsygvx(const char uplo, const int n, double* a, const int ia, const int ja,
+/// @copydoc dlaf_pssygvd
+DLAF_EXTERN_C void dlaf_pdsygvd(const char uplo, const int n, double* a, const int ia, const int ja,
                                 const int desca[9], double* b, const int ib, const int jb,
                                 const int descb[9], double* w, double* z, const int iz, const int jz,
                                 const int descz[9], int* info) DLAF_NOEXCEPT;
 
-/// @copydoc dlaf_pssygvx
-DLAF_EXTERN_C void dlaf_pchegvx(const char uplo, const int n, dlaf_complex_c* a, const int ia,
+/// @copydoc dlaf_pssygvd
+DLAF_EXTERN_C void dlaf_pchegvd(const char uplo, const int n, dlaf_complex_c* a, const int ia,
                                 const int ja, const int desca[9], dlaf_complex_c* b, const int ib,
                                 const int jb, const int descb[9], float* w, dlaf_complex_c* z,
                                 const int iz, const int jz, const int descz[9], int* info) DLAF_NOEXCEPT;
 
-/// @copydoc dlaf_pssygvx
-DLAF_EXTERN_C void dlaf_pzhegvx(const char uplo, const int n, dlaf_complex_z* a, const int ia,
+/// @copydoc dlaf_pssygvd
+DLAF_EXTERN_C void dlaf_pzhegvd(const char uplo, const int n, dlaf_complex_z* a, const int ia,
                                 const int ja, const int desca[9], dlaf_complex_z* b, const int ib,
                                 const int jb, const int descb[9], double* w, dlaf_complex_z* z,
                                 const int iz, const int jz, const int descz[9], int* info) DLAF_NOEXCEPT;

--- a/src/c_api/eigensolver/gen_eigensolver.cpp
+++ b/src/c_api/eigensolver/gen_eigensolver.cpp
@@ -54,31 +54,31 @@ int dlaf_hermitian_generalized_eigensolver_z(const int dlaf_context, const char 
 
 #ifdef DLAF_WITH_SCALAPACK
 
-void dlaf_pssygvx(const char uplo, const int m, float* a, const int ia, const int ja, const int desca[9],
+void dlaf_pssygvd(const char uplo, const int m, float* a, const int ia, const int ja, const int desca[9],
                   float* b, const int ib, const int jb, const int descb[9], float* w, float* z,
                   const int iz, const int jz, const int descz[9], int* info) noexcept {
-  pxhegvx<float>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
+  pxhegvd<float>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
-void dlaf_pdsygvx(const char uplo, const int m, double* a, const int ia, const int ja,
+void dlaf_pdsygvd(const char uplo, const int m, double* a, const int ia, const int ja,
                   const int desca[9], double* b, const int ib, const int jb, const int descb[9],
                   double* w, double* z, const int iz, const int jz, const int descz[9],
                   int* info) noexcept {
-  pxhegvx<double>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
+  pxhegvd<double>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
-void dlaf_pchegvx(const char uplo, const int m, dlaf_complex_c* a, const int ia, const int ja,
+void dlaf_pchegvd(const char uplo, const int m, dlaf_complex_c* a, const int ia, const int ja,
                   const int desca[9], dlaf_complex_c* b, const int ib, const int jb, const int descb[9],
                   float* w, dlaf_complex_c* z, const int iz, const int jz, const int descz[9],
                   int* info) noexcept {
-  pxhegvx<std::complex<float>>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
+  pxhegvd<std::complex<float>>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
-void dlaf_pzhegvx(const char uplo, const int m, dlaf_complex_z* a, const int ia, const int ja,
+void dlaf_pzhegvd(const char uplo, const int m, dlaf_complex_z* a, const int ia, const int ja,
                   const int desca[9], dlaf_complex_z* b, const int ib, const int jb, const int descb[9],
                   double* w, dlaf_complex_z* z, const int iz, const int jz, const int descz[9],
                   int* info) noexcept {
-  pxhegvx<std::complex<double>>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
+  pxhegvd<std::complex<double>>(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, *info);
 }
 
 #endif

--- a/src/c_api/eigensolver/gen_eigensolver.h
+++ b/src/c_api/eigensolver/gen_eigensolver.h
@@ -81,7 +81,7 @@ int hermitian_generalized_eigensolver(const int dlaf_context, const char uplo, T
 #ifdef DLAF_WITH_SCALAPACK
 
 template <typename T>
-void pxhegvx(const char uplo, const int m, T* a, const int ia, const int ja, const int desca[9], T* b,
+void pxhegvd(const char uplo, const int m, T* a, const int ia, const int ja, const int desca[9], T* b,
              const int ib, const int jb, const int descb[9], dlaf::BaseType<T>* w, T* z, const int iz,
              int jz, const int descz[9], int& info) {
   DLAF_ASSERT(desca[0] == 1, desca[0]);

--- a/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
@@ -166,19 +166,19 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
       int desc_z[] = {1, dlaf_context, (int) m, (int) m, (int) mb, (int) mb, 0, 0, lld_eigenvectors};
       int info = -1;
       if constexpr (std::is_same_v<T, double>) {
-        C_dlaf_pdsygvx(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
+        C_dlaf_pdsygvd(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
                        eigenvalues_ptr, local_eigenvectors_ptr, 1, 1, desc_z, &info);
       }
       else if constexpr (std::is_same_v<T, float>) {
-        C_dlaf_pssygvx(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
+        C_dlaf_pssygvd(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
                        eigenvalues_ptr, local_eigenvectors_ptr, 1, 1, desc_z, &info);
       }
       else if constexpr (std::is_same_v<T, std::complex<double>>) {
-        C_dlaf_pzhegvx(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
+        C_dlaf_pzhegvd(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
                        eigenvalues_ptr, local_eigenvectors_ptr, 1, 1, desc_z, &info);
       }
       else if constexpr (std::is_same_v<T, std::complex<float>>) {
-        C_dlaf_pchegvx(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
+        C_dlaf_pchegvd(dlaf_uplo, (int) m, local_a_ptr, 1, 1, desc_a, local_b_ptr, 1, 1, desc_b,
                        eigenvalues_ptr, local_eigenvectors_ptr, 1, 1, desc_z, &info);
       }
       else {

--- a/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api_wrapper.c
+++ b/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api_wrapper.c
@@ -46,30 +46,30 @@ int C_dlaf_hermitian_generalized_eigensolver_z(const int dlaf_context, const cha
 
 #ifdef DLAF_WITH_SCALAPACK
 
-void C_dlaf_pssygvx(char uplo, const int m, float* a, const int ia, const int ja, const int desca[9],
+void C_dlaf_pssygvd(char uplo, const int m, float* a, const int ia, const int ja, const int desca[9],
                     float* b, const int ib, const int jb, const int descb[9], float* w, float* z,
                     const int iz, const int jz, const int descz[9], int* info) {
-  dlaf_pssygvx(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
+  dlaf_pssygvd(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
 }
 
-void C_dlaf_pdsygvx(const char uplo, const int m, double* a, const int ia, const int ja,
+void C_dlaf_pdsygvd(const char uplo, const int m, double* a, const int ia, const int ja,
                     const int desca[9], double* b, const int ib, const int jb, const int descb[9],
                     double* w, double* z, const int iz, const int jz, const int descz[9], int* info) {
-  dlaf_pdsygvx(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
+  dlaf_pdsygvd(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
 }
 
-void C_dlaf_pchegvx(const char uplo, const int m, dlaf_complex_c* a, const int ia, const int ja,
+void C_dlaf_pchegvd(const char uplo, const int m, dlaf_complex_c* a, const int ia, const int ja,
                     const int desca[9], dlaf_complex_c* b, const int ib, const int jb,
                     const int descb[9], float* w, dlaf_complex_c* z, const int iz, const int jz,
                     const int descz[9], int* info) {
-  dlaf_pchegvx(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
+  dlaf_pchegvd(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
 }
 
-void C_dlaf_pzhegvx(const char uplo, const int m, dlaf_complex_z* a, const int ia, const int ja,
+void C_dlaf_pzhegvd(const char uplo, const int m, dlaf_complex_z* a, const int ia, const int ja,
                     const int desca[9], dlaf_complex_z* b, const int ib, const int jb,
                     const int descb[9], double* w, dlaf_complex_z* z, const int iz, const int jz,
                     const int descz[9], int* info) {
-  dlaf_pzhegvx(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
+  dlaf_pzhegvd(uplo, m, a, ia, ja, desca, b, ib, jb, descb, w, z, iz, jz, descz, info);
 }
 
 #endif

--- a/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api_wrapper.h
+++ b/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api_wrapper.h
@@ -35,22 +35,22 @@ DLAF_EXTERN_C int C_dlaf_hermitian_generalized_eigensolver_z(
     const struct DLAF_descriptor descz);
 
 #ifdef DLAF_WITH_SCALAPACK
-DLAF_EXTERN_C void C_dlaf_pssygvx(char uplo, const int m, float* a, const int ia, const int ja,
+DLAF_EXTERN_C void C_dlaf_pssygvd(char uplo, const int m, float* a, const int ia, const int ja,
                                   const int desca[9], float* b, const int ib, const int jb,
                                   const int descb[9], float* w, float* z, const int iz, const int jz,
                                   const int descz[9], int* info);
 
-DLAF_EXTERN_C void C_dlaf_pdsygvx(const char uplo, const int m, double* a, const int ia, const int ja,
+DLAF_EXTERN_C void C_dlaf_pdsygvd(const char uplo, const int m, double* a, const int ia, const int ja,
                                   const int desca[9], double* b, const int ib, const int jb,
                                   const int descb[9], double* w, double* z, const int iz, const int jz,
                                   const int descz[9], int* info);
 
-DLAF_EXTERN_C void C_dlaf_pchegvx(const char uplo, const int m, dlaf_complex_c* a, const int ia,
+DLAF_EXTERN_C void C_dlaf_pchegvd(const char uplo, const int m, dlaf_complex_c* a, const int ia,
                                   const int ja, const int desca[9], dlaf_complex_c* b, const int ib,
                                   const int jb, const int descb[9], float* w, dlaf_complex_c* z,
                                   const int iz, const int jz, const int descz[9], int* info);
 
-DLAF_EXTERN_C void C_dlaf_pzhegvx(const char uplo, const int m, dlaf_complex_z* a, const int ia,
+DLAF_EXTERN_C void C_dlaf_pzhegvd(const char uplo, const int m, dlaf_complex_z* a, const int ia,
                                   const int ja, const int desca[9], dlaf_complex_z* b, const int ib,
                                   const int jb, const int descb[9], double* w, dlaf_complex_z* z,
                                   const int iz, const int jz, const int descz[9], int* info);


### PR DESCRIPTION
ScaLAPACK only implements `pxhegvx`, but the correct name for our implementation is `pxhegvd` (see LAPACK naming conventions).

This is a breaking change that will require changes to the Fortran API and its use by downstream projects (currently CP2K).