### PR TITLE
Use slightly fewer threads for pika in CI

### DIFF
--- a/ci/mpi-ctest
+++ b/ci/mpi-ctest
@@ -17,6 +17,9 @@ then
     echo "Rank $SLURM_PROCID: set CUDA_VISIBLE_DEVICE=$CUDA_VISIBLE_DEVICE"
 fi
 
+# Reserve one core for non-pika threads
+export PIKA_THREADS=$((SLURM_CPUS_PER_TASK - 1))
+
 # Run the tests, only output on the first rank
 if [[ $SLURM_PROCID == "0" ]]; then
     TZ=CET date +"Run started at: %H:%M:%S %z"


### PR DESCRIPTION
Requires pika 0.32.0 for the `PIKA_THREADS` environment variable to have an effect.