### PR TITLE
scripts: introduce pyproject.toml

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -2,11 +2,20 @@
 name = "dlaf-benchmarks"
 version = "0.1.0"
 description = "Utilities for running DLA-Future benchmarks."
+requires-python = ">= 3.13"
 dependencies = [
     "matplotlib>=3.10.3",
     "numpy>=2.3.2",
     "pandas>=2.2.3",
     "parse>=1.20.2",
+]
+
+[dependency-groups]
+notebook = [
+    "ipympl>=0.9.7",
+    "ipywidgets>=8.1.7",
+    "jupyter>=1.1.1",
+    "tqdm>=4.67.1",
 ]
 
 [tool.black]

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "dlaf-benchmarks"
+version = "0.1.0"
+description = "Utilities for running DLA-Future benchmarks."
+dependencies = [
+    "matplotlib>=3.10.3",
+    "numpy>=2.3.2",
+    "pandas>=2.2.3",
+    "parse>=1.20.2",
+]
+
+[tool.black]
+line-length = 105

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -20,3 +20,6 @@ notebook = [
 
 [tool.black]
 line-length = 105
+
+[tool.ruff]
+line-length = 105

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,0 @@
-matplotlib
-numpy
-pandas
-parse


### PR DESCRIPTION
If everyone uses `uv` (or `poetry`) IMHO we can drop `requirements.txt` and avoid the burden of maintaining both files.

The main two benefit of having `pyproject.toml`:
- we can store configuration parameters for tools, e.g. black and ruff, and editors are generally able to use them
- we can have dependency group: I added a group named `notebook` that provides also `jupyter` and some plugins, allowing to run notebooks for analysis