### PR TITLE
Improve broadcast transposed

### DIFF
--- a/include/dlaf/eigensolver/gen_to_std/impl.h
+++ b/include/dlaf/eigensolver/gen_to_std/impl.h
@@ -340,7 +340,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid& grid, Matrix<T
     auto& a_panel = a_panels.nextResource();
     auto& a_panelT = a_panelsT.nextResource();
     l_panel.setRangeStart(kk);
-    l_panelT.setRangeStart(kk);
+    l_panelT.setRange(kk, {nrtile - 1, nrtile - 1});
     a_panelT.setRange({0, 0}, kk);
 
     if (k == nrtile - 1) {
@@ -438,7 +438,7 @@ void GenToStd<backend, device, T>::call_L(comm::CommunicatorGrid& grid, Matrix<T
       a_panelT.reset();
     }
 
-    a_panelT.setRange(at, common::indexFromOrigin(distr.nrTiles()));
+    a_panelT.setRange(at, {nrtile - 1, nrtile - 1});
 
     broadcast(kk_rank.col(), a_panel, a_panelT, mpi_row_task_chain, mpi_col_task_chain);
 
@@ -610,7 +610,7 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid& grid, Matrix<T
     auto& a_panel = a_panels.nextResource();
     auto& a_panelT = a_panelsT.nextResource();
     u_panel.setRangeStart(kk);
-    u_panelT.setRangeStart(kk);
+    u_panelT.setRange(kk, {nrtile - 1, nrtile - 1});
     a_panelT.setRange({0, 0}, kk);
 
     if (k == nrtile - 1) {
@@ -709,7 +709,7 @@ void GenToStd<backend, device, T>::call_U(comm::CommunicatorGrid& grid, Matrix<T
       a_panelT.reset();
     }
 
-    a_panelT.setRange(at, common::indexFromOrigin(distr.nrTiles()));
+    a_panelT.setRange(at, {nrtile - 1, nrtile - 1});
 
     broadcast(kk_rank.row(), a_panel, a_panelT, mpi_row_task_chain, mpi_col_task_chain);
 

--- a/include/dlaf/factorization/cholesky/impl.h
+++ b/include/dlaf/factorization/cholesky/impl.h
@@ -265,7 +265,7 @@ void Cholesky<backend, device, T>::call_L(comm::CommunicatorGrid& grid, Matrix<T
       panelT.reset();
     }
 
-    panelT.setRange({kt, kt}, indexFromOrigin(distr.nrTiles()));
+    panelT.setRange({kt, kt}, {nrtile - 1, nrtile - 1});
 
     broadcast(kk_rank.col(), panel, panelT, mpi_row_task_chain, mpi_col_task_chain);
 
@@ -411,7 +411,7 @@ void Cholesky<backend, device, T>::call_U(comm::CommunicatorGrid& grid, Matrix<T
       panelT.reset();
     }
 
-    panelT.setRange({kt, kt}, indexFromOrigin(distr.nrTiles()));
+    panelT.setRange({kt, kt}, {nrtile - 1, nrtile - 1});
 
     broadcast(kk_rank.row(), panel, panelT, mpi_row_task_chain, mpi_col_task_chain);
 

--- a/test/unit/communication/test_broadcast_panel.cpp
+++ b/test/unit/communication/test_broadcast_panel.cpp
@@ -122,7 +122,7 @@ std::vector<ParamsBcastTranspose> test_params_bcast_transpose{
     {{0, 0}, {1, 1}, {0, 0}, {0, 0}},      // empty matrix
     {{10, 10}, {2, 2}, {5, 5}, {5, 5}},    // empty panel (due to offset)
     {{20, 20}, {2, 2}, {9, 9}, {10, 10}},  // just last tile (communicate without transpose)
-    {{25, 25}, {5, 5}, {1, 1}, {1, 1}},
+    {{25, 25}, {5, 5}, {1, 1}, {1, 1}},    //
     {{25, 25}, {5, 5}, {1, 1}, {3, 3}},
 };
 


### PR DESCRIPTION
Made broadcast-transposed more flexible:

Before:
panel and transposed panel same start and end
last tile of the transposed panel was skipped

After:
transposed panel has to be contained but can be smaller than panel
all the tiles of the transposed panel are bcasted

advantages:
can skip first/last/no tiles depending on the algorithm need.