### PR TITLE
Fix typo in C API tests

### DIFF
--- a/test/include/dlaf_c_test/c_api_helpers.h
+++ b/test/include/dlaf_c_test/c_api_helpers.h
@@ -26,8 +26,8 @@
 enum class API { dlaf, scalapack };
 
 template <API api>
-int c_api_test_inititialize(int pika_argc, const char* pika_argv[], int dlaf_argc,
-                            const char* dlaf_argv[], const dlaf::comm::CommunicatorGrid& grid) {
+int c_api_test_initialize(int pika_argc, const char* pika_argv[], int dlaf_argc, const char* dlaf_argv[],
+                          const dlaf::comm::CommunicatorGrid& grid) {
   dlaf_initialize(pika_argc, pika_argv, dlaf_argc, dlaf_argv);
 
   char grid_order = grid_ordering(MPI_COMM_WORLD, grid.size().rows(), grid.size().cols(),

--- a/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_eigensolver_c_api.cpp
@@ -80,7 +80,7 @@ void testEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType mb,
   // The final check needs to happen on all m eigenvalues/eigenvectors
   const SizeType eval_idx_end = eigenvalues_index_end.value_or(m);
 
-  auto dlaf_context = c_api_test_inititialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
+  auto dlaf_context = c_api_test_initialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
 
   // In normal use the runtime is resumed by the C API call
   // The pika runtime is suspended by dlaf_initialize

--- a/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
+++ b/test/unit/c_api/eigensolver/test_gen_eigensolver_c_api.cpp
@@ -81,7 +81,7 @@ void testGenEigensolver(const blas::Uplo uplo, const SizeType m, const SizeType 
   // The final check needs to happen on all m eigenvalues/eigenvectors
   const SizeType eval_idx_end = eigenvalues_index_end.value_or(m);
 
-  auto dlaf_context = c_api_test_inititialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
+  auto dlaf_context = c_api_test_initialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
 
   // In normal use the runtime is resumed by the C API call
   // The pika runtime is suspended by dlaf_initialize

--- a/test/unit/c_api/factorization/test_cholesky_c_api.cpp
+++ b/test/unit/c_api/factorization/test_cholesky_c_api.cpp
@@ -62,7 +62,7 @@ const std::vector<std::tuple<SizeType, SizeType>> sizes = {
 template <class T, Backend B, Device D, API api>
 void testCholesky(comm::CommunicatorGrid& grid, const blas::Uplo uplo, const SizeType m,
                   const SizeType mb) {
-  auto dlaf_context = c_api_test_inititialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
+  auto dlaf_context = c_api_test_initialize<api>(pika_argc, pika_argv, dlaf_argc, dlaf_argv, grid);
 
   // In normal use the runtime is resumed by the C API call
   // The pika runtime is suspended by dlaf_initialize


### PR DESCRIPTION
Change "inititialize" to "initialize".