### PR TITLE
Small documentation and test fixes

### DIFF
--- a/include/dlaf/multiplication/hermitian.h
+++ b/include/dlaf/multiplication/hermitian.h
@@ -31,10 +31,10 @@ namespace dlaf {
 /// @param mat_a contains the hermitian matrix A. Only the tiles of the matrix which contain the upper or
 /// the lower triangular part which represent the Hermitian matrix (depending on the value of uplo)
 /// are accessed in read-only mode (the elements are not modified),
-/// @pre @p mat_b is not distributed
-/// @pre @p mat_b has size (N x M)
-/// @pre @p mat_b has blocksize (NB x NB)
-/// @pre @p mat_b has tilesize (NB x NB)
+/// @pre @p mat_a is not distributed
+/// @pre @p mat_a has size (N x M)
+/// @pre @p mat_a has blocksize (NB x NB)
+/// @pre @p mat_a has tilesize (NB x NB)
 ///
 /// @param mat_b contains the matrix B accessed in read-only mode (the elements are not modified),
 /// @pre @p mat_b is not distributed
@@ -44,10 +44,10 @@ namespace dlaf {
 ///
 /// @param mat_c on entry it contains the matrix C, on exit the matrix elements are overwritten with the
 /// elements of the result.
-/// @pre @p mat_b is not distributed
-/// @pre @p mat_b has size (N x K)
-/// @pre @p mat_b has blocksize (NB x NB)
-/// @pre @p mat_b has tilesize (NB x NB)
+/// @pre @p mat_c is not distributed
+/// @pre @p mat_c has size (N x K)
+/// @pre @p mat_c has blocksize (NB x NB)
+/// @pre @p mat_c has tilesize (NB x NB)
 template <Backend B, Device D, class T>
 void hermitian_multiplication(blas::Side side, blas::Uplo uplo, const T alpha, Matrix<const T, D>& mat_a,
                               Matrix<const T, D>& mat_b, const T beta, Matrix<T, D>& mat_c) {
@@ -92,10 +92,10 @@ void hermitian_multiplication(blas::Side side, blas::Uplo uplo, const T alpha, M
 /// @param mat_a contains the hermitian matrix A. Only the tiles of the matrix which contain the upper or
 /// the lower triangular part which represent the Hermitian matrix (depending on the value of uplo)
 /// are accessed in read-only mode (the elements are not modified),
-/// @pre @p mat_b is distributed according to @p grid
-/// @pre @p mat_b has size (N x M)
-/// @pre @p mat_b has blocksize (NB x NB)
-/// @pre @p mat_b has tilesize (NB x NB)
+/// @pre @p mat_a is distributed according to @p grid
+/// @pre @p mat_a has size (N x M)
+/// @pre @p mat_a has blocksize (NB x NB)
+/// @pre @p mat_a has tilesize (NB x NB)
 ///
 /// @param mat_b contains the matrix B accessed in read-only mode (the elements are not modified),
 /// @pre @p mat_b is distributed according to @p grid
@@ -105,10 +105,10 @@ void hermitian_multiplication(blas::Side side, blas::Uplo uplo, const T alpha, M
 ///
 /// @param mat_c on entry it contains the matrix C, on exit the matrix elements are overwritten with the
 /// elements of the result.
-/// @pre @p mat_b is distributed according to @p grid
-/// @pre @p mat_b has size (N x K)
-/// @pre @p mat_b has blocksize (NB x NB)
-/// @pre @p mat_b has tilesize (NB x NB)
+/// @pre @p mat_c is distributed according to @p grid
+/// @pre @p mat_c has size (N x K)
+/// @pre @p mat_c has blocksize (NB x NB)
+/// @pre @p mat_c has tilesize (NB x NB)
 template <Backend B, Device D, class T>
 void hermitian_multiplication(comm::CommunicatorGrid& grid, blas::Side side, blas::Uplo uplo,
                               const T alpha, Matrix<const T, D>& mat_a, Matrix<const T, D>& mat_b,

--- a/test/unit/matrix/test_retiled_matrix.cpp
+++ b/test/unit/matrix/test_retiled_matrix.cpp
@@ -78,7 +78,7 @@ const std::vector<std::tuple<LocalElementSize, TileElementSize, LocalTileSize>> 
     {{4, 4}, {4, 4}, {1, 1}},
 });
 
-TYPED_TEST(RetiledMatrixTest, LocalConstructor) {
+TYPED_TEST(RetiledMatrixLocalTest, LocalConstructor) {
   using Type = TypeParam;
 
   auto el1 = [](const GlobalElementIndex& index) {
@@ -208,7 +208,7 @@ TYPED_TEST(RetiledMatrixTest, GlobalConstructor) {
   }
 }
 
-TYPED_TEST(RetiledMatrixTest, Dependencies) {
+TYPED_TEST(RetiledMatrixLocalTest, Dependencies) {
   using Type = TypeParam;
 
   for (const auto& [size, tile_size, tiles_per_block] : deps_sizes_tests) {


### PR DESCRIPTION
De-clutter https://github.com/eth-cscs/DLA-Future/pull/1194 by moving out some un-related changes separately.

* Use local test class in `test_retiled_matrix`
* Small fixes to hermitian multiplication documentation