### PR TITLE
Fix blaspp/lapackpp deprecations of enum conversions (Uplo, Op, ...) from and to string

### DIFF
--- a/include/dlaf/blas/enum_parse.h
+++ b/include/dlaf/blas/enum_parse.h
@@ -1,0 +1,25 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2024, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <blas/util.hh>
+
+namespace dlaf::internal {
+
+inline blas::Uplo char2uplo(const char uplo_c) {
+  blas::Uplo uplo;
+  blas::from_string(std::to_string(uplo_c), &uplo);
+  return uplo;
+}
+
+}

--- a/include/dlaf/blas/enum_parse.h
+++ b/include/dlaf/blas/enum_parse.h
@@ -12,13 +12,15 @@
 
 /// @file
 
+#include <string>
+
 #include <blas/util.hh>
 
 namespace dlaf::internal {
 
 inline blas::Uplo char2uplo(const char uplo_c) {
   blas::Uplo uplo;
-  blas::from_string(std::to_string(uplo_c), &uplo);
+  blas::from_string(std::string(&uplo_c, 1), &uplo);
   return uplo;
 }
 

--- a/include/dlaf/lapack/enum_output.h
+++ b/include/dlaf/lapack/enum_output.h
@@ -37,7 +37,7 @@ inline std::ostream& operator<<(std::ostream& out, const Norm& norm) {
 }
 
 inline std::ostream& operator<<(std::ostream& out, const lapack::MatrixType& mtype) {
-  out << lapack::matrixtype2str(mtype);
+  out << to_c_string(mtype);
   return out;
 }
 

--- a/miniapp/include/dlaf/miniapp/options.h
+++ b/miniapp/include/dlaf/miniapp/options.h
@@ -316,36 +316,36 @@ inline pika::program_options::options_description getMiniappKernelOptionsDescrip
 
 inline void addLayoutOption(pika::program_options::options_description& desc,
                             const blas::Layout def = blas::Layout::ColMajor) {
-  desc.add_options()(
-      "layout", pika::program_options::value<std::string>()->default_value({blas::layout2char(def)}),
-      "'C' (ColMajor), 'R' (RowMajor)");
+  desc.add_options()("layout",
+                     pika::program_options::value<std::string>()->default_value({blas::to_char(def)}),
+                     "'C' (ColMajor), 'R' (RowMajor)");
 }
 
 inline void addOpOption(pika::program_options::options_description& desc,
                         const blas::Op def = blas::Op::NoTrans) {
   desc.add_options()("op",
-                     pika::program_options::value<std::string>()->default_value({blas::op2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::to_char(def)}),
                      "'N' (NoTrans), 'T' (Trans), 'C' (ConjTrans)");
 }
 
 inline void addUploOption(pika::program_options::options_description& desc,
                           const blas::Uplo def = blas::Uplo::Lower) {
   desc.add_options()("uplo",
-                     pika::program_options::value<std::string>()->default_value({blas::uplo2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::to_char(def)}),
                      "'L' (Lower), 'U' (Upper), 'G' (General)");
 }
 
 inline void addDiagOption(pika::program_options::options_description& desc,
                           const blas::Diag def = blas::Diag::NonUnit) {
   desc.add_options()("diag",
-                     pika::program_options::value<std::string>()->default_value({blas::diag2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::to_char(def)}),
                      "'N' (NonUnit), 'U' (Unit)");
 }
 
 inline void addSideOption(pika::program_options::options_description& desc,
                           const blas::Side def = blas::Side::Left) {
   desc.add_options()("side",
-                     pika::program_options::value<std::string>()->default_value({blas::side2char(def)}),
+                     pika::program_options::value<std::string>()->default_value({blas::to_char(def)}),
                      "'L' (Left), 'R' (Right)");
 }
 }

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -68,7 +68,13 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("blas")
     depends_on("lapack")
     depends_on("scalapack", when="+scalapack")
+
     depends_on("blaspp@2022.05.00:")
+
+    # see https://github.com/eth-cscs/DLA-Future/pull/1181
+    depends_on("blaspp@2024.05.31:", when="@0.6.1:")
+    conflicts("^blasspp@2025.05:", when="@:0.6.0")
+
     depends_on("lapackpp@2022.05.00:")
     depends_on("intel-oneapi-mkl +cluster", when="^[virtuals=scalapack] intel-oneapi-mkl")
 

--- a/src/c_api/eigensolver/eigensolver.h
+++ b/src/c_api/eigensolver/eigensolver.h
@@ -15,6 +15,7 @@
 
 #include <pika/init.hpp>
 
+#include <dlaf/blas/enum_parse.h>
 #include <dlaf/common/assert.h>
 #include <dlaf/eigensolver/eigensolver.h>
 #include <dlaf/matrix/create_matrix.h>
