### PR TITLE
Remove redundant CAPI tests.

### DIFF
--- a/include/dlaf/memory/memory_type.h
+++ b/include/dlaf/memory/memory_type.h
@@ -1,0 +1,91 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#ifdef DLAF_WITH_GPU
+#include <whip.hpp>
+#endif
+
+#include <dlaf/common/assert.h>
+
+namespace dlaf::memory::internal {
+
+enum class MemoryType { Host, Device, Managed, Unified };
+
+#ifdef DLAF_WITH_CUDA
+inline MemoryType get_memory_type(const void* p) {
+  cudaPointerAttribute_t attributes{};
+  cudaError_t status = cudaPointerGetAttributes(&attributes, p);
+  if (status == cudaErrorInvalidValue) {
+    // If Cuda returns cudaErrorInvalidValue we assume it's due
+    // to Cuda not recognizing a non-Cuda allocated pointer as
+    // host memory, and we assume the type is host.
+    return MemoryType::Host;
+  }
+  else if (status != cudaSuccess) {
+    throw whip::exception(status);
+  }
+
+  switch (attributes.type) {
+    case cudaMemoryTypeUnregistered:
+      [[fallthrough]];
+    case cudaMemoryTypeHost:
+      return MemoryType::Host;
+    case cudaMemoryTypeDevice:
+      return MemoryType::Device;
+    case cudaMemoryTypeManaged:
+      return MemoryType::Managed;
+    default:
+      DLAF_UNREACHABLE_PLAIN;
+  }
+}
+#elif defined(DLAF_WITH_HIP)
+// Note that hipMemoryTypeManaged is not available in older versions, but it is
+// already available in 5.3 so we don't do a separate check for availability.
+inline MemoryType get_memory_type(const void* p) {
+  hipPointerAttribute_t attributes{};
+  hipError_t status = hipPointerGetAttributes(&attributes, p);
+  if (status == hipErrorInvalidValue) {
+    // If HIP returns hipErrorInvalidValue we assume it's due
+    // to HIP not recognizing a non-HIP allocated pointer as
+    // host memory, and we assume the type is host.
+    return MemoryType::Host;
+  }
+  else if (status != hipSuccess) {
+    throw whip::exception(status);
+  }
+
+  switch (attributes.type) {
+#if HIP_VERSION >= 60000000
+    case hipMemoryTypeUnregistered:
+      [[fallthrough]];
+#endif
+    case hipMemoryTypeHost:
+      return MemoryType::Host;
+    case hipMemoryTypeArray:
+      [[fallthrough]];
+    case hipMemoryTypeDevice:
+      return MemoryType::Device;
+    case hipMemoryTypeUnified:
+      return MemoryType::Unified;
+    case hipMemoryTypeManaged:
+      return MemoryType::Managed;
+    default:
+      DLAF_UNREACHABLE_PLAIN;
+  }
+}
+#else
+inline MemoryType get_memory_type(const void*) noexcept {
+  return MemoryType::Host;
+}
+#endif
+
+}

--- a/include/dlaf/memory/memory_type.h
+++ b/include/dlaf/memory/memory_type.h
@@ -22,7 +22,7 @@ enum class MemoryType { Host, Device, Managed, Unified };
 
 #ifdef DLAF_WITH_CUDA
 inline MemoryType get_memory_type(const void* p) {
-  cudaPointerAttribute_t attributes{};
+  cudaPointerAttributes attributes{};
   cudaError_t status = cudaPointerGetAttributes(&attributes, p);
   if (status == cudaErrorInvalidValue) {
     // If Cuda returns cudaErrorInvalidValue we assume it's due
@@ -44,7 +44,7 @@ inline MemoryType get_memory_type(const void* p) {
     case cudaMemoryTypeManaged:
       return MemoryType::Managed;
     default:
-      DLAF_UNREACHABLE_PLAIN;
+      return DLAF_UNREACHABLE(MemoryType);
   }
 }
 #elif defined(DLAF_WITH_HIP)
@@ -79,7 +79,7 @@ inline MemoryType get_memory_type(const void* p) {
     case hipMemoryTypeManaged:
       return MemoryType::Managed;
     default:
-      DLAF_UNREACHABLE_PLAIN;
+      return DLAF_UNREACHABLE(MemoryType);
   }
 }
 #else

