### PR TITLE
Enable timestamps in CI logs

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -6,6 +6,9 @@ stages:
   - build
   - test
 
+variables:
+  FF_TIMESTAMPS: true
+
 ##
 ## BUILDS
 ##

--- a/ci/ctest_to_gitlab.sh
+++ b/ci/ctest_to_gitlab.sh
@@ -28,6 +28,9 @@ stages:
   - upload
 
 variables:
+  FF_TIMESTAMPS: true
+
+variables:
   SLURM_EXCLUSIVE: ''
   SLURM_EXACT: ''
   SLURM_CONSTRAINT: $SLURM_CONSTRAINT
@@ -77,6 +80,9 @@ image: $IMAGE
 
 stages:
   - test
+
+variables:
+  FF_TIMESTAMPS: true
 
 variables:
   SLURM_EXCLUSIVE: ''


### PR DESCRIPTION
Enables timestamps in CI logs (according to https://docs.gitlab.com/runner/configuration/feature-flags.html). Raw logs become slightly more verbose. The GitLab UI renders the timestamps in a dark gray (same color as the line number) separately from the actual log output (see e.g. https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/479009878135925/5304355110917878/-/jobs/8557603567).

I find this is useful to see if e.g. a test hung for a long time before eventually being killed by slurm, or if it ran for only a few seconds before being killed. Without timestamps one only sees the total time taken for a full command.