### PR TITLE
Make sure `Matrix::waitLocalTiles` actually consumes the tile wrappers immediately

### DIFF
--- a/include/dlaf/matrix/matrix.h
+++ b/include/dlaf/matrix/matrix.h
@@ -349,12 +349,11 @@ void Matrix<const T, D>::waitLocalTiles() noexcept {
   const auto range_local = common::iterate_range2d(distribution().local_nr_tiles());
 
   auto s = pika::execution::experimental::when_all_vector(internal::selectGeneric(
-               [this](const LocalTileIndex& index) {
-                 return this->tile_managers_[tileLinearIndex(index)].readwrite();
-               },
-               range_local)) |
-           pika::execution::experimental::drop_value();
-  pika::this_thread::experimental::sync_wait(std::move(s));
+      [this](const LocalTileIndex& index) {
+        return this->tile_managers_[tileLinearIndex(index)].readwrite();
+      },
+      range_local));
+  [[maybe_unused]] auto tiles = pika::this_thread::experimental::sync_wait(std::move(s));
 }
 
 template <class T, Device D>


### PR DESCRIPTION
Together with https://github.com/pika-org/pika/pull/1373, this should be at least another step towards avoiding yielding after calling `waitLocalTiles`. https://github.com/pika-org/pika/pull/1373 made sure that the continuation that gets access to a wrapper, actually contains the last reference to the internal shared state and thus is able to release the next access as soon as that wrapper is released.

This PR ensures that the wrapper is actually used by the continuation in `waitLocalTiles`. I had implemented `waitLocalTiles` wrongly in the sense that `drop_value` does indeed ignore the  value sent from the predecessor, but it takes the value by forwarding reference and thus doesn't actually consume the wrapper. Before this PR, when `sync_wait` returns the last access is semantically "done", but the wrapper has not necessarily been released by that time. Most of the time this is good enough to guarantee that the next access is inline, but sometimes the wrapper will be released too late. By actually waiting for the wrapper(s) and taking them into the local function scope where `sync_wait` is called, we guarantee that the wrapper is released in the function scope.

An alternative way to implement this would be to replace `drop_value` by `then([](auto){})`. `drop_value` is effectively `then([](auto&&){})`. The former consumes the wrapper in the continuation while the latter only takes a reference and releases the wrapper much later.

Since CI is still using pika 0.30.1 and https://github.com/pika-org/pika/pull/1373 is in 0.31.0 this PR alone won't get rid of issues in e.g. `test_bt_reduction_to_band`, but it's a necessary step.