### PR TITLE
bug fix: HDF5 test should wait before cleaning up

### DIFF
--- a/test/unit/matrix/test_matrix_hdf5.cpp
+++ b/test/unit/matrix/test_matrix_hdf5.cpp
@@ -53,8 +53,13 @@ protected:
   }
 
   ~MatrixHDF5Test() override {
-    if (exists(filepath) && isMasterRank())
+    // Note:
+    // Ensures that all tests have finished on all ranks, before cleaning up.
+    DLAF_MPI_CHECK_ERROR(MPI_Barrier(world));
+
+    if (exists(filepath) && isMasterRank()) {
       std::filesystem::remove(filepath);
+    }
   }
 
   bool isMasterRank() const {


### PR DESCRIPTION
`test_matrix_hdf5` let a rank manage a file on the filesystem used by all other ranks too. The problem was that if the `master` rank finished earlier than others, the tear down procedure of the test deleted the file used also by other ranks while they were still using it.

The proposed fix is to just put a barrier on test tear down so that we are sure that test is completed on all ranks before actually removing the file from the filesystem.