### PR TITLE
benchmark scripts: Extract partial backtransformation metadata

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -457,7 +457,18 @@ def calc_chol_metrics(df):
 
 
 def calc_trsm_metrics(df):
-    return _calc_metrics(["matrix_rows", "matrix_cols", "block_rows", "nodes", "bench_name"], df)
+    return _calc_metrics(
+        [
+            "matrix_rows",
+            "matrix_cols",
+            "block_rows",
+            "nodes",
+            "bench_name",
+            "from_ev",
+            "to_ev",
+        ],
+        df,
+    )
 
 
 def calc_trmm_metrics(df):
@@ -481,19 +492,65 @@ def calc_trid_evp_metrics(df):
 
 
 def calc_bt_band2trid_metrics(df):
-    return _calc_metrics(["matrix_rows", "matrix_cols", "block_rows", "band", "nodes", "bench_name"], df)
+    return _calc_metrics(
+        [
+            "matrix_rows",
+            "matrix_cols",
+            "block_rows",
+            "band",
+            "nodes",
+            "bench_name",
+            "from_ev",
+            "to_ev",
+        ],
+        df,
+    )
 
 
 def calc_bt_red2band_metrics(df):
-    return _calc_metrics(["matrix_rows", "matrix_cols", "block_rows", "band", "nodes", "bench_name"], df)
+    return _calc_metrics(
+        [
+            "matrix_rows",
+            "matrix_cols",
+            "block_rows",
+            "band",
+            "nodes",
+            "bench_name",
+            "from_ev",
+            "to_ev",
+        ],
+        df,
+    )
 
 
 def calc_evp_metrics(df):
-    return _calc_metrics(["matrix_rows", "block_rows", "band", "nodes", "bench_name"], df)
+    return _calc_metrics(
+        [
+            "matrix_rows",
+            "block_rows",
+            "band",
+            "nodes",
+            "bench_name",
+            "from_ev",
+            "to_ev",
+        ],
+        df,
+    )
 
 
 def calc_gevp_metrics(df):
-    return _calc_metrics(["matrix_rows", "block_rows", "band", "nodes", "bench_name"], df)
+    return _calc_metrics(
+        [
+            "matrix_rows",
+            "block_rows",
+            "band",
+            "nodes",
+            "bench_name",
+            "from_ev",
+            "to_ev",
+        ],
+        df,
+    )
 
 
 # Customization that add a simple legend

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -641,6 +641,9 @@ def _gen_plot(
         if has_band:
             group_list += ["band"]
 
+    if "from_ev" in df.columns:
+        group_list += ["from_ev", "to_ev"]
+
     # silence a warning in pandas.
     if len(group_list) == 1:
         group_list = group_list[0]
@@ -669,6 +672,7 @@ def _gen_plot(
         title = f"{name}: {scaling} scaling"
         filename_ppn = f"{filename}_{scaling}_ppn"
         filename_time = f"{filename}_{scaling}_time"
+
         if size_type == "m":
             title += f" ({m} x {m})"
             filename_ppn += f"_{m}"
@@ -677,6 +681,12 @@ def _gen_plot(
             title += f" ({m} x {n})"
             filename_ppn += f"_{m}_{n}"
             filename_time += f"_{m}_{n}"
+
+        if "from_ev" in df.columns:
+            partial_spectrum_suffix = "-".join(x[-2:])
+            filename_ppn += f"_{partial_spectrum_suffix}"
+            filename_time += f"_{partial_spectrum_suffix}"
+
         if not combine_mb:
             title += f", block_size = {mb} x {mb}"
             filename_ppn += f"_{mb}"

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -203,7 +203,7 @@ def _calc_metrics(cols, df):
     )
 
 
-@with_pattern(r"(|\s+\S+)")
+@with_pattern(r"(?:\s+\S+)?")
 def _parse_optional_text(text):
     text = text.strip()
     # TODO: Prefer empty string or None?

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -15,7 +15,6 @@ import re
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 from parse import parse, with_pattern
 


### PR DESCRIPTION
Changelog:
- extract `(from_ev, to_ev)` information (back-compatible, if not parsed set to `(0, matrix_rows)`)
- `calc_metrics` for backtransformation algorithms now group also over `from_ev` and `to_ev`
- fix parsing (make patterns given to `with_pattern` non capturing): it was not causing any major problem apparently, but at least the number of threads was parsed incorrectly
- add a suffix with spectrum information to make plot filenames distinct to avoid overwriting
- add "tag" features used for analysis (mainly it indicates the cluster type) and try to merge it with the "label" feature (not fully tested)