### PR TITLE
Remove Umpire version constraint in CI

### DIFF
--- a/ci/docker/debug-cuda-gh200.yaml
+++ b/ci/docker/debug-cuda-gh200.yaml
@@ -33,7 +33,3 @@ spack:
         - '@0.30.1'
         - 'build_type=Debug'
         - 'malloc=system'
-    # For correct code coverage
-    # https://github.com/eth-cscs/DLA-Future/pull/1002
-    umpire:
-      require: '@2022.03.1'


### PR DESCRIPTION
Not urgent, but I just noticed that we still have this version constraint in place, though it's no longer needed. All versions have been patched in spack, and the latest releases have it fixed without patches as well. I think it's good if we can test with the latest version that we would normally be using for benchmarks etc. as well.