### PR TITLE
Add CI configuration with ROCm 6

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -17,3 +17,4 @@ include:
   - local: 'ci/cuda/gcc13_release_stdexec.yml'
   - local: 'ci/rocm/clang14_release.yml'
   - local: 'ci/rocm/clang14_release_stdexec.yml'
+  - local: 'ci/rocm/clang15_release_stdexec.yml'

--- a/ci/docker/release-rocm602-stdexec.yaml
+++ b/ci/docker/release-rocm602-stdexec.yaml
@@ -1,0 +1,70 @@
+#
+# Distributed Linear Algebra with Future (DLAF)
+#
+# Copyright (c) 2018-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+spack:
+  include:
+  - /spack_environment/common.yaml
+
+  view: false
+  concretizer:
+    unify:
+      true
+
+  specs:
+  - dla-future@master +rocm amdgpu_target=gfx90a:xnack- +miniapps +ci-test
+
+  packages:
+    all:
+      variants:
+      - build_type=Release
+      - cxxstd=20
+      - amdgpu_target=gfx90a:xnack-
+    pika:
+      require:
+        - '+stdexec'
+    blas:
+      require:: openblas
+    lapack:
+      require:: openblas
+    mpich:
+      require:
+        - '~rocm'
+        - 'device=ch3'
+        - 'netmod=tcp'
+    llvm-amdgpu:
+      externals:
+      - spec: llvm-amdgpu@6.0.2 ~rocm-device-libs
+        prefix: /opt/rocm-6.0.2/llvm
+      buildable: false
+    rocm-device-libs:
+      externals:
+      - spec: rocm-device-libs@6.0.2
+        prefix: /opt/rocm-6.0.2
+      buildable: false
+    hip:
+      externals:
+      - spec: hip@6.0.2
+        prefix: /opt/rocm-6.0.2
+      buildable: false
+    rocblas:
+      externals:
+      - spec: rocblas@6.0.2
+        prefix: /opt/rocm-6.0.2
+      buildable: false
+    rocsolver:
+      externals:
+      - spec: rocsolver@6.0.2
+        prefix: /opt/rocm-6.0.2
+      buildable: false
+    hsa-rocr-dev:
+      externals:
+      - spec: hsa-rocr-dev@6.0.2
+        prefix: /opt/rocm-6.0.2
+      buildable: false

--- a/ci/rocm/clang15_release_stdexec.yml
+++ b/ci/rocm/clang15_release_stdexec.yml
@@ -1,0 +1,21 @@
+include:
+  - local: 'ci/common-ci.yml'
+
+rocm clang15 stdexec release deps:
+  extends: .build_deps_common
+  variables:
+    BASE_IMAGE: docker.io/rocm/dev-ubuntu-22.04:6.0.2
+    EXTRA_APTGET: "clang-15 libomp-15-dev rocblas rocblas-dev rocsolver rocsolver-dev llvm-amdgpu rocm-device-libs"
+    COMPILER: clang@15
+    USE_ROCBLAS: "ON"
+    SPACK_ENVIRONMENT: ci/docker/release-rocm602-stdexec.yaml
+    DEPS_IMAGE: $CSCS_REGISTRY_PATH/rocm-clang15-stdexec-release/deps
+
+rocm clang15 stdexec release build:
+  extends:
+    - .build_common
+  after_script: null
+  needs:
+    - rocm clang15 stdexec release deps
+  variables:
+    DLAF_IMAGE: $CSCS_REGISTRY_PATH/rocm-clang15-stdexec-release/dlaf:$CI_COMMIT_SHA


### PR DESCRIPTION
Adds a ROCm 6.0.2 CI configuration based on ubuntu 22.04 to test for issues like #1239.