### PR TITLE
Improve release script

### DIFF
--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -145,10 +145,8 @@ fi
 
 # Extract the changelog for this version
 VERSION_DESCRIPTION=$(
-    # Find the correct heading and print everything until next heading
-    awk "/^## DLA-Future ${REGEX_VERSION_FULL}/{f=1; next} f==0{next} /## DLA-Future/{exit};1" CHANGELOG.md |
-        # Remove empty lines at the beginning
-        awk 'NF {p=1} p' |
+    # Find the correct heading and print everything (removing empty lines at the beginning) until next heading
+    awk "/^## DLA-Future ${REGEX_VERSION_FULL}/{f=1; next} f==0{next} /## DLA-Future/{exit} NF{p=1} p" CHANGELOG.md |
         # Move headings one level up, i.e. transform ### to ##, ## to #, etc. There should be no
         # top-level heading in the file except for "# Changelog".
         sed 's/^##/#/'


### PR DESCRIPTION
Fixed version description detection on macOS (again GNU extensions of sed).

Moved exit due of errors after detecting and printing release details (easier to debug the script)

Make option to override local repo to be clean (Can release and make PR for updating release script later)