### PR TITLE
Adjust CI timeouts

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -72,7 +72,7 @@ variables:
     - .build_deps_common_base
   variables:
     COMMON_SPACK_ENVIRONMENT: ci/docker/common-gh200.yaml
-    SLURM_TIMELIMIT: 00:45:00
+    SLURM_TIMELIMIT: '00:45:00'
 
 ## BUILD DLAF
 
@@ -115,7 +115,7 @@ variables:
     - .build_common_base
   variables:
     DLAF_LD_PRELOAD: "/lib/aarch64-linux-gnu/libSegFault.so"
-    SLURM_TIMELIMIT: 00:45:00
+    SLURM_TIMELIMIT: '00:45:00'
 
 .build_for_eiger:
   variables:


### PR DESCRIPTION
Last rebuild of deps images took less than 25 min for all cases, therefore a timeout of 45 mins looks appropriate.

The same holds for build images (except for rocm builds where the slowest takes ~45 mins -> timeout of 1h30m)