### PR TITLE
Add back C++20 conflict with CUDA for older versions

### DIFF
--- a/spack/packages/dla-future/package.py
+++ b/spack/packages/dla-future/package.py
@@ -99,6 +99,10 @@ class DlaFuture(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("pika +cuda", when="+cuda")
     depends_on("pika +rocm", when="+rocm")
 
+    for cxxstd in ("20", "23"):
+        conflicts(f"^pika cxxstd={cxxstd}", when="@:0.6 +cuda ^pika@:0.29")
+    conflicts("^pika +stdexec", when="@:0.6 +cuda")
+
     depends_on("whip +cuda", when="+cuda")
     depends_on("whip +rocm", when="+rocm")
 


### PR DESCRIPTION
#1188 allowed compiling DLA-Future with CUDA and stdexec with C++20. It also completely removed the spack package conflict that previously prevented that spec from actually being concretized. This PR adds back the conflict for older versions of DLA-Future (i.e. 0.6 and older), and expands it a bit.

- Previously the conflict was only for `pika cxxstd=20`, while `cxxstd=23` is also an allowed option and concretization could end up with that instead. 23 is just as a bad as 20 though, so this adds a conflict for 23 as well.
- pika 0.30.0 fixed an issue with including pika headers in CUDA mode with C++20 (https://github.com/pika-org/pika/pull/1249), so the conflicts have an upper bound on pika 0.29.
- With DLA-Future 0.6 and older, no version of pika with stdexec could be compiled because stdexec does not compile under nvcc, so there's a new conflict for that.
- After DLA-Future 0.6 any (otherwise allowed) combination of pika/stdexec/cxxstd is ok with CUDA, since we no longer include problematic headers in CUDA files.