### PR TITLE
Fix README install instructions to use `CMAKE_PREFIX_PATH` instead of `CMAKE_INSTALL_PREFIX`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ export DLAF_INSTALL_PREFIX=`spack location -i dla-future`
 Then, you can configure your project with one of the following:
 
 ```bash
-# By appending the value to the CMAKE_INSTALL_PREFIX
-cmake -DCMAKE_INSTALL_PREFIX=${DLAF_INSTALL_PREFIX} ..
+# By appending the value to the CMAKE_PREFIX_PATH
+cmake -DCMAKE_PREFIX_PATH=${DLAF_INSTALL_PREFIX} ..
 
 # ... or by setting DLAF_DIR
 cmake -DDLAF_DIR="$DLAF_INSTALL_PREFIX/lib/cmake" ..


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html#variable:CMAKE_INSTALL_PREFIX vs. https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html#variable:CMAKE_PREFIX_PATH. I think this is probably what was intended all along (https://github.com/eth-cscs/DLA-Future/pull/262#discussion_r473942247).