### PR TITLE
Move CPU CI to eiger again

### DIFF
--- a/ci/cpu/asan_ubsan_lsan.yml
+++ b/ci/cpu/asan_ubsan_lsan.yml
@@ -13,7 +13,7 @@ cpu asan ubsan lsan deps:
 cpu asan ubsan lsan build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu asan ubsan lsan deps
   variables:

--- a/ci/cpu/clang15_release.yml
+++ b/ci/cpu/clang15_release.yml
@@ -13,7 +13,7 @@ cpu clang15 release deps:
 cpu clang15 release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu clang15 release deps
   variables:

--- a/ci/cpu/clang15_release_cxx20.yml
+++ b/ci/cpu/clang15_release_cxx20.yml
@@ -14,7 +14,7 @@ cpu clang15 cxx20 release deps:
 cpu clang15 cxx20 release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu clang15 cxx20 release deps
   variables:

--- a/ci/cpu/clang15_release_stdexec.yml
+++ b/ci/cpu/clang15_release_stdexec.yml
@@ -14,7 +14,7 @@ cpu clang15 stdexec release deps:
 cpu clang15 stdexec release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu clang15 stdexec release deps
   variables:

--- a/ci/cpu/clang16_release.yml
+++ b/ci/cpu/clang16_release.yml
@@ -13,7 +13,7 @@ cpu clang16 release deps:
 cpu clang16 release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu clang16 release deps
   variables:

--- a/ci/cpu/clang18_release.yml
+++ b/ci/cpu/clang18_release.yml
@@ -13,7 +13,7 @@ cpu clang18 release deps:
 cpu clang18 release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu clang18 release deps
   variables:

--- a/ci/cpu/gcc11_debug_stdexec.yml
+++ b/ci/cpu/gcc11_debug_stdexec.yml
@@ -14,7 +14,7 @@ cpu gcc11 stdexec debug deps:
 cpu gcc11 stdexec debug build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu gcc11 stdexec debug deps
   variables:

--- a/ci/cpu/gcc11_release_stdexec.yml
+++ b/ci/cpu/gcc11_release_stdexec.yml
@@ -14,7 +14,7 @@ cpu gcc11 stdexec release deps:
 cpu gcc11 stdexec release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu gcc11 stdexec release deps
   variables:

--- a/ci/cpu/gcc12_release_cxx20.yml
+++ b/ci/cpu/gcc12_release_cxx20.yml
@@ -14,7 +14,7 @@ cpu gcc12 cxx20 release deps:
 cpu gcc12 cxx20 release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu gcc12 cxx20 release deps
   variables:

--- a/ci/cpu/gcc13_codecov.yml
+++ b/ci/cpu/gcc13_codecov.yml
@@ -12,7 +12,7 @@ cpu gcc13 codecov deps:
 cpu gcc13 codecov build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu gcc13 codecov deps
   variables:

--- a/ci/cpu/gcc13_release.yml
+++ b/ci/cpu/gcc13_release.yml
@@ -12,7 +12,7 @@ cpu gcc13 release deps:
 cpu gcc13 release build:
   extends:
     - .build_common
-    - .build_for_daint-mc
+    - .build_for_eiger
   needs:
     - cpu gcc13 release deps
   variables:


### PR DESCRIPTION
This reverts #1247. Daint XC is now down for good.