### PR TITLE
Move stdexec compilation to c++ files + add CI for cuda stdexec configuration

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -15,5 +15,6 @@ include:
   - local: 'ci/cuda/gcc11_release_scalapack.yml'
   - local: 'ci/cuda/gcc11_codecov.yml'
   - local: 'ci/cuda/gcc11_debug_scalapack.yml'
+  - local: 'ci/cuda/gcc13_release_stdexec.yml'
   - local: 'ci/rocm/clang14_release.yml'
   - local: 'ci/rocm/clang14_release_stdexec.yml'

--- a/ci/cuda/gcc13_release_stdexec.yml
+++ b/ci/cuda/gcc13_release_stdexec.yml
@@ -19,12 +19,3 @@ cuda gcc13 stdexec release build:
     - cuda gcc13 stdexec release deps
   variables:
     DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc13-release/deploy:$CI_COMMIT_SHA
-
-cuda gcc13 release test:
-  extends: .run_common
-  needs:
-    - cuda gcc13 release build
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cuda gcc13 release build

--- a/ci/cuda/gcc13_release_stdexec.yml
+++ b/ci/cuda/gcc13_release_stdexec.yml
@@ -1,0 +1,30 @@
+include:
+  - local: 'ci/common-ci.yml'
+
+cuda gcc13 stdexec release deps:
+  extends: .build_deps_common
+  variables:
+    BASE_IMAGE: docker.io/nvidia/cuda:12.6.1-devel-ubuntu24.04
+    COMPILER: gcc@13
+    CXXSTD: 20
+    SPACK_ENVIRONMENT: ci/docker/release-cuda-stdexec.yaml
+    USE_MKL: "ON"
+    BUILD_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc13-release-stdexec/build
+
+cuda gcc13 stdexec release build:
+  extends:
+    - .build_common
+    - .build_for_daint-gpu
+  needs:
+    - cuda gcc13 stdexec release deps
+  variables:
+    DEPLOY_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc13-release/deploy:$CI_COMMIT_SHA
+
+cuda gcc13 release test:
+  extends: .run_common
+  needs:
+    - cuda gcc13 release build
+  trigger:
+    include:
+      - artifact: pipeline.yml
+        job: cuda gcc13 release build

--- a/ci/docker/release-cuda-stdexec.yaml
+++ b/ci/docker/release-cuda-stdexec.yaml
@@ -1,0 +1,32 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+spack:
+  include:
+  - /spack_environment/common.yaml
+
+  view: false
+  concretizer:
+    unify:
+      true
+
+  specs:
+    - dla-future@master +cuda +miniapps +ci-test
+
+  packages:
+    all:
+      variants:
+        - 'build_type=Release'
+    pika:
+      require:
+        - '+stdexec'
+    stdexec:
+      require:
+        - '@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main'

--- a/include/dlaf/communication/kernels/internal/all_reduce.h
+++ b/include/dlaf/communication/kernels/internal/all_reduce.h
@@ -17,6 +17,7 @@
 #include <mpi.h>
 
 #include <pika/execution.hpp>
+#include <pika/execution_base/any_sender.hpp>
 
 #include <dlaf/common/callable_object.h>
 #include <dlaf/common/eti.h>
@@ -80,8 +81,9 @@ template <Device DCommIn, Device DCommOut, class T, Device DIn, Device DOut>
     // written into the output tile instead).  The reduction is explicitly done
     // on CPU memory so that we can manage potential asynchronous copies between
     // CPU and GPU. A reduction requires contiguous memory.
-    return withTemporaryTile<DCommIn, CopyToDestination::Yes, CopyFromDestination::No,
-                             RequireContiguous::Yes>(std::move(tile_in), std::move(all_reduce));
+    return pika::execution::experimental::make_unique_any_sender(
+        withTemporaryTile<DCommIn, CopyToDestination::Yes, CopyFromDestination::No,
+                          RequireContiguous::Yes>(std::move(tile_in), std::move(all_reduce)));
   };
 
 #if !defined(DLAF_WITH_MPI_GPU_AWARE)

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -159,7 +159,7 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
         values=cxxstds,
         description="Use the specified C++ standard when building",
     )
-    conflicts("cxxstd=20", when="+cuda")
+    conflicts("cxxstd=20", when="+cuda ^cuda@:11")
 
     for cxxstd in cxxstds:
         depends_on(f"pika cxxstd={cxxstd}", when=f"cxxstd={cxxstd}")

--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -98,8 +98,6 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("pika +cuda", when="+cuda")
     depends_on("pika +rocm", when="+rocm")
 
-    conflicts("^pika cxxstd=20", when="+cuda")
-
     depends_on("whip +cuda", when="+cuda")
     depends_on("whip +rocm", when="+rocm")
 


### PR DESCRIPTION
- Move stdexec compilation out of cuda files.
- Remove spack conflict when cuda and pika cxxstd=20.
- Attempt to add CI with gcc 12, cuda 11 and stdexec.
- Use @msimberg's fix for latest stdexec, I'll rebased when #1187 is merged.