### PR TITLE
Patch gtest to terminate as soon as it detects that a `ScopedTrace` has migrated to another worker thread

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -33,7 +33,7 @@ do
       # Check if tab are present.
       egrep -Hn $'\t' $FILE && TAB_FOUND=1 || true
       ;;
-    *.pdf|*.hdf5|*.jpg|*.png|*.ppt|*.pptx|*.ipe)
+    *.pdf|*.hdf5|*.jpg|*.patch|*.png|*.ppt|*.pptx|*.ipe)
       # Exclude some binary files types,
       # others can be excluded as needed.
       ;;

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,7 +18,9 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG v1.13.0
   # Patch for int to float conversion warning.
-  PATCH_COMMAND git cherry-pick -n 5cd81a7848203d3df6959c148eb91f1a4ff32c1d -m 1
+  PATCH_COMMAND
+    git reset --hard HEAD && git cherry-pick -n 5cd81a7848203d3df6959c148eb91f1a4ff32c1d -m 1 && git
+    apply "${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch"
 )
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")

--- a/external/scoped_trace_terminate_on_thread_migrate.patch
+++ b/external/scoped_trace_terminate_on_thread_migrate.patch
@@ -1,0 +1,76 @@
+diff --git a/googletest/include/gtest/gtest.h b/googletest/include/gtest/gtest.h
+index 3e452a50..c51dd607 100644
+--- a/googletest/include/gtest/gtest.h
++++ b/googletest/include/gtest/gtest.h
+@@ -58,6 +58,7 @@
+ #include <set>
+ #include <sstream>
+ #include <string>
++#include <thread>
+ #include <type_traits>
+ #include <vector>
+ 
+@@ -2056,15 +2057,18 @@ class GTEST_API_ ScopedTrace {
+   // Slow, but flexible.
+   template <typename T>
+   ScopedTrace(const char* file, int line, const T& message) {
++    id = std::this_thread::get_id();
+     PushTrace(file, line, (Message() << message).GetString());
+   }
+ 
+   // Optimize for some known types.
+   ScopedTrace(const char* file, int line, const char* message) {
++    id = std::this_thread::get_id();
+     PushTrace(file, line, message ? message : "(null)");
+   }
+ 
+   ScopedTrace(const char* file, int line, const std::string& message) {
++    id = std::this_thread::get_id();
+     PushTrace(file, line, message);
+   }
+ 
+@@ -2079,6 +2083,8 @@ class GTEST_API_ ScopedTrace {
+ 
+   ScopedTrace(const ScopedTrace&) = delete;
+   ScopedTrace& operator=(const ScopedTrace&) = delete;
++
++  std::thread::id id;
+ };
+ 
+ // Causes a trace (including the source file path, the current line
+diff --git a/googletest/src/gtest.cc b/googletest/src/gtest.cc
+index a64e887c..2e1fccb9 100644
+--- a/googletest/src/gtest.cc
++++ b/googletest/src/gtest.cc
+@@ -44,14 +44,17 @@
+ #include <chrono>  // NOLINT
+ #include <cmath>
+ #include <cstdint>
++#include <exception>
+ #include <initializer_list>
+ #include <iomanip>
++#include <iostream>
+ #include <iterator>
+ #include <limits>
+ #include <list>
+ #include <map>
+ #include <ostream>  // NOLINT
+ #include <sstream>
++#include <thread>
+ #include <unordered_set>
+ #include <vector>
+ 
+@@ -6838,6 +6841,13 @@ void ScopedTrace::PushTrace(const char* file, int line, std::string message) {
+ 
+ // Pops the info pushed by the c'tor.
+ ScopedTrace::~ScopedTrace() GTEST_LOCK_EXCLUDED_(&UnitTest::mutex_) {
++  if (id != std::this_thread::get_id()) {
++    std::cerr << "ScopedTrace was created and destroyed on different "
++                 "std::threads, terminating to avoid segfaults, hangs, or "
++                 "silent corruption. Are you using any pika functionality that "
++                 "may yield a task after creating the ScopedTrace?\n";
++    std::terminate();
++  }
+   UnitTest::GetInstance()->PopGTestTrace();
+ }
+ 


### PR DESCRIPTION
See first commit message for more details.

I've added a temporary commit which explicitly adds more yields while holding a `ScopedTrace` to check that it actually works in CI.

I've opted for a local patch which I think is easily updated if we update the gtest tag. An alternative strategy could be to apply the patch through the spack package and I don't have a strong preference either way, other than me not (yet) knowing how to apply the patch with spack to something that is pulled only at the CMake configure stage. One benefit of patching gtest like this is that it will always apply, even if one uses a spack build-env which doesn't run CMake through spack.