### PR TITLE
Add configuration option for choosing number of GPU streams when they're not per-thread

### DIFF
--- a/include/dlaf/init.h
+++ b/include/dlaf/init.h
@@ -36,6 +36,8 @@ struct configuration {
   //   values
   // - getOptionsDescription to add a corresponding command line option
   bool print_config = false;
+  std::size_t num_np_gpu_streams = 32;
+  std::size_t num_hp_gpu_streams = 32;
   std::size_t num_np_gpu_streams_per_thread = 3;
   std::size_t num_hp_gpu_streams_per_thread = 3;
   std::size_t umpire_host_memory_pool_initial_block_bytes = 1 << 30;

--- a/test/unit/init/test_init.cpp
+++ b/test/unit/init/test_init.cpp
@@ -21,8 +21,8 @@
 #include <gtest/gtest.h>
 
 static const char* binary_name = "init_test";
-static const char* env_var_name = "DLAF_NUM_HP_GPU_STREAMS_PER_THREAD";
-static const char* command_line_option_name = "--dlaf:num-hp-gpu-streams-per-thread";
+static const char* env_var_name = "DLAF_NUM_GPU_BLAS_HANDLES";
+static const char* command_line_option_name = "--dlaf:num-gpu-blas-handles";
 static const char* print_bind = "--pika:print-bind";
 
 static int argc_without_option = 1;
@@ -91,10 +91,10 @@ class InitTest : public ::testing::TestWithParam<InitializerType> {};
 
 int precedence_main(int, char*[]) {
   const dlaf::configuration default_cfg;
-  const std::size_t default_val = default_cfg.num_hp_gpu_streams_per_thread;
-  // Note that this test doesn't mean that the default value has to be 3. It is
+  const std::size_t default_val = default_cfg.num_gpu_blas_handles;
+  // Note that this test doesn't mean that the default value has to be 16. It is
   // included to help catch unexpected changes in the configuration handling.
-  EXPECT_EQ(default_val, 3);
+  EXPECT_EQ(default_val, 16);
 
   // Make sure environment is clean for the test.
   unsetenv(env_var_name);
@@ -103,37 +103,37 @@ int precedence_main(int, char*[]) {
   {
     InitializeTester init(current_initializer_type, argc_without_option, argv_without_option);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(default_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(default_val, cfg.num_gpu_blas_handles);
   }
 
   // User configuration should take precedence over default configuration.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
 
     InitializeTester init(current_initializer_type, argc_without_option, argv_without_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(user_cfg.num_hp_gpu_streams_per_thread, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(user_cfg.num_gpu_blas_handles, cfg.num_gpu_blas_handles);
   }
 
   // Environment variables should take precedence over user configuration.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
-    const std::size_t env_var_val = user_cfg.num_hp_gpu_streams_per_thread + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_gpu_blas_handles + 1;
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
 
     InitializeTester init(current_initializer_type, argc_without_option, argv_without_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(env_var_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(env_var_val, cfg.num_gpu_blas_handles);
   }
 
   // Command-line options should take precedence over environment variables.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
-    const std::size_t env_var_val = user_cfg.num_hp_gpu_streams_per_thread + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_gpu_blas_handles + 1;
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
     const std::size_t command_line_option_val = env_var_val + 1;
@@ -145,7 +145,7 @@ int precedence_main(int, char*[]) {
 
     InitializeTester init(current_initializer_type, argc_with_option, argv_with_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(command_line_option_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(command_line_option_val, cfg.num_gpu_blas_handles);
   }
 
   pika::finalize();
@@ -160,10 +160,10 @@ TEST_P(InitTest, Precedence) {
 
 int vm_no_command_line_option_main(pika::program_options::variables_map& vm) {
   const dlaf::configuration default_cfg;
-  const std::size_t default_val = default_cfg.num_hp_gpu_streams_per_thread;
-  // Note that this test doesn't mean that the default value has to be 3. It is
+  const std::size_t default_val = default_cfg.num_gpu_blas_handles;
+  // Note that this test doesn't mean that the default value has to be 16. It is
   // included to help catch unexpected changes in the configuration handling.
-  EXPECT_EQ(default_val, 3);
+  EXPECT_EQ(default_val, 16);
 
   // Make sure environment is clean for the test.
   unsetenv(env_var_name);
@@ -172,37 +172,37 @@ int vm_no_command_line_option_main(pika::program_options::variables_map& vm) {
   {
     InitializeTester init(current_initializer_type, vm);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(default_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(default_val, cfg.num_gpu_blas_handles);
   }
 
   // User configuration should take precedence over default configuration.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
 
     InitializeTester init(current_initializer_type, vm, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(user_cfg.num_hp_gpu_streams_per_thread, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(user_cfg.num_gpu_blas_handles, cfg.num_gpu_blas_handles);
   }
 
   // Environment variables should take precedence over user configuration.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
-    const std::size_t env_var_val = user_cfg.num_hp_gpu_streams_per_thread + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_gpu_blas_handles + 1;
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
 
     InitializeTester init(current_initializer_type, vm, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(env_var_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(env_var_val, cfg.num_gpu_blas_handles);
   }
 
   // Command-line options should take precedence over environment variables.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
-    const std::size_t env_var_val = user_cfg.num_hp_gpu_streams_per_thread + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_gpu_blas_handles + 1;
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
     const std::size_t command_line_option_val = env_var_val + 1;
@@ -214,7 +214,7 @@ int vm_no_command_line_option_main(pika::program_options::variables_map& vm) {
 
     InitializeTester init(current_initializer_type, argc_with_option, argv_with_option, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(command_line_option_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(command_line_option_val, cfg.num_gpu_blas_handles);
   }
 
   pika::finalize();
@@ -229,20 +229,20 @@ TEST_P(InitTest, VariablesMapNoCommandLineOption) {
 
 int vm_command_line_option_main(pika::program_options::variables_map& vm) {
   dlaf::configuration default_cfg;
-  const std::size_t default_val = default_cfg.num_hp_gpu_streams_per_thread;
+  const std::size_t default_val = default_cfg.num_gpu_blas_handles;
 
   // Command-line options should take precedence over everything else.
   {
     dlaf::configuration user_cfg = default_cfg;
-    user_cfg.num_hp_gpu_streams_per_thread = default_val + 1;
-    const std::size_t env_var_val = user_cfg.num_hp_gpu_streams_per_thread + 1;
+    user_cfg.num_gpu_blas_handles = default_val + 1;
+    const std::size_t env_var_val = user_cfg.num_gpu_blas_handles + 1;
     const std::string env_var_val_str = std::to_string(env_var_val);
     setenv(env_var_name, env_var_val_str.c_str(), 1);
     const std::size_t command_line_option_val = env_var_val + 1;
 
     InitializeTester init(current_initializer_type, vm, user_cfg);
     dlaf::configuration cfg = dlaf::internal::getConfiguration();
-    EXPECT_EQ(command_line_option_val, cfg.num_hp_gpu_streams_per_thread);
+    EXPECT_EQ(command_line_option_val, cfg.num_gpu_blas_handles);
   }
 
   pika::finalize();
@@ -259,10 +259,10 @@ TEST_P(InitTest, VariablesMapCommandLineOption) {
   p.desc_cmdline = options;
 
   dlaf::configuration default_cfg;
-  const std::size_t default_val = default_cfg.num_hp_gpu_streams_per_thread;
-  // Note that this test doesn't mean that the default value has to be 3. It is
+  const std::size_t default_val = default_cfg.num_gpu_blas_handles;
+  // Note that this test doesn't mean that the default value has to be 16. It is
   // included to help catch unexpected changes in the configuration handling.
-  EXPECT_EQ(default_val, 3);
+  EXPECT_EQ(default_val, 16);
 
   std::size_t command_line_option_val = default_val + 3;
   std::string command_line_option_val_str = std::to_string(command_line_option_val);


### PR DESCRIPTION
https://github.com/pika-org/pika/pull/1294 will be part of pika 0.31.0, and changes the meaning of the "number of streams" parameters passed to the `cuda_pool`. Instead of signaling the number of streams per worker thread, they now mean the number of streams in total. This is unfortunately a silent breaking change in pika, but this PR attempts to make it somewhat loud in DLA-Future.

This PR introduces two new configuration options: `num_np_gpu_streams` and `num_hp_gpu_streams`. These will be used when pika is version 0.31.0 or newer. The old options will be used when using a version before 0.31.0. When attempting to use an option with the wrong version of pika, DLA-Future will print a warning that the option will be ignored. For compatibility one can set both the old and the new options at the same time to cover any version of pika, at the cost of a warning.

I'm not too worried about this causing problems, since so far we've never had the need to change the defaults on different systems.

32 streams (each for normal and high priority) is the same as the default in pika. DLA-Future's miniapps show no meaningful performance difference with the new option compared to the old per-thread streams. 32 was chosen as a reasonable middle ground. Going to something low like 4 or 8 showed a small slowdown, and going to something really high like 128 has no use since the GPUs don't support that much concurrency anyway. Note that with the previous setup we would actually create 192 normal and high priority streams on e.g. Grace (with 64 worker threads), which was clearly overkill. Despite creating so many streams, we could still be limited by the three streams per worker thread.

Note that the change in pika is really meant as a conceptual simplification (rather than a performance improvement), since it's easier to reason about how much concurrency the pool provides when the number of streams given is the total, rather than varying with the number of worker threads. It also matches now how we deal with the cuBLAS and cuSOLVER handles. However, it may allow corner cases to exploit more concurrency as well. In the case that @albestro encountered, where different continuations (launching CUDA work) end up running on the same worker thread, this new option allows the same worker thread to use all streams instead of being limited to the previous default of three streams per worker thread.

Note that I've updated `test_init` to test with a different configuration option. This is simply to avoid having to do tests conditional on the pika version there. The actual configuration option used for testing was never the important part, just that _some_ configuration option is used.

Until pika 0.31.0 is released, pika main identifies itself as 0.30.1, so DLA-Future will not use the correct option, despite pika main already having the change from https://github.com/pika-org/pika/pull/1294. I recommend staying with pika 0.30.1 until then.