### PR TITLE
GTest update: revert erroneous removal of git reset for gtest patch application

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,7 +17,8 @@ FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG v1.16.0
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch
+  PATCH_COMMAND git reset --hard HEAD && git apply
+                ${CMAKE_CURRENT_SOURCE_DIR}/scoped_trace_terminate_on_thread_migrate.patch
 )
 set(BUILD_GMOCK OFF CACHE INTERNAL "")
 set(INSTALL_GTEST OFF CACHE INTERNAL "")


### PR DESCRIPTION
This is a follow up of #1301, where I erroneously removed the `git reset --hard` step.

It's there because it allows to re-configure, otherwise it would try to apply a patch over an already patched source, failing miserably.

Thanks @rasolca for reporting it.