### PR TITLE
Copy local matrices with different tile sizes

### DIFF
--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -72,8 +72,6 @@ variables:
     CXXSTD: 20
     USE_MKL: "OFF"
     USE_CODECOV: "false"
-    KUBERNETES_MEMORY_REQUEST: '64Gi'
-    KUBERNETES_MEMORY_LIMIT: '64Gi'
 
 .build_deps_common:
   extends:

--- a/ci/common-ci.yml
+++ b/ci/common-ci.yml
@@ -72,6 +72,8 @@ variables:
     CXXSTD: 20
     USE_MKL: "OFF"
     USE_CODECOV: "false"
+    KUBERNETES_MEMORY_REQUEST: '64Gi'
+    KUBERNETES_MEMORY_LIMIT: '64Gi'
 
 .build_deps_common:
   extends:

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -69,13 +69,53 @@ void copy(LocalTileIndex idx_begin, LocalTileSize sz, Matrix<const T, Source>& s
   copy(sz, idx_begin, source, idx_begin, dest);
 }
 
-/// \overload copy()
+/// This overload copies all local tiles of @p source to @p dest starting at tile (0, 0).
 ///
-/// This overload makes sure that all local tiles of @p source are copied to @p dest starting at tile (0, 0).
+/// If @p source and @p dest have different tile sizes (only supported for local matrices),
+/// both are retiled to a common granularity and copied tile-by-tile.
 ///
+/// @pre source.size() == dest.size()
+/// @pre If tile sizes differ: local_matrix(source) && local_matrix(dest)
+/// @pre If tile sizes differ: single_tile_per_block(source) && single_tile_per_block(dest)
+/// @pre If tile sizes differ: tile sizes must be commensurate (divisible by their min)
 template <class T, Device Source, Device Destination>
 void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
