### PR TITLE
Add a plot_strong script to allow to generate all the plots for strong scaling

### DIFF
--- a/scripts/plot_strong.sh
+++ b/scripts/plot_strong.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# This script helps to plot the results of different benchmarks.
+
 set -eu
 
 ####################################################################################################


### PR DESCRIPTION
I think I would have gained quite some time if I had this kind of scripts in the repo. Also because passing the root directory where z/ and d/ are is actually plotting an aggregation of both which leads to high variance.
The script doesn't have defaults so it forces the user to set at least 2 variables (the base_paths: list of path to the data we want to plot, root of z/ and d/ directories + the output path where we want the plots).