### PR TITLE
Set `cuda_arch=90` on GH200 CI configurations

### DIFF
--- a/ci/docker/common-gh200.yaml
+++ b/ci/docker/common-gh200.yaml
@@ -11,6 +11,8 @@
 packages:
   all:
     target: [neoverse_v2]
+    require:
+      - 'cuda_arch=90'
   # Set nvpl as default blas, lapack and scalapack provider.
   # Can be overwritten in environments if needed.
   blas:


### PR DESCRIPTION
It was previously concretized to `cuda_arch=none`, which CMake will default to 60, 70, and 80.