### PR TITLE
scripts: let the user know if submitting with sbatch failed

### DIFF
--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -157,6 +157,17 @@ class JobText:
             stdout=PIPE,
             stderr=PIPE,
         )
+
+        try:
+            raw_stdout, raw_stderr = process.communicate(timeout=10)
+            retcode = process.returncode
+            if retcode != 0:
+                print(f"Job submission failed with return code {retcode}")
+                print(raw_stderr.strip())
+        except TimeoutExpired:
+            process.kill()
+            print("Job submission timed out")
+
         # sleep to not overload the scheduler
         sleep(1)
 

--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -158,15 +158,11 @@ class JobText:
             stderr=PIPE,
         )
 
-        try:
-            raw_stdout, raw_stderr = process.communicate(timeout=10)
-            retcode = process.returncode
-            if retcode != 0:
-                print(f"Job submission failed with return code {retcode}")
-                print(raw_stderr.strip())
-        except TimeoutExpired:
-            process.kill()
-            print("Job submission timed out")
+        raw_stdout, raw_stderr = process.communicate()
+        print(raw_stdout, end="")
+        print(raw_stderr, end="")
+        if process.returncode != 0:
+            print(f"Job submission FAILED.")
 
         # sleep to not overload the scheduler
         sleep(1)


### PR DESCRIPTION
Currently the script submitting benchmark jobs is not reporting anything from the sbatch submission, resulting in the user now knowing if the job has been queued or not.

With this PR, in case of error the output is reported to the user("soft failure", just error reported without making the launching script to terminate).

```
(dla-future)[todi][ialberto@todi-ln001 dla-future.master]$ python3 scripts/gen-dlaf-strong-panel-workers.py
Submitting : sbatch --chdir=/capstor/scratch/cscs/ialberto/20241204-dlaf-strong-panel-workers-local-40/d/0.25 /capstor/scratch/cscs/ialberto/20241204-dlaf-strong-panel-workers-local-40/d/0.25/job_dlaf.sh using shell /usr/local/bin/bash
Submitting : sbatch --chdir=/capstor/scratch/cscs/ialberto/20241204-dlaf-strong-panel-workers-local-50/d/0.25 /capstor/scratch/cscs/ialberto/20241204-dlaf-strong-panel-workers-local-50/d/0.25/job_dlaf.sh using shell /usr/local/bin/bash
Job submission failed with return code 1
sbatch: error: QOSMaxSubmitJobPerUserLimit
sbatch: error: Batch job submission failed: Job violates accounting/QOS policy (job submit limit, user's size and/or time limits)

```

Any suggestions/preference is welcome. Some possible discussion points:
- should we report the error code at all?
- add a success message when everything works