### PR TITLE
Disable tests for CUDA configurations in CI

### DIFF
--- a/ci/cuda/gcc11_codecov.yml
+++ b/ci/cuda/gcc11_codecov.yml
@@ -20,13 +20,13 @@ cuda gcc11 codecov build:
     DOCKERFILE: ci/docker/codecov.Dockerfile
     DLAF_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc11-codecov/dlaf:$CI_COMMIT_SHA
 
-cuda gcc11 codecov test:
-  extends: .run_common
-  variables:
-    PIKA_MPI_ENABLE_POOL: 1
-  needs:
-    - cuda gcc11 codecov build
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cuda gcc11 codecov build
+# cuda gcc11 codecov test:
+#   extends: .run_common
+#   variables:
+#     PIKA_MPI_ENABLE_POOL: 1
+#   needs:
+#     - cuda gcc11 codecov build
+#   trigger:
+#     include:
+#       - artifact: pipeline.yml
+#         job: cuda gcc11 codecov build

--- a/ci/cuda/gcc11_debug_scalapack.yml
+++ b/ci/cuda/gcc11_debug_scalapack.yml
@@ -18,13 +18,13 @@ cuda gcc11 debug scalapack build:
   variables:
     DLAF_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc11-scalapack-debug/dlaf:$CI_COMMIT_SHA
 
-cuda gcc11 debug scalapack test:
-  extends: .run_common
-  variables:
-    PIKA_MPI_ENABLE_POOL: 1
-  needs:
-    - cuda gcc11 debug scalapack build
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cuda gcc11 debug scalapack build
+# cuda gcc11 debug scalapack test:
+#   extends: .run_common
+#   variables:
+#     PIKA_MPI_ENABLE_POOL: 1
+#   needs:
+#     - cuda gcc11 debug scalapack build
+#   trigger:
+#     include:
+#       - artifact: pipeline.yml
+#         job: cuda gcc11 debug scalapack build

--- a/ci/cuda/gcc11_release.yml
+++ b/ci/cuda/gcc11_release.yml
@@ -19,13 +19,13 @@ cuda gcc11 release build:
   variables:
     DLAF_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc11-release/dlaf:$CI_COMMIT_SHA
 
-cuda gcc11 release test:
-  extends: .run_common
-  variables:
-    PIKA_MPI_ENABLE_POOL: 1
-  needs:
-    - cuda gcc11 release build
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cuda gcc11 release build
+# cuda gcc11 release test:
+#   extends: .run_common
+#   variables:
+#     PIKA_MPI_ENABLE_POOL: 1
+#   needs:
+#     - cuda gcc11 release build
+#   trigger:
+#     include:
+#       - artifact: pipeline.yml
+#         job: cuda gcc11 release build

--- a/ci/cuda/gcc11_release_scalapack.yml
+++ b/ci/cuda/gcc11_release_scalapack.yml
@@ -19,13 +19,13 @@ cuda gcc11 release scalapack build:
   variables:
     DLAF_IMAGE: $CSCS_REGISTRY_PATH/cuda-gcc11-scalapack-release/dlaf:$CI_COMMIT_SHA
 
-cuda gcc11 release scalapack test:
-  extends: .run_common
-  variables:
-    PIKA_MPI_ENABLE_POOL: 1
-  needs:
-    - cuda gcc11 release scalapack build
-  trigger:
-    include:
-      - artifact: pipeline.yml
-        job: cuda gcc11 release scalapack build
+# cuda gcc11 release scalapack test:
+#   extends: .run_common
+#   variables:
+#     PIKA_MPI_ENABLE_POOL: 1
+#   needs:
+#     - cuda gcc11 release scalapack build
+#   trigger:
+#     include:
+#       - artifact: pipeline.yml
+#         job: cuda gcc11 release scalapack build


### PR DESCRIPTION
We can't yet have #1225, so disable CUDA tests for now and leave the CUDA builds in place in CI.