### PR TITLE
Simplify the the specification of allocation details for matrices.

### DIFF
--- a/include/dlaf/matrix/allocation.h
+++ b/include/dlaf/matrix/allocation.h
@@ -24,6 +24,7 @@ namespace dlaf::matrix {
 class MatrixAllocation {
   static constexpr auto layout_0 = AllocationLayoutDefault{};
   static constexpr auto ld_0 = LdDefault{};
+
 public:
   using AllocationLayoutType = std::variant<AllocationLayoutDefault, AllocationLayout>;
   using LdType = std::variant<LdDefault, LdSpec>;

--- a/include/dlaf/matrix/allocation_io.h
+++ b/include/dlaf/matrix/allocation_io.h
@@ -1,0 +1,42 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <ostream>
+
+#include <dlaf/matrix/allocation.h>
+
+namespace dlaf::matrix {
+
+inline AllocationLayout get_allocation_layout(std::string layout) {
+  if (layout == "ColMajor")
+    return AllocationLayout::ColMajor;
+  else if (layout == "Blocks")
+    return AllocationLayout::Blocks;
+  else if (layout == "Tiles")
+    return AllocationLayout::Tiles;
+  return DLAF_UNREACHABLE(AllocationLayout);
+}
+
+inline std::ostream& operator<<(std::ostream& os, AllocationLayout layout) {
+  switch (layout) {
+    case AllocationLayout::ColMajor:
+      os << "ColMajor";
+      break;
+    case AllocationLayout::Blocks:
+      os << "Blocks";
+      break;
+    case AllocationLayout::Tiles:
+      os << "Tiles";
+  }
+  return os;
+}
+}

--- a/include/dlaf/matrix/allocation_types.h
+++ b/include/dlaf/matrix/allocation_types.h
@@ -1,0 +1,32 @@
+//
+// Distributed Linear Algebra with Future (DLAF)
+//
+// Copyright (c) ETH Zurich
+// All rights reserved.
+//
+// Please, refer to the LICENSE file in the root directory.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+/// @file
+
+#include <variant>
+
+#include <dlaf/types.h>
+
+namespace dlaf::matrix {
+
+enum class AllocationLayout { ColMajor, Blocks, Tiles };
+
+enum class Ld { Compact, Padded };
+// Ld::Padded: leading dimension is set to an optimal value that might introduce padding.
+// Ld::Compact: leading dimension is set to the minimum value.
+
+using LdSpec = std::variant<Ld, SizeType>;
+
+struct AllocationLayoutDefault {};
+struct LdDefault {};
+
+}

--- a/include/dlaf/matrix/check_allocation.h
+++ b/include/dlaf/matrix/check_allocation.h
@@ -11,7 +11,7 @@
 #pragma once
 
 /// @file
-/// Utilities to check if a matrix is allocated correctly according to the given MatrixAllocation parameter.
+/// Utilities to check if a matrix is allocated correctly according to the given AllocationLayout parameter.
 ///
 /// These functions are included in DLAF as they can be used by the users to test custom defined layouts.
 /// Note: These functions are blocking and meant only for testing purpose. Do not use them in applications.
@@ -42,7 +42,7 @@ SizeType sync_tile_ld(MatrixLike& mat, const LocalTileIndex& ij) {
 
 template <class MatrixLike>
 bool is_allocated_as_col_major(MatrixLike& mat) {
-  if (mat.allocation() != MatrixAllocation::ColMajor)
+  if (mat.allocation() != AllocationLayout::ColMajor)
     return false;
 
   Distribution dist = mat.distribution();
@@ -67,7 +67,7 @@ bool is_allocated_as_col_major(MatrixLike& mat) {
 
 template <class MatrixLike>
 bool is_allocated_as_blocks(MatrixLike& mat) {
-  if (mat.allocation() != MatrixAllocation::Blocks)
+  if (mat.allocation() != AllocationLayout::Blocks)
     return false;
 
   const Distribution& dist = mat.distribution();
@@ -124,17 +124,17 @@ bool is_allocated_as_blocks(MatrixLike& mat) {
 
 template <class MatrixLike>
 bool is_allocated_as_tiles(MatrixLike& mat) {
-  return mat.allocation() == MatrixAllocation::Tiles;
+  return mat.allocation() == AllocationLayout::Tiles;
 }
 
 template <class MatrixLike>
-bool is_allocated_as(MatrixLike& mat, MatrixAllocation alloc) {
+bool is_allocated_as(MatrixLike& mat, AllocationLayout alloc) {
   switch (alloc) {
-    case MatrixAllocation::ColMajor:
+    case AllocationLayout::ColMajor:
       return is_allocated_as_col_major(mat);
-    case MatrixAllocation::Blocks:
+    case AllocationLayout::Blocks:
       return is_allocated_as_blocks(mat);
-    case MatrixAllocation::Tiles:
+    case AllocationLayout::Tiles:
       return is_allocated_as_tiles(mat);
   }
   return false;

--- a/include/dlaf/matrix/col_major_layout.h
+++ b/include/dlaf/matrix/col_major_layout.h
@@ -103,8 +103,8 @@ public:
     return dist_;
   }
 
-  constexpr static MatrixAllocation allocation() noexcept {
-    return MatrixAllocation::ColMajor;
+  constexpr static AllocationLayout allocation() noexcept {
+    return AllocationLayout::ColMajor;
   }
 
 private:

--- a/include/dlaf/matrix/matrix_ref.h
+++ b/include/dlaf/matrix/matrix_ref.h
@@ -123,7 +123,7 @@ public:
     return splitTile(std::move(tile_sender), SubTileSpec{ij_tile, tile_size});
   }
 
-  MatrixAllocation allocation() const noexcept {
+  AllocationLayout allocation() const noexcept {
     return mat_const_.allocation();
   }
 

--- a/include/dlaf/matrix/panel.h
+++ b/include/dlaf/matrix/panel.h
@@ -389,7 +389,7 @@ protected:
           LocalElementSize(CT, panel_size.get<CT>() + dist.offset().get<CT>(), panel_size.get<axis>());
 
     Distribution dist_internal{panel_size, dist.tile_size()};
-    return {std::move(dist_internal), MatrixAllocation::Tiles};
+    return {std::move(dist_internal), {AllocationLayout::Tiles}};
   }
 
   /// Create a Panel related to Matrix represented by given Distribution.

--- a/include/dlaf/permutations/general/impl.h
+++ b/include/dlaf/permutations/general/impl.h
@@ -598,8 +598,9 @@ void permuteOnCPU(
   // Local matrices used for packing data for communication. Both matrices are in column-major order.
   // The particular constructor is used on purpose to guarantee that columns are stored contiguosly,
   // such that there is no padding and gaps between them.
-  Matrix<T, D> mat_send(sz_loc, blk, MatrixAllocation::ColMajor, matrix::Ld::Compact);
-  Matrix<T, D> mat_recv(sz_loc, blk, MatrixAllocation::ColMajor, matrix::Ld::Compact);
+  MatrixAllocation packed_col_major(AllocationLayout::ColMajor, matrix::Ld::Compact);
+  Matrix<T, D> mat_send(sz_loc, blk, packed_col_major);
+  Matrix<T, D> mat_recv(sz_loc, blk, packed_col_major);
 
   // Initialize the unpacking index
   copyLocalPartsFromGlobalIndex<D, C>(i_loc_begin.get<C>(), dist, perms, local2global_index);

--- a/include/dlaf/tune.h
+++ b/include/dlaf/tune.h
@@ -20,6 +20,7 @@
 #include <pika/init.hpp>
 #include <pika/runtime.hpp>
 
+#include <dlaf/matrix/allocation_types.h>
 #include <dlaf/types.h>
 
 namespace dlaf {
@@ -62,6 +63,10 @@ namespace dlaf {
 ///     Enable dump of tridiagonal solver input/output data to "tridiagonal.h5" file that will be
 ///     created in the working folder (it should not exist before the execution).
 ///     Set with environment variable DLAF_DEBUG_DUMP_TRIDIAG_SOLVER_DATA.
+/// - default_allocation_layout:
+///     Specify the default AllocationLayout for Matrices.
+///     Allowed values: ColMajor (default), Blocks, Tiles.
+///     Set with environment variable DLAF_DEFAULT_ALLOCATION_LAYOUT.
 /// - tfactor_num_threads:
 ///     The maximum number of threads to use for computing tfactor (e.g. which is used for
 ///     instance in red2band and its backtransformation). Set with --dlaf:tfactor-num-threads or env
@@ -139,6 +144,8 @@ struct TuneParameters {
   bool debug_dump_inverse_from_cholesky_factor_data = false;
   bool debug_dump_triangular_inverse_data = false;
   bool debug_dump_tridiag_solver_data = false;
+
+  matrix::AllocationLayout default_allocation_layout = matrix::AllocationLayout::ColMajor;
 
   std::size_t tfactor_num_threads = 1;
   std::size_t tfactor_num_streams = 4;

--- a/miniapp/miniapp_communication.cpp
+++ b/miniapp/miniapp_communication.cpp
@@ -61,8 +61,8 @@ using dlaf::comm::Size2D;
 using dlaf::common::iterate_range2d;
 using dlaf::common::Ordering;
 using dlaf::internal::RequireContiguous;
+using dlaf::matrix::AllocationLayout;
 using dlaf::matrix::local_matrix;
-using dlaf::matrix::MatrixAllocation;
 
 struct Options
     : dlaf::miniapp::MiniappOptions<dlaf::miniapp::SupportReal::Yes, dlaf::miniapp::SupportComplex::Yes> {
@@ -85,7 +85,7 @@ struct Options
 template <Device D, class T>
 Matrix<T, D> get_matrix_on_device_sync(Matrix<const T, Device::CPU>& matrix_ref) {
   DLAF_ASSERT(local_matrix(matrix_ref), matrix_ref);
-  Matrix<T, D> matrix(matrix_ref.distribution(), MatrixAllocation::ColMajor);
+  Matrix<T, D> matrix(matrix_ref.distribution(), {AllocationLayout::ColMajor});
   copy(matrix_ref, matrix);
   matrix.waitLocalTiles();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,6 +25,7 @@
 #include <dlaf/common/assert.h>
 #include <dlaf/communication/error.h>
 #include <dlaf/init.h>
+#include <dlaf/matrix/allocation_io.h>
 #include <dlaf/memory/memory_chunk.h>
 #include <dlaf/tune.h>
 
@@ -281,6 +282,11 @@ void updateConfiguration(const pika::program_options::variables_map& vm, configu
   // These are added automatically by updateConfigurationValue.
   auto& param = getTuneParameters();
   // clang-format off
+  std::string default_allocation_layout_str = "";
+  updateConfigurationValue(vm, default_allocation_layout_str, "DEFAULT_ALLOCATION_LAYOUT", "default_allocation_layout");
+  if (default_allocation_layout_str != "") {
+    param.default_allocation_layout = matrix::get_allocation_layout(default_allocation_layout_str);
+  }
   updateConfigurationValue(vm, param.tfactor_num_threads, "TFACTOR_NUM_THREADS", "tfactor-num-threads");
   updateConfigurationValue(vm, param.tfactor_num_streams, "TFACTOR_NUM_STREAMS", "tfactor-num-streams");
   updateConfigurationValue(vm, param.tfactor_barrier_busy_wait_us, "TFACTOR_BARRIER_BUSY_WAIT_US", "tfactor-barrier-busy-wait-us");
@@ -340,6 +346,7 @@ pika::program_options::options_description getOptionsDescription() {
   desc.add_options()("dlaf:no-mpi-pool", pika::program_options::bool_switch(), "Disable the MPI pool.");
 
   // Tune parameters command line options
+  desc.add_options()("dlaf:default_allocation_layout", pika::program_options::value<std::string>(), "The default AllocationLayout for Matrices.");
   desc.add_options()("dlaf:tfactor-num-threads", pika::program_options::value<std::size_t>(), "The maximum number of threads to use for computing the tfactor.");
   desc.add_options()("dlaf:tfactor-num-streams", pika::program_options::value<std::size_t>(), "The maximum number of GPU streams to use for computing the tfactor.");
   desc.add_options()("dlaf:tfactor-barrier-busy-wait-us", pika::program_options::value<std::size_t>(), "The duration in microseconds to busy-wait in barriers in the tfactor algorithm.");

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -9,6 +9,7 @@
 //
 
 #include <dlaf/init.h>
+#include <dlaf/matrix/allocation_io.h>
 #include <dlaf/tune.h>
 
 namespace dlaf {
@@ -19,6 +20,7 @@ TuneParameters& getTuneParameters() {
 }
 
 std::ostream& operator<<(std::ostream& os, const TuneParameters& params) {
+  os << "  default_allocation_layout = " << params.default_allocation_layout << std::endl;
   os << "  tfactor_num_threads = " << params.tfactor_num_threads << std::endl;
   os << "  tfactor_num_streams = " << params.tfactor_num_streams << std::endl;
   os << "  tfactor_barrier_busy_wait_us = " << params.tfactor_barrier_busy_wait_us << std::endl;

--- a/test/unit/communication/test_collective_async.cpp
+++ b/test/unit/communication/test_collective_async.cpp
@@ -44,7 +44,7 @@ protected:
 template <class T, Device D>
 auto newBlockMatrixContiguous() {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
-  auto matrix = matrix::Matrix<T, D>(dist, matrix::MatrixAllocation::ColMajor, matrix::Ld::Compact);
+  auto matrix = matrix::Matrix<T, D>(dist, {matrix::AllocationLayout::ColMajor, matrix::Ld::Compact});
 
   auto tile = tt::sync_wait(matrix.read(LocalTileIndex(0, 0)));
   EXPECT_TRUE(data_iscontiguous(common::make_data(tile.get())));
@@ -55,7 +55,7 @@ auto newBlockMatrixContiguous() {
 template <class T, Device D>
 auto newBlockMatrixStrided() {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
-  auto matrix = matrix::Matrix<T, D>(dist, matrix::MatrixAllocation::ColMajor, 26);
+  auto matrix = matrix::Matrix<T, D>(dist, {matrix::AllocationLayout::ColMajor, 26});
 
   auto tile = tt::sync_wait(matrix.read(LocalTileIndex(0, 0)));
   EXPECT_FALSE(data_iscontiguous(common::make_data(tile.get())));

--- a/test/unit/communication/test_comm_p2p.cpp
+++ b/test/unit/communication/test_comm_p2p.cpp
@@ -98,14 +98,16 @@ void testSendRecv(comm::Communicator world, matrix::Matrix<T, D> matrix) {
   tt::sync_wait(checkTileEq(input_tile, matrix.read(idx)));
 }
 
+const matrix::MatrixAllocation tiles_compact(matrix::AllocationLayout::Tiles, matrix::Ld::Compact);
+
 TEST_F(P2PTestMC, SendRecv) {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
 
   // single tile matrix whose columns are stored in contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::Tiles, matrix::Ld::Compact));
+  testSendRecv(world, MatrixT(dist, tiles_compact));
 
   // single tile matrix whose columns are stored in non-contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::ColMajor, 26));
+  testSendRecv(world, MatrixT(dist, {matrix::AllocationLayout::Tiles, 26}));
 }
 
 #ifdef DLAF_WITH_GPU
@@ -113,10 +115,10 @@ TEST_F(P2PTestGPU, SendRecv) {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
 
   // single tile matrix whose columns are stored in contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::Tiles, matrix::Ld::Compact));
+  testSendRecv(world, MatrixT(dist, tiles_compact));
 
   // single tile matrix whose columns are stored in non-contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::ColMajor, 26));
+  testSendRecv(world, MatrixT(dist, {matrix::AllocationLayout::Tiles, 26}));
 }
 #endif
 
@@ -175,10 +177,10 @@ TEST_F(P2PTestMC, SendRecvMixTags) {
   const auto dist = matrix::Distribution({10, 10}, {3, 3});
 
   // each tile is stored in contiguous memory (i.e. ld == blocksize.rows())
-  testSendRecvMixTags(world, MatrixT(dist, matrix::MatrixAllocation::Tiles, matrix::Ld::Compact));
+  testSendRecvMixTags(world, MatrixT(dist, tiles_compact));
 
   // tiles are stored in non-contiguous memory
-  testSendRecvMixTags(world, MatrixT(dist, matrix::MatrixAllocation::ColMajor, 16));
+  testSendRecvMixTags(world, MatrixT(dist, {matrix::AllocationLayout::ColMajor, 16}));
 }
 
 template <Backend B, Device D, class T>
@@ -214,10 +216,10 @@ TEST_F(P2PTestMC, AllSum) {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
 
   // single tile matrix whose columns are stored in contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::Tiles, matrix::Ld::Compact));
+  testSendRecv(world, MatrixT(dist, tiles_compact));
 
   // single tile matrix whose columns are stored in non-contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::ColMajor, 26));
+  testSendRecv(world, MatrixT(dist, {matrix::AllocationLayout::ColMajor, 26}));
 }
 
 #ifdef DLAF_WITH_GPU
@@ -225,10 +227,10 @@ TEST_F(P2PTestGPU, AllSum) {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
 
   // single tile matrix whose columns are stored in contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::Tiles, matrix::Ld::Compact));
+  testSendRecv(world, MatrixT(dist, tiles_compact));
 
   // single tile matrix whose columns are stored in non-contiguous memory
-  testSendRecv(world, MatrixT(dist, matrix::MatrixAllocation::ColMajor, 26));
+  testSendRecv(world, MatrixT(dist, {matrix::AllocationLayout::ColMajor, 26}));
 }
 #endif
 
@@ -291,8 +293,8 @@ TEST_F(P2PTestMC, AllSumMixTags) {
   const auto dist = matrix::Distribution({10, 10}, {3, 3});
 
   // each tile is stored in contiguous memory (i.e. ld == blocksize.rows())
-  testSendRecvMixTags(world, MatrixT(dist, matrix::MatrixAllocation::Tiles, matrix::Ld::Compact));
+  testSendRecvMixTags(world, MatrixT(dist, tiles_compact));
 
   // tiles are stored in non-contiguous memory
-  testSendRecvMixTags(world, MatrixT(dist, matrix::MatrixAllocation::ColMajor, 16));
+  testSendRecvMixTags(world, MatrixT(dist, {matrix::AllocationLayout::ColMajor, 16}));
 }

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -44,6 +44,13 @@ DLAF_addTest(
 )
 
 DLAF_addTest(
+  test_allocation
+  SOURCES test_allocation.cpp
+  LIBRARIES dlaf.core
+  USE_MAIN PIKA
+)
+
+DLAF_addTest(
   test_matrix
   SOURCES test_matrix.cpp
   LIBRARIES dlaf.core

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -73,6 +73,8 @@ T outputValues(const GlobalElementIndex&) noexcept {
   return TypeUtilities<T>::element(13, 26);
 }
 
+const MatrixAllocation compact_tiles(AllocationLayout::Tiles, Ld::Compact);
+
 TYPED_TEST(MatrixCopyTest, FullMatrixCPU) {
   using dlaf::matrix::util::set;
 
@@ -81,11 +83,11 @@ TYPED_TEST(MatrixCopyTest, FullMatrixCPU) {
       const GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
 
       const Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> mat_src(distribution, MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::CPU> mat_src(distribution, compact_tiles);
       set(mat_src, inputValues<TypeParam>);
       Matrix<const TypeParam, Device::CPU> mat_src_const = std::move(mat_src);
 
-      Matrix<TypeParam, Device::CPU> mat_dst(distribution, MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::CPU> mat_dst(distribution, compact_tiles);
       set(mat_dst, outputValues<TypeParam>);
 
       copy(mat_src_const, mat_dst);
@@ -104,14 +106,14 @@ TYPED_TEST(MatrixCopyTest, FullMatrixGPU) {
       const GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
 
       const Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> mat_src(distribution, MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::CPU> mat_src(distribution, compact_tiles);
       set(mat_src, inputValues<TypeParam>);
       Matrix<const TypeParam, Device::CPU> mat_src_const = std::move(mat_src);
 
-      Matrix<TypeParam, Device::GPU> mat_gpu1(distribution, MatrixAllocation::Tiles, Ld::Compact);
-      Matrix<TypeParam, Device::GPU> mat_gpu2(distribution, MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::GPU> mat_gpu1(distribution, compact_tiles);
+      Matrix<TypeParam, Device::GPU> mat_gpu2(distribution, compact_tiles);
 
-      Matrix<TypeParam, Device::CPU> mat_dst(distribution, MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::CPU> mat_dst(distribution, compact_tiles);
       set(mat_dst, outputValues<TypeParam>);
 
       copy(mat_src_const, mat_gpu1);
@@ -164,8 +166,8 @@ const std::vector<SubMatrixCopyConfig> sub_configs{
 template <class T>
 void testSubMatrix(const SubMatrixCopyConfig& test, const matrix::Distribution& dist_in,
                    const matrix::Distribution& dist_out) {
-  Matrix<T, Device::CPU> mat_in(dist_in, MatrixAllocation::Tiles, Ld::Compact);
-  Matrix<T, Device::CPU> mat_out(dist_out, MatrixAllocation::Tiles, Ld::Compact);
+  Matrix<T, Device::CPU> mat_in(dist_in, compact_tiles);
+  Matrix<T, Device::CPU> mat_out(dist_out, compact_tiles);
 
   // Note: currently `subPipeline`-ing does not support sub-matrices
   if (isFullMatrix(dist_in, test.sub_in())) {
@@ -231,12 +233,12 @@ template <class T>
 void testSubMatrixOnGPU(const SubMatrixCopyConfig& test, const matrix::Distribution& dist_in,
                         const matrix::Distribution& dist_out) {
   // CPU
-  Matrix<T, Device::CPU> mat_in(dist_in, MatrixAllocation::Tiles, Ld::Compact);
-  Matrix<T, Device::CPU> mat_out(dist_out, MatrixAllocation::Tiles, Ld::Compact);
+  Matrix<T, Device::CPU> mat_in(dist_in, compact_tiles);
+  Matrix<T, Device::CPU> mat_out(dist_out, compact_tiles);
 
   // GPU
-  Matrix<T, Device::GPU> mat_in_gpu(dist_in, MatrixAllocation::Tiles, Ld::Compact);
-  Matrix<T, Device::GPU> mat_out_gpu(dist_out, MatrixAllocation::Tiles, Ld::Compact);
+  Matrix<T, Device::GPU> mat_in_gpu(dist_in, compact_tiles);
+  Matrix<T, Device::GPU> mat_out_gpu(dist_out, compact_tiles);
 
   // Note: currently `subPipeline`-ing does not support sub-matrices
   if (isFullMatrix(dist_in, test.sub_in())) {

--- a/test/unit/matrix/test_matrix.cpp
+++ b/test/unit/matrix/test_matrix.cpp
@@ -80,6 +80,8 @@ GlobalElementSize global_test_size(const LocalElementSize& size, const Size2D& g
   return {size.rows() * grid_size.rows(), size.cols() * grid_size.cols()};
 }
 
+const matrix::MatrixAllocation tiles_compact(AllocationLayout::Tiles, Ld::Compact);
+
 template <class T, Device D>
 void testStaticAPI() {
   using matrix_t = Matrix<T, D>;
@@ -202,7 +204,7 @@ SizeType expected_ld(MatrixLike& mat, LdSpec ld) {
 
 TYPED_TEST(MatrixLocalTest, ConstructorColMajor) {
   using namespace col_major;
-  constexpr auto alloc = MatrixAllocation::ColMajor;
+  constexpr auto alloc = AllocationLayout::ColMajor;
   using Type = TypeParam;
   BaseType<Type> c = 0.0;
   auto el = [&](const GlobalElementIndex& index) {
@@ -225,7 +227,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorColMajor) {
       EXPECT_TRUE(is_allocated_as_col_major(mat));
     }
     {
-      Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       const SizeType exp_ld = expected_ld_from_00(mat);
@@ -236,7 +238,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorColMajor) {
       EXPECT_TRUE(is_allocated_as_col_major(mat));
     }
     {
-      Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       const SizeType exp_ld = expected_ld_from_00(mat);
@@ -251,7 +253,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorColMajor) {
     std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
     for (const auto& ld : lds) {
       {
-        Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         const SizeType exp_ld = expected_ld(mat, ld);
@@ -262,7 +264,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorColMajor) {
         EXPECT_TRUE(is_allocated_as_col_major(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         const SizeType exp_ld = expected_ld(mat, ld);
@@ -273,7 +275,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorColMajor) {
         EXPECT_TRUE(is_allocated_as_col_major(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         const SizeType exp_ld = expected_ld(mat, ld);
@@ -336,7 +338,7 @@ void check_ld(MatrixLike& mat, const LdSpec ld) {
 
 TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
   using namespace blocks;
-  constexpr auto alloc = MatrixAllocation::Blocks;
+  constexpr auto alloc = AllocationLayout::Blocks;
   using Type = TypeParam;
   BaseType<Type> c = 0.0;
   auto el = [&](const GlobalElementIndex& index) {
@@ -348,7 +350,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
   for (const auto& test : sizes_tests) {
     const Distribution dist = Distribution(LocalElementSize{test.m, test.n}, test.tile_size);
     {
-      Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       check_ld(mat);
@@ -358,7 +360,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
       EXPECT_TRUE(is_allocated_as_blocks(mat));
     }
     {
-      Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       check_ld(mat);
@@ -368,7 +370,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
       EXPECT_TRUE(is_allocated_as_blocks(mat));
     }
     {
-      Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       check_ld(mat);
@@ -382,7 +384,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
     std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
     for (const auto& ld : lds) {
       {
-        Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat, ld);
@@ -392,7 +394,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
         EXPECT_TRUE(is_allocated_as_blocks(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat, ld);
@@ -402,7 +404,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorBlocks) {
         EXPECT_TRUE(is_allocated_as_blocks(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat, ld);
@@ -452,7 +454,7 @@ void check_ld(MatrixLike& mat, const LdSpec ld) {
 
 TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
   using namespace tiles;
-  constexpr auto alloc = MatrixAllocation::Tiles;
+  constexpr auto alloc = AllocationLayout::Tiles;
   using Type = TypeParam;
   BaseType<Type> c = 0.0;
   auto el = [&](const GlobalElementIndex& index) {
@@ -464,7 +466,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
   for (const auto& test : sizes_tests) {
     const Distribution dist = Distribution(LocalElementSize{test.m, test.n}, test.tile_size);
     {
-      Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       check_ld(mat);
@@ -474,7 +476,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
       EXPECT_TRUE(is_allocated_as_tiles(mat));
     }
     {
-      Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       check_ld(mat);
@@ -484,7 +486,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
       EXPECT_TRUE(is_allocated_as_tiles(mat));
     }
     {
-      Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, alloc);
+      Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, {alloc});
       EXPECT_EQ(dist, mat.distribution());
 
       check_ld(mat);
@@ -498,7 +500,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
     std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
     for (const auto& ld : lds) {
       {
-        Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat({test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat, ld);
@@ -508,7 +510,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
         EXPECT_TRUE(is_allocated_as_tiles(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat(LocalElementSize{test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat, ld);
@@ -518,7 +520,7 @@ TYPED_TEST(MatrixLocalTest, ConstructorTiles) {
         EXPECT_TRUE(is_allocated_as_tiles(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, alloc, ld);
+        Matrix<Type, Device::CPU> mat(GlobalElementSize{test.m, test.n}, test.tile_size, {alloc, ld});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat, ld);
@@ -591,7 +593,7 @@ TYPED_TEST(MatrixTest, Constructor) {
 
 TYPED_TEST(MatrixTest, ConstructorColMajor) {
   using namespace col_major;
-  constexpr auto alloc = MatrixAllocation::ColMajor;
+  constexpr auto alloc = AllocationLayout::ColMajor;
   using Type = TypeParam;
   BaseType<Type> c = 0.0;
   auto el = [&](const GlobalElementIndex& index) {
@@ -610,7 +612,7 @@ TYPED_TEST(MatrixTest, ConstructorColMajor) {
                               src_rank_index);
 
       {
-        Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, alloc);
+        Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, {alloc});
 
         EXPECT_EQ(dist0, mat.distribution());
 
@@ -638,7 +640,7 @@ TYPED_TEST(MatrixTest, ConstructorColMajor) {
         const SizeType min_ld = std::max<SizeType>(1, dist0.local_size().rows());
         std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
         for (const auto& ld : lds) {
-          Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, alloc, ld);
+          Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, {alloc, ld});
           EXPECT_EQ(dist0, mat.distribution());
 
           const SizeType exp_ld = expected_ld(mat, ld);
@@ -654,7 +656,7 @@ TYPED_TEST(MatrixTest, ConstructorColMajor) {
         const SizeType min_ld = std::max<SizeType>(1, dist.local_size().rows());
         std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
         for (const auto& ld : lds) {
-          Matrix<Type, Device::CPU> mat(dist, alloc, ld);
+          Matrix<Type, Device::CPU> mat(dist, {alloc, ld});
           EXPECT_EQ(dist, mat.distribution());
 
           const SizeType exp_ld = expected_ld(mat, ld);
@@ -671,7 +673,7 @@ TYPED_TEST(MatrixTest, ConstructorColMajor) {
 
 TYPED_TEST(MatrixTest, ConstructorBlocks) {
   using namespace blocks;
-  constexpr auto alloc = MatrixAllocation::Blocks;
+  constexpr auto alloc = AllocationLayout::Blocks;
   using Type = TypeParam;
   BaseType<Type> c = 0.0;
   auto el = [&](const GlobalElementIndex& index) {
@@ -689,7 +691,7 @@ TYPED_TEST(MatrixTest, ConstructorBlocks) {
       const Distribution dist(size, test.block_size, test.tile_size, comm_grid.size(), comm_grid.rank(),
                               src_rank_index);
       {
-        Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, alloc);
+        Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, {alloc});
         EXPECT_EQ(dist0, mat.distribution());
 
         check_ld(mat);
@@ -699,7 +701,7 @@ TYPED_TEST(MatrixTest, ConstructorBlocks) {
         EXPECT_TRUE(is_allocated_as_blocks(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(dist, alloc);
+        Matrix<Type, Device::CPU> mat(dist, {alloc});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat);
@@ -713,7 +715,7 @@ TYPED_TEST(MatrixTest, ConstructorBlocks) {
       std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
       for (const auto& ld : lds) {
         {
-          Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, alloc, ld);
+          Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, {alloc, ld});
           EXPECT_EQ(dist0, mat.distribution());
 
           check_ld(mat, ld);
@@ -723,7 +725,7 @@ TYPED_TEST(MatrixTest, ConstructorBlocks) {
           EXPECT_TRUE(is_allocated_as_blocks(mat));
         }
         {
-          Matrix<Type, Device::CPU> mat(dist, alloc, ld);
+          Matrix<Type, Device::CPU> mat(dist, {alloc, ld});
           EXPECT_EQ(dist, mat.distribution());
 
           check_ld(mat, ld);
@@ -739,7 +741,7 @@ TYPED_TEST(MatrixTest, ConstructorBlocks) {
 
 TYPED_TEST(MatrixTest, ConstructorTiles) {
   using namespace tiles;
-  constexpr auto alloc = MatrixAllocation::Tiles;
+  constexpr auto alloc = AllocationLayout::Tiles;
   using Type = TypeParam;
   BaseType<Type> c = 0.0;
   auto el = [&](const GlobalElementIndex& index) {
@@ -757,7 +759,7 @@ TYPED_TEST(MatrixTest, ConstructorTiles) {
       const Distribution dist(size, test.block_size, test.tile_size, comm_grid.size(), comm_grid.rank(),
                               src_rank_index);
       {
-        Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, alloc);
+        Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, {alloc});
         EXPECT_EQ(dist0, mat.distribution());
 
         check_ld(mat);
@@ -767,7 +769,7 @@ TYPED_TEST(MatrixTest, ConstructorTiles) {
         EXPECT_TRUE(is_allocated_as_tiles(mat));
       }
       {
-        Matrix<Type, Device::CPU> mat(dist, alloc);
+        Matrix<Type, Device::CPU> mat(dist, {alloc});
         EXPECT_EQ(dist, mat.distribution());
 
         check_ld(mat);
@@ -781,7 +783,7 @@ TYPED_TEST(MatrixTest, ConstructorTiles) {
       std::initializer_list<LdSpec> lds{Ld::Compact, Ld::Padded, min_ld, min_ld + 20};
       for (const auto& ld : lds) {
         {
-          Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, alloc, ld);
+          Matrix<Type, Device::CPU> mat(size, test.tile_size, comm_grid, {alloc, ld});
           EXPECT_EQ(dist0, mat.distribution());
 
           check_ld(mat, ld);
@@ -791,7 +793,7 @@ TYPED_TEST(MatrixTest, ConstructorTiles) {
           EXPECT_TRUE(is_allocated_as_tiles(mat));
         }
         {
-          Matrix<Type, Device::CPU> mat(dist, alloc, ld);
+          Matrix<Type, Device::CPU> mat(dist, {alloc, ld});
           EXPECT_EQ(dist, mat.distribution());
 
           check_ld(mat, ld);
@@ -934,7 +936,7 @@ TYPED_TEST(MatrixTest, LocalGlobalAccessOperatorCall) {
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(),
                                 src_rank_index);
 
-      Matrix<TypeParam, Device::CPU> mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::CPU> mat(std::move(distribution), tiles_compact);
       const Distribution& dist = mat.distribution();
 
       for (SizeType j = 0; j < dist.nrTiles().cols(); ++j) {
@@ -980,7 +982,7 @@ TYPED_TEST(MatrixTest, LocalGlobalAccessRead) {
                                    std::max(0, comm_grid.size().cols() - 1));
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(),
                                 src_rank_index);
-      Matrix<TypeParam, Device::CPU> mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<TypeParam, Device::CPU> mat(std::move(distribution), tiles_compact);
 
       const Distribution& dist = mat.distribution();
 
@@ -1346,7 +1348,7 @@ TYPED_TEST(MatrixTest, DependenciesConst) {
       GlobalElementSize size = global_test_size({test.m, test.n}, comm_grid.size());
 
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<Type, Device::CPU> mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<Type, Device::CPU> mat(std::move(distribution), tiles_compact);
       Matrix<const Type, Device::CPU>& const_mat = mat;
 
       auto rosenders1 = getReadSendersUsingGlobalIndex(const_mat);
@@ -1367,7 +1369,7 @@ TYPED_TEST(MatrixTest, DependenciesConstSubPipelineConst) {
 
       Distribution distribution(size, test.block_size, test.tile_size, comm_grid.size(),
                                 comm_grid.rank(), {0, 0});
-      Matrix<Type, Device::CPU> mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      Matrix<Type, Device::CPU> mat(std::move(distribution), tiles_compact);
       Matrix<const Type, Device::CPU>& const_mat = mat;
 
       auto rosenders1 = getReadSendersUsingGlobalIndex(const_mat);
@@ -1862,7 +1864,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadonly) {
       GlobalElementSize size = global_test_size({test.m, test.n}, comm_grid.size());
 
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      MatrixT mat{distribution, MatrixAllocation::Tiles, Ld::Compact};
+      MatrixT mat{distribution, tiles_compact};
 
       // if this rank has no tiles locally, there's nothing interesting to do...
       if (distribution.localNrTiles().isEmpty())
@@ -1906,7 +1908,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadonlySubPipeline) {
       GlobalElementSize size = global_test_size({test.m, test.n}, comm_grid.size());
 
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      MatrixT mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      MatrixT mat(std::move(distribution), tiles_compact);
       auto mat_sub = mat.subPipeline();
 
       // if this rank has no tiles locally, there's nothing interesting to do...
@@ -1951,7 +1953,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadwrite) {
       GlobalElementSize size = global_test_size({test.m, test.n}, comm_grid.size());
 
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      MatrixT mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      MatrixT mat(std::move(distribution), tiles_compact);
 
       // if this rank has no tiles locally, there's nothing interesting to do...
       if (distribution.localNrTiles().isEmpty())
@@ -1995,7 +1997,7 @@ TEST_F(MatrixGenericTest, SelectTilesReadwriteSubPipeline) {
       GlobalElementSize size = global_test_size({test.m, test.n}, comm_grid.size());
 
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      MatrixT mat(std::move(distribution), MatrixAllocation::Tiles, Ld::Compact);
+      MatrixT mat(std::move(distribution), tiles_compact);
       auto mat_sub = mat.subPipeline();
 
       // if this rank has no tiles locally, there's nothing interesting to do...
@@ -2337,7 +2339,7 @@ TEST_F(MatrixGenericTest, SyncBarrier) {
       GlobalElementSize size = global_test_size({test.m, test.n}, comm_grid.size());
 
       Distribution distribution(size, test.tile_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      MatrixT matrix{distribution, MatrixAllocation::Tiles, Ld::Compact};
+      MatrixT matrix{distribution, tiles_compact};
 
       const auto local_size = distribution.localNrTiles();
       const LocalTileIndex tile_tl(0, 0);

--- a/test/unit/matrix/test_matrix_ref.cpp
+++ b/test/unit/matrix/test_matrix_ref.cpp
@@ -88,8 +88,8 @@ TYPED_TEST(MatrixRefTest, Basic) {
   for (auto& comm_grid : this->commGrids()) {
     for (const auto& test : tests_sub_matrix) {
       for (const auto& alloc :
-           {MatrixAllocation::ColMajor, MatrixAllocation::Blocks, MatrixAllocation::Tiles}) {
-        Matrix<Type, device> mat(test.size, test.tile_size, comm_grid, alloc);
+           {AllocationLayout::ColMajor, AllocationLayout::Blocks, AllocationLayout::Tiles}) {
+        Matrix<Type, device> mat(test.size, test.tile_size, comm_grid, {alloc});
         Matrix<const Type, device>& mat_const = mat;
 
         const SubMatrixSpec spec{test.sub_origin, test.sub_size};

--- a/test/unit/matrix/test_retiled_matrix.cpp
+++ b/test/unit/matrix/test_retiled_matrix.cpp
@@ -97,17 +97,17 @@ TYPED_TEST(RetiledMatrixLocalTest, LocalConstructor) {
 
   for (const auto& [size, tile_size, tiles_per_block] : local_sizes_tests) {
     for (const auto& alloc :
-         {MatrixAllocation::ColMajor, MatrixAllocation::Blocks, MatrixAllocation::Tiles}) {
-      const MatrixAllocation exp_alloc =
-          alloc == MatrixAllocation::Tiles && tiles_per_block != LocalTileSize{1, 1}
-              ? MatrixAllocation::Blocks
+         {AllocationLayout::ColMajor, AllocationLayout::Blocks, AllocationLayout::Tiles}) {
+      const AllocationLayout exp_alloc =
+          alloc == AllocationLayout::Tiles && tiles_per_block != LocalTileSize{1, 1}
+              ? AllocationLayout::Blocks
               : alloc;
       const GlobalElementSize block_size(tile_size.rows() * tiles_per_block.rows(),
                                          tile_size.cols() * tiles_per_block.cols());
       Distribution expected_distribution({size.rows(), size.cols()}, block_size, tile_size, {1, 1},
                                          {0, 0}, {0, 0});
 
-      Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, alloc);
+      Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, {alloc});
       ASSERT_TRUE(is_allocated_as(mat, alloc));
 
       // Non-const retiled matrix
@@ -173,17 +173,17 @@ TYPED_TEST(RetiledMatrixTest, GlobalConstructor) {
   for (auto& comm_grid : this->commGrids()) {
     for (const auto& [size, tile_size, tiles_per_block] : global_sizes_tests) {
       for (const auto& alloc :
-           {MatrixAllocation::ColMajor, MatrixAllocation::Blocks, MatrixAllocation::Tiles}) {
-        const MatrixAllocation exp_alloc =
-            alloc == MatrixAllocation::Tiles && tiles_per_block != LocalTileSize{1, 1}
-                ? MatrixAllocation::Blocks
+           {AllocationLayout::ColMajor, AllocationLayout::Blocks, AllocationLayout::Tiles}) {
+        const AllocationLayout exp_alloc =
+            alloc == AllocationLayout::Tiles && tiles_per_block != LocalTileSize{1, 1}
+                ? AllocationLayout::Blocks
                 : alloc;
         const GlobalElementSize block_size(tile_size.rows() * tiles_per_block.rows(),
                                            tile_size.cols() * tiles_per_block.cols());
         Distribution expected_distribution(size, block_size, tile_size, comm_grid.size(),
                                            comm_grid.rank(), {0, 0});
 
-        Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, comm_grid, alloc);
+        Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, comm_grid, {alloc});
         ASSERT_TRUE(is_allocated_as(mat, alloc));
 
         // Non-const retiled matrix

--- a/test/unit/matrix/test_retiled_matrix_ref.cpp
+++ b/test/unit/matrix/test_retiled_matrix_ref.cpp
@@ -137,10 +137,10 @@ TYPED_TEST(RetiledMatrixRefLocalTest, LocalConstructor) {
 
   for (const auto& [size, tile_size, tiles_per_block, dist_origin, dist_size] : local_sizes_tests) {
     for (const auto& alloc :
-         {MatrixAllocation::ColMajor, MatrixAllocation::Blocks, MatrixAllocation::Tiles}) {
-      const MatrixAllocation exp_alloc =
-          alloc == MatrixAllocation::Tiles && tiles_per_block != LocalTileSize{1, 1}
-              ? MatrixAllocation::Blocks
+         {AllocationLayout::ColMajor, AllocationLayout::Blocks, AllocationLayout::Tiles}) {
+      const AllocationLayout exp_alloc =
+          alloc == AllocationLayout::Tiles && tiles_per_block != LocalTileSize{1, 1}
+              ? AllocationLayout::Blocks
               : alloc;
       const GlobalElementSize block_size(tile_size.rows() * tiles_per_block.rows(),
                                          tile_size.cols() * tiles_per_block.cols());
@@ -149,7 +149,7 @@ TYPED_TEST(RetiledMatrixRefLocalTest, LocalConstructor) {
       Distribution expected_distribution({dist_size.rows(), dist_size.cols()}, block_size, tile_size,
                                          {1, 1}, {0, 0}, {0, 0});
 
-      Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, alloc);
+      Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, {alloc});
       ASSERT_TRUE(is_allocated_as(mat, alloc));
 
       // Matrix ref
@@ -225,10 +225,10 @@ TYPED_TEST(RetiledMatrixRefTest, GlobalConstructor) {
   for (auto& comm_grid : this->commGrids()) {
     for (const auto& [size, tile_size, tiles_per_block, dist_origin, dist_size] : global_sizes_tests) {
       for (const auto& alloc :
-           {MatrixAllocation::ColMajor, MatrixAllocation::Blocks, MatrixAllocation::Tiles}) {
-        const MatrixAllocation exp_alloc =
-            alloc == MatrixAllocation::Tiles && tiles_per_block != LocalTileSize{1, 1}
-                ? MatrixAllocation::Blocks
+           {AllocationLayout::ColMajor, AllocationLayout::Blocks, AllocationLayout::Tiles}) {
+        const AllocationLayout exp_alloc =
+            alloc == AllocationLayout::Tiles && tiles_per_block != LocalTileSize{1, 1}
+                ? AllocationLayout::Blocks
                 : alloc;
         const GlobalElementSize block_size(tile_size.rows() * tiles_per_block.rows(),
                                            tile_size.cols() * tiles_per_block.cols());
@@ -237,7 +237,7 @@ TYPED_TEST(RetiledMatrixRefTest, GlobalConstructor) {
         Distribution expected_distribution({dist_size.rows(), dist_size.cols()}, block_size, tile_size,
                                            comm_grid.size(), comm_grid.rank(), {0, 0});
 
-        Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, comm_grid, alloc);
+        Matrix<Type, Device::CPU> mat(size, {block_size.rows(), block_size.cols()}, comm_grid, {alloc});
         ASSERT_TRUE(is_allocated_as(mat, alloc));
 
         // Matrix ref

--- a/test/unit/matrix/test_util_matrix.cpp
+++ b/test/unit/matrix/test_util_matrix.cpp
@@ -67,13 +67,14 @@ GlobalElementSize globalSquareTestSize(const LocalElementSize& size, const comm:
   return GlobalElementSize{size.rows() * k, size.cols() * k};
 }
 
+const MatrixAllocation alloc(AllocationLayout::Tiles, Ld::Compact);
+
 TYPED_TEST(MatrixUtilsTest, Set0) {
   for (auto& comm_grid : this->commGrids()) {
     for (const auto& test : sizes_tests) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), MatrixAllocation::Tiles,
-                                            Ld::Compact);
+      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), alloc);
 
       auto null_matrix = [](const GlobalElementIndex&) { return TypeParam(0); };
 
@@ -89,8 +90,7 @@ TYPED_TEST(MatrixUtilsTest, Set) {
     for (const auto& test : sizes_tests) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), MatrixAllocation::Tiles,
-                                            Ld::Compact);
+      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), alloc);
 
       auto linear_matrix = [size = matrix.size()](const GlobalElementIndex& index) {
         auto linear_index = common::computeLinearIndex<int>(common::Ordering::RowMajor, index, size);
@@ -111,8 +111,7 @@ TYPED_TEST(MatrixUtilsTest, SetRandom) {
     for (const auto& test : sizes_tests) {
       GlobalElementSize size = globalTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), MatrixAllocation::Tiles,
-                                            Ld::Compact);
+      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), alloc);
 
       matrix::util::set_random(matrix);
 
@@ -188,8 +187,7 @@ TYPED_TEST(MatrixUtilsTest, SetRandomHermitianPositiveDefinite) {
     for (const auto& test : square_blocks_configs) {
       GlobalElementSize size = globalSquareTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), MatrixAllocation::Tiles,
-                                            Ld::Compact);
+      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), alloc);
 
       auto N = matrix.size().rows();
       auto identity_2N = [N](const GlobalElementIndex& index) {
@@ -221,8 +219,7 @@ TYPED_TEST(MatrixUtilsTest, SetRandomNonZeroDiagonal) {
     for (const auto& test : square_blocks_configs) {
       GlobalElementSize size = globalSquareTestSize(test.size, comm_grid.size());
       Distribution distribution(size, test.block_size, comm_grid.size(), comm_grid.rank(), {0, 0});
-      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), MatrixAllocation::Tiles,
-                                            Ld::Compact);
+      Matrix<TypeParam, Device::CPU> matrix(std::move(distribution), alloc);
 
       matrix::util::set_random_non_zero_diagonal(matrix);
 

--- a/test/unit/sender/test_with_temporary_tile.cpp
+++ b/test/unit/sender/test_with_temporary_tile.cpp
@@ -28,7 +28,7 @@ namespace tt = pika::this_thread::experimental;
 template <class T, Device D>
 auto newBlockMatrixContiguous() {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
-  auto matrix = matrix::Matrix<T, D>(dist, matrix::MatrixAllocation::ColMajor, matrix::Ld::Compact);
+  auto matrix = matrix::Matrix<T, D>(dist, {matrix::AllocationLayout::ColMajor, matrix::Ld::Compact});
 
   EXPECT_TRUE(
       data_iscontiguous(common::make_data(tt::sync_wait(matrix.read(LocalTileIndex(0, 0))).get())));
@@ -39,7 +39,7 @@ auto newBlockMatrixContiguous() {
 template <class T, Device D>
 auto newBlockMatrixStrided() {
   auto dist = matrix::Distribution({13, 13}, {13, 13});
-  auto matrix = matrix::Matrix<T, D>(dist, matrix::MatrixAllocation::ColMajor, 26);
+  auto matrix = matrix::Matrix<T, D>(dist, {matrix::AllocationLayout::ColMajor, 26});
 
   EXPECT_FALSE(
       data_iscontiguous(common::make_data(tt::sync_wait(matrix.read(LocalTileIndex(0, 0))).get())));


### PR DESCRIPTION
A tune parameter for the default AllocationLayout has been added too.