### PR TITLE
Preparation for 0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## DLA-Future 0.7.3
+
+### Bug fixes
+
+- Changed C ScaLAPACK API indexing convention to 1-based for partial eigenspectrum. (#1248)
+
+## DLA-Future 0.7.2
+
+Not released.
+
 ## DLA-Future 0.7.1
 
 ### Bug fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: DLA-Future 0.7.1
+title: DLA-Future 0.7.3
 repository-code: https://github.com/eth-cscs/DLA-Future
 message: >-
   If you use this software, please cite it using the
@@ -54,5 +54,5 @@ keywords:
   - mpi
 license: BSD-3-Clause
 license-url: https://opensource.org/license/bsd-3-clause
-version: 0.7.1
-date-released: '2024-12-18'
+version: 0.7.3
+date-released: '2024-12-20'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-project(DLAF VERSION 0.7.1)
+project(DLAF VERSION 0.7.3)
 
 # ---------------------------------------------------------------------------
 # CMake configurations

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3,6 +3,7 @@
 ## API documentation
 
 - [Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
+- [Documentation of `v0.7.3`](https://eth-cscs.github.io/DLA-Future/v0.7.3/)
 - [Documentation of `v0.7.1`](https://eth-cscs.github.io/DLA-Future/v0.7.1/)
 - [Documentation of `v0.7.0`](https://eth-cscs.github.io/DLA-Future/v0.7.0/)
 - [Documentation of `v0.6.0`](https://eth-cscs.github.io/DLA-Future/v0.6.0/)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ target_link_libraries(<your_target> PRIVATE DLAF::DLAF)
 ### Documentation
 
 - [Documentation of `master` branch](https://eth-cscs.github.io/DLA-Future/master/)
-- [Documentation of `v0.7.1`](https://eth-cscs.github.io/DLA-Future/v0.7.1/)
+- [Documentation of `v0.7.3`](https://eth-cscs.github.io/DLA-Future/v0.7.3/)
 
 See [DOCUMENTATION.md](DOCUMENTATION.md) for the documentation of older versions, or for the instructions to build it.
 


### PR DESCRIPTION
This PR is now targeting `master` and will be cherry picked to branch `version_0.7`.