### PR TITLE
Change `FI_MR_CACHE_MONITOR` default value to `userfaultfd` on alps

### DIFF
--- a/scripts/systems.py
+++ b/scripts/systems.py
@@ -217,7 +217,7 @@ cscs["alps-gh200"] = {
 #SBATCH --no-requeue
 
 # Env
-export FI_MR_CACHE_MONITOR=disabled
+export FI_MR_CACHE_MONITOR=userfaultfd
 export MPICH_GPU_SUPPORT_ENABLED=1
 export MIMALLOC_EAGER_COMMIT_DELAY=0
 export MIMALLOC_ALLOW_LARGE_OS_PAGES=1


### PR DESCRIPTION
From our testing in the last few months it seems like `userfaultfd` does not lead to hangs and performs better than `disabled`. Changing it now upstream before I forget that I'm using it locally. We can always change back if we find that it causes problems after more testing. I'm not changing the same value for lumi since I haven't done any recent tests there.