### PR TITLE
Remove unused `transformMPIDetach`, `transformMPILift`, and `transformMPILiftDetach`

### DIFF
--- a/include/dlaf/sender/transform_mpi.h
+++ b/include/dlaf/sender/transform_mpi.h
@@ -19,7 +19,6 @@
 #include <dlaf/communication/communicator.h>
 #include <dlaf/communication/communicator_pipeline.h>
 #include <dlaf/sender/transform.h>
-#include <dlaf/sender/when_all_lift.h>
 
 namespace dlaf::comm::internal {
 
@@ -96,31 +95,6 @@ template <typename F, typename Sender,
          ex::drop_operation_state();
 }
 
-/// Fire-and-forget transformMPI. This submits the work and returns void.
-template <typename F, typename Sender,
-          typename = std::enable_if_t<pika::execution::experimental::is_sender_v<Sender>>>
-void transformMPIDetach(F&& f, Sender&& sender) {
-  pika::execution::experimental::start_detached(transformMPI(std::forward<F>(f),
-                                                             std::forward<Sender>(sender)));
-}
-
-/// Lazy transformMPI. This does not submit the work and returns a sender. First
-/// lifts non-senders into senders using just, and then calls transform with a
-/// when_all sender of the lifted senders.
-template <typename F, typename... Ts>
-[[nodiscard]] decltype(auto) transformMPILift(F&& f, Ts&&... ts) {
-  return transformMPI(std::forward<F>(f), dlaf::internal::whenAllLift(std::forward<Ts>(ts)...));
-}
-
-/// Fire-and-forget transformMPI. This submits the work and returns void. First
-/// lifts non-senders into senders using just, and then calls transform with a
-/// when_all sender of the lifted senders.
-template <typename F, typename... Ts>
-void transformMPILiftDetach(F&& f, Ts&&... ts) {
-  pika::execution::experimental::start_detached(transformLift(std::forward<F>(f),
-                                                              std::forward<Ts>(ts)...));
-}
-
 template <typename F>
 struct PartialTransformMPIBase {
   std::decay_t<F> f_;
@@ -148,29 +122,6 @@ public:
 template <typename F>
 PartialTransformMPI(F&& f) -> PartialTransformMPI<std::decay_t<F>>;
 
-/// A partially applied transformMPIDetach, with the callable object given, but
-/// the predecessor sender missing. The predecessor sender is applied when
-/// calling the operator| overload.
-template <typename F>
-class PartialTransformMPIDetach : private PartialTransformMPIBase<F> {
-public:
-  template <typename F_>
-  PartialTransformMPIDetach(F_&& f) : PartialTransformMPIBase<F>{std::forward<F_>(f)} {}
-  PartialTransformMPIDetach(PartialTransformMPIDetach&&) = default;
-  PartialTransformMPIDetach(const PartialTransformMPIDetach&) = default;
-  PartialTransformMPIDetach& operator=(PartialTransformMPIDetach&&) = default;
-  PartialTransformMPIDetach& operator=(const PartialTransformMPIDetach&) = default;
-
-  template <typename Sender>
-  friend auto operator|(Sender&& sender, PartialTransformMPIDetach pa) {
-    return pika::execution::experimental::start_detached(transformMPI(std::move(pa.f_),
-                                                                      std::forward<Sender>(sender)));
-  }
-};
-
-template <typename F>
-PartialTransformMPIDetach(F&& f) -> PartialTransformMPIDetach<std::decay_t<F>>;
-
 /// \overload transformMPI
 ///
 /// This overload partially applies the MPI transform for later use with
@@ -178,14 +129,5 @@ PartialTransformMPIDetach(F&& f) -> PartialTransformMPIDetach<std::decay_t<F>>;
 template <typename F>
 [[nodiscard]] decltype(auto) transformMPI(F&& f) {
   return PartialTransformMPI{std::forward<F>(f)};
-}
-
-/// \overload transformMPIDetach
-///
-/// This overload partially applies transformMPIDetach for later use with
-/// operator| with a sender on the left-hand side.
-template <typename F>
-[[nodiscard]] decltype(auto) transformMPIDetach(F&& f) {
-  return PartialTransformMPIDetach{std::forward<F>(f)};
 }
 }


### PR DESCRIPTION
We could do the same for a few `transform*` variants as well, but they're actually used still, so we'd need to do some rewriting. I think generally the explicit `start_detached(...)` is clearer to understand (and easier to grep for), so I'm starting by removing the unused `transformMPI*` variants.