### PR TITLE
Red2Band: quick return for banded matrices

### DIFF
--- a/include/dlaf/eigensolver/reduction_to_band/impl.h
+++ b/include/dlaf/eigensolver/reduction_to_band/impl.h
@@ -344,6 +344,9 @@ void computePanelReflectors(MatrixLikeA& mat_a, MatrixLikeTaus& mat_taus, const 
 
           barrier_ptr->arrive_and_wait(barrier_busy_wait);
 
+          if (taus({j, 0}) == T(0))
+            continue;
+
           // STEP2a: compute w (multi-threaded)
           const SizeType pt_cols = cols - (j + 1);
           if (pt_cols == 0)
@@ -672,6 +675,9 @@ void computePanelReflectors(TriggerSender&& trigger, comm::IndexT_MPI rank_v0,
             taus({j, 0}) = computeReflector(has_head, pcomm.get(), tiles, j);
           }
           barrier_ptr->arrive_and_wait(barrier_busy_wait);
+
+          if (taus({j, 0}) == T(0))
+            continue;
 
           // STEP2a: compute w (multi-threaded)
           const SizeType pt_cols = cols - (j + 1);


### PR DESCRIPTION
This somehow completes #980. Indeed, it added a quick return skipping the computation of the reflector, now this adds an additional quick return that skips the update of the trailing panel (together with an `AllReduce` in the distributed case).

