### PR TITLE
Upgrade gtest: 1.13.0 -> 1.16.0

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -16,11 +16,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.13.0
-  # Patch for int to float conversion warning.
-  PATCH_COMMAND
-    git reset --hard HEAD && git cherry-pick -n 5cd81a7848203d3df6959c148eb91f1a4ff32c1d -m 1 && git
-    apply "${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch"
+  GIT_TAG v1.16.0
 )
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -13,11 +13,7 @@ set(CMAKE_CXX_STANDARD 17)
 ### GoogleTest
 include(FetchContent)
 
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.16.0
-)
+FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.16.0)
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -13,7 +13,12 @@ set(CMAKE_CXX_STANDARD 17)
 ### GoogleTest
 include(FetchContent)
 
-FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.16.0)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.16.0
+  PATCH_COMMAND patch -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch"
+)
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,7 +17,7 @@ FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG v1.16.0
-  PATCH_COMMAND patch -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch"
+  PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch
 )
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")

--- a/external/scoped_trace_terminate_on_thread_migrate.patch
+++ b/external/scoped_trace_terminate_on_thread_migrate.patch
@@ -1,8 +1,8 @@
 diff --git a/googletest/include/gtest/gtest.h b/googletest/include/gtest/gtest.h
-index 3e452a50..c51dd607 100644
+index c8996695..e4bd164d 100644
 --- a/googletest/include/gtest/gtest.h
 +++ b/googletest/include/gtest/gtest.h
-@@ -58,6 +58,7 @@
+@@ -57,6 +57,7 @@
  #include <set>
  #include <sstream>
  #include <string>
@@ -10,7 +10,7 @@ index 3e452a50..c51dd607 100644
  #include <type_traits>
  #include <vector>
  
-@@ -2056,15 +2057,18 @@ class GTEST_API_ ScopedTrace {
+@@ -2077,15 +2078,18 @@ class GTEST_API_ ScopedTrace {
    // Slow, but flexible.
    template <typename T>
    ScopedTrace(const char* file, int line, const T& message) {
@@ -29,7 +29,7 @@ index 3e452a50..c51dd607 100644
      PushTrace(file, line, message);
    }
  
-@@ -2079,6 +2083,8 @@ class GTEST_API_ ScopedTrace {
+@@ -2100,6 +2104,8 @@ class GTEST_API_ ScopedTrace {
  
    ScopedTrace(const ScopedTrace&) = delete;
    ScopedTrace& operator=(const ScopedTrace&) = delete;
@@ -59,7 +59,7 @@ index 7ff82546..6e658ebc 100644
  #include <utility>
  #include <vector>
 @@ -6991,6 +6993,13 @@ void ScopedTrace::PushTrace(const char* file, int line, std::string message) {
-
+ 
  // Pops the info pushed by the c'tor.
  ScopedTrace::~ScopedTrace() GTEST_LOCK_EXCLUDED_(&UnitTest::mutex_) {
 +  if (id != std::this_thread::get_id()) {
@@ -71,3 +71,4 @@ index 7ff82546..6e658ebc 100644
 +  }
    UnitTest::GetInstance()->PopGTestTrace();
  }
+ 

--- a/external/scoped_trace_terminate_on_thread_migrate.patch
+++ b/external/scoped_trace_terminate_on_thread_migrate.patch
@@ -39,29 +39,27 @@ index 3e452a50..c51dd607 100644
  
  // Causes a trace (including the source file path, the current line
 diff --git a/googletest/src/gtest.cc b/googletest/src/gtest.cc
-index a64e887c..2e1fccb9 100644
+index 7ff82546..6e658ebc 100644
 --- a/googletest/src/gtest.cc
 +++ b/googletest/src/gtest.cc
-@@ -44,14 +44,17 @@
- #include <chrono>  // NOLINT
- #include <cmath>
+@@ -47,6 +47,7 @@
  #include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
 +#include <exception>
  #include <initializer_list>
  #include <iomanip>
-+#include <iostream>
- #include <iterator>
- #include <limits>
- #include <list>
- #include <map>
+ #include <ios>
+@@ -58,6 +59,7 @@
  #include <ostream>  // NOLINT
+ #include <set>
  #include <sstream>
 +#include <thread>
  #include <unordered_set>
+ #include <utility>
  #include <vector>
- 
-@@ -6838,6 +6841,13 @@ void ScopedTrace::PushTrace(const char* file, int line, std::string message) {
- 
+@@ -6991,6 +6993,13 @@ void ScopedTrace::PushTrace(const char* file, int line, std::string message) {
+
  // Pops the info pushed by the c'tor.
  ScopedTrace::~ScopedTrace() GTEST_LOCK_EXCLUDED_(&UnitTest::mutex_) {
 +  if (id != std::this_thread::get_id()) {
@@ -73,4 +71,3 @@ index a64e887c..2e1fccb9 100644
 +  }
    UnitTest::GetInstance()->PopGTestTrace();
  }
- 


### PR DESCRIPTION
GTest 1.13.0 have as minimum requirement CMake 3.5 which has been deprecated (moreover we were using it with a patch). Starting from 1.14.0 the requirement has been updated to CMake 3.13.

Since I didn't face any problem with the newest version, I opted for doing the full step. In case we'd see problems in the CI, we can always downscale the upgrade to one of the intermediate steps.