### PR TITLE
Use bigger stacks and guard pages in CI

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -136,3 +136,5 @@ variables:
     strategy: depend
     forward:
       pipeline_variables: true
+  variables:
+    PIKA_USE_GUARD_PAGES: 1

--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -137,4 +137,6 @@ variables:
     forward:
       pipeline_variables: true
   variables:
+    PIKA_SMALL_STACK_SIZE: 0x40000
+    PIKA_MEDIUM_STACK_SIZE: 0x40000
     PIKA_USE_GUARD_PAGES: 1


### PR DESCRIPTION
The reporting of stack overflows with guard pages in pika is still severely lacking (meaning you might still just get an error saying "segfault" or even worse nothing), but enabling them in CI should make failures a bit more predictable since stack overflows are less likely to write into other tasks' stacks (and should instead "only" trigger segfaults when trying to use the guard page). 