### PR TITLE
Patch addAlpha definitions to work around buggy HIP complex operator overloads

### DIFF
--- a/src/lapack/gpu/add.cu
+++ b/src/lapack/gpu/add.cu
@@ -32,6 +32,20 @@ __device__ inline void addAlpha(const T& alpha, const T& a, T& b) {
   b = b + alpha * a;
 }
 
+#ifdef DLAF_WITH_HIP
+template <>
+__device__ inline void addAlpha<hipFloatComplex>(const hipFloatComplex& alpha, const hipFloatComplex& a,
+                                                 hipFloatComplex& b) {
+  b = b + hipCmulf(alpha, a);
+}
+
+template <>
+__device__ inline void addAlpha<hipDoubleComplex>(const hipDoubleComplex& alpha,
+                                                  const hipDoubleComplex& a, hipDoubleComplex& b) {
+  b = b + hipCmul(alpha, a);
+}
+#endif
+
 template <class T>
 __device__ inline void sum(const T& /*alpha*/, const T& a, T& b) {
   b = b + a;


### PR DESCRIPTION
Replaces #1083 (at least "temporarily"). This simply takes the patch we already use in upstream spack and proposes to make it semi-permanent, until we some day decide to revisit #1083. This came up again when compiling DLA-Future without patches on LUMI with HIP 6 (also without patches, unlike the spack-installed HIP 6).