### PR TITLE
scripts: add cuSOLVER and cuSOLVERMp `miniapp_evp`s to the set of benchmarkable libraries

### DIFF
--- a/scripts/miniapps.py
+++ b/scripts/miniapps.py
@@ -660,6 +660,16 @@ def evp(
         elif dtype == "z":
             app = f"{miniapp_dir}/miniapp_evp_elpa_z"
         opts = f"{m_sz} {mb_sz} {grid_rows} {grid_cols} {nruns} {stages}"
+    elif lib == "cusolver":
+        _only_type_d(dtype)
+        env += f" OMP_NUM_THREADS={cores_per_rank}"
+        app = f"{miniapp_dir}/miniapp_evp_cusolver"
+        opts = f"{m_sz} {nruns}"
+    elif lib == "cusolvermp":
+        _only_type_d(dtype)
+        env += f" OMP_NUM_THREADS={cores_per_rank}"
+        app = f"{miniapp_dir}/miniapp_evp_cusolvermp"
+        opts = f"{m_sz} {mb_sz} {grid_rows} {grid_cols} {nruns}"
     else:
         raise ValueError(_err_msg(lib))
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -283,6 +283,12 @@ def _parse_line_based(fout, bench_name, nodes):
             + stages
             + " {time:g}s {matrix_type} ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
         )
+    elif bench_name.startswith("evp_cusolver"):
+        pstr_arr = []
+        pstr_res = "[{run_index:d}] cuSOLVER {time:g}s {matrix_type} ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
+    elif bench_name.startswith("evp_cusolvermp"):
+        pstr_arr = []
+        pstr_res = "[{run_index:d}] cuSOLVERMp {time:g}s {matrix_type} ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
     else:
         raise ValueError("Unknown bench_name: " + bench_name)
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -335,7 +335,9 @@ def _parse_line_based(fout, bench_name, nodes):
             # Note: DPLASMA trsm miniapp does not respect `--nruns`. This is a workaround
             # to make _calc_metrics not skipping the first run, the only one available, by
             # not setting 'run_index' field (=NaN).
-            if not "dlaf" in bench_name and not bench_name.startswith("trsm_dplasma"):
+            if all(
+                [keyword not in bench_name for keyword in ["dlaf", "cusolver"]]
+            ) and not bench_name.startswith("trsm_dplasma"):
                 rd["run_index"] = run_index
                 run_index += 1
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -283,12 +283,12 @@ def _parse_line_based(fout, bench_name, nodes):
             + stages
             + " {time:g}s {matrix_type} ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
         )
+    elif bench_name.startswith("evp_cusolvermp"):
+        pstr_arr = []
+        pstr_res = "[{run_index:d}] cuSOLVERMp {time:g}s {matrix_type}L ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
     elif bench_name.startswith("evp_cusolver"):
         pstr_arr = []
         pstr_res = "[{run_index:d}] cuSOLVER {time:g}s {matrix_type} ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
-    elif bench_name.startswith("evp_cusolvermp"):
-        pstr_arr = []
-        pstr_res = "[{run_index:d}] cuSOLVERMp {time:g}s {matrix_type} ({matrix_rows:d}, {matrix_cols:d}) ({block_rows:d}, {block_cols:d}) ({grid_rows:d}, {grid_cols:d})"
     else:
         raise ValueError("Unknown bench_name: " + bench_name)
 


### PR DESCRIPTION
Add our custom cuSOLVER and cuSOLVERMp `miniapp_evp` https://git.cscs.ch/rasolca/miniapp_evp to the set of benchmarkable libraries.