### PR TITLE
Add llvm-18 explicitly to installed packages in address sanitizer CI pipeline

### DIFF
--- a/ci/cpu/asan_ubsan_lsan.yml
+++ b/ci/cpu/asan_ubsan_lsan.yml
@@ -4,7 +4,7 @@ include:
 cpu asan ubsan lsan deps:
   extends: .build_deps_common
   variables:
-    EXTRA_APTGET: "clang-18 libclang-rt-18-dev libomp-18-dev"
+    EXTRA_APTGET: "clang-18 libclang-rt-18-dev libomp-18-dev llvm-18"
     COMPILER: clang@18
     SPACK_ENVIRONMENT: ci/docker/asan-ubsan-lsan.yaml
     USE_MKL: "ON"


### PR DESCRIPTION
`llvm-18` provides `llvm-symbolizer-18`, required to get readable stacktraces from sanitizers.

`llvm-18` is a recommended package of `clang-18`, and will be installed with a regular `apt install clang`, but it's not a required dependency so it will not be installed with `--no-install-recommends`.