### PR TITLE
ReductionToBand: Dynamic number of workers for Panel computation (bulk)

### DIFF
--- a/include/dlaf/eigensolver/internal/get_red2band_panel_nworkers.h
+++ b/include/dlaf/eigensolver/internal/get_red2band_panel_nworkers.h
@@ -19,7 +19,7 @@
 
 namespace dlaf::eigensolver::internal {
 
-inline size_t getReductionToBandPanelNWorkers() noexcept {
+inline size_t get_red2band_panel_nworkers() noexcept {
   // Note: precautionarily we leave at least 1 thread "free" to do other stuff (if possible)
   const std::size_t available_workers = pika::resource::get_thread_pool("default").get_os_thread_count();
   const std::size_t min_workers = 1;

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -313,7 +313,7 @@ void computePanelReflectors(MatrixLikeA& mat_a, MatrixLikeTaus& mat_taus, const 
 
   const std::size_t nworkers = [nrtiles = panel_tiles.size()]() {
     const std::size_t min_workers = 1;
-    const std::size_t available_workers = getReductionToBandPanelNWorkers();
+    const std::size_t available_workers = get_red2band_panel_nworkers();
     const std::size_t ideal_workers = to_sizet(nrtiles);
     return std::clamp(ideal_workers, min_workers, available_workers);
   }();
@@ -638,7 +638,7 @@ void computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
 
   const std::size_t nworkers = [nrtiles = panel_tiles.size()]() {
     const std::size_t min_workers = 1;
-    const std::size_t available_workers = getReductionToBandPanelNWorkers();
+    const std::size_t available_workers = get_red2band_panel_nworkers();
     const std::size_t ideal_workers = util::ceilDiv(to_sizet(nrtiles), to_sizet(2));
     return std::clamp(ideal_workers, min_workers, available_workers);
   }();


### PR DESCRIPTION
Currently the number of workers available (per configuration) was used as is for spawning an equivalent number of workers for the panel computation, where each worker was in charge of working on a integral number of tiles.

When not enough tiles were available, some worker might end up participating to the synchronisation points, but without any work to do. This happens for sure with small matrices, but due to the iterative nature of the reduction to band algorithm, it was happening anyway also during "tail" iterations in bigger matrices.

With this PR, the configuration is acquired as maximum number of workers available, but now the algorithm ensures that just worker with at least 1 tile to work on get spawned.

TODO:
- [ ] set a different default in benchmarking scripts for GPU systems

Notes:
- minimum amount of work is set to 1 tile per worker (it might eventually become a config parameter as well); after some not very extensive benchmark, at least 2 tile per worker resulted in slightly worse performances
- took the chance also to rename to snake_case the configure getter