### PR TITLE
Removed outdated pika restriction from miniapps CMakeLists

### DIFF
--- a/miniapp/CMakeLists.txt
+++ b/miniapp/CMakeLists.txt
@@ -14,7 +14,7 @@ project(DLAF-miniapps)
 list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(DLAF REQUIRED)
-find_package(pika 0.11.0 REQUIRED)
+find_package(pika REQUIRED)
 
 include(DLAF_AddMiniapp)
 include(DLAF_AddTargetWarnings)


### PR DESCRIPTION
Removing outdated `pika` restriction assuming miniapps as a project is only intended for internal testing.

The alternative, is to update both `pika` and `dla-future` version, matching the ones in the root `CMakeLists.txt` file (and to add a comment to the `RELEASE_PROCEDURE` file).