--- a/include/dlaf_c/eigensolver/eigensolver.h
+++ b/include/dlaf_c/eigensolver/eigensolver.h
@@ -98,7 +98,7 @@ DLAF_EXTERN_C int dlaf_hermitian_eigensolver_partial_spectrum_z(
 ///
 /// @param uplo indicates whether the upper ('U') or lower ('L') triangular part of the global submatrix
 /// \f$\mathbf{A}\f$ is referenced
-/// @param n order of the sumbatrix \f$\mathbf{A}\f$ used in the computation
+/// @param n order of the submatrix \f$\mathbf{A}\f$ used in the computation
 /// @param a Local part of the global matrix \f$\mathbf{A}\f$
 /// @param ia row index of the global matrix \f$\mathbf{A}\f$ identifying the first row of the submatrix
 /// \f$\mathbf{A}\f$, has to be 1

--- a/include/dlaf_c/eigensolver/gen_eigensolver.h
+++ b/include/dlaf_c/eigensolver/gen_eigensolver.h
@@ -181,7 +181,7 @@ DLAF_EXTERN_C int dlaf_hermitian_generalized_eigensolver_partial_spectrum_factor
 ///
 /// @param uplo indicates whether the upper ('U') or lower ('L') triangular part of the global submatrix
 /// \f$\mathbf{A}\f$ is referenced
-/// @param n order of the sumbatrix \f$\mathbf{A}\f$ used in the computation
+/// @param n order of the submatrix \f$\mathbf{A}\f$ used in the computation
 /// @param a Local part of the global matrix \f$\mathbf{A}\f$
 /// @param ia row index of the global matrix \f$\mathbf{A}\f$ identifying the first row of the submatrix
 /// $A$, has to be 1
@@ -275,7 +275,7 @@ DLAF_EXTERN_C void dlaf_pzhegvd_partial_spectrum(
 ///
 /// @param uplo indicates whether the upper ('U') or lower ('L') triangular part of the global submatrix
 /// \f$\mathbf{A}\f$ is referenced
-/// @param n order of the sumbatrix \f$\mathbf{A}\f$ used in the computation
+/// @param n order of the submatrix \f$\mathbf{A}\f$ used in the computation
 /// @param a Local part of the global matrix \f$\mathbf{A}\f$
 /// @param ia row index of the global matrix \f$\mathbf{A}\f$ identifying the first row of the submatrix
 /// $A$, has to be 1

--- a/include/dlaf_c/factorization/cholesky.h
+++ b/include/dlaf_c/factorization/cholesky.h
@@ -63,7 +63,7 @@ DLAF_EXTERN_C int dlaf_cholesky_factorization_z(const int dlaf_context, const ch
 ///
 /// @param uplo indicates whether the upper ('U') or lower ('L') triangular part of the global submatrix
 /// \f$\mathbf{A}\f$ is referenced
-/// @param n order of the sumbatrix \f$\mathbf{A}\f$ used in the computation
+/// @param n order of the submatrix \f$\mathbf{A}\f$ used in the computation
 /// @param a Local part of the global matrix \f$\mathbf{A}\f$
 /// @param ia row index of the global matrix \f$\mathbf{A}\f$ identifying the first row of the submatrix
 /// \f$\mathbf{A}\f$, has to be 1

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -16,6 +16,7 @@
 #include <dlaf/gpu/assert.cu.h>
 #include <dlaf/gpu/blas/api.h>
 #include <dlaf/lapack/gpu/lacpy.h>
+#include <dlaf/memory/memory_type.h>
 #include <dlaf/types.h>
 #include <dlaf/util_cublas.h>
 #include <dlaf/util_math.h>
@@ -109,65 +110,32 @@ __global__ void lacpy(cublasFillMode_t uplo, const unsigned m, const unsigned n,
 }
 
 static whip::memcpy_kind get_lacpy_memcpy_kind(const void* src, const void* dst) {
-// If HIP is version 5.6 or newer, avoid the use of hipMemcpyDefault as it is
-// buggy with 2D memcpy.  Instead try to infer the memory type using
-// hipPointerGetAttributes. See:
-// - https://github.com/ROCm/clr/commit/56daa6c4891b43ec233e9c63f755e3f7b45842b4
-// - https://github.com/ROCm/clr/commit/d3bfb55d7a934355257a72fab538a0a634b43cad
-//
-// Note that hipMemoryTypeManaged is not available in older versions, but it is
-// already available in 5.3 so we don't do a separate check for availability.
 #if defined(DLAF_WITH_HIP) && HIP_VERSION >= 50600000
-  constexpr auto get_memory_type = [](const void* p) {
-    hipPointerAttribute_t attributes{};
-    hipError_t status = hipPointerGetAttributes(&attributes, p);
-    if (status == hipErrorInvalidValue) {
-      // If HIP returns hipErrorInvalidValue we assume it's due
-      // to HIP not recognizing a non-HIP allocated pointer as
-      // host memory, and we assume the type is host.
-      return hipMemoryTypeHost;
-    }
-    else if (status != hipSuccess) {
-      throw whip::exception(status);
-    }
+  // If HIP is version 5.6 or newer, avoid the use of hipMemcpyDefault as it is
+  // buggy with 2D memcpy.  Instead try to infer the memory type using
+  // hipPointerGetAttributes. See:
+  // - https://github.com/ROCm/clr/commit/56daa6c4891b43ec233e9c63f755e3f7b45842b4
+  // - https://github.com/ROCm/clr/commit/d3bfb55d7a934355257a72fab538a0a634b43cad
+  using dlaf::memory::internal::get_memory_type;
+  using dlaf::memory::internal::MemoryType;
 
-    switch (attributes.type) {
-#if HIP_VERSION >= 60000000
-      case hipMemoryTypeUnregistered:
-        [[fallthrough]];
-#endif
-      case hipMemoryTypeHost:
-        return hipMemoryTypeHost;
-      case hipMemoryTypeArray:
-        [[fallthrough]];
-      case hipMemoryTypeDevice:
-        return hipMemoryTypeDevice;
-      case hipMemoryTypeUnified:
-        return hipMemoryTypeUnified;
-      case hipMemoryTypeManaged:
-        return hipMemoryTypeManaged;
-      default:
-        DLAF_UNREACHABLE_PLAIN;
-    }
-  };
+  MemoryType src_type = get_memory_type(src);
+  MemoryType dst_type = get_memory_type(dst);
 
-  hipMemoryType src_type = get_memory_type(src);
-  hipMemoryType dst_type = get_memory_type(dst);
-
-  if (src_type == hipMemoryTypeDevice && dst_type == hipMemoryTypeHost) {
+  if (src_type == MemoryType::Device && dst_type == MemoryType::Host) {
     return whip::memcpy_device_to_host;
   }
-  else if (src_type == hipMemoryTypeHost && dst_type == hipMemoryTypeDevice) {
+  else if (src_type == MemoryType::Host && dst_type == MemoryType::Device) {
     return whip::memcpy_host_to_device;
   }
-  else if (src_type == hipMemoryTypeDevice && dst_type == hipMemoryTypeDevice) {
+  else if (src_type == MemoryType::Device && dst_type == MemoryType::Device) {
     return whip::memcpy_device_to_device;
   }
-  else if (src_type == hipMemoryTypeManaged || src_type == hipMemoryTypeUnified ||
-           dst_type == hipMemoryTypeManaged || dst_type == hipMemoryTypeUnified) {
+  else if (src_type == MemoryType::Managed || src_type == MemoryType::Unified ||
+           dst_type == MemoryType::Managed || dst_type == MemoryType::Unified) {
     return whip::memcpy_default;
   }
-  else if (src_type == hipMemoryTypeHost && dst_type == hipMemoryTypeHost) {
+  else if (src_type == MemoryType::Host && dst_type == MemoryType::Host) {
     DLAF_ASSERT(
         false,
         "Attempting to do a HIP lacpy with host source and destination, use the CPU lacpy instead");

--- a/src/lapack/gpu/lacpy.cu
+++ b/src/lapack/gpu/lacpy.cu
@@ -142,8 +142,7 @@ static whip::memcpy_kind get_lacpy_memcpy_kind(const void* src, const void* dst)
   }
   else {
     DLAF_ASSERT(false,
-                "Attempting to do a HIP lacpy with unsupported source and destination memory type",
-                src_type, dst_type);
+                "Attempting to do a HIP lacpy with unsupported source and destination memory type");
   }
 #else
   dlaf::internal::silenceUnusedWarningFor(src, dst);


### PR DESCRIPTION
In some CAPI tests CPU matrices were constructed with GPU pointers.

A check has been added to avoid it.