### PR TITLE
Reenable CUDA stdexec CI configuration

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -14,7 +14,7 @@ include:
   - local: 'ci/cuda/gcc13_release_scalapack.yml'
   - local: 'ci/cuda/gcc13_debug.yml'
   - local: 'ci/cuda/gcc13_debug_scalapack.yml'
-  # - local: 'ci/cuda/gcc13_release_stdexec.yml'
+  - local: 'ci/cuda/gcc13_release_stdexec.yml'
   - local: 'ci/rocm/clang14_release_stdexec.yml'
   - local: 'ci/rocm/clang15_release.yml'
   - local: 'ci/rocm/clang15_release_stdexec.yml'


### PR DESCRIPTION
Fix #1276.

The issue fixed by https://github.com/eth-cscs/DLA-Future/pull/1292 seems to be the main cause of problems on GH200 CI pipelines. stdexec does not seem to be responsible for failures, though it's hard to completely exclude it with so many failrues caused by the issue in #1292.