### PR TITLE
Reenable stdexec GCC CI configurations

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -5,9 +5,8 @@ include:
   - local: 'ci/cpu/clang15_release.yml'
   - local: 'ci/cpu/clang16_release.yml'
   - local: 'ci/cpu/clang18_release.yml'
-  # https://github.com/eth-cscs/DLA-Future/issues/1184
-  # - local: 'ci/cpu/gcc11_release_stdexec.yml'
-  # - local: 'ci/cpu/gcc11_debug_stdexec.yml'
+  - local: 'ci/cpu/gcc11_release_stdexec.yml'
+  - local: 'ci/cpu/gcc11_debug_stdexec.yml'
   - local: 'ci/cpu/gcc12_release_cxx20.yml'
   - local: 'ci/cpu/gcc13_codecov.yml'
   - local: 'ci/cpu/gcc13_release.yml'

--- a/include/dlaf/communication/kernels/internal/all_reduce.h
+++ b/include/dlaf/communication/kernels/internal/all_reduce.h
@@ -80,8 +80,9 @@ template <Device DCommIn, Device DCommOut, class T, Device DIn, Device DOut>
     // written into the output tile instead).  The reduction is explicitly done
     // on CPU memory so that we can manage potential asynchronous copies between
     // CPU and GPU. A reduction requires contiguous memory.
-    return withTemporaryTile<DCommIn, CopyToDestination::Yes, CopyFromDestination::No,
-                             RequireContiguous::Yes>(std::move(tile_in), std::move(all_reduce));
+    return pika::execution::experimental::make_unique_any_sender(
+        withTemporaryTile<DCommIn, CopyToDestination::Yes, CopyFromDestination::No,
+                          RequireContiguous::Yes>(std::move(tile_in), std::move(all_reduce)));
   };
 
 #if !defined(DLAF_WITH_MPI_GPU_AWARE)


### PR DESCRIPTION
Fixes #1184. Based on #1180, since that disables the stdexec CI.

This is a workaround to avoid compilation errors like:
```
error: exception specification of 'decltype(auto) stdexec::dependent_domain::transform_sender(_Sender&&, const _Env&) const [with _Sender = stdexec::__sexpr<<lambda closure object>stdexec::{anonymous}::<lambda()>(), stdexec::{anonymous}::__anon>; _Env = stdexec::__env::env<>]' depends on itself
  179 |     noexcept(__is_nothrow_transform_sender<_Sender, _Env>()) -> decltype(auto) {
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

This is triggered by the two nested `withTemporaryTiles` used in `all_reduce.h` (https://github.com/eth-cscs/DLA-Future/blob/a64c82287863fb1d6bc04c9b6e991c165640f0a5/include/dlaf/communication/kernels/internal/all_reduce.h#L51-L99). The smallest reproducer I've found so far involves both pika and stdexec, so I can't yet conclude if it's a bug in either or if we should just avoid this pattern in general.