### PR TITLE
Test pika async_rw_mutex refactoring branch

### DIFF
--- a/ci/docker/common-gh200.yaml
+++ b/ci/docker/common-gh200.yaml
@@ -53,3 +53,6 @@ packages:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040
     buildable: false
+  pika:
+    require:
+      - '@git.b70a76f6cd520bb99107fe7d1a41b4fbbba7e64a=main'

--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -46,3 +46,6 @@ packages:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040
     buildable: false
+  pika:
+    require:
+      - '@git.b70a76f6cd520bb99107fe7d1a41b4fbbba7e64a=main'

--- a/ci/docker/debug-cuda-gh200-scalapack.yaml
+++ b/ci/docker/debug-cuda-gh200-scalapack.yaml
@@ -35,6 +35,6 @@ spack:
         - '+fortran'
     pika:
       require:
-        - '@0.30.1'
+        # - '@0.30.1'
         - 'build_type=Debug'
         - 'malloc=system'


### PR DESCRIPTION
Testing https://github.com/pika-org/pika/pull/1379. Performance already looks good with that branch (unchanged), so running further tests in CI to see that correctness is as expected. That pika branch will soon enough become the 0.33.0 release.