### PR TITLE
Add compatibility for `transfer` to `continues_on` rename

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -35,7 +35,7 @@ stages:
     reports:
       dotenv: build.env
   variables:
-    SPACK_SHA: 1b9ba2b27d94a88fe384a07b4c8fd64f1cf23fb7
+    SPACK_SHA: develop-2024-10-06
     SPACK_DLAF_REPO: ./spack
     DOCKER_BUILD_ARGS: '[
         "BASE_IMAGE",

--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -35,7 +35,7 @@ stages:
     reports:
       dotenv: build.env
   variables:
-    SPACK_SHA: 0905edf592752742eb4ddab3a528d3aee8f92930
+    SPACK_SHA: 1b9ba2b27d94a88fe384a07b4c8fd64f1cf23fb7
     SPACK_DLAF_REPO: ./spack
     DOCKER_BUILD_ARGS: '[
         "BASE_IMAGE",

--- a/ci/docker/debug-cpu-stdexec.yaml
+++ b/ci/docker/debug-cpu-stdexec.yaml
@@ -29,7 +29,3 @@ spack:
         - '+stdexec'
         - 'build_type=Debug'
         - 'malloc=system'
-    stdexec:
-      require:
-        - '@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main'
-        - 'build_type=Debug'

--- a/ci/docker/release-cpu-stdexec.yaml
+++ b/ci/docker/release-cpu-stdexec.yaml
@@ -27,6 +27,3 @@ spack:
     pika:
       require:
         - '+stdexec'
-    stdexec:
-      require:
-        - '@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main'

--- a/ci/docker/release-cuda-stdexec.yaml
+++ b/ci/docker/release-cuda-stdexec.yaml
@@ -27,6 +27,3 @@ spack:
     pika:
       require:
         - '+stdexec'
-    stdexec:
-      require:
-        - '@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main'

--- a/ci/docker/release-rocm533-stdexec.yaml
+++ b/ci/docker/release-rocm533-stdexec.yaml
@@ -29,9 +29,6 @@ spack:
     pika:
       require:
         - '+stdexec'
-    stdexec:
-      require:
-        - '@git.8bc7c7f06fe39831dea6852407ebe7f6be8fa9fd=main'
     blas:
       require:: openblas
     lapack:

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -170,6 +170,7 @@ void Permutations<B, D, T, C>::call(const SizeType i_begin, const SizeType i_end
   namespace ex = pika::execution::experimental;
   namespace dist_extra = dlaf::matrix::internal::distribution;
   using dist_extra::local_element_distance_from_global_tile;
+  using dlaf::internal::continues_on;
 
   if (i_begin == i_end)
     return;
@@ -210,7 +211,7 @@ void Permutations<B, D, T, C>::call(const SizeType i_begin, const SizeType i_end
       applyPermutationOnCPU<T, C>(i_perm, subm_dist, perm_arr, mat_in_tiles, mat_out_tiles);
     };
 
-    ex::start_detached(std::move(sender) | ex::transfer(dlaf::internal::getBackendScheduler<B>()) |
+    ex::start_detached(std::move(sender) | continues_on(dlaf::internal::getBackendScheduler<B>()) |
                        ex::bulk(nperms, std::move(permute_fn)));
   }
   else {
@@ -430,7 +431,7 @@ void applyPackingIndex(const matrix::Distribution& subm_dist, IndexMapSender&& i
       applyPermutationOnCPU<T, C>(i_perm, subm_dist, perm_arr, mat_in_tiles, mat_out_tiles);
     };
 
-    ex::start_detached(std::move(sender) | ex::transfer(di::getBackendScheduler<Backend::MC>()) |
+    ex::start_detached(std::move(sender) | di::continues_on(di::getBackendScheduler<Backend::MC>()) |
                        ex::bulk(nperms, std::move(permute_fn)));
   }
   else {

--- a/include/dlaf/sender/continues_on.h
+++ b/include/dlaf/sender/continues_on.h
@@ -1,0 +1,20 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) 2018-2024, ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+#pragma once
+
+#include <pika/execution.hpp>
+
+namespace dlaf::internal {
+#if PIKA_VERSION_FULL < 0x001D00  // < 0.29.0
+inline constexpr pika::execution::experimental::transfer_t continues_on{};
+#else
+using pika::execution::experimental::continues_on;
+#endif
+}

--- a/include/dlaf/sender/transform_mpi.h
+++ b/include/dlaf/sender/transform_mpi.h
@@ -18,6 +18,7 @@
 #include <dlaf/common/unwrap.h>
 #include <dlaf/communication/communicator.h>
 #include <dlaf/communication/communicator_pipeline.h>
+#include <dlaf/sender/continues_on.h>
 #include <dlaf/sender/transform.h>
 #include <dlaf/sender/when_all_lift.h>
 
@@ -89,9 +90,10 @@ MPICallHelper(F&&) -> MPICallHelper<std::decay_t<F>>;
 template <typename F, typename Sender,
           typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
 [[nodiscard]] decltype(auto) transformMPI(F&& f, Sender&& sender) {
+  using dlaf::internal::continues_on;
   namespace ex = pika::execution::experimental;
 
-  return ex::transfer(std::forward<Sender>(sender), dlaf::internal::getMPIScheduler()) |
+  return continues_on(std::forward<Sender>(sender), dlaf::internal::getMPIScheduler()) |
          ex::then(dlaf::common::internal::ConsumeRvalues{MPICallHelper{std::forward<F>(f)}}) |
          ex::drop_operation_state();
 }


### PR DESCRIPTION
If pika is older than 0.29.0, the adaptor is still called `transfer`. In that case we rename it to `continues_on` in an internal namespace. For 0.29.0 and later we simply alias pika's `continues_on` into an internal namespace.