-  copy(source.distribution().localNrTiles(), LocalTileIndex(0, 0), source, LocalTileIndex(0, 0), dest);
+  if (source.tile_size() == dest.tile_size()) {
+    copy(source.distribution().local_nr_tiles(), LocalTileIndex(0, 0), source, LocalTileIndex(0, 0),
+         dest);
+    return;
+  }
+
+  namespace ex = pika::execution::experimental;
+
+  DLAF_ASSERT_MODERATE(equal_size(source, dest), source.size(), dest.size());
+  DLAF_ASSERT(local_matrix(source), source);
+  DLAF_ASSERT(local_matrix(dest), dest);
+  DLAF_ASSERT_MODERATE(single_tile_per_block(source), source);
+  DLAF_ASSERT_MODERATE(single_tile_per_block(dest), dest);
+
+  const TileElementSize tile_sizes_src = source.tile_size();
+  const TileElementSize tile_sizes_dst = dest.tile_size();
+
+  const SizeType mb = std::min(tile_sizes_src.rows(), tile_sizes_dst.rows());
+  const SizeType nb = std::min(tile_sizes_src.cols(), tile_sizes_dst.cols());
+
+  DLAF_ASSERT_MODERATE(tile_sizes_src.rows() % mb == 0, tile_sizes_src.rows(), mb);
+  DLAF_ASSERT_MODERATE(tile_sizes_dst.rows() % mb == 0, tile_sizes_dst.rows(), mb);
+  DLAF_ASSERT_MODERATE(tile_sizes_src.cols() % nb == 0, tile_sizes_src.cols(), nb);
+  DLAF_ASSERT_MODERATE(tile_sizes_dst.cols() % nb == 0, tile_sizes_dst.cols(), nb);
+
+  const LocalTileSize scale_factor_src{tile_sizes_src.rows() / mb, tile_sizes_src.cols() / nb};
+  const LocalTileSize scale_factor_dst{tile_sizes_dst.rows() / mb, tile_sizes_dst.cols() / nb};
+
+  Matrix<const T, Source> src_retiled = source.retiled_sub_pipeline_const(scale_factor_src);
+  Matrix<T, Destination> dst_retiled = dest.retiled_sub_pipeline(scale_factor_dst);
+
+  const dlaf::internal::Policy<internal::CopyBackend_v<Source, Destination>> policy;
+  for (const LocalTileIndex ij : common::iterate_range2d(dst_retiled.distribution().local_nr_tiles())) {
+    ex::start_detached(ex::when_all(src_retiled.read(ij), dst_retiled.readwrite(ij)) |
+                       matrix::copy(policy));
+  }
 }
 
 namespace internal {
@@ -168,8 +208,8 @@ void copy(Matrix<const T, Source>& src, Matrix<T, Destination>& dst, comm::Commu
   const LocalTileSize scale_factor_src{tile_size_src.rows() / mb, tile_size_src.cols() / nb};
   const LocalTileSize scale_factor_dst{tile_size_dst.rows() / mb, tile_size_dst.cols() / nb};
 
-  Matrix<const T, Source> src_retiled = src.retiledSubPipelineConst(scale_factor_src);
-  Matrix<T, Destination> dst_retiled = dst.retiledSubPipeline(scale_factor_dst);
+  Matrix<const T, Source> src_retiled = src.retiled_sub_pipeline_const(scale_factor_src);
+  Matrix<T, Destination> dst_retiled = dst.retiled_sub_pipeline(scale_factor_dst);
 
   const comm::Index2D rank = grid.rank();
   auto mpi_chain = grid.full_communicator_pipeline();

--- a/include/dlaf/matrix/copy.h
+++ b/include/dlaf/matrix/copy.h
@@ -91,8 +91,6 @@ void copy(Matrix<const T, Source>& source, Matrix<T, Destination>& dest) {
   DLAF_ASSERT_MODERATE(equal_size(source, dest), source.size(), dest.size());
   DLAF_ASSERT(local_matrix(source), source);
   DLAF_ASSERT(local_matrix(dest), dest);
-  DLAF_ASSERT_MODERATE(single_tile_per_block(source), source);
-  DLAF_ASSERT_MODERATE(single_tile_per_block(dest), dest);
 
   const TileElementSize tile_sizes_src = source.tile_size();
   const TileElementSize tile_sizes_dst = dest.tile_size();

--- a/test/unit/matrix/test_copy.cpp
+++ b/test/unit/matrix/test_copy.cpp
@@ -97,6 +97,78 @@ TYPED_TEST(MatrixCopyTest, FullMatrixCPU) {
   }
 }
 
+struct DifferentTileSizeCopyConfig {
+  LocalElementSize size;
+  TileElementSize tile_size_src;
+  TileElementSize tile_size_dst;
+};
+
+const std::vector<DifferentTileSizeCopyConfig> different_tile_sizes_tests({
+    // Same tile sizes (no retiling needed)
+    {{12, 12}, {4, 4}, {4, 4}},
+    // Source tiles are larger than destination tiles
+    {{12, 12}, {6, 6}, {3, 3}},
+    {{12, 12}, {6, 6}, {2, 2}},
+    // Destination tiles are larger than source tiles
+    {{12, 12}, {3, 3}, {6, 6}},
+    {{12, 12}, {2, 2}, {6, 6}},
+    // Non-square tiles
+    {{12, 18}, {6, 9}, {3, 3}},
+    {{12, 18}, {3, 3}, {6, 9}},
+    // Mixed: one dimension same, other different
+    {{12, 12}, {6, 4}, {3, 4}},
+    {{12, 12}, {3, 4}, {6, 4}},
+    // Empty matrix
+    {{0, 0}, {6, 6}, {3, 3}},
+    // Single row/column of tiles
+    {{3, 12}, {3, 6}, {3, 3}},
+    {{12, 3}, {6, 3}, {3, 3}},
+});
+
+TYPED_TEST(MatrixCopyTest, FullMatrixLocalDifferentTileSizesCPU) {
+  using dlaf::matrix::util::set;
+
+  for (const auto& test : different_tile_sizes_tests) {
+    Matrix<TypeParam, Device::CPU> mat_src(test.size, test.tile_size_src);
+    set(mat_src, inputValues<TypeParam>);
+    Matrix<const TypeParam, Device::CPU> mat_src_const = std::move(mat_src);
+
+    Matrix<TypeParam, Device::CPU> mat_dst_1(test.size, test.tile_size_dst);
+    set(mat_dst_1, outputValues<TypeParam>);
+
+    Matrix<TypeParam, Device::CPU> mat_dst_2(test.size, test.tile_size_src);
+    set(mat_dst_2, outputValues<TypeParam>);
+
+    copy(mat_src_const, mat_dst_1);
+    CHECK_MATRIX_NEAR(inputValues<TypeParam>, mat_dst_1, 0, TypeUtilities<TypeParam>::error);
+
+    copy(mat_dst_1, mat_dst_2);
+    CHECK_MATRIX_NEAR(inputValues<TypeParam>, mat_dst_2, 0, TypeUtilities<TypeParam>::error);
+  }
+}
+
+#if DLAF_WITH_GPU
+TYPED_TEST(MatrixCopyTest, FullMatrixLocalDifferentTileSizesGPU) {
+  using dlaf::matrix::util::set;
+
+  for (const auto& test : different_tile_sizes_tests) {
+    Matrix<TypeParam, Device::CPU> mat_src(test.size, test.tile_size_src);
+    set(mat_src, inputValues<TypeParam>);
+    Matrix<const TypeParam, Device::CPU> mat_src_const = std::move(mat_src);
+
+    Matrix<TypeParam, Device::GPU> mat_gpu(test.size, test.tile_size_dst);
+
+    Matrix<TypeParam, Device::CPU> mat_dst(test.size, test.tile_size_src);
+    set(mat_dst, outputValues<TypeParam>);
+
+    copy(mat_src_const, mat_gpu);
+    copy(mat_gpu, mat_dst);
+
+    CHECK_MATRIX_NEAR(inputValues<TypeParam>, mat_dst, 0, TypeUtilities<TypeParam>::error);
+  }
+}
+#endif
+
 #if DLAF_WITH_GPU
 TYPED_TEST(MatrixCopyTest, FullMatrixGPU) {
   using dlaf::matrix::util::set;


### PR DESCRIPTION
Needed for the eigenvectors, which are local but require the same tile sizes of the distributed matrices.