### PR TITLE
Don't use `SCOPED_TRACE` in `test_multiplication_hermitian`

### DIFF
--- a/test/unit/multiplication/test_multiplication_hermitian.cpp
+++ b/test/unit/multiplication/test_multiplication_hermitian.cpp
@@ -96,9 +96,6 @@ void testHermitianMultiplication(const blas::Side side, const blas::Uplo uplo, c
     hermitian_multiplication<B>(side, uplo, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
-  // SCOPED_TRACE cannot yield.
-  mat_ch.waitLocalTiles();
-  SCOPED_TRACE(::testing::Message() << "m " << m << "n " << n << ", mb " << mb << ", nb " << nb);
   CHECK_MATRIX_NEAR(res_c, mat_ch, 10 * (m + 1) * TypeUtilities<T>::error,
                     10 * (m + 1) * TypeUtilities<T>::error);
 }


### PR DESCRIPTION
The pika task may yield while the `SCOPED_TRACE` is in scope, and if it resumes on a different thread there will be segfaults. This PR removes the use of `SCOPED_TRACE` in that test.

It's still unclear what exactly in pika ends up yielding, since it's not expected to yield. That will be investigated separately.

Part of #603.