### PR TITLE
ReductionToBand: fix minimal amount of work per worker

### DIFF
--- a/include/dlaf/eigensolver/internal/get_red2band_panel_nworkers.h
+++ b/include/dlaf/eigensolver/internal/get_red2band_panel_nworkers.h
@@ -19,6 +19,10 @@
 
 namespace dlaf::eigensolver::internal {
 
+inline size_t get_red2band_panel_worker_minwork() noexcept {
+  return 1;
+}
+
 inline size_t get_red2band_panel_nworkers() noexcept {
   // Note: precautionarily we leave at least 1 thread "free" to do other stuff (if possible)
   const std::size_t available_workers = pika::resource::get_thread_pool("default").get_os_thread_count();

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -314,7 +314,8 @@ void computePanelReflectors(MatrixLikeA& mat_a, MatrixLikeTaus& mat_taus, const 
   const std::size_t nworkers = [nrtiles = panel_tiles.size()]() {
     const std::size_t min_workers = 1;
     const std::size_t available_workers = get_red2band_panel_nworkers();
-    const std::size_t ideal_workers = to_sizet(nrtiles);
+    const std::size_t ideal_workers =
+        util::ceilDiv(to_sizet(nrtiles), get_red2band_panel_worker_minwork());
     return std::clamp(ideal_workers, min_workers, available_workers);
   }();
   ex::start_detached(
@@ -639,7 +640,8 @@ void computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
   const std::size_t nworkers = [nrtiles = panel_tiles.size()]() {
     const std::size_t min_workers = 1;
     const std::size_t available_workers = get_red2band_panel_nworkers();
-    const std::size_t ideal_workers = util::ceilDiv(to_sizet(nrtiles), to_sizet(2));
+    const std::size_t ideal_workers =
+        util::ceilDiv(to_sizet(nrtiles), get_red2band_panel_worker_minwork());
     return std::clamp(ideal_workers, min_workers, available_workers);
   }();
 


### PR DESCRIPTION
With #1232 it has been introduced a small performance regression. This was apparently due to the default value used for minimal amount of work that has been set to 2, while it was previously 1.

Moreover, this value was not even unified between local and distributed implementation.

This PR aims at fixing that.

TODO
- [ ] Run benchmarks
- [ ] Decide if it is worth adding minimal amount of work as proper DLAF parameter (i.e. expose it instead of having it hard-coded)