### PR TITLE
ReductionToBand, BTReductionToBand, TFactor: Taus on GPU

### DIFF
--- a/include/dlaf/eigensolver/bt_reduction_to_band.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band.h
@@ -43,7 +43,7 @@ namespace dlaf::eigensolver::internal {
 /// factor for the j-th HH tranformation.
 template <Backend backend, Device device, class T>
 void bt_reduction_to_band(const SizeType b, MatrixRef<T, device>& mat_c, Matrix<const T, device>& mat_v,
-                          Matrix<const T, Device::CPU>& mat_taus) {
+                          Matrix<const T, device>& mat_taus) {
   DLAF_ASSERT(matrix::local_matrix(mat_c), mat_c);
   DLAF_ASSERT(matrix::local_matrix(mat_v), mat_v);
   DLAF_ASSERT(square_size(mat_v), mat_v);
@@ -84,7 +84,7 @@ void bt_reduction_to_band(const SizeType b, MatrixRef<T, device>& mat_c, Matrix<
 /// factor for the j-th HH tranformation.
 template <Backend backend, Device device, class T>
 void bt_reduction_to_band(comm::CommunicatorGrid& grid, const SizeType b, MatrixRef<T, device>& mat_c,
-                          Matrix<const T, device>& mat_v, Matrix<const T, Device::CPU>& mat_taus) {
+                          Matrix<const T, device>& mat_v, Matrix<const T, device>& mat_taus) {
   DLAF_ASSERT(matrix::equal_process_grid(mat_c, grid), mat_c, grid);
   DLAF_ASSERT(matrix::equal_process_grid(mat_v, grid), mat_v, grid);
   DLAF_ASSERT(square_size(mat_v), mat_v);

--- a/include/dlaf/eigensolver/bt_reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/api.h
@@ -22,10 +22,10 @@ using matrix::internal::MatrixRef;
 template <Backend backend, Device device, class T>
 struct BackTransformationReductionToBand {
   static void call(SizeType b, MatrixRef<T, device>& mat_c, Matrix<const T, device>& mat_v,
-                   Matrix<const T, Device::CPU>& mat_taus);
+                   Matrix<const T, device>& mat_taus);
 
   static void call(comm::CommunicatorGrid& grid, const SizeType b, MatrixRef<T, device>& mat_c,
-                   Matrix<const T, device>& mat_v, Matrix<const T, Device::CPU>& mat_taus);
+                   Matrix<const T, device>& mat_v, Matrix<const T, device>& mat_taus);
 };
 
 // ETI

--- a/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
@@ -222,7 +222,7 @@ void BackTransformationReductionToBand<backend, device, T>::call(const SizeType 
     const LocalTileIndex taus_index{Coord::Row, k};
     const LocalTileIndex t_index{Coord::Col, k};
 
-    // computeTFactor<B>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS);
+    computeTFactor<backend>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS);
 
     // W = V T
     auto tile_t = panelT.read(t_index);
@@ -356,8 +356,8 @@ void BackTransformationReductionToBand<B, D, T>::call(comm::CommunicatorGrid& gr
       const SizeType k_local = dist_t.template localTileFromGlobalTile<Coord::Col>(k);
       const LocalTileIndex t_index{Coord::Col, k_local};
 
-      // computeTFactor<B>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS,
-      //                   mpi_col_task_chain);
+      computeTFactor<B>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS,
+                        mpi_col_task_chain);
 
       // WH = V T
       for (const auto& idx : panel_view.iteratorLocal()) {

--- a/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
@@ -131,9 +131,10 @@ void gemmTrailingMatrix(pika::execution::thread_priority priority, PanelTileSend
 // G. H. Golub and C. F. Van Loan, Matrix Computations, chapter 5, The Johns Hopkins University Press
 
 template <Backend backend, Device device, class T>
-void BackTransformationReductionToBand<backend, device, T>::call(
-    const SizeType b, MatrixRef<T, device>& mat_c, Matrix<const T, device>& mat_v,
-    Matrix<const T, Device::CPU>& mat_taus) {
+void BackTransformationReductionToBand<backend, device, T>::call(const SizeType b,
+                                                                 MatrixRef<T, device>& mat_c,
+                                                                 Matrix<const T, device>& mat_v,
+                                                                 Matrix<const T, device>& mat_taus) {
   using namespace bt_red_band;
   using dlaf::factorization::internal::computeTFactor;
 
@@ -253,7 +254,7 @@ void BackTransformationReductionToBand<backend, device, T>::call(
 template <Backend B, Device D, class T>
 void BackTransformationReductionToBand<B, D, T>::call(comm::CommunicatorGrid& grid, const SizeType b,
                                                       MatrixRef<T, D>& mat_c, Matrix<const T, D>& mat_v,
-                                                      Matrix<const T, Device::CPU>& mat_taus) {
+                                                      Matrix<const T, D>& mat_taus) {
   namespace ex = pika::execution::experimental;
   using namespace bt_red_band;
   using dlaf::factorization::internal::computeTFactor;

--- a/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/bt_reduction_to_band/impl.h
@@ -222,7 +222,7 @@ void BackTransformationReductionToBand<backend, device, T>::call(const SizeType 
     const LocalTileIndex taus_index{Coord::Row, k};
     const LocalTileIndex t_index{Coord::Col, k};
 
-    computeTFactor<backend>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS);
+    // computeTFactor<B>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS);
 
     // W = V T
     auto tile_t = panelT.read(t_index);
@@ -356,8 +356,8 @@ void BackTransformationReductionToBand<B, D, T>::call(comm::CommunicatorGrid& gr
       const SizeType k_local = dist_t.template localTileFromGlobalTile<Coord::Col>(k);
       const LocalTileIndex t_index{Coord::Col, k_local};
 
-      computeTFactor<B>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS,
-                        mpi_col_task_chain);
+      // computeTFactor<B>(panelV, mat_taus.read(taus_index), panelT.readwrite(t_index), panelWS,
+      //                   mpi_col_task_chain);
 
       // WH = V T
       for (const auto& idx : panel_view.iteratorLocal()) {

--- a/include/dlaf/eigensolver/reduction_to_band.h
+++ b/include/dlaf/eigensolver/reduction_to_band.h
@@ -38,7 +38,7 @@ namespace dlaf::eigensolver::internal {
 /// @return the tau vector as needed by backtransformationReductionToBand
 ///
 template <Backend B, Device D, class T>
-Matrix<T, Device::CPU> reduction_to_band(Matrix<T, D>& mat_a, const SizeType band_size) {
+Matrix<T, D> reduction_to_band(Matrix<T, D>& mat_a, const SizeType band_size) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);
@@ -107,8 +107,8 @@ v v v v * *
 ///
 /// @return the tau vector as needed by backtransformationReductionToBand
 template <Backend B, Device D, class T>
-Matrix<T, Device::CPU> reduction_to_band(comm::CommunicatorGrid& grid, Matrix<T, D>& mat_a,
-                                         const SizeType band_size) {
+Matrix<T, D> reduction_to_band(comm::CommunicatorGrid& grid, Matrix<T, D>& mat_a,
+                               const SizeType band_size) {
   DLAF_ASSERT(matrix::square_size(mat_a), mat_a);
   DLAF_ASSERT(matrix::square_blocksize(mat_a), mat_a);
   DLAF_ASSERT(matrix::single_tile_per_block(mat_a), mat_a);

--- a/include/dlaf/eigensolver/reduction_to_band/api.h
+++ b/include/dlaf/eigensolver/reduction_to_band/api.h
@@ -21,9 +21,8 @@ namespace dlaf::eigensolver::internal {
 
 template <Backend B, Device D, class T>
 struct ReductionToBand {
-  static Matrix<T, Device::CPU> call(Matrix<T, D>& mat_a, const SizeType band_size);
-  static Matrix<T, Device::CPU> call(comm::CommunicatorGrid& grid, Matrix<T, D>& mat_a,
-                                     const SizeType band_size);
+  static Matrix<T, D> call(Matrix<T, D>& mat_a, const SizeType band_size);
+  static Matrix<T, D> call(comm::CommunicatorGrid& grid, Matrix<T, D>& mat_a, const SizeType band_size);
 };
 
 // ETI

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -470,8 +470,6 @@ void gemmUpdateX(matrix::Panel<Coord::Col, T, D>& x, matrix::Matrix<const T, D>&
 template <Backend B, Device D, class T>
 void hemmComputeX(matrix::Panel<Coord::Col, T, D>& x, const matrix::SubMatrixView& view,
                   matrix::Matrix<const T, D>& a, matrix::Panel<Coord::Col, const T, D>& w) {
-  namespace ex = pika::execution::experimental;
-
   using pika::execution::thread_priority;
 
   const auto dist = a.distribution();

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -894,7 +894,7 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
   ComputePanelHelper(const std::size_t n_workspaces, matrix::Distribution dist_a)
       : panels_v(n_workspaces, dist_a) {}
 
-  void call(Matrix<T, Device::GPU>& mat_a, Matrix<T, Device::CPU>& mat_taus, const SizeType j_sub,
+  void call(Matrix<T, Device::GPU>& mat_a, Matrix<T, Device::GPU>& mat_taus, const SizeType j_sub,
             const matrix::SubPanelView& panel_view) {
     using red2band::local::computePanelReflectors;
 
@@ -908,13 +908,13 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
     auto& v = panels_v.nextResource();
 
     copyToCPU(panel_view, mat_a, v);
-    computePanelReflectors(v, mat_taus, j_sub, panel_view);
+    // computePanelReflectors(v, mat_taus, j_sub, panel_view);
     copyFromCPU(panel_view, v, mat_a);
   }
 
   template <Device D, class CommSender, class TriggerSender>
   void call(TriggerSender&& trigger, comm::IndexT_MPI rank_v0, CommSender&& mpi_col_chain_panel,
-            Matrix<T, D>& mat_a, Matrix<T, Device::CPU>& mat_taus, SizeType j_sub,
+            Matrix<T, D>& mat_a, Matrix<T, D>& mat_taus, SizeType j_sub,
             const matrix::SubPanelView& panel_view) {
     auto& v = panels_v.nextResource();
 
@@ -977,7 +977,7 @@ protected:
 
 // Local implementation of reduction to band
 template <Backend B, Device D, class T>
-Matrix<T, Device::CPU> ReductionToBand<B, D, T>::call(Matrix<T, D>& mat_a, const SizeType band_size) {
+Matrix<T, D> ReductionToBand<B, D, T>::call(Matrix<T, D>& mat_a, const SizeType band_size) {
   using dlaf::matrix::Matrix;
   using dlaf::matrix::Panel;
 
@@ -998,16 +998,16 @@ Matrix<T, Device::CPU> ReductionToBand<B, D, T>::call(Matrix<T, D>& mat_a, const
 
   // Row-vector that is distributed over columns, but exists locally on all rows of the grid
   DLAF_ASSERT(mat_a.blockSize().cols() % band_size == 0, mat_a.blockSize().cols(), band_size);
-  Matrix<T, Device::CPU> mat_taus(matrix::Distribution(GlobalElementSize(nrefls, 1),
-                                                       TileElementSize(mat_a.blockSize().cols(), 1),
-                                                       comm::Size2D(mat_a.commGridSize().cols(), 1),
-                                                       comm::Index2D(mat_a.rankIndex().col(), 0),
-                                                       comm::Index2D(mat_a.sourceRankIndex().col(), 0)));
+  Matrix<T, D> mat_taus(matrix::Distribution(GlobalElementSize(nrefls, 1),
+                                             TileElementSize(mat_a.blockSize().cols(), 1),
+                                             comm::Size2D(mat_a.commGridSize().cols(), 1),
+                                             comm::Index2D(mat_a.rankIndex().col(), 0),
+                                             comm::Index2D(mat_a.sourceRankIndex().col(), 0)));
 
   if (nrefls == 0)
     return mat_taus;
 
-  Matrix<T, Device::CPU> mat_taus_retiled =
+  Matrix<T, D> mat_taus_retiled =
       mat_taus.retiledSubPipeline(LocalTileSize(mat_a.blockSize().cols() / band_size, 1));
 
   const SizeType ntiles = (nrefls - 1) / band_size + 1;
@@ -1133,8 +1133,8 @@ Matrix<T, Device::CPU> ReductionToBand<B, D, T>::call(Matrix<T, D>& mat_a, const
 
 // Distributed implementation of reduction to band
 template <Backend B, Device D, class T>
-Matrix<T, Device::CPU> ReductionToBand<B, D, T>::call(comm::CommunicatorGrid& grid, Matrix<T, D>& mat_a,
-                                                      const SizeType band_size) {
+Matrix<T, D> ReductionToBand<B, D, T>::call(comm::CommunicatorGrid& grid, Matrix<T, D>& mat_a,
+                                            const SizeType band_size) {
   using namespace red2band::distributed;
 
   using common::iterate_range2d;
@@ -1179,11 +1179,11 @@ Matrix<T, Device::CPU> ReductionToBand<B, D, T>::call(comm::CommunicatorGrid& gr
 
   // Row-vector that is distributed over columns, but exists locally on all rows of the grid
   DLAF_ASSERT(mat_a.blockSize().cols() % band_size == 0, mat_a.blockSize().cols(), band_size);
-  Matrix<T, Device::CPU> mat_taus(matrix::Distribution(GlobalElementSize(nrefls, 1),
-                                                       TileElementSize(mat_a.blockSize().cols(), 1),
-                                                       comm::Size2D(mat_a.commGridSize().cols(), 1),
-                                                       comm::Index2D(mat_a.rankIndex().col(), 0),
-                                                       comm::Index2D(mat_a.sourceRankIndex().col(), 0)));
+  Matrix<T, D> mat_taus(matrix::Distribution(GlobalElementSize(nrefls, 1),
+                                             TileElementSize(mat_a.blockSize().cols(), 1),
+                                             comm::Size2D(mat_a.commGridSize().cols(), 1),
+                                             comm::Index2D(mat_a.rankIndex().col(), 0),
+                                             comm::Index2D(mat_a.sourceRankIndex().col(), 0)));
 
   if (nrefls == 0) {
 #ifdef DLAF_WITH_HDF5
@@ -1197,7 +1197,7 @@ Matrix<T, Device::CPU> ReductionToBand<B, D, T>::call(comm::CommunicatorGrid& gr
     return mat_taus;
   }
 
-  Matrix<T, Device::CPU> mat_taus_retiled =
+  Matrix<T, D> mat_taus_retiled =
       mat_taus.retiledSubPipeline(LocalTileSize(mat_a.blockSize().cols() / band_size, 1));
 
   const SizeType ntiles = (nrefls - 1) / band_size + 1;

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -914,7 +914,7 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
         ex::when_all(mat_taus_cpu.read(GlobalTileIndex(j_sub, 0)),
                      mat_taus.readwrite(GlobalTileIndex(j_sub, 0))) |
         dlaf::matrix::copy(
-            dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::GPU, Device::CPU>>(
+            dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::CPU, Device::GPU>>(
                 pika::execution::thread_priority::high)));
 
     copyFromCPU(panel_view, v, mat_a);
@@ -945,7 +945,7 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
         ex::when_all(mat_taus_cpu.read(GlobalTileIndex(j_sub, 0)),
                      mat_taus.readwrite(GlobalTileIndex(j_sub, 0))) |
         dlaf::matrix::copy(
-            dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::GPU, Device::CPU>>(
+            dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::CPU, Device::GPU>>(
                 pika::execution::thread_priority::high)));
 
     copyFromCPU(panel_view, v, mat_a);

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -980,11 +980,9 @@ protected:
     using pika::execution::thread_priority;
     using pika::execution::thread_stacksize;
 
-    ex::start_detached(
-        ex::when_all(std::move(src), std::move(dst)) |
-        dlaf::matrix::copy(
-            dlaf::internal::Policy<dlaf::matrix::internal::CopyBackend_v<Device::CPU, Device::GPU>>(
-                thread_priority::high, thread_stacksize::nostack)));
+    ex::start_detached(ex::when_all(std::move(src), std::move(dst)) |
+                       dlaf::matrix::copy(Policy<CopyBackend_v<Device::CPU, Device::GPU>>(
+                           thread_priority::high, thread_stacksize::nostack)));
   }
 };
 #endif

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -923,9 +923,9 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
 
     // compute on CPU
     using dlaf::eigensolver::internal::red2band::distributed::computePanelReflectors;
-    computePanelReflectors(std::forward<TriggerSender>(trigger), rank_v0,
-                           std::forward<CommSender>(mpi_col_chain_panel), v, mat_taus, j_sub,
-                           panel_view);
+    // computePanelReflectors(std::forward<TriggerSender>(trigger), rank_v0,
+    //                        std::forward<CommSender>(mpi_col_chain_panel), v, mat_taus, j_sub,
+    //                        panel_view);
 
     // copy back to GPU
     copyFromCPU(panel_view, v, mat_a);

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -1075,7 +1075,7 @@ Matrix<T, D> ReductionToBand<B, D, T>::call(Matrix<T, D>& mat_a, const SizeType 
     // TODO used just by the column, maybe we can re-use a panel tile?
     // TODO probably the first one in any panel is ok?
     Matrix<T, D> t({nrefls_tile, nrefls_tile}, dist.blockSize());
-    computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws);
+    // computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws);
     ws.reset();
 
     // PREPARATION FOR TRAILING MATRIX UPDATE
@@ -1277,8 +1277,8 @@ Matrix<T, D> ReductionToBand<B, D, T>::call(comm::CommunicatorGrid& grid, Matrix
       red2band::local::setupReflectorPanelV<B, D, T>(rank.row() == rank_v0.row(), panel_view,
                                                      nrefls_tile, v, mat_a, !is_full_band);
 
-      computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws,
-                        mpi_col_chain);
+      // computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws,
+      //                   mpi_col_chain);
       ws.reset();
     }
 

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -898,8 +898,6 @@ struct ComputePanelHelper<Backend::GPU, Device::GPU, T> {
             const matrix::SubPanelView& panel_view) {
     using red2band::local::computePanelReflectors;
 
-    namespace ex = pika::execution::experimental;
-
     // Note:
     // - copy panel_view from GPU to CPU
     // - computePanelReflectors on CPU (on a matrix like, with just a panel)

--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -1099,7 +1099,7 @@ Matrix<T, D> ReductionToBand<B, D, T>::call(Matrix<T, D>& mat_a, const SizeType 
     // TODO used just by the column, maybe we can re-use a panel tile?
     // TODO probably the first one in any panel is ok?
     Matrix<T, D> t({nrefls_tile, nrefls_tile}, dist.blockSize());
-    // computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws);
+    computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws);
     ws.reset();
 
     // PREPARATION FOR TRAILING MATRIX UPDATE
@@ -1302,8 +1302,8 @@ Matrix<T, D> ReductionToBand<B, D, T>::call(comm::CommunicatorGrid& grid, Matrix
       red2band::local::setupReflectorPanelV<B, D, T>(rank.row() == rank_v0.row(), panel_view,
                                                      nrefls_tile, v, mat_a, !is_full_band);
 
-      // computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws,
-      //                   mpi_col_chain);
+      computeTFactor<B>(v, mat_taus_retiled.read(GlobalTileIndex(j_sub, 0)), t.readwrite(t_idx), ws,
+                        mpi_col_chain);
       ws.reset();
     }
 

--- a/include/dlaf/factorization/qr.h
+++ b/include/dlaf/factorization/qr.h
@@ -59,8 +59,7 @@ namespace dlaf::factorization::internal {
 /// @pre hh_panel.getWidth() <= t.get().size().rows && hh_panel.getWidth() <= t.get().size().cols()
 template <Backend backend, Device device, class T>
 void computeTFactor(matrix::Panel<Coord::Col, T, device>& hh_panel,
-                    matrix::ReadOnlyTileSender<T, Device::CPU> taus,
-                    matrix::ReadWriteTileSender<T, device> t,
+                    matrix::ReadOnlyTileSender<T, device> taus, matrix::ReadWriteTileSender<T, device> t,
                     matrix::Panel<Coord::Col, T, device>& workspaces) {
   QR_Tfactor<backend, device, T>::call(hh_panel, std::move(taus), std::move(t), workspaces);
 }
@@ -105,8 +104,7 @@ void computeTFactor(matrix::Panel<Coord::Col, T, device>& hh_panel,
 /// @pre hh_panel.getWidth() <= t.get().size().rows && hh_panel.getWidth() <= t.get().size().cols()
 template <Backend backend, Device device, class T>
 void computeTFactor(matrix::Panel<Coord::Col, T, device>& hh_panel,
-                    matrix::ReadOnlyTileSender<T, Device::CPU> taus,
-                    matrix::ReadWriteTileSender<T, device> t,
+                    matrix::ReadOnlyTileSender<T, device> taus, matrix::ReadWriteTileSender<T, device> t,
                     matrix::Panel<Coord::Col, T, device>& workspaces,
                     comm::CommunicatorPipeline<comm::CommunicatorType::Col>& mpi_col_task_chain) {
   QR_Tfactor<backend, device, T>::call(hh_panel, std::move(taus), std::move(t), workspaces,

--- a/include/dlaf/factorization/qr/api.h
+++ b/include/dlaf/factorization/qr/api.h
@@ -28,12 +28,10 @@ struct QR {};
 template <Backend backend, Device device, class T>
 struct QR_Tfactor {
   static void call(matrix::Panel<Coord::Col, T, device>& hh_panel,
-                   matrix::ReadOnlyTileSender<T, Device::CPU> taus,
-                   matrix::ReadWriteTileSender<T, device> t,
+                   matrix::ReadOnlyTileSender<T, device> taus, matrix::ReadWriteTileSender<T, device> t,
                    matrix::Panel<Coord::Col, T, device>& workspaces);
   static void call(matrix::Panel<Coord::Col, T, device>& hh_panel,
-                   matrix::ReadOnlyTileSender<T, Device::CPU> taus,
-                   matrix::ReadWriteTileSender<T, device> t,
+                   matrix::ReadOnlyTileSender<T, device> taus, matrix::ReadWriteTileSender<T, device> t,
                    matrix::Panel<Coord::Col, T, device>& workspaces,
                    comm::CommunicatorPipeline<comm::CommunicatorType::Col>& mpi_col_task_chain);
 };

--- a/include/dlaf/factorization/qr/t_factor_impl.h
+++ b/include/dlaf/factorization/qr/t_factor_impl.h
@@ -346,8 +346,7 @@ struct Helpers<Backend::GPU, Device::GPU, T> {
       DLAF_GPUBLAS_CHECK_ERROR(cublasGetStream(handle, &stream));
 
       const SizeType k = tile_t.size().cols();
-      gpulapack::lacpy(blas::Uplo::General, 1, k, taus.ptr(), 1, tile_t.ptr(), tile_t.ld() + 1, stream);
-      gpulapack::larft_gemv1_fixtau(k, tile_t.ptr(), tile_t.ld() + 1, tile_t.ptr(), tile_t.ld(), stream);
+      gpulapack::larft_gemv1_fixtau(k, taus.ptr(), 1, tile_t.ptr(), tile_t.ld(), stream);
 
       loop_trmv(handle, tile_t);
     };

--- a/include/dlaf/factorization/qr/t_factor_impl.h
+++ b/include/dlaf/factorization/qr/t_factor_impl.h
@@ -235,7 +235,7 @@ struct Helpers<Backend::GPU, Device::GPU, T> {
                          });
   }
   static matrix::ReadWriteTileSender<T, Device::GPU> step_gemv(
-      matrix::Panel<Coord::Col, T, Device::GPU>& hh_panel,
+      matrix::Panel<Coord::Col, const T, Device::GPU>& hh_panel,
       matrix::ReadOnlyTileSender<T, Device::GPU> taus,
       matrix::ReadWriteTileSender<T, Device::GPU> tile_t,
       matrix::Panel<Coord::Col, T, Device::GPU>& workspaces) {

--- a/include/dlaf/factorization/qr/t_factor_impl.h
+++ b/include/dlaf/factorization/qr/t_factor_impl.h
@@ -291,14 +291,12 @@ struct Helpers<Backend::GPU, Device::GPU, T> {
                 matrix::Tile<T, Device::GPU> tile_t = tile_t_full.subTileReference({{0, 0}, {k, k}});
 
                 // Note:
-                // prepare the diagonal of taus in t and reset the rest
+                // set tile_t to zero (next loop_gemv cumulates results in it)
                 whip::stream_t stream;
                 DLAF_GPUBLAS_CHECK_ERROR(cublasGetStream(handle, &stream));
 
                 whip::memset_2d_async(tile_t.ptr(), sizeof(T) * to_sizet(tile_t.ld()), 0,
                                       sizeof(T) * to_sizet(k), to_sizet(k), stream);
-                gpulapack::lacpy(blas::Uplo::General, 1, k, taus.ptr(), 1, tile_t.ptr(), tile_t.ld() + 1,
-                                 stream);
 
                 // Note:
                 // - call one gemv per tile

--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -184,7 +184,7 @@ void testBackTransformationReductionToBand(SizeType m, SizeType n, SizeType mb, 
   auto mat_taus_h = setUpTest(mb, b, c_loc, v_loc);
 
   {
-    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
+    MatrixMirror<const T, D, Device::CPU> mat_taus(mat_taus_h);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
     matrix::internal::MatrixRef mat_c_ref(mat_c.get());
@@ -224,7 +224,7 @@ void testBackTransformationReductionToBand(comm::CommunicatorGrid& grid, SizeTyp
   auto mat_taus_h = setUpTest(mb, b, c_loc, v_loc, std::optional(std::ref(grid)), src_rank_index);
 
   {
-    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
+    MatrixMirror<const T, D, Device::CPU> mat_taus(mat_taus_h);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
     matrix::internal::MatrixRef mat_c_ref(mat_c.get());

--- a/test/unit/eigensolver/test_bt_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_bt_reduction_to_band.cpp
@@ -181,13 +181,14 @@ void testBackTransformationReductionToBand(SizeType m, SizeType n, SizeType mb, 
   auto c_loc = dlaf::matrix::test::allGather<T>(blas::Uplo::General, mat_c_h);
   auto v_loc = dlaf::matrix::test::allGather<T>(blas::Uplo::Lower, mat_v_h);
 
-  auto mat_taus = setUpTest(mb, b, c_loc, v_loc);
+  auto mat_taus_h = setUpTest(mb, b, c_loc, v_loc);
 
   {
+    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
     matrix::internal::MatrixRef mat_c_ref(mat_c.get());
-    eigensolver::internal::bt_reduction_to_band<B, D, T>(b, mat_c_ref, mat_v.get(), mat_taus);
+    eigensolver::internal::bt_reduction_to_band<B, D, T>(b, mat_c_ref, mat_v.get(), mat_taus.get());
   }
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };
@@ -220,13 +221,15 @@ void testBackTransformationReductionToBand(comm::CommunicatorGrid& grid, SizeTyp
   auto c_loc = dlaf::matrix::test::allGather<T>(blas::Uplo::General, mat_c_h, grid);
   auto v_loc = dlaf::matrix::test::allGather<T>(blas::Uplo::Lower, mat_v_h, grid);
 
-  auto mat_taus = setUpTest(mb, b, c_loc, v_loc, std::optional(std::ref(grid)), src_rank_index);
+  auto mat_taus_h = setUpTest(mb, b, c_loc, v_loc, std::optional(std::ref(grid)), src_rank_index);
 
   {
+    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
     MatrixMirror<T, D, Device::CPU> mat_c(mat_c_h);
     MatrixMirror<const T, D, Device::CPU> mat_v(mat_v_h);
     matrix::internal::MatrixRef mat_c_ref(mat_c.get());
-    eigensolver::internal::bt_reduction_to_band<B, D, T>(grid, b, mat_c_ref, mat_v.get(), mat_taus);
+    eigensolver::internal::bt_reduction_to_band<B, D, T>(grid, b, mat_c_ref, mat_v.get(),
+                                                         mat_taus.get());
   }
 
   auto result = [&c_loc](const GlobalElementIndex& index) { return c_loc(index); };

--- a/test/unit/eigensolver/test_reduction_to_band.cpp
+++ b/test/unit/eigensolver/test_reduction_to_band.cpp
@@ -196,7 +196,7 @@ void splitReflectorsAndBand(MatrixLocal<const T>& mat_v, MatrixLocal<T>& mat_b,
 }
 
 template <class T>
-auto allGatherTaus(const SizeType k, Matrix<T, Device::CPU>& mat_local_taus) {
+auto allGatherTaus(const SizeType k, Matrix<const T, Device::CPU>& mat_local_taus) {
   auto local_taus_tiles = sync_wait(when_all_vector(selectRead(
       mat_local_taus, common::iterate_range2d(LocalTileSize(mat_local_taus.nrTiles().rows(), 1)))));
 
@@ -212,7 +212,7 @@ auto allGatherTaus(const SizeType k, Matrix<T, Device::CPU>& mat_local_taus) {
 }
 
 template <class T>
-auto allGatherTaus(const SizeType k, Matrix<T, Device::CPU>& mat_taus,
+auto allGatherTaus(const SizeType k, Matrix<const T, Device::CPU>& mat_taus,
                    comm::CommunicatorGrid& comm_grid) {
   const auto local_num_tiles = mat_taus.distribution().localNrTiles().rows();
   const auto num_tiles = mat_taus.distribution().nrTiles().rows();
@@ -340,7 +340,7 @@ void testReductionToBandLocal(const LocalElementSize size, const TileElementSize
     return eigensolver::internal::reduction_to_band<B, D, T>(mat_a.get(), band_size);
   }();
 
-  MatrixMirror<T, Device::CPU, D> mat_local_taus_h(mat_local_taus);
+  MatrixMirror<const T, Device::CPU, D> mat_local_taus_h(mat_local_taus);
 
   ASSERT_EQ(mat_local_taus.blockSize().rows(), block_size.rows());
 
@@ -429,7 +429,7 @@ void testReductionToBand(comm::CommunicatorGrid& grid, const LocalElementSize si
     return eigensolver::internal::reduction_to_band<B>(grid, matrix_a.get(), band_size);
   }();
 
-  MatrixMirror<T, Device::CPU, D> mat_local_taus_h(mat_local_taus);
+  MatrixMirror<const T, Device::CPU, D> mat_local_taus_h(mat_local_taus);
 
   ASSERT_EQ(mat_local_taus.blockSize().rows(), block_size.rows());
 

--- a/test/unit/factorization/test_compute_t_factor.cpp
+++ b/test/unit/factorization/test_compute_t_factor.cpp
@@ -288,7 +288,7 @@ void testComputeTFactor(const SizeType m, const SizeType k, const SizeType mb, c
 
   auto v_local = dlaf::matrix::test::allGather<const T>(blas::Uplo::General, v_h);
 
-  auto [mat_taus, h_expected] = computeHAndTFactor(k, v_local, v_start);
+  auto [mat_taus_h, h_expected] = computeHAndTFactor(k, v_local, v_start);
 
   is_orthogonal(h_expected);
 
@@ -298,6 +298,8 @@ void testComputeTFactor(const SizeType m, const SizeType k, const SizeType mb, c
   {
     MatrixMirror<T, D, Device::CPU> v(v_h);
     MatrixMirror<T, D, Device::CPU> t_output(t_output_h);
+    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
+
     const matrix::SubPanelView panel_view(dist_v, v_start, k);
     Panel<Coord::Col, T, D> panel_v(dist_v);
     panel_v.setRangeStart(v_start);
@@ -314,8 +316,8 @@ void testComputeTFactor(const SizeType m, const SizeType k, const SizeType mb, c
                                               {nrefls_step, nrefls_step}});
     }();
 
-    computeTFactor<B>(panel_v, mat_taus.read(GlobalTileIndex(0, 0)), t_output.get().readwrite(t_idx),
-                      workspaces);
+    computeTFactor<B>(panel_v, mat_taus.get().read(GlobalTileIndex(0, 0)),
+                      t_output.get().readwrite(t_idx), workspaces);
   }
 
   // Note:
@@ -377,7 +379,7 @@ void testComputeTFactor(comm::CommunicatorGrid& grid, const SizeType m, const Si
   if (dist_v.rankIndex().col() != source_rank_index.col())
     return;
 
-  auto [mat_taus, h_expected] = computeHAndTFactor(k, v_local, v_start);
+  auto [mat_taus_h, h_expected] = computeHAndTFactor(k, v_local, v_start);
 
   is_orthogonal(h_expected);
 
@@ -389,6 +391,7 @@ void testComputeTFactor(comm::CommunicatorGrid& grid, const SizeType m, const Si
   {
     MatrixMirror<T, D, Device::CPU> v(v_h);
     MatrixMirror<T, D, Device::CPU> t_output(t_output_h);
+    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
     const matrix::SubPanelView panel_view(dist_v, v_start, k);
     Panel<Coord::Col, T, D> panel_v(dist_v);
     panel_v.setRangeStart(v_start);
@@ -405,8 +408,8 @@ void testComputeTFactor(comm::CommunicatorGrid& grid, const SizeType m, const Si
                                               {nrefls_step, nrefls_step}});
     }();
 
-    computeTFactor<B>(panel_v, mat_taus.read(GlobalTileIndex(0, 0)), t_output.get().readwrite(t_idx),
-                      workspaces, serial_comm);
+    computeTFactor<B>(panel_v, mat_taus.get().read(GlobalTileIndex(0, 0)),
+                      t_output.get().readwrite(t_idx), workspaces, serial_comm);
   }
 
   // Note:

--- a/test/unit/factorization/test_compute_t_factor.cpp
+++ b/test/unit/factorization/test_compute_t_factor.cpp
@@ -296,9 +296,9 @@ void testComputeTFactor(const SizeType m, const SizeType k, const SizeType mb, c
   const LocalTileIndex t_idx(0, 0);
 
   {
-    MatrixMirror<T, D, Device::CPU> v(v_h);
+    MatrixMirror<const T, D, Device::CPU> v(v_h);
     MatrixMirror<T, D, Device::CPU> t_output(t_output_h);
-    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
+    MatrixMirror<const T, D, Device::CPU> mat_taus(mat_taus_h);
 
     const matrix::SubPanelView panel_view(dist_v, v_start, k);
     Panel<Coord::Col, T, D> panel_v(dist_v);
@@ -389,9 +389,9 @@ void testComputeTFactor(comm::CommunicatorGrid& grid, const SizeType m, const Si
   const LocalTileIndex t_idx(0, 0);
 
   {
-    MatrixMirror<T, D, Device::CPU> v(v_h);
+    MatrixMirror<const T, D, Device::CPU> v(v_h);
     MatrixMirror<T, D, Device::CPU> t_output(t_output_h);
-    MatrixMirror<T, D, Device::CPU> mat_taus(mat_taus_h);
+    MatrixMirror<const T, D, Device::CPU> mat_taus(mat_taus_h);
     const matrix::SubPanelView panel_view(dist_v, v_start, k);
     Panel<Coord::Col, T, D> panel_v(dist_v);
     panel_v.setRangeStart(v_start);


### PR DESCRIPTION
The target of this PR is moving TAUS from being stored on CPU to be stored on GPU memory.
It's more a cleanup than an optimisation.

Changelog:
- (trivially) some changes in the API (and test accordingly too)
- reduction to band still computes taus on CPU, but then it copies them immediately to GPU. This required allocation of an additional support matrix on CPU (i.e. `ComputePanelHelper<GPU>::mat_taus_cpu`).
- in TFactor a couple of copies have been skipped: one becuase it was a leftover, the other because now having taus on GPU they can be used in-place without copying them in the diagonal of the TFactor tile.
- in TFactor Since CPU and GPU differs a bit in the implementation, it is now explicit, by making them `private`, that `loop_gemv` and `loop_trmv` are internal functions. These clarifies that these functions might have different signatures between the two different backends. Actually, in GPU version of `loop_gemv`, `taus` parameter was superfluous so it has been dropped now.

TODO
- [x] Run benchmarks