### PR TITLE
minor: fix ETI

### DIFF
--- a/include/dlaf/common/eti.h
+++ b/include/dlaf/common/eti.h
@@ -25,7 +25,7 @@
   ETI_MACRO(KWORD, float, Device::GPU);                \
   ETI_MACRO(KWORD, double, Device::GPU);               \
   ETI_MACRO(KWORD, std::complex<float>, Device::GPU);  \
-  ETI_MACRO(KWORD, std::complex<double>, Device::GPU);
+  ETI_MACRO(KWORD, std::complex<double>, Device::GPU)
 #define DLAF_EXPAND_ETI_SDCZ_DEVICE_VA_ARGS(ETI_MACRO, KWORD, ...)  \
   ETI_MACRO(KWORD, float, Device::CPU, __VA_ARGS__);                \
   ETI_MACRO(KWORD, double, Device::CPU, __VA_ARGS__);               \
@@ -34,16 +34,16 @@
   ETI_MACRO(KWORD, float, Device::GPU, __VA_ARGS__);                \
   ETI_MACRO(KWORD, double, Device::GPU, __VA_ARGS__);               \
   ETI_MACRO(KWORD, std::complex<float>, Device::GPU, __VA_ARGS__);  \
-  ETI_MACRO(KWORD, std::complex<double>, Device::GPU, __VA_ARGS__);
+  ETI_MACRO(KWORD, std::complex<double>, Device::GPU, __VA_ARGS__)
 #else
 #define DLAF_EXPAND_ETI_SDCZ_DEVICE(ETI_MACRO, KWORD) \
   ETI_MACRO(KWORD, float, Device::CPU);               \
   ETI_MACRO(KWORD, double, Device::CPU);              \
   ETI_MACRO(KWORD, std::complex<float>, Device::CPU); \
-  ETI_MACRO(KWORD, std::complex<double>, Device::CPU);
+  ETI_MACRO(KWORD, std::complex<double>, Device::CPU)
 #define DLAF_EXPAND_ETI_SDCZ_DEVICE_VA_ARGS(ETI_MACRO, KWORD, ...) \
   ETI_MACRO(KWORD, float, Device::CPU, __VA_ARGS__);               \
   ETI_MACRO(KWORD, double, Device::CPU, __VA_ARGS__);              \
   ETI_MACRO(KWORD, std::complex<float>, Device::CPU, __VA_ARGS__); \
-  ETI_MACRO(KWORD, std::complex<double>, Device::CPU, __VA_ARGS__);
+  ETI_MACRO(KWORD, std::complex<double>, Device::CPU, __VA_ARGS__)
 #endif


### PR DESCRIPTION
Not sure why (not investigated) but this does not seem to be considered a warning by all compilers.

Anyway on `gcc@9.3.0` this was considered as a problem (with reasons), so I just took the chance to fix it.

```bash
In file included from /users/ialberto/workspace/dla-future.master/test/unit/communication/test_collective_async.cpp:19:
/users/ialberto/workspace/dla-future.master/include/dlaf/communication/kernels/all_reduce.h:47:66: warning: extra ';' [-Wpedantic]
   47 | DLAF_EXPAND_ETI_SDCZ_DEVICE(DLAF_SCHEDULE_ALL_REDUCE_ETI, extern);
      |                                                                  ^
/users/ialberto/workspace/dla-future.master/include/dlaf/communication/kernels/all_reduce.h:65:75: warning: extra ';' [-Wpedantic]
   65 | DLAF_EXPAND_ETI_SDCZ_DEVICE(DLAF_SCHEDULE_ALL_REDUCE_IN_PLACE_ETI, extern);
      |                                                                           ^
In file included from /users/ialberto/workspace/dla-future.master/test/unit/communication/test_collective_async.cpp:20:
/users/ialberto/workspace/dla-future.master/include/dlaf/communication/kernels/reduce.h:45:76: warning: extra ';' [-Wpedantic]
   45 | DLAF_EXPAND_ETI_SDCZ_DEVICE(DLAF_SCHEDULE_REDUCE_RECV_IN_PLACE_ETI, extern);
      |                                                                            ^
/users/ialberto/workspace/dla-future.master/include/dlaf/communication/kernels/reduce.h:64:67: warning: extra ';' [-Wpedantic]
   64 | DLAF_EXPAND_ETI_SDCZ_DEVICE(DLAF_SCHEDULE_REDUCE_SEND_ETI, extern);
      |                                                                   ^
```