@@ -60,7 +61,8 @@ int hermitian_eigensolver(const int dlaf_context, const char uplo, T* a,
     MatrixBaseMirror eigenvalues(eigenvalues_host);
 
     dlaf::hermitian_eigensolver<dlaf::Backend::Default, dlaf::Device::Default, T>(
-        communicator_grid, blas::char2uplo(uplo), matrix.get(), eigenvalues.get(), eigenvectors.get());
+        communicator_grid, dlaf::internal::char2uplo(uplo), matrix.get(), eigenvalues.get(),
+        eigenvectors.get());
   }  // Destroy mirror
 
   // Ensure data is copied back to the host

--- a/src/c_api/eigensolver/gen_eigensolver.h
+++ b/src/c_api/eigensolver/gen_eigensolver.h
@@ -15,6 +15,7 @@
 
 #include <pika/init.hpp>
 
+#include <dlaf/blas/enum_parse.h>
 #include <dlaf/common/assert.h>
 #include <dlaf/eigensolver/gen_eigensolver.h>
 #include <dlaf/matrix/create_matrix.h>
@@ -67,12 +68,13 @@ int hermitian_generalized_eigensolver_helper(const int dlaf_context, const char 
 
     if (!factorized) {
       dlaf::hermitian_generalized_eigensolver<dlaf::Backend::Default, dlaf::Device::Default, T>(
-          communicator_grid, blas::char2uplo(uplo), matrix_a.get(), matrix_b.get(), eigenvalues.get(),
-          eigenvectors.get());
+          communicator_grid, dlaf::internal::char2uplo(uplo), matrix_a.get(), matrix_b.get(),
+          eigenvalues.get(), eigenvectors.get());
     }
     else {
       dlaf::hermitian_generalized_eigensolver_factorized<dlaf::Backend::Default, dlaf::Device::Default,
-                                                         T>(communicator_grid, blas::char2uplo(uplo),
+                                                         T>(communicator_grid,
+                                                            dlaf::internal::char2uplo(uplo),
                                                             matrix_a.get(), matrix_b.get(),
                                                             eigenvalues.get(), eigenvectors.get());
     }

--- a/src/c_api/factorization/cholesky.h
+++ b/src/c_api/factorization/cholesky.h
@@ -18,6 +18,7 @@
 
 #include <pika/init.hpp>
 
+#include <dlaf/blas/enum_parse.h>
 #include <dlaf/factorization/cholesky.h>
 #include <dlaf/matrix/matrix.h>
 #include <dlaf/matrix/matrix_mirror.h>
@@ -47,9 +48,8 @@ int cholesky_factorization(const int dlaf_context, const char uplo, T* a,
   {
     MatrixMirror matrix(matrix_host);
 
-    dlaf::cholesky_factorization<dlaf::Backend::Default, dlaf::Device::Default, T>(communicator_grid,
-                                                                                   blas::char2uplo(uplo),
-                                                                                   matrix.get());
+    dlaf::cholesky_factorization<dlaf::Backend::Default, dlaf::Device::Default, T>(
+        communicator_grid, dlaf::internal::char2uplo(uplo), matrix.get());
   }  // Destroy mirror
 
   matrix_host.waitLocalTiles();

--- a/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
@@ -101,7 +101,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
     eigenvalues.waitLocalTiles();
     eigenvectors.waitLocalTiles();
 
-    char dlaf_uplo = blas::uplo2char(uplo);
+    char dlaf_uplo = blas::to_char(uplo);
 
     // Get top left local tiles
     auto [local_a_ptr, lld_a] = top_left_tile(mat_a_h);

--- a/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
@@ -115,7 +115,7 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
     eigenvalues.waitLocalTiles();
     eigenvectors.waitLocalTiles();
 
-    char dlaf_uplo = blas::uplo2char(uplo);
+    char dlaf_uplo = blas::to_char(uplo);
 
     // Get top left local tiles
     auto [local_a_ptr, lld_a] = top_left_tile(mat_a_h);

--- a/test/unit/c_api/factorization/test_cholesky_c_api.cpp
+++ b/test/unit/c_api/factorization/test_cholesky_c_api.cpp
@@ -80,7 +80,7 @@ void testCholesky(comm::CommunicatorGrid& grid, const blas::Uplo uplo, const Siz
   set(mat_h, el);
   mat_h.waitLocalTiles();
 
-  char dlaf_uplo = blas::uplo2char(uplo);
+  char dlaf_uplo = blas::to_char(uplo);
 
   // Get pointer to first element of local matrix
   auto [local_a_ptr, lld] = top_left_tile(mat_h);


### PR DESCRIPTION
Close #1165

From `blaspp@2024.05.31` [release notes](https://github.com/icl-utk-edu/blaspp/releases/tag/v2024.05.31)

> - Updated enum parameters to have to_string, from_string; deprecate `<enum>`2str, str2`<enum>`