### PR TITLE
Use stdexec 25.03 in CI

### DIFF
--- a/ci/docker/common-gh200.yaml
+++ b/ci/docker/common-gh200.yaml
@@ -53,3 +53,6 @@ packages:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040
     buildable: false
+  stdexec:
+    require:
+      - '@git.nvhpc-25.03.rc1=25.03'

--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -46,3 +46,6 @@ packages:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040
     buildable: false
+  stdexec:
+    require:
+      - '@git.nvhpc-25.03.rc1=25.03'


### PR DESCRIPTION
stdexec 24.09 has a known data race in `split` that could the cause of issues in stdexec CI pipelines. The data race is fixed in 25.03 (https://github.com/NVIDIA/stdexec/pull/1460). I don't have any evidence to say that this is the cause, but it shouldn't hurt to bump the stdexec version in CI anyway. Unfortunately 25.03, the next release, only has an rc1 tag at the moment.