### PR TITLE
Don't use `SCOPED_TRACE` in `test_multiplication_hermitian`, part 2

### DIFF
--- a/test/unit/multiplication/test_multiplication_hermitian.cpp
+++ b/test/unit/multiplication/test_multiplication_hermitian.cpp
@@ -138,9 +138,6 @@ void testHermitianMultiplication(comm::CommunicatorGrid& grid, const blas::Side 
     hermitian_multiplication<B>(grid, side, uplo, alpha, mat_a.get(), mat_b.get(), beta, mat_c.get());
   }
 
-  // SCOPED_TRACE cannot yield.
-  mat_ch.waitLocalTiles();
-  SCOPED_TRACE(::testing::Message() << "m " << m << ", n " << n << ", mb " << mb << ", nb " << nb);
   CHECK_MATRIX_NEAR(res_c, mat_ch, 10 * (m + 1) * TypeUtilities<T>::error,
                     10 * (m + 1) * TypeUtilities<T>::error);
 }


### PR DESCRIPTION
Similar to #1206, remove also the second use of `SCOPED_TRACE` in the test, to avoid potentially yielding while holding onto the `SCOPED_TRACE`, which will segfault if the task migrates to a different worker